### PR TITLE
fix(devnet): adapt harness scripts to single-root sync publish

### DIFF
--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for devnet test scripts — rc.12+ single-root sync publish.
+#
+# Since #925, POST /api/shared-memory/publish rejects `selection: "all"`
+# when multiple root entities exist (MULTI_ROOT_PUBLISH_NOT_ATOMIC). Scripts
+# that previously published whole SWM graphs in one call must publish one root
+# at a time.
+#
+# Usage: source this file AFTER defining `api_call NODE METHOD PATH [DATA]`.
+#
+#   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false)
+#   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false '"epochs":1')
+#
+devnet_publish_swm_all_roots() {
+  local node="$1" cg="$2" clear_after="${3:-false}"
+  local extra_fields="${4:-}"
+
+  local probe_body
+  probe_body=$(node -e "
+    const cg = process.argv[1];
+    const clearAfter = process.argv[2] === 'true';
+    const extra = process.argv[3] ? JSON.parse('{' + process.argv[3] + '}') : {};
+    console.log(JSON.stringify({ contextGraphId: cg, selection: 'all', clearAfter, ...extra }));
+  " "$cg" "$clear_after" "$extra_fields")
+
+  local probe
+  probe=$(api_call "$node" POST /api/shared-memory/publish "$probe_body")
+
+  if ! printf '%s' "$probe" | grep -q 'MULTI_ROOT_PUBLISH_NOT_ATOMIC'; then
+    printf '%s' "$probe"
+    return 0
+  fi
+
+  local roots_json count i last_resp root ca st
+  roots_json=$(printf '%s' "$probe" | node -e '
+    let d=""; process.stdin.on("data",c=>d+=c);
+    process.stdin.on("end",()=>{
+      try { console.log(JSON.stringify(JSON.parse(d).rootEntities || [])); }
+      catch { console.log("[]"); }
+    });
+  ')
+  count=$(printf '%s' "$roots_json" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).length))')
+  if [ "$count" -eq 0 ]; then
+    printf '%s' "$probe" >&2
+    return 1
+  fi
+
+  i=0
+  last_resp=""
+  while [ "$i" -lt "$count" ]; do
+    root=$(printf '%s' "$roots_json" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])]))" "$i")
+    ca="$clear_after"
+    if [ "$clear_after" = "true" ] && [ "$i" -lt $((count - 1)) ]; then
+      ca="false"
+    fi
+    last_resp=$(node -e "
+      const cg = process.argv[1];
+      const root = process.argv[2];
+      const clearAfter = process.argv[3] === 'true';
+      const extra = process.argv[4] ? JSON.parse('{' + process.argv[4] + '}') : {};
+      console.log(JSON.stringify({
+        contextGraphId: cg,
+        selection: { rootEntities: [root] },
+        clearAfter,
+        ...extra,
+      }));
+    " "$cg" "$root" "$ca" "$extra_fields")
+    last_resp=$(api_call "$node" POST /api/shared-memory/publish "$last_resp")
+    st=$(printf '%s' "$last_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).status||"")}catch{}})' 2>/dev/null || echo "")
+    if [ "$st" != "confirmed" ] && [ "$st" != "finalized" ]; then
+      printf '%s' "$last_resp" >&2
+      return 1
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  printf '%s' "$last_resp"
+  return 0
+}

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -12,9 +12,86 @@
 #   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false)
 #   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false '"epochs":1')
 #
+# After a call, DEVNET_PUBLISH_ALL_RESPONSES holds a JSON array of every
+# publish response (one element when the graph is single-root). When a
+# multi-root split occurred, DEVNET_PUBLISH_ROOT_ENTITIES lists the root
+# entity IRIs in publish order (same index as DEVNET_PUBLISH_ALL_RESPONSES).
+#
+DEVNET_PUBLISH_ALL_RESPONSES='[]'
+DEVNET_PUBLISH_ROOT_ENTITIES='[]'
+
+devnet_json_field() {
+  printf '%s' "$1" | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>{
+      try { const j=JSON.parse(d); const v=j$2; console.log(v == null ? '' : v); }
+      catch { process.exit(1); }
+    })
+  "
+}
+
+devnet_kc_merkle_root() {
+  local node="$1" kc="$2"
+  local meta
+  meta=$(api_call "$node" GET "/api/kc/$kc")
+  devnet_json_field "$meta" '.merkleRoot'
+}
+
+# Args: node cg quads_payload_json (stringified { contextGraphId, quads })
+# Verifies each published root entity against its KC merkleRoot via verify-batch.
+devnet_verify_each_published_root() {
+  local node="$1" cg="$2" quads_payload="$3"
+  local count i kc merkle body resp ok actual
+
+  count=$(printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e '
+    let d=""; process.stdin.on("data",c=>d+=c);
+    process.stdin.on("end",()=>{ try { console.log(JSON.parse(d).length); } catch { console.log(0); } });
+  ')
+  if [ "$count" -eq 0 ]; then
+    count=1
+  fi
+
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    kc=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c);
+      process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
+    " "$i")
+    merkle=$(devnet_kc_merkle_root "$node" "$kc")
+    body=$(QUADS_PAYLOAD="$quads_payload" ROOT_IDX="$i" ROOTS="$DEVNET_PUBLISH_ROOT_ENTITIES" CG="$cg" MERKLE="$merkle" KC="$kc" node -e '
+      const roots = JSON.parse(process.env.ROOTS || "[]");
+      const rootIdx = Number(process.env.ROOT_IDX);
+      const payload = JSON.parse(process.env.QUADS_PAYLOAD);
+      let quads = payload.quads;
+      if (roots.length > 0) {
+        const root = roots[rootIdx];
+        quads = quads.filter((q) => q.subject === root || q.subject.startsWith(root + "/"));
+      }
+      console.log(JSON.stringify({
+        contextGraphId: process.env.CG,
+        expectedMerkleRoot: process.env.MERKLE,
+        batchId: process.env.KC,
+        quads,
+      }));
+    ')
+    resp=$(api_call "$node" POST /api/shared-memory/verify-batch "$body")
+    ok=$(devnet_json_field "$resp" '.ok')
+    actual=$(devnet_json_field "$resp" '.actualRoot')
+    if [ "$ok" != "true" ] || [ "$actual" != "$merkle" ]; then
+      printf '%s\n' "$resp" >&2
+      return 1
+    fi
+    i=$((i + 1))
+  done
+  return 0
+}
+
 devnet_publish_swm_all_roots() {
   local node="$1" cg="$2" clear_after="${3:-false}"
   local extra_fields="${4:-}"
+
+  DEVNET_PUBLISH_ALL_RESPONSES='[]'
+  DEVNET_PUBLISH_ROOT_ENTITIES='[]'
 
   local probe_body
   probe_body=$(node -e "
@@ -28,11 +105,15 @@ devnet_publish_swm_all_roots() {
   probe=$(api_call "$node" POST /api/shared-memory/publish "$probe_body")
 
   if ! printf '%s' "$probe" | grep -q 'MULTI_ROOT_PUBLISH_NOT_ATOMIC'; then
+    DEVNET_PUBLISH_ALL_RESPONSES=$(printf '%s' "$probe" | node -e '
+      let d=""; process.stdin.on("data",c=>d+=c);
+      process.stdin.on("end",()=>console.log(JSON.stringify([JSON.parse(d)])));
+    ')
     printf '%s' "$probe"
     return 0
   fi
 
-  local roots_json count i last_resp root ca st
+  local roots_json count i last_resp root ca st all_resps
   roots_json=$(printf '%s' "$probe" | node -e '
     let d=""; process.stdin.on("data",c=>d+=c);
     process.stdin.on("end",()=>{
@@ -40,12 +121,14 @@ devnet_publish_swm_all_roots() {
       catch { console.log("[]"); }
     });
   ')
+  DEVNET_PUBLISH_ROOT_ENTITIES="$roots_json"
   count=$(printf '%s' "$roots_json" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).length))')
   if [ "$count" -eq 0 ]; then
     printf '%s' "$probe" >&2
     return 1
   fi
 
+  all_resps="[]"
   i=0
   last_resp=""
   while [ "$i" -lt "$count" ]; do
@@ -72,9 +155,15 @@ devnet_publish_swm_all_roots() {
       printf '%s' "$last_resp" >&2
       return 1
     fi
+    all_resps=$(node -e "
+      const arr = JSON.parse(process.argv[1]);
+      arr.push(JSON.parse(process.argv[2]));
+      console.log(JSON.stringify(arr));
+    " "$all_resps" "$last_resp")
     i=$((i + 1))
     sleep 1
   done
+  DEVNET_PUBLISH_ALL_RESPONSES="$all_resps"
   printf '%s' "$last_resp"
   return 0
 }

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -14,10 +14,12 @@
 #
 # Command substitution runs the publish helper in a subshell, so metadata is
 # persisted to DEVNET_PUBLISH_STATE_FILE and must be loaded in the caller shell.
-# The state file is scoped to the current bash process (BASHPID) so concurrent
-# devnet scripts do not clobber each other's publish metadata.
+# The state file is scoped to the parent shell PID ($$). Unlike BASHPID, $$ is
+# stable across command-substitution subshells, so the path the helper writes
+# inside `$(...)` matches the one the parent later reads. It also keeps
+# concurrent devnet scripts from clobbering each other's publish metadata.
 #
-DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state-${BASHPID:-$$}.json}"
+DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state-$$.json}"
 DEVNET_PUBLISH_ALL_RESPONSES='[]'
 DEVNET_PUBLISH_ROOT_ENTITIES='[]'
 
@@ -31,8 +33,10 @@ devnet_json_field() {
   "
 }
 
+# Honor an already-set DEVNET_PUBLISH_STATE_FILE; otherwise derive a
+# parent-stable path from $$ (NOT BASHPID, which changes inside subshells).
 _devnet_publish_init_state_file() {
-  DEVNET_PUBLISH_STATE_FILE="${DEVNET_DIR:-/tmp}/.devnet-publish-state-${BASHPID:-$$}.json"
+  : "${DEVNET_PUBLISH_STATE_FILE:=${DEVNET_DIR:-/tmp}/.devnet-publish-state-$$.json}"
 }
 
 _devnet_publish_persist_state() {
@@ -82,6 +86,34 @@ devnet_publish_ka_id_at() {
     let d=''; process.stdin.on('data',c=>d+=c);
     process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
   " "$idx"
+}
+
+# Args: root_subject
+# Resolve the kaId of the batch that published a given root entity. The helper
+# preserves publish order (allResponses[i] <-> rootEntities[i]), but the
+# daemon's rootEntities order is NOT tied to the original quad order, so callers
+# must look the batch up by subject rather than positional index. For a
+# single-root (non-split) publish, rootEntities is empty and we return the only
+# batch's kaId.
+devnet_publish_ka_id_for_root() {
+  local root="$1"
+  devnet_publish_load_state
+  ALL="$DEVNET_PUBLISH_ALL_RESPONSES" ROOTS="$DEVNET_PUBLISH_ROOT_ENTITIES" ROOT="$root" node -e '
+    const all = JSON.parse(process.env.ALL || "[]");
+    const roots = JSON.parse(process.env.ROOTS || "[]");
+    const root = process.env.ROOT;
+    if (roots.length === 0) {
+      if (!all.length) { console.error("no published batches in state"); process.exit(1); }
+      console.log(all[0].kaId);
+      process.exit(0);
+    }
+    const idx = roots.indexOf(root);
+    if (idx < 0 || !all[idx]) {
+      console.error("no published batch for root " + root);
+      process.exit(1);
+    }
+    console.log(all[idx].kaId);
+  '
 }
 
 devnet_kc_merkle_root() {

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -37,6 +37,14 @@ devnet_json_field() {
   "
 }
 
+# Publish statuses the devnet harness treats as success (matches devnet-test.sh).
+_devnet_publish_status_ok() {
+  case "$1" in
+    confirmed|finalized|tentative) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Honor an already-set DEVNET_PUBLISH_STATE_FILE; otherwise derive a
 # parent-stable path from $$ (NOT BASHPID, which changes inside subshells).
 _devnet_publish_init_state_file() {
@@ -243,10 +251,11 @@ devnet_publish_swm_all_roots() {
     console.log(JSON.stringify({ contextGraphId: cg, selection: 'all', clearAfter, ...extra }));
   " "$cg" "$clear_after" "$extra_fields")
 
-  local probe
+  local probe probe_code
   probe=$(api_call "$node" POST /api/shared-memory/publish "$probe_body")
+  probe_code=$(devnet_json_field "$probe" '.code')
 
-  if ! printf '%s' "$probe" | grep -q 'MULTI_ROOT_PUBLISH_NOT_ATOMIC'; then
+  if [ "$probe_code" != "MULTI_ROOT_PUBLISH_NOT_ATOMIC" ]; then
     local single_arr single_roots
     single_arr=$(printf '%s' "$probe" | node -e '
       let d=""; process.stdin.on("data",c=>d+=c);
@@ -305,8 +314,8 @@ devnet_publish_swm_all_roots() {
       }));
     " "$cg" "$root" "$ca" "$extra_fields")
     last_resp=$(api_call "$node" POST /api/shared-memory/publish "$last_resp")
-    st=$(printf '%s' "$last_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).status||"")}catch{}})' 2>/dev/null || echo "")
-    if [ "$st" != "confirmed" ] && [ "$st" != "finalized" ]; then
+    st=$(devnet_json_field "$last_resp" '.status')
+    if ! _devnet_publish_status_ok "$st"; then
       printf '%s' "$last_resp" >&2
       return 1
     fi

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -22,6 +22,10 @@
 DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state-$$.json}"
 DEVNET_PUBLISH_ALL_RESPONSES='[]'
 DEVNET_PUBLISH_ROOT_ENTITIES='[]'
+# Node that performed the last publish. KC metadata (merkleRoot, KCS records)
+# must be read from this node — late-joining/non-curator verifier peers may not
+# have materialized the batch yet, which would race verify-batch.
+DEVNET_PUBLISH_NODE=''
 
 devnet_json_field() {
   printf '%s' "$1" | node -e "
@@ -40,16 +44,17 @@ _devnet_publish_init_state_file() {
 }
 
 _devnet_publish_persist_state() {
-  local all_responses="$1" root_entities="${2:-[]}"
+  local all_responses="$1" root_entities="${2:-[]}" publish_node="${3:-}"
   node -e "
     require('fs').writeFileSync(
       process.argv[1],
       JSON.stringify({
         allResponses: JSON.parse(process.argv[2]),
         rootEntities: JSON.parse(process.argv[3]),
+        publishNode: process.argv[4],
       }),
     );
-  " "$DEVNET_PUBLISH_STATE_FILE" "$all_responses" "$root_entities"
+  " "$DEVNET_PUBLISH_STATE_FILE" "$all_responses" "$root_entities" "$publish_node"
 }
 
 devnet_publish_load_state() {
@@ -57,6 +62,7 @@ devnet_publish_load_state() {
   if [ ! -f "$DEVNET_PUBLISH_STATE_FILE" ]; then
     DEVNET_PUBLISH_ALL_RESPONSES='[]'
     DEVNET_PUBLISH_ROOT_ENTITIES='[]'
+    DEVNET_PUBLISH_NODE=''
     return 0
   fi
   DEVNET_PUBLISH_ALL_RESPONSES=$(node -e "
@@ -66,6 +72,10 @@ devnet_publish_load_state() {
   DEVNET_PUBLISH_ROOT_ENTITIES=$(node -e "
     const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
     console.log(JSON.stringify(s.rootEntities || []));
+  " "$DEVNET_PUBLISH_STATE_FILE")
+  DEVNET_PUBLISH_NODE=$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(s.publishNode || '');
   " "$DEVNET_PUBLISH_STATE_FILE")
 }
 
@@ -92,9 +102,11 @@ devnet_publish_ka_id_at() {
 # Resolve the kaId of the batch that published a given root entity. The helper
 # preserves publish order (allResponses[i] <-> rootEntities[i]), but the
 # daemon's rootEntities order is NOT tied to the original quad order, so callers
-# must look the batch up by subject rather than positional index. For a
-# single-root (non-split) publish, rootEntities is empty and we return the only
-# batch's kaId.
+# must look the batch up by subject rather than positional index. Lookups fail
+# fast when the requested root has no recorded root->batch mapping (e.g. a typo,
+# or a single-root publish where the subject was never recorded) instead of
+# silently resolving to the wrong batch — use devnet_publish_ka_id_at for
+# positional access to a single-batch publish.
 devnet_publish_ka_id_for_root() {
   local root="$1"
   devnet_publish_load_state
@@ -103,9 +115,11 @@ devnet_publish_ka_id_for_root() {
     const roots = JSON.parse(process.env.ROOTS || "[]");
     const root = process.env.ROOT;
     if (roots.length === 0) {
-      if (!all.length) { console.error("no published batches in state"); process.exit(1); }
-      console.log(all[0].kaId);
-      process.exit(0);
+      console.error(
+        "no root->batch mapping recorded for " + root +
+        " (single-root publish records no subject; use devnet_publish_ka_id_at instead)",
+      );
+      process.exit(1);
     }
     const idx = roots.indexOf(root);
     if (idx < 0 || !all[idx]) {
@@ -142,6 +156,7 @@ const fs = require("fs"); const path = require("path");
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
   const contracts = JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON, "utf8")).contracts;
   const kcsAddr = contracts.DKGKnowledgeAssets?.evmAddress ?? contracts.KnowledgeCollectionStorage?.evmAddress;
+  if (!kcsAddr) throw new Error("DKGKnowledgeAssets / KnowledgeCollectionStorage not deployed");
   const kcsAbiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json"))
     ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
   const kas = new ethers.Contract(kcsAddr,
@@ -164,20 +179,25 @@ const fs = require("fs"); const path = require("path");
   )
 }
 
-# Args: node cg quads_payload_json (stringified { contextGraphId, quads })
+# Args: node cg quads_payload_json [metadata_node]
 # Verifies each published root entity against its KC merkleRoot via verify-batch.
+# verify-batch runs on `node` (often a late-joining/non-curator peer), but the
+# expected merkleRoot is read from `metadata_node` — defaults to the node that
+# performed the publish — to avoid racing that peer's KC chain-sync.
 devnet_verify_each_published_root() {
-  local node="$1" cg="$2" quads_payload="$3"
+  local node="$1" cg="$2" quads_payload="$3" meta_node="${4:-}"
   local count i kc merkle body resp ok actual
 
   devnet_publish_load_state
+  [ -z "$meta_node" ] && meta_node="${DEVNET_PUBLISH_NODE:-$node}"
+  [ -z "$meta_node" ] && meta_node="$node"
 
   count=$(devnet_publish_root_count)
 
   i=0
   while [ "$i" -lt "$count" ]; do
     kc=$(devnet_publish_ka_id_at "$i")
-    merkle=$(devnet_kc_merkle_root "$node" "$kc")
+    merkle=$(devnet_kc_merkle_root "$meta_node" "$kc")
     body=$(QUADS_PAYLOAD="$quads_payload" ROOT_IDX="$i" ROOTS="$DEVNET_PUBLISH_ROOT_ENTITIES" CG="$cg" MERKLE="$merkle" KC="$kc" node -e '
       const genidPrefix = "/.well-known/genid/";
       const quadBelongsToRoot = (q, root) =>
@@ -227,12 +247,24 @@ devnet_publish_swm_all_roots() {
   probe=$(api_call "$node" POST /api/shared-memory/publish "$probe_body")
 
   if ! printf '%s' "$probe" | grep -q 'MULTI_ROOT_PUBLISH_NOT_ATOMIC'; then
-    local single_arr
+    local single_arr single_roots
     single_arr=$(printf '%s' "$probe" | node -e '
       let d=""; process.stdin.on("data",c=>d+=c);
       process.stdin.on("end",()=>console.log(JSON.stringify([JSON.parse(d)])));
     ')
-    _devnet_publish_persist_state "$single_arr" '[]'
+    # Record the published root subject when the response exposes it so
+    # devnet_publish_ka_id_for_root can validate single-root lookups too.
+    single_roots=$(printf '%s' "$probe" | node -e '
+      let d=""; process.stdin.on("data",c=>d+=c);
+      process.stdin.on("end",()=>{
+        try {
+          const j = JSON.parse(d);
+          const roots = j.rootEntities || j.publishedRootEntities || j.roots || [];
+          console.log(JSON.stringify(Array.isArray(roots) ? roots : []));
+        } catch { console.log("[]"); }
+      });
+    ')
+    _devnet_publish_persist_state "$single_arr" "$single_roots" "$node"
     printf '%s' "$probe"
     return 0
   fi
@@ -286,7 +318,7 @@ devnet_publish_swm_all_roots() {
     i=$((i + 1))
     sleep 1
   done
-  _devnet_publish_persist_state "$all_resps" "$roots_json"
+  _devnet_publish_persist_state "$all_resps" "$roots_json" "$node"
   printf '%s' "$last_resp"
   return 0
 }

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -10,13 +10,12 @@
 # Usage: source this file AFTER defining `api_call NODE METHOD PATH [DATA]`.
 #
 #   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false)
-#   PUBLISH_RESP=$(devnet_publish_swm_all_roots "$NODE" "$CG_ID" false '"epochs":1')
+#   devnet_publish_load_state
 #
-# After a call, DEVNET_PUBLISH_ALL_RESPONSES holds a JSON array of every
-# publish response (one element when the graph is single-root). When a
-# multi-root split occurred, DEVNET_PUBLISH_ROOT_ENTITIES lists the root
-# entity IRIs in publish order (same index as DEVNET_PUBLISH_ALL_RESPONSES).
+# Command substitution runs the publish helper in a subshell, so metadata is
+# persisted to DEVNET_PUBLISH_STATE_FILE and must be loaded in the caller shell.
 #
+DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state.json}"
 DEVNET_PUBLISH_ALL_RESPONSES='[]'
 DEVNET_PUBLISH_ROOT_ENTITIES='[]'
 
@@ -28,6 +27,35 @@ devnet_json_field() {
       catch { process.exit(1); }
     })
   "
+}
+
+_devnet_publish_persist_state() {
+  local all_responses="$1" root_entities="${2:-[]}"
+  node -e "
+    require('fs').writeFileSync(
+      process.argv[1],
+      JSON.stringify({
+        allResponses: JSON.parse(process.argv[2]),
+        rootEntities: JSON.parse(process.argv[3]),
+      }),
+    );
+  " "$DEVNET_PUBLISH_STATE_FILE" "$all_responses" "$root_entities"
+}
+
+devnet_publish_load_state() {
+  if [ ! -f "$DEVNET_PUBLISH_STATE_FILE" ]; then
+    DEVNET_PUBLISH_ALL_RESPONSES='[]'
+    DEVNET_PUBLISH_ROOT_ENTITIES='[]'
+    return 0
+  fi
+  DEVNET_PUBLISH_ALL_RESPONSES=$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(JSON.stringify(s.allResponses || []));
+  " "$DEVNET_PUBLISH_STATE_FILE")
+  DEVNET_PUBLISH_ROOT_ENTITIES=$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(JSON.stringify(s.rootEntities || []));
+  " "$DEVNET_PUBLISH_STATE_FILE")
 }
 
 devnet_kc_merkle_root() {
@@ -42,6 +70,8 @@ devnet_kc_merkle_root() {
 devnet_verify_each_published_root() {
   local node="$1" cg="$2" quads_payload="$3"
   local count i kc merkle body resp ok actual
+
+  devnet_publish_load_state
 
   count=$(printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e '
     let d=""; process.stdin.on("data",c=>d+=c);
@@ -90,9 +120,6 @@ devnet_publish_swm_all_roots() {
   local node="$1" cg="$2" clear_after="${3:-false}"
   local extra_fields="${4:-}"
 
-  DEVNET_PUBLISH_ALL_RESPONSES='[]'
-  DEVNET_PUBLISH_ROOT_ENTITIES='[]'
-
   local probe_body
   probe_body=$(node -e "
     const cg = process.argv[1];
@@ -105,10 +132,12 @@ devnet_publish_swm_all_roots() {
   probe=$(api_call "$node" POST /api/shared-memory/publish "$probe_body")
 
   if ! printf '%s' "$probe" | grep -q 'MULTI_ROOT_PUBLISH_NOT_ATOMIC'; then
-    DEVNET_PUBLISH_ALL_RESPONSES=$(printf '%s' "$probe" | node -e '
+    local single_arr
+    single_arr=$(printf '%s' "$probe" | node -e '
       let d=""; process.stdin.on("data",c=>d+=c);
       process.stdin.on("end",()=>console.log(JSON.stringify([JSON.parse(d)])));
     ')
+    _devnet_publish_persist_state "$single_arr" '[]'
     printf '%s' "$probe"
     return 0
   fi
@@ -121,7 +150,6 @@ devnet_publish_swm_all_roots() {
       catch { console.log("[]"); }
     });
   ')
-  DEVNET_PUBLISH_ROOT_ENTITIES="$roots_json"
   count=$(printf '%s' "$roots_json" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).length))')
   if [ "$count" -eq 0 ]; then
     printf '%s' "$probe" >&2
@@ -163,7 +191,7 @@ devnet_publish_swm_all_roots() {
     i=$((i + 1))
     sleep 1
   done
-  DEVNET_PUBLISH_ALL_RESPONSES="$all_resps"
+  _devnet_publish_persist_state "$all_resps" "$roots_json"
   printf '%s' "$last_resp"
   return 0
 }

--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -14,8 +14,10 @@
 #
 # Command substitution runs the publish helper in a subshell, so metadata is
 # persisted to DEVNET_PUBLISH_STATE_FILE and must be loaded in the caller shell.
+# The state file is scoped to the current bash process (BASHPID) so concurrent
+# devnet scripts do not clobber each other's publish metadata.
 #
-DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state.json}"
+DEVNET_PUBLISH_STATE_FILE="${DEVNET_PUBLISH_STATE_FILE:-${DEVNET_DIR:-/tmp}/.devnet-publish-state-${BASHPID:-$$}.json}"
 DEVNET_PUBLISH_ALL_RESPONSES='[]'
 DEVNET_PUBLISH_ROOT_ENTITIES='[]'
 
@@ -27,6 +29,10 @@ devnet_json_field() {
       catch { process.exit(1); }
     })
   "
+}
+
+_devnet_publish_init_state_file() {
+  DEVNET_PUBLISH_STATE_FILE="${DEVNET_DIR:-/tmp}/.devnet-publish-state-${BASHPID:-$$}.json"
 }
 
 _devnet_publish_persist_state() {
@@ -43,6 +49,7 @@ _devnet_publish_persist_state() {
 }
 
 devnet_publish_load_state() {
+  _devnet_publish_init_state_file
   if [ ! -f "$DEVNET_PUBLISH_STATE_FILE" ]; then
     DEVNET_PUBLISH_ALL_RESPONSES='[]'
     DEVNET_PUBLISH_ROOT_ENTITIES='[]'
@@ -58,11 +65,71 @@ devnet_publish_load_state() {
   " "$DEVNET_PUBLISH_STATE_FILE")
 }
 
+# Echo the number of root-entity publishes in the last devnet_publish_swm_all_roots call.
+devnet_publish_root_count() {
+  devnet_publish_load_state
+  printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e '
+    let d=""; process.stdin.on("data",c=>d+=c);
+    process.stdin.on("end",()=>{ try { const n=JSON.parse(d).length; console.log(n > 0 ? n : 1); } catch { console.log(1); } });
+  '
+}
+
+# Args: zero-based index into the last publish batch list.
+devnet_publish_ka_id_at() {
+  local idx="$1"
+  devnet_publish_load_state
+  printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
+  " "$idx"
+}
+
 devnet_kc_merkle_root() {
   local node="$1" kc="$2"
   local meta
   meta=$(api_call "$node" GET "/api/kc/$kc")
   devnet_json_field "$meta" '.merkleRoot'
+}
+
+# Args: expected_minted_per_kc (default 1)
+# Requires REPO_ROOT, HARDHAT_PORT, CONTRACTS_JSON, EVM_ABI_DIR in caller env.
+devnet_kcs_readback_all_published() {
+  local expected_minted="${1:-1}"
+  devnet_publish_load_state
+  (
+    cd "${REPO_ROOT:?REPO_ROOT must be set}/packages/evm-module" && \
+    RPC_URL="http://127.0.0.1:${HARDHAT_PORT:-8545}" \
+    CONTRACTS_JSON="${CONTRACTS_JSON:?CONTRACTS_JSON must be set}" \
+    ABI_DIR="${EVM_ABI_DIR:?EVM_ABI_DIR must be set}" \
+    ALL_KCS="$DEVNET_PUBLISH_ALL_RESPONSES" \
+    EXPECTED_MINTED="$expected_minted" \
+    node -e '
+const { ethers } = require("ethers");
+const fs = require("fs"); const path = require("path");
+(async () => {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const contracts = JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON, "utf8")).contracts;
+  const kcsAddr = contracts.DKGKnowledgeAssets?.evmAddress ?? contracts.KnowledgeCollectionStorage?.evmAddress;
+  const kcsAbiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json"))
+    ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
+  const kas = new ethers.Contract(kcsAddr,
+    JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR, kcsAbiFile), "utf8")), provider);
+  const kcs = JSON.parse(process.env.ALL_KCS);
+  const expectedMinted = BigInt(process.env.EXPECTED_MINTED);
+  if (!kcs.length) throw new Error("no published KC responses in state");
+  for (const pub of kcs) {
+    const batchId = pub.kaId;
+    const [merkleRoots, , minted, byteSize] = await kas.getKnowledgeAssetMetadata(BigInt(batchId));
+    if (!merkleRoots || merkleRoots.length === 0) throw new Error("no merkleRoots for kaId=" + batchId);
+    if (byteSize === 0n) throw new Error("byteSize=0 for kaId=" + batchId);
+    if (minted !== expectedMinted) {
+      throw new Error("kaId=" + batchId + ": expected " + expectedMinted + " KAs minted, got " + minted);
+    }
+  }
+  console.log("✓ KCS: " + kcs.length + " KC(s) each minted=" + expectedMinted);
+})().catch(e => { console.error(e?.message || e); process.exit(1); });
+    '
+  )
 }
 
 # Args: node cg quads_payload_json (stringified { contextGraphId, quads })
@@ -73,29 +140,23 @@ devnet_verify_each_published_root() {
 
   devnet_publish_load_state
 
-  count=$(printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e '
-    let d=""; process.stdin.on("data",c=>d+=c);
-    process.stdin.on("end",()=>{ try { console.log(JSON.parse(d).length); } catch { console.log(0); } });
-  ')
-  if [ "$count" -eq 0 ]; then
-    count=1
-  fi
+  count=$(devnet_publish_root_count)
 
   i=0
   while [ "$i" -lt "$count" ]; do
-    kc=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e "
-      let d=''; process.stdin.on('data',c=>d+=c);
-      process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
-    " "$i")
+    kc=$(devnet_publish_ka_id_at "$i")
     merkle=$(devnet_kc_merkle_root "$node" "$kc")
     body=$(QUADS_PAYLOAD="$quads_payload" ROOT_IDX="$i" ROOTS="$DEVNET_PUBLISH_ROOT_ENTITIES" CG="$cg" MERKLE="$merkle" KC="$kc" node -e '
+      const genidPrefix = "/.well-known/genid/";
+      const quadBelongsToRoot = (q, root) =>
+        q.subject === root || q.subject.startsWith(root + genidPrefix);
       const roots = JSON.parse(process.env.ROOTS || "[]");
       const rootIdx = Number(process.env.ROOT_IDX);
       const payload = JSON.parse(process.env.QUADS_PAYLOAD);
       let quads = payload.quads;
       if (roots.length > 0) {
         const root = roots[rootIdx];
-        quads = quads.filter((q) => q.subject === root || q.subject.startsWith(root + "/"));
+        quads = quads.filter((q) => quadBelongsToRoot(q, root));
       }
       console.log(JSON.stringify({
         contextGraphId: process.env.CG,
@@ -119,6 +180,8 @@ devnet_verify_each_published_root() {
 devnet_publish_swm_all_roots() {
   local node="$1" cg="$2" clear_after="${3:-false}"
   local extra_fields="${4:-}"
+
+  _devnet_publish_init_state_file
 
   local probe_body
   probe_body=$(node -e "
@@ -194,4 +257,17 @@ devnet_publish_swm_all_roots() {
   _devnet_publish_persist_state "$all_resps" "$roots_json"
   printf '%s' "$last_resp"
   return 0
+}
+
+# Filter quads to those belonging to a published root entity (matches publisher selection).
+devnet_quads_for_root_json() {
+  local quads_payload="$1" root="$2"
+  QUADS_PAYLOAD="$quads_payload" ROOT="$root" node -e '
+    const genidPrefix = "/.well-known/genid/";
+    const quadBelongsToRoot = (q, root) =>
+      q.subject === root || q.subject.startsWith(root + genidPrefix);
+    const payload = JSON.parse(process.env.QUADS_PAYLOAD);
+    const quads = payload.quads.filter((q) => quadBelongsToRoot(q, process.env.ROOT));
+    console.log(JSON.stringify(quads));
+  '
 }

--- a/scripts/devnet-test-rfc38-curator-offline-midbatch.sh
+++ b/scripts/devnet-test-rfc38-curator-offline-midbatch.sh
@@ -48,6 +48,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 API_PORT_BASE=9201
 CURATOR_NODE=5
@@ -365,10 +368,7 @@ fi
 # ===========================================================================
 act "5. M1 (non-curator) publishes to VM with the curator still offline"
 # ===========================================================================
-PUB_RESP=$(api_call "$M1_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$M1_NODE" "$CG_ID" false)
 log "M1 publish response: $PUB_RESP"
 STATUS=$(parse_json "$PUB_RESP" '.status')
 TX=$(parse_json    "$PUB_RESP" '.txHash')

--- a/scripts/devnet-test-rfc38-e2e.sh
+++ b/scripts/devnet-test-rfc38-e2e.sh
@@ -218,42 +218,19 @@ PUBLISH_BLOCK=$(parse_json "$PUBLISH_RESP" '.blockNumber')
 [ "$PUBLISH_STATUS" = "confirmed" ] || fail "publish: expected status=confirmed, got '$PUBLISH_STATUS'"
 [[ "$PUBLISH_TX" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "publish: txHash '$PUBLISH_TX' not valid 32-byte hex"
 [ -n "$PUBLISH_KC" ] && [ "$PUBLISH_KC" != "0" ] || fail "publish: invalid kaId '$PUBLISH_KC'"
-log "✓ publish landed: kaId=$PUBLISH_KC tx=$PUBLISH_TX block=$PUBLISH_BLOCK"
+EXPECTED_ROOTS=6
+PUBLISH_COUNT=$(devnet_publish_root_count)
+[ "$PUBLISH_COUNT" = "$EXPECTED_ROOTS" ] || fail "expected $EXPECTED_ROOTS root publishes, got $PUBLISH_COUNT"
+log "✓ publish landed: ${PUBLISH_COUNT} root batch(es), last kaId=$PUBLISH_KC tx=$PUBLISH_TX block=$PUBLISH_BLOCK"
 
-# Read KC metadata via daemon
+PUBLISH_KC=$(devnet_publish_ka_id_at 0)
 KC_META_RESP=$(api_call "$CURATOR_NODE" GET "/api/kc/$PUBLISH_KC")
 MERKLE_ROOT=$(parse_json "$KC_META_RESP" '.merkleRoot')
 [[ "$MERKLE_ROOT" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "GET /api/kc/$PUBLISH_KC did not return a hex merkleRoot — response: $KC_META_RESP"
-log "✓ KC merkleRoot from chain: $MERKLE_ROOT"
+log "✓ first KC merkleRoot from chain: $MERKLE_ROOT"
 
-# Cross-check via Hardhat KCS read-back
-log "Cross-check: reading KC $PUBLISH_KC back from KnowledgeCollectionStorage..."
-(
-cd "$REPO_ROOT/packages/evm-module" && \
-RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" \
-CONTRACTS_JSON="$CONTRACTS_JSON" \
-ABI_DIR="$EVM_ABI_DIR" \
-BATCH_ID="$PUBLISH_KC" \
-node -e '
-const { ethers } = require("ethers");
-const fs = require("fs");
-const path = require("path");
-(async () => {
-  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
-  const contracts = JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON, "utf8")).contracts;
-  const kcsAddr = contracts.DKGKnowledgeAssets?.evmAddress ?? contracts.KnowledgeCollectionStorage?.evmAddress;
-  if (!kcsAddr) throw new Error("DKGKnowledgeAssets / KnowledgeCollectionStorage not deployed");
-  const abiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json")) ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
-  const abi = JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR, abiFile), "utf8"));
-  const kas = new ethers.Contract(kcsAddr, abi, provider);
-  const [merkleRoots, burned, minted, byteSize, , , tokenAmount] =
-    await kas.getKnowledgeAssetMetadata(BigInt(process.env.BATCH_ID));
-  if (!merkleRoots || merkleRoots.length === 0) throw new Error("merkleRoots empty");
-  if (byteSize === 0n) throw new Error("byteSize=0");
-  console.log("KC read-back OK: merkleRoots=" + merkleRoots.length + " byteSize=" + byteSize + " minted=" + minted + " tokenAmount=" + tokenAmount);
-})().catch(e => { console.error("[kas] " + (e?.shortMessage || e?.message || e)); process.exit(1); });
-'
-) || fail "KC read-back failed"
+log "Cross-check: reading all $PUBLISH_COUNT published KCs back from KnowledgeCollectionStorage..."
+devnet_kcs_readback_all_published 1 || fail "KC read-back failed"
 
 # ===========================================================================
 # ACT 2 — Member late-joins, catches up via SWMCatchupRequest (LU-7)
@@ -358,7 +335,7 @@ devnet_verify_each_published_root "$MEMBER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
   || fail "member verify-batch failed for one or more published roots"
 log "✓ member verify-batch passes for all published roots"
 
-PUBLISH_KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+PUBLISH_KC=$(devnet_publish_ka_id_at 0)
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$PUBLISH_KC")
 
 # Forge a tampered quads array — recompute against bad data must fail

--- a/scripts/devnet-test-rfc38-e2e.sh
+++ b/scripts/devnet-test-rfc38-e2e.sh
@@ -335,7 +335,9 @@ devnet_verify_each_published_root "$MEMBER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
   || fail "member verify-batch failed for one or more published roots"
 log "✓ member verify-batch passes for all published roots"
 
-PUBLISH_KC=$(devnet_publish_ka_id_at 0)
+# LU-9 below mints/verifies an attestation for alice's leaf, so resolve the
+# batch that published alice's root rather than assuming it is publish index 0.
+PUBLISH_KC=$(devnet_publish_ka_id_for_root "urn:e2e:${STAMP}/alice")
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$PUBLISH_KC")
 
 # Forge a tampered quads array — recompute against bad data must fail

--- a/scripts/devnet-test-rfc38-e2e.sh
+++ b/scripts/devnet-test-rfc38-e2e.sh
@@ -62,6 +62,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -203,10 +206,7 @@ log "✓ 12 triples written to curator's SWM (op=$(parse_json "$WRITE_RESP" '.sh
 sleep 2
 
 log "Publishing curated CG to VM..."
-PUBLISH_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUBLISH_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
 log "publish response: $PUBLISH_RESP"
 
 PUBLISH_STATUS=$(parse_json "$PUBLISH_RESP" '.status')

--- a/scripts/devnet-test-rfc38-e2e.sh
+++ b/scripts/devnet-test-rfc38-e2e.sh
@@ -207,6 +207,7 @@ sleep 2
 
 log "Publishing curated CG to VM..."
 PUBLISH_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
+devnet_publish_load_state
 log "publish response: $PUBLISH_RESP"
 
 PUBLISH_STATUS=$(parse_json "$PUBLISH_RESP" '.status')

--- a/scripts/devnet-test-rfc38-e2e.sh
+++ b/scripts/devnet-test-rfc38-e2e.sh
@@ -353,23 +353,12 @@ act 3 "Member verifies the on-chain batch post-decrypt (LU-8)"
 # recompute would fail. Explicit-quads input is the correct
 # semantic for "member verifies decrypted batch."
 log "Member calls verify-batch with explicit decrypted quads (12 user triples)..."
-VERIFY_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" PUBLISH_KC="$PUBLISH_KC" node -e "
-  const payload = JSON.parse(process.env.QUADS_PAYLOAD);
-  console.log(JSON.stringify({
-    contextGraphId: payload.contextGraphId,
-    expectedMerkleRoot: process.env.MERKLE_ROOT,
-    batchId: process.env.PUBLISH_KC,
-    quads: payload.quads
-  }));
-")
-VERIFY_CURATOR=$(api_call "$MEMBER_NODE" POST /api/shared-memory/verify-batch "$VERIFY_BODY")
-log "member verify response: $VERIFY_CURATOR"
-VC_OK=$(parse_json "$VERIFY_CURATOR" '.ok')
-VC_LEAF=$(parse_json "$VERIFY_CURATOR" '.leafCount')
-VC_ACTUAL=$(parse_json "$VERIFY_CURATOR" '.actualRoot')
-[ "$VC_OK" = "true" ] || fail "member verify-batch returned ok=$VC_OK (expected true) — response: $VERIFY_CURATOR"
-[ "$VC_ACTUAL" = "$MERKLE_ROOT" ] || fail "actualRoot != expectedRoot ($VC_ACTUAL vs $MERKLE_ROOT)"
-log "✓ member verify-batch passes: leafCount=$VC_LEAF actualRoot==expected"
+devnet_verify_each_published_root "$MEMBER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
+  || fail "member verify-batch failed for one or more published roots"
+log "✓ member verify-batch passes for all published roots"
+
+PUBLISH_KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$PUBLISH_KC")
 
 # Forge a tampered quads array — recompute against bad data must fail
 log "Building tampered quads array to provoke a root-mismatch..."

--- a/scripts/devnet-test-rfc38-lu10.sh
+++ b/scripts/devnet-test-rfc38-lu10.sh
@@ -222,27 +222,18 @@ act "3. VERIFY-BATCH SWEEP (explicit quads, public CG)"
 # ===========================================================================
 
 log "Outsider calls verify-batch with the published quads + chain merkleRoot..."
-VERIFY_OK_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" node -e "
-  const payload = JSON.parse(process.env.QUADS_PAYLOAD);
-  console.log(JSON.stringify({
-    contextGraphId: payload.contextGraphId,
-    expectedMerkleRoot: process.env.MERKLE_ROOT,
-    batchId: process.env.KC,
-    quads: payload.quads
-  }));
-")
-VERIFY_OK=$(api_call "$OUTSIDER_NODE" POST /api/shared-memory/verify-batch "$VERIFY_OK_BODY")
-log "verify (good) response: $VERIFY_OK"
-VOK=$(parse_json "$VERIFY_OK" '.ok')
-VOK_ROOT=$(parse_json "$VERIFY_OK" '.actualRoot')
-[ "$VOK" = "true" ] || fail "outsider-side verify-batch returned ok=$VOK (expected true)"
-[ "$VOK_ROOT" = "$MERKLE_ROOT" ] || fail "outsider-side actualRoot != expectedRoot"
-log "✓ outsider verifies public batch: ok=true actualRoot==expected"
+devnet_verify_each_published_root "$OUTSIDER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
+  || fail "outsider-side verify-batch failed for one or more roots"
+log "✓ outsider verifies public batch: ok=true for all published roots"
+
+KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 log "Outsider calls verify-batch with tampered quads..."
 VERIFY_BAD_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" STAMP="$STAMP" node -e "
   const payload = JSON.parse(process.env.QUADS_PAYLOAD);
-  const tampered = [...payload.quads];
+  const root = payload.quads[0].subject;
+  const tampered = payload.quads.filter((q) => q.subject === root || q.subject.startsWith(root + '/'));
   tampered.push({ subject: 'urn:lu10:' + process.env.STAMP + '/forged', predicate: 'http://schema.org/title', object: '\"Mallory\"', graph: '' });
   console.log(JSON.stringify({
     contextGraphId: payload.contextGraphId,
@@ -266,6 +257,9 @@ act "4. ATTESTATION SWEEP (curator mints, outsider verifies)"
 LEAF_SUBJECT="urn:lu10:${STAMP}/doc-a"
 LEAF_PREDICATE="http://schema.org/title"
 LEAF_OBJECT='"Whitepaper"'
+
+KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
   const { hashTripleV10 } = await import("./dist/index.js");

--- a/scripts/devnet-test-rfc38-lu10.sh
+++ b/scripts/devnet-test-rfc38-lu10.sh
@@ -134,6 +134,7 @@ log "✓ 10 triples written to SWM"
 sleep 2
 
 PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
+devnet_publish_load_state
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-lu10.sh
+++ b/scripts/devnet-test-rfc38-lu10.sh
@@ -209,16 +209,17 @@ devnet_verify_each_published_root "$OUTSIDER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
   || fail "outsider-side verify-batch failed for one or more roots"
 log "✓ outsider verifies public batch: ok=true for all published roots"
 
-KC=$(devnet_publish_ka_id_at 0)
+TAMPER_ROOT=$(printf '%s' "$QUADS_PAYLOAD" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).quads[0].subject))')
+KC=$(devnet_publish_ka_id_for_root "$TAMPER_ROOT")
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 log "Outsider calls verify-batch with tampered quads..."
-VERIFY_BAD_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" STAMP="$STAMP" node -e "
+VERIFY_BAD_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" TAMPER_ROOT="$TAMPER_ROOT" STAMP="$STAMP" node -e "
   const genidPrefix = '/.well-known/genid/';
   const quadBelongsToRoot = (q, root) =>
     q.subject === root || q.subject.startsWith(root + genidPrefix);
   const payload = JSON.parse(process.env.QUADS_PAYLOAD);
-  const root = payload.quads[0].subject;
+  const root = process.env.TAMPER_ROOT;
   const tampered = payload.quads.filter((q) => quadBelongsToRoot(q, root));
   tampered.push({ subject: 'urn:lu10:' + process.env.STAMP + '/forged', predicate: 'http://schema.org/title', object: '\"Mallory\"', graph: '' });
   console.log(JSON.stringify({
@@ -244,7 +245,7 @@ LEAF_SUBJECT="urn:lu10:${STAMP}/doc-a"
 LEAF_PREDICATE="http://schema.org/title"
 LEAF_OBJECT='"Whitepaper"'
 
-KC=$(devnet_publish_ka_id_at 0)
+KC=$(devnet_publish_ka_id_for_root "$LEAF_SUBJECT")
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '

--- a/scripts/devnet-test-rfc38-lu10.sh
+++ b/scripts/devnet-test-rfc38-lu10.sh
@@ -38,6 +38,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -130,10 +133,7 @@ log "✓ 10 triples written to SWM"
 
 sleep 2
 
-PUB_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-lu10.sh
+++ b/scripts/devnet-test-rfc38-lu10.sh
@@ -144,32 +144,14 @@ KC=$(parse_json    "$PUB_RESP" '.kaId')
 [[ "$TX" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "invalid txHash '$TX'"
 log "✓ public CG publish: kaId=$KC tx=$TX"
 
-KC_META=$(api_call "$CURATOR_NODE" GET "/api/kc/$KC")
-MERKLE_ROOT=$(parse_json "$KC_META" '.merkleRoot')
-[[ "$MERKLE_ROOT" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "invalid merkleRoot from /api/kc/$KC: $KC_META"
-log "✓ chain merkleRoot: $MERKLE_ROOT"
+PUBLISH_COUNT=$(devnet_publish_root_count)
+[ "$PUBLISH_COUNT" = "5" ] || fail "expected 5 root publishes, got $PUBLISH_COUNT"
+devnet_kcs_readback_all_published 1 || fail "KCS read-back failed"
 
-# Cross-check via Hardhat KCS
-(
-cd "$REPO_ROOT/packages/evm-module" && \
-RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" CONTRACTS_JSON="$CONTRACTS_JSON" ABI_DIR="$EVM_ABI_DIR" BATCH_ID="$KC" \
-node -e '
-const { ethers } = require("ethers");
-const fs = require("fs"); const path = require("path");
-(async () => {
-  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
-  const contracts = JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON, "utf8")).contracts;
-  const kcsAddr = contracts.DKGKnowledgeAssets?.evmAddress ?? contracts.KnowledgeCollectionStorage.evmAddress;
-  const kcsAbiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json")) ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
-  const kas = new ethers.Contract(kcsAddr,
-    JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR, kcsAbiFile), "utf8")), provider);
-  const [merkleRoots, , minted, byteSize] = await kas.getKnowledgeAssetMetadata(BigInt(process.env.BATCH_ID));
-  if (!merkleRoots || merkleRoots.length === 0) throw new Error("no merkleRoots");
-  if (minted !== 5n) throw new Error("expected 5 KAs (one per root entity), got " + minted);
-  console.log("KCS read-back OK: merkleRoots=" + merkleRoots.length + " minted=" + minted + " byteSize=" + byteSize);
-})().catch(e => { console.error(e?.message || e); process.exit(1); });
-'
-) || fail "KCS read-back failed"
+KC=$(devnet_publish_ka_id_at 0)
+MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
+[[ "$MERKLE_ROOT" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "invalid merkleRoot from /api/kc/$KC"
+log "✓ chain merkleRoot (first root): $MERKLE_ROOT"
 
 # Public publishes MUST NOT carry the curated chain-key AEAD wrap
 EDGE_LOG=$(node_log "$CURATOR_NODE")
@@ -227,14 +209,17 @@ devnet_verify_each_published_root "$OUTSIDER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
   || fail "outsider-side verify-batch failed for one or more roots"
 log "✓ outsider verifies public batch: ok=true for all published roots"
 
-KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+KC=$(devnet_publish_ka_id_at 0)
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 log "Outsider calls verify-batch with tampered quads..."
 VERIFY_BAD_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" STAMP="$STAMP" node -e "
+  const genidPrefix = '/.well-known/genid/';
+  const quadBelongsToRoot = (q, root) =>
+    q.subject === root || q.subject.startsWith(root + genidPrefix);
   const payload = JSON.parse(process.env.QUADS_PAYLOAD);
   const root = payload.quads[0].subject;
-  const tampered = payload.quads.filter((q) => q.subject === root || q.subject.startsWith(root + '/'));
+  const tampered = payload.quads.filter((q) => quadBelongsToRoot(q, root));
   tampered.push({ subject: 'urn:lu10:' + process.env.STAMP + '/forged', predicate: 'http://schema.org/title', object: '\"Mallory\"', graph: '' });
   console.log(JSON.stringify({
     contextGraphId: payload.contextGraphId,
@@ -259,7 +244,7 @@ LEAF_SUBJECT="urn:lu10:${STAMP}/doc-a"
 LEAF_PREDICATE="http://schema.org/title"
 LEAF_OBJECT='"Whitepaper"'
 
-KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+KC=$(devnet_publish_ka_id_at 0)
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '

--- a/scripts/devnet-test-rfc38-lu5-public.sh
+++ b/scripts/devnet-test-rfc38-lu5-public.sh
@@ -16,6 +16,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -74,10 +77,7 @@ printf '%s' "$WRITE_RESP" | grep -qE '"triplesWritten":[1-9]' || fail "public SW
 sleep 2
 
 log "Publishing public CG to VM..."
-PUBLISH_RESP=$(api_call "$EDGE_CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "${CG_LOCAL_ID}", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUBLISH_RESP=$(devnet_publish_swm_all_roots "$EDGE_CURATOR_NODE" "${CG_LOCAL_ID}" false)
 log "publish response: $PUBLISH_RESP"
 
 parse_json() { printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const j=JSON.parse(d);const v=j$2;console.log(v==null?'':v)}catch(e){process.exit(1)}})"; }

--- a/scripts/devnet-test-rfc38-lu5.sh
+++ b/scripts/devnet-test-rfc38-lu5.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -153,14 +156,7 @@ sleep 2  # let SWM gossip settle
 # --- 5. Publish SWM → VM ----------------------------------------------------
 
 log "Publishing curated CG to VM..."
-PUBLISH_RESP=$(api_call "$EDGE_CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{
-  "contextGraphId": "${CG_URI}",
-  "selection": "all",
-  "clearAfter": false
-}
-EOF
-)")
+PUBLISH_RESP=$(devnet_publish_swm_all_roots "$EDGE_CURATOR_NODE" "${CG_URI}" false)
 log "publish response: $PUBLISH_RESP"
 
 # Use jq-equivalent via node for portability.

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -121,7 +121,7 @@ KC_ID=$(parse_json "$PUB_RESP" '.kaId')
 [ -n "$KC_ID" ] || fail "no kaId in publish response — required for merkleRoot lookup"
 
 # Use the first published root for single-batch negative tests below.
-KC_ID=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+KC_ID=$(devnet_publish_ka_id_at 0)
 log "Fetching merkleRoot from chain (KC #${KC_ID}) via daemon API..."
 KC_RESP=$(api_call "$CURATOR_NODE" GET "/api/kc/${KC_ID}")
 log "kc lookup: $KC_RESP"

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -119,6 +119,8 @@ KC_ID=$(parse_json "$PUB_RESP" '.kaId')
 [ -n "$TX_HASH" ] || fail "no txHash in publish response — cannot proceed without on-chain anchor"
 [ -n "$KC_ID" ] || fail "no kaId in publish response — required for merkleRoot lookup"
 
+# Use the first published root for single-batch negative tests below.
+KC_ID=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
 log "Fetching merkleRoot from chain (KC #${KC_ID}) via daemon API..."
 KC_RESP=$(api_call "$CURATOR_NODE" GET "/api/kc/${KC_ID}")
 log "kc lookup: $KC_RESP"
@@ -162,30 +164,9 @@ fi
 # path a member uses after catchup once they've decrypted ciphertext, and is
 # the only path that's batch-scoped for the verifier API.
 log "Calling verify-batch with explicit caller-supplied quads (member-side simulation)..."
-EXPLICIT_QUADS=$(node -e "
-  const quads = [];
-  for (let i = 0; i < 5; i++) {
-    quads.push({
-      subject: 'urn:lu8/item' + i,
-      predicate: 'http://schema.org/name',
-      object: '\"Item' + i + '\"',
-      graph: ''
-    });
-  }
-  console.log(JSON.stringify({
-    contextGraphId: '$PUB_CG',
-    expectedMerkleRoot: '$MERKLE_ROOT',
-    quads
-  }));
-")
-VERIFY_EXPLICIT=$(api_call "$MEMBER_NODE" POST /api/shared-memory/verify-batch "$EXPLICIT_QUADS")
-log "verify-batch explicit: $VERIFY_EXPLICIT"
-EXPLICIT_OK=$(parse_json "$VERIFY_EXPLICIT" '.ok')
-if [ "$EXPLICIT_OK" = "true" ]; then
-  log "✓ Scenario 1b: explicit-quads verify ok=true (member can verify once it has the plaintext)"
-else
-  warn "explicit-quads verify returned ok=$EXPLICIT_OK (expected true)"
-fi
+devnet_verify_each_published_root "$MEMBER_NODE" "$PUB_CG" "$QUADS" \
+  && log "✓ Scenario 1b: explicit-quads verify ok=true for all published roots (member can verify once it has the plaintext)" \
+  || warn "explicit-quads verify failed for one or more roots"
 
 # ===========================================================================
 # SCENARIO 2 — Root-mismatch detection.
@@ -198,25 +179,13 @@ log "================================================================"
 
 log "Member calls verify-batch with forged quads (extra injected triple)..."
 FORGED_QUADS=$(node -e "
-  const quads = [];
-  for (let i = 0; i < 5; i++) {
-    quads.push({
-      subject: 'urn:lu8/item' + i,
-      predicate: 'http://schema.org/name',
-      object: '\"Item' + i + '\"',
-      graph: ''
-    });
-  }
-  quads.push({
-    subject: 'urn:lu8/injected',
-    predicate: 'http://schema.org/name',
-    object: '\"Mallory\"',
-    graph: ''
-  });
   console.log(JSON.stringify({
     contextGraphId: '$PUB_CG',
     expectedMerkleRoot: '$MERKLE_ROOT',
-    quads,
+    quads: [
+      { subject: 'urn:lu8/item0', predicate: 'http://schema.org/name', object: '\"Item0\"', graph: '' },
+      { subject: 'urn:lu8/injected', predicate: 'http://schema.org/name', object: '\"Mallory\"', graph: '' },
+    ],
     batchId: 'lu8-forged-${STAMP}'
   }));
 ")

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -113,6 +113,7 @@ WRITE_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/write "$QUADS")
 
 log "Curator publishes selection to VM..."
 PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$PUB_CG" false '"epochs":1')
+devnet_publish_load_state
 log "publish response: $PUB_RESP"
 TX_HASH=$(parse_json "$PUB_RESP" '.txHash')
 KC_ID=$(parse_json "$PUB_RESP" '.kaId')
@@ -164,9 +165,13 @@ fi
 # path a member uses after catchup once they've decrypted ciphertext, and is
 # the only path that's batch-scoped for the verifier API.
 log "Calling verify-batch with explicit caller-supplied quads (member-side simulation)..."
-devnet_verify_each_published_root "$MEMBER_NODE" "$PUB_CG" "$QUADS" \
-  && log "✓ Scenario 1b: explicit-quads verify ok=true for all published roots (member can verify once it has the plaintext)" \
-  || warn "explicit-quads verify failed for one or more roots"
+if devnet_verify_each_published_root "$MEMBER_NODE" "$PUB_CG" "$QUADS"; then
+  EXPLICIT_OK=true
+  log "✓ Scenario 1b: explicit-quads verify ok=true for all published roots (member can verify once it has the plaintext)"
+else
+  EXPLICIT_OK=false
+  warn "explicit-quads verify failed for one or more roots"
+fi
 
 # ===========================================================================
 # SCENARIO 2 — Root-mismatch detection.

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -120,8 +120,8 @@ KC_ID=$(parse_json "$PUB_RESP" '.kaId')
 [ -n "$TX_HASH" ] || fail "no txHash in publish response — cannot proceed without on-chain anchor"
 [ -n "$KC_ID" ] || fail "no kaId in publish response — required for merkleRoot lookup"
 
-# Use the first published root for single-batch negative tests below.
-KC_ID=$(devnet_publish_ka_id_at 0)
+# Negative tests below operate on item0's batch; resolve its KC by root subject.
+KC_ID=$(devnet_publish_ka_id_for_root "urn:lu8/item0")
 log "Fetching merkleRoot from chain (KC #${KC_ID}) via daemon API..."
 KC_RESP=$(api_call "$CURATOR_NODE" GET "/api/kc/${KC_ID}")
 log "kc lookup: $KC_RESP"

--- a/scripts/devnet-test-rfc38-lu8.sh
+++ b/scripts/devnet-test-rfc38-lu8.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 API_PORT_BASE=9201
 CURATOR_NODE=5
@@ -109,10 +112,7 @@ WRITE_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/write "$QUADS")
 [ "$(parse_json "$WRITE_RESP" '.triplesWritten')" = "5" ] || fail "expected 5 triples written, got: $WRITE_RESP"
 
 log "Curator publishes selection to VM..."
-PUB_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$PUB_CG", "selection": "all", "epochs": 1 }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$PUB_CG" false '"epochs":1')
 log "publish response: $PUB_RESP"
 TX_HASH=$(parse_json "$PUB_RESP" '.txHash')
 KC_ID=$(parse_json "$PUB_RESP" '.kaId')

--- a/scripts/devnet-test-rfc38-lu9.sh
+++ b/scripts/devnet-test-rfc38-lu9.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 API_PORT_BASE=9201
 CURATOR_NODE=5
@@ -91,10 +94,7 @@ WRITE_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/write "$QUADS")
 log "✓ Wrote 1 triple"
 
 log "Curator publishes selection to VM..."
-PUB_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG", "selection": "all", "epochs": 1 }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG" false '"epochs":1')
 log "publish response: $PUB_RESP"
 KC_ID=$(parse_json "$PUB_RESP" '.kaId')
 [ -n "$KC_ID" ] || fail "no kaId: $PUB_RESP"

--- a/scripts/devnet-test-rfc38-multi-member.sh
+++ b/scripts/devnet-test-rfc38-multi-member.sh
@@ -192,7 +192,7 @@ LEAF_SUBJECT="urn:mm:${STAMP}/alpha"
 LEAF_PREDICATE="http://schema.org/name"
 LEAF_OBJECT="\"alpha\""
 
-KC=$(devnet_publish_ka_id_at 0)
+KC=$(devnet_publish_ka_id_for_root "$LEAF_SUBJECT")
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
   const { hashTripleV10 } = await import("./dist/index.js");

--- a/scripts/devnet-test-rfc38-multi-member.sh
+++ b/scripts/devnet-test-rfc38-multi-member.sh
@@ -163,6 +163,7 @@ log "✓ 6 triples written to SWM"
 sleep 2
 
 PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
+devnet_publish_load_state
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-multi-member.sh
+++ b/scripts/devnet-test-rfc38-multi-member.sh
@@ -171,33 +171,14 @@ KC=$(parse_json    "$PUB_RESP" '.kaId')
 [ "$STATUS" = "confirmed" ] || fail "publish status=$STATUS"
 log "✓ publish: kaId=$KC tx=$TX"
 
-KC_META=$(api_call "$CURATOR_NODE" GET "/api/kc/$KC")
-MERKLE_ROOT=$(parse_json "$KC_META" '.merkleRoot')
-[[ "$MERKLE_ROOT" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "no merkleRoot from /api/kc/$KC: $KC_META"
-log "✓ merkleRoot: $MERKLE_ROOT"
-
 # ===========================================================================
 act "3. All non-curator members independently verify-batch"
 # ===========================================================================
-VERIFY_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" node -e "
-  const p = JSON.parse(process.env.QUADS_PAYLOAD);
-  console.log(JSON.stringify({
-    contextGraphId: p.contextGraphId,
-    expectedMerkleRoot: process.env.MERKLE_ROOT,
-    batchId: process.env.KC,
-    quads: p.quads
-  }));
-")
-
 verify_on_node() {
   local node="$1" label="$2"
-  local resp; resp=$(api_call "$node" POST /api/shared-memory/verify-batch "$VERIFY_BODY")
-  log "$label verify response: $resp"
-  local ok; ok=$(parse_json "$resp" '.ok')
-  local actual; actual=$(parse_json "$resp" '.actualRoot')
-  [ "$ok" = "true" ] || fail "$label verify-batch ok=$ok"
-  [ "$actual" = "$MERKLE_ROOT" ] || fail "$label actualRoot ($actual) != expected ($MERKLE_ROOT)"
-  log "✓ $label verify-batch: ok=true actualRoot==expected"
+  devnet_verify_each_published_root "$node" "$CG_ID" "$QUADS_PAYLOAD" \
+    || fail "$label verify-batch failed for one or more roots"
+  log "✓ $label verify-batch: ok=true for all published roots"
 }
 verify_on_node "$CURATOR_NODE"     "curator"
 verify_on_node "$EDGE_MEMBER_NODE" "edge-member"
@@ -210,6 +191,8 @@ LEAF_SUBJECT="urn:mm:${STAMP}/alpha"
 LEAF_PREDICATE="http://schema.org/name"
 LEAF_OBJECT="\"alpha\""
 
+KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
   const { hashTripleV10 } = await import("./dist/index.js");
   const leafBytes = hashTripleV10(process.env.LEAF_SUBJECT, process.env.LEAF_PREDICATE, process.env.LEAF_OBJECT);

--- a/scripts/devnet-test-rfc38-multi-member.sh
+++ b/scripts/devnet-test-rfc38-multi-member.sh
@@ -192,7 +192,7 @@ LEAF_SUBJECT="urn:mm:${STAMP}/alpha"
 LEAF_PREDICATE="http://schema.org/name"
 LEAF_OBJECT="\"alpha\""
 
-KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d)[0].kaId))')
+KC=$(devnet_publish_ka_id_at 0)
 MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
 CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
   const { hashTripleV10 } = await import("./dist/index.js");

--- a/scripts/devnet-test-rfc38-multi-member.sh
+++ b/scripts/devnet-test-rfc38-multi-member.sh
@@ -49,6 +49,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -159,10 +162,7 @@ log "✓ 6 triples written to SWM"
 
 sleep 2
 
-PUB_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-scale.sh
+++ b/scripts/devnet-test-rfc38-scale.sh
@@ -128,6 +128,7 @@ log "✓ $WRITTEN triples written to SWM"
 act "3. Publish all $TRIPLE_COUNT triples to VM"
 # ===========================================================================
 PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
+devnet_publish_load_state
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-scale.sh
+++ b/scripts/devnet-test-rfc38-scale.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE=9201
@@ -124,10 +127,7 @@ log "✓ $WRITTEN triples written to SWM"
 # ===========================================================================
 act "3. Publish all $TRIPLE_COUNT triples to VM"
 # ===========================================================================
-PUB_RESP=$(api_call "$CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{ "contextGraphId": "$CG_ID", "selection": "all", "clearAfter": false }
-EOF
-)")
+PUB_RESP=$(devnet_publish_swm_all_roots "$CURATOR_NODE" "$CG_ID" false)
 log "publish response: $PUB_RESP"
 
 STATUS=$(parse_json "$PUB_RESP" '.status')

--- a/scripts/devnet-test-rfc38-scale.sh
+++ b/scripts/devnet-test-rfc38-scale.sh
@@ -161,7 +161,7 @@ for leaf_idx in 0 $((TRIPLE_COUNT / 4 - 1)) $((TRIPLE_COUNT / 2 - 1)); do
   LEAF_PREDICATE="http://schema.org/name"
   LEAF_OBJECT="\"Document ${leaf_idx}\""
 
-  KC=$(devnet_publish_ka_id_at "$leaf_idx")
+  KC=$(devnet_publish_ka_id_for_root "$LEAF_SUBJECT")
   MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
   CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
     const { hashTripleV10 } = await import("./dist/index.js");

--- a/scripts/devnet-test-rfc38-scale.sh
+++ b/scripts/devnet-test-rfc38-scale.sh
@@ -135,19 +135,15 @@ TX=$(parse_json    "$PUB_RESP" '.txHash')
 KC=$(parse_json    "$PUB_RESP" '.kaId')
 [ "$STATUS" = "confirmed" ] || fail "publish status=$STATUS"
 [[ "$TX" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "invalid txHash"
-log "✓ publish: kaId=$KC tx=$TX"
+PUBLISH_COUNT=$(printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).length||1))')
+log "✓ publish: ${PUBLISH_COUNT} root batch(es), last kaId=$KC tx=$TX"
 
-KC_META=$(api_call "$CURATOR_NODE" GET "/api/kc/$KC")
-MERKLE_ROOT=$(parse_json "$KC_META" '.merkleRoot')
-[[ "$MERKLE_ROOT" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "no merkleRoot: $KC_META"
-log "✓ merkleRoot: $MERKLE_ROOT"
-
-# Cross-check via KCS: minted should equal TRIPLE_COUNT / 2 (one KA per
-# root entity).
+# Cross-check each KC via KCS: rc.12+ publishes one root entity per KC.
 EXPECTED_MINTED=$((TRIPLE_COUNT / 2))
 (
 cd "$REPO_ROOT/packages/evm-module" && \
-RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" CONTRACTS_JSON="$CONTRACTS_JSON" ABI_DIR="$EVM_ABI_DIR" BATCH_ID="$KC" EXPECTED_MINTED="$EXPECTED_MINTED" \
+RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" CONTRACTS_JSON="$CONTRACTS_JSON" ABI_DIR="$EVM_ABI_DIR" \
+ALL_KCS="$DEVNET_PUBLISH_ALL_RESPONSES" EXPECTED_MINTED="1" \
 node -e '
 const { ethers } = require("ethers");
 const fs = require("fs"); const path = require("path");
@@ -158,36 +154,26 @@ const fs = require("fs"); const path = require("path");
   const kcsAbiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json")) ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
   const kas = new ethers.Contract(kcsAddr,
     JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR, kcsAbiFile), "utf8")), provider);
-  const [merkleRoots, , minted, byteSize] = await kas.getKnowledgeAssetMetadata(BigInt(process.env.BATCH_ID));
-  if (!merkleRoots || merkleRoots.length === 0) throw new Error("no merkleRoots");
+  const kcs = JSON.parse(process.env.ALL_KCS);
   const expectedMinted = BigInt(process.env.EXPECTED_MINTED);
-  if (minted !== expectedMinted) throw new Error("expected " + expectedMinted + " KAs minted, got " + minted);
-  console.log("✓ KCS: merkleRoots=" + merkleRoots.length + " minted=" + minted + " byteSize=" + byteSize);
+  for (const pub of kcs) {
+    const batchId = pub.kaId;
+    const [merkleRoots, , minted] = await kas.getKnowledgeAssetMetadata(BigInt(batchId));
+    if (!merkleRoots || merkleRoots.length === 0) throw new Error("no merkleRoots for kaId=" + batchId);
+    if (minted !== expectedMinted) throw new Error("kaId=" + batchId + ": expected " + expectedMinted + " KAs minted, got " + minted);
+  }
+  console.log("✓ KCS: " + kcs.length + " KC(s) each minted=" + expectedMinted);
 })().catch(e => { console.error(e?.message || e); process.exit(1); });
 '
 ) || fail "KCS read-back failed"
+[ "$PUBLISH_COUNT" = "$EXPECTED_MINTED" ] || fail "expected $EXPECTED_MINTED publishes, got $PUBLISH_COUNT"
 
 # ===========================================================================
 act "4. Member verify-batch over all $TRIPLE_COUNT decrypted quads"
 # ===========================================================================
-VERIFY_BODY=$(QUADS_PAYLOAD="$QUADS_PAYLOAD" MERKLE_ROOT="$MERKLE_ROOT" KC="$KC" node -e "
-  const p = JSON.parse(process.env.QUADS_PAYLOAD);
-  console.log(JSON.stringify({
-    contextGraphId: p.contextGraphId,
-    expectedMerkleRoot: process.env.MERKLE_ROOT,
-    batchId: process.env.KC,
-    quads: p.quads
-  }));
-")
-VERIFY=$(api_call "$MEMBER_NODE" POST /api/shared-memory/verify-batch "$VERIFY_BODY")
-log "verify response: $VERIFY"
-V_OK=$(parse_json "$VERIFY" '.ok')
-V_LEAF=$(parse_json "$VERIFY" '.leafCount')
-V_ACTUAL=$(parse_json "$VERIFY" '.actualRoot')
-[ "$V_OK" = "true" ] || fail "verify-batch ok=$V_OK ($VERIFY)"
-[ "$V_LEAF" = "$TRIPLE_COUNT" ] || fail "expected leafCount=$TRIPLE_COUNT, got $V_LEAF"
-[ "$V_ACTUAL" = "$MERKLE_ROOT" ] || fail "actualRoot != expectedRoot"
-log "✓ verify-batch passes over $V_LEAF decrypted leaves"
+devnet_verify_each_published_root "$MEMBER_NODE" "$CG_ID" "$QUADS_PAYLOAD" \
+  || fail "verify-batch failed for one or more published roots"
+log "✓ verify-batch passes for all $PUBLISH_COUNT published root(s)"
 
 # ===========================================================================
 act "5. Mint + verify 3 attestations across the batch"
@@ -199,6 +185,11 @@ for leaf_idx in 0 $((TRIPLE_COUNT / 4 - 1)) $((TRIPLE_COUNT / 2 - 1)); do
   LEAF_PREDICATE="http://schema.org/name"
   LEAF_OBJECT="\"Document ${leaf_idx}\""
 
+  KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c);
+    process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
+  " "$leaf_idx")
+  MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
   CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
     const { hashTripleV10 } = await import("./dist/index.js");
     const leafBytes = hashTripleV10(process.env.LEAF_SUBJECT, process.env.LEAF_PREDICATE, process.env.LEAF_OBJECT);
@@ -239,9 +230,8 @@ log "================================================================"
 log "  Curated CG:    $CG_ID  (onChainId=$ON_CHAIN_ID)"
 log "  Triples:       $TRIPLE_COUNT"
 log "  KAs minted:    $EXPECTED_MINTED"
-log "  KC published:  $KC"
+log "  KCs published: $PUBLISH_COUNT"
 log "  TX:            $TX"
-log "  MerkleRoot:    $MERKLE_ROOT"
-log "  verify-batch:  ok=true leafCount=$V_LEAF"
+log "  verify-batch:  ok=true for all roots"
 log "  Attestations:  3 of 3 verified"
 log "================================================================"

--- a/scripts/devnet-test-rfc38-scale.sh
+++ b/scripts/devnet-test-rfc38-scale.sh
@@ -136,37 +136,12 @@ TX=$(parse_json    "$PUB_RESP" '.txHash')
 KC=$(parse_json    "$PUB_RESP" '.kaId')
 [ "$STATUS" = "confirmed" ] || fail "publish status=$STATUS"
 [[ "$TX" =~ ^0x[0-9a-fA-F]{64}$ ]] || fail "invalid txHash"
-PUBLISH_COUNT=$(printf '%s' "$DEVNET_PUBLISH_ROOT_ENTITIES" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>console.log(JSON.parse(d).length||1))')
+PUBLISH_COUNT=$(devnet_publish_root_count)
 log "✓ publish: ${PUBLISH_COUNT} root batch(es), last kaId=$KC tx=$TX"
 
 # Cross-check each KC via KCS: rc.12+ publishes one root entity per KC.
 EXPECTED_MINTED=$((TRIPLE_COUNT / 2))
-(
-cd "$REPO_ROOT/packages/evm-module" && \
-RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" CONTRACTS_JSON="$CONTRACTS_JSON" ABI_DIR="$EVM_ABI_DIR" \
-ALL_KCS="$DEVNET_PUBLISH_ALL_RESPONSES" EXPECTED_MINTED="1" \
-node -e '
-const { ethers } = require("ethers");
-const fs = require("fs"); const path = require("path");
-(async () => {
-  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
-  const contracts = JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON, "utf8")).contracts;
-  const kcsAddr = contracts.DKGKnowledgeAssets?.evmAddress ?? contracts.KnowledgeCollectionStorage.evmAddress;
-  const kcsAbiFile = fs.existsSync(path.join(process.env.ABI_DIR, "DKGKnowledgeAssets.json")) ? "DKGKnowledgeAssets.json" : "DKGKnowledgeAssets.json";
-  const kas = new ethers.Contract(kcsAddr,
-    JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR, kcsAbiFile), "utf8")), provider);
-  const kcs = JSON.parse(process.env.ALL_KCS);
-  const expectedMinted = BigInt(process.env.EXPECTED_MINTED);
-  for (const pub of kcs) {
-    const batchId = pub.kaId;
-    const [merkleRoots, , minted] = await kas.getKnowledgeAssetMetadata(BigInt(batchId));
-    if (!merkleRoots || merkleRoots.length === 0) throw new Error("no merkleRoots for kaId=" + batchId);
-    if (minted !== expectedMinted) throw new Error("kaId=" + batchId + ": expected " + expectedMinted + " KAs minted, got " + minted);
-  }
-  console.log("✓ KCS: " + kcs.length + " KC(s) each minted=" + expectedMinted);
-})().catch(e => { console.error(e?.message || e); process.exit(1); });
-'
-) || fail "KCS read-back failed"
+devnet_kcs_readback_all_published 1 || fail "KCS read-back failed"
 [ "$PUBLISH_COUNT" = "$EXPECTED_MINTED" ] || fail "expected $EXPECTED_MINTED publishes, got $PUBLISH_COUNT"
 
 # ===========================================================================
@@ -186,10 +161,7 @@ for leaf_idx in 0 $((TRIPLE_COUNT / 4 - 1)) $((TRIPLE_COUNT / 2 - 1)); do
   LEAF_PREDICATE="http://schema.org/name"
   LEAF_OBJECT="\"Document ${leaf_idx}\""
 
-  KC=$(printf '%s' "$DEVNET_PUBLISH_ALL_RESPONSES" | node -e "
-    let d=''; process.stdin.on('data',c=>d+=c);
-    process.stdin.on('end',()=>console.log(JSON.parse(d)[Number(process.argv[1])].kaId));
-  " "$leaf_idx")
+  KC=$(devnet_publish_ka_id_at "$leaf_idx")
   MERKLE_ROOT=$(devnet_kc_merkle_root "$CURATOR_NODE" "$KC")
   CANDIDATE_LEAF=$(cd "$REPO_ROOT/packages/core" && LEAF_SUBJECT="$LEAF_SUBJECT" LEAF_PREDICATE="$LEAF_PREDICATE" LEAF_OBJECT="$LEAF_OBJECT" node --input-type=module -e '
     const { hashTripleV10 } = await import("./dist/index.js");

--- a/scripts/devnet-test-rfc39-comprehensive.sh
+++ b/scripts/devnet-test-rfc39-comprehensive.sh
@@ -52,6 +52,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE="${API_PORT_BASE:-9201}"
@@ -362,14 +365,7 @@ EOF
 
   log "Publishing $visibility_label CG to VM..."
   local publish_resp
-  publish_resp=$(api_call "$EDGE_CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{
-  "contextGraphId": "${cg_uri}",
-  "selection": "all",
-  "clearAfter": false
-}
-EOF
-)")
+  publish_resp=$(devnet_publish_swm_all_roots "$EDGE_CURATOR_NODE" "${cg_uri}" false)
   local publish_status publish_tx publish_kc publish_block
   publish_status=$(printf '%s' "$publish_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).status||"")}catch(e){console.log("")}})')
   publish_tx=$(printf '%s' "$publish_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).txHash||"")}catch(e){console.log("")}})')
@@ -586,14 +582,7 @@ EOF
 
   log "Publishing curated CG to VM (only nodes ${sibling_nodes[*]} are listening)..."
   local publish_resp publish_status publish_tx publish_kc
-  publish_resp=$(api_call "$EDGE_CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{
-  "contextGraphId": "${cg_uri}",
-  "selection": "all",
-  "clearAfter": false
-}
-EOF
-)")
+  publish_resp=$(devnet_publish_swm_all_roots "$EDGE_CURATOR_NODE" "${cg_uri}" false)
   publish_status=$(printf '%s' "$publish_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).status||"")}catch(e){console.log("")}})')
   publish_tx=$(printf '%s' "$publish_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).txHash||"")}catch(e){console.log("")}})')
   publish_kc=$(printf '%s' "$publish_resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{console.log(JSON.parse(d).kaId||"")}catch(e){console.log("")}})')

--- a/scripts/devnet-test-rfc39-curated-random-sampling.sh
+++ b/scripts/devnet-test-rfc39-curated-random-sampling.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 API_PORT_BASE="${API_PORT_BASE:-9201}"
@@ -138,14 +141,7 @@ sleep 2
 # --- 5. Publish (chunked path) ----------------------------------------------
 
 log "Publishing curated CG to VM (LU-11 chunked path)..."
-PUBLISH_RESP=$(api_call "$EDGE_CURATOR_NODE" POST /api/shared-memory/publish "$(cat <<EOF
-{
-  "contextGraphId": "${CG_URI}",
-  "selection": "all",
-  "clearAfter": false
-}
-EOF
-)")
+PUBLISH_RESP=$(devnet_publish_swm_all_roots "$EDGE_CURATOR_NODE" "${CG_URI}" false)
 log "publish response: $PUBLISH_RESP"
 
 parse_json() {

--- a/scripts/devnet-test-sharing.sh
+++ b/scripts/devnet-test-sharing.sh
@@ -35,6 +35,19 @@ c() {
     -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" "$@"
 }
 
+# Adapter for devnet-publish-helpers.sh (node-numbered API calls).
+api_call() {
+  local node="$1" method="$2" path="$3" data="${4:-}"
+  local port=$((9200 + node))
+  if [ -n "$data" ]; then
+    c -X "$method" "http://127.0.0.1:${port}${path}" -d "$data"
+  else
+    c -X "$method" "http://127.0.0.1:${port}${path}"
+  fi
+}
+# shellcheck source=devnet-publish-helpers.sh
+source "$SCRIPT_DIR/devnet-publish-helpers.sh"
+
 ok()   { PASS=$((PASS+1)); echo "  [PASS] $1"; }
 fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
 warn() { WARN=$((WARN+1)); echo "  [WARN] $1"; }
@@ -971,8 +984,7 @@ fi
 sleep 3
 
 echo "--- 15a: Publish SWM data to VM on Node 1 (promote-test project) ---"
-PUBLISH=$(c -X POST "http://127.0.0.1:9201/api/shared-memory/publish" \
-  -d "{\"contextGraphId\":\"$CG3_ID\",\"selection\":\"all\",\"clearAfter\":false}")
+PUBLISH=$(devnet_publish_swm_all_roots 1 "$CG3_ID" false)
 PUB_STATUS=$(json_get "$PUBLISH" status)
 PUB_KCID=$(json_get "$PUBLISH" kaId)
 PUB_KAS=$(echo "$PUBLISH" | python3 -c '
@@ -1066,8 +1078,7 @@ fi
 sleep 3
 
 echo "--- 16a: Publish CG1 SWM → VM on Node 1 ---"
-PUB_CG1=$(c -X POST "http://127.0.0.1:9201/api/shared-memory/publish" \
-  -d "{\"contextGraphId\":\"$CG_ID\",\"selection\":\"all\",\"clearAfter\":false}")
+PUB_CG1=$(devnet_publish_swm_all_roots 1 "$CG_ID" false)
 PUB_CG1_STATUS=$(json_get "$PUB_CG1" status)
 PUB_CG1_KAS=$(echo "$PUB_CG1" | python3 -c '
 import sys,json
@@ -1141,8 +1152,7 @@ for port_label in "9202:Node2" "9204:Node4" "9203:Node3"; do
 done
 
 echo "--- 16f: Publish with clearAfter=true, then verify SWM is empty ---"
-PUB_CLEAR=$(c -X POST "http://127.0.0.1:9201/api/shared-memory/publish" \
-  -d "{\"contextGraphId\":\"$CG3_ID\",\"selection\":\"all\",\"clearAfter\":true}")
+PUB_CLEAR=$(devnet_publish_swm_all_roots 1 "$CG3_ID" true)
 PUB_CLEAR_STATUS=$(json_get "$PUB_CLEAR" status)
 sleep 2
 N1_SWM_CLEARED=$(c -X POST "http://127.0.0.1:9201/api/query" \


### PR DESCRIPTION
## Summary
- Adds `scripts/devnet-publish-helpers.sh` with `devnet_publish_swm_all_roots`, which probes `MULTI_ROOT_PUBLISH_NOT_ATOMIC` and publishes one SWM root entity per call.
- Updates RFC-38/39 devnet scripts and `devnet-test-sharing.sh` to use the helper instead of `selection: "all"` multi-root publishes blocked since #925.

## Test plan
- [ ] `./scripts/devnet.sh clean && ./scripts/devnet.sh start 6`
- [ ] `./scripts/devnet-test-rfc38-lu5-public.sh`
- [ ] `./scripts/devnet-test-rfc38-e2e.sh`
- [ ] `./scripts/devnet-test-sharing.sh`


Made with [Cursor](https://cursor.com)