### PR TITLE
fix(devnet): seal private updates in v10-rc-validation §4

### DIFF
--- a/scripts/devnet-update-helpers.sh
+++ b/scripts/devnet-update-helpers.sh
@@ -49,13 +49,17 @@ sys.exit(1)
 PY
 }
 
-# Args: node_num kaId contextGraphId quads_json_array_string
+# Args: node_num kaId contextGraphId quads_json_array_string [private_quads_json_array_string]
 build_update_body() {
-  local node=$1 kc=$2 cg=$3 quads_json=$4 key seal owner_line
+  local node=$1 kc=$2 cg=$3 quads_json=$4 private_quads_json="${5:-[]}" key seal owner_line seal_args
   owner_line=$(ka_owner_key "$kc") || return 1
   key="${owner_line##*$'\t'}"
   [ -z "$key" ] && return 1
-  seal=$($UPDATE_SEAL --key "$key" --ka-id "$kc" --quads-json "$quads_json") || return 1
+  seal_args=(--key "$key" --ka-id "$kc" --quads-json "$quads_json")
+  if [ "$private_quads_json" != "[]" ] && [ -n "$private_quads_json" ]; then
+    seal_args+=(--private-quads-json "$private_quads_json")
+  fi
+  seal=$($UPDATE_SEAL "${seal_args[@]}") || return 1
   python3 -c "
 import json, sys
 wrap = json.loads(sys.argv[1])
@@ -68,6 +72,9 @@ body = {
     'quads': json.loads(sys.argv[4]),
     'precomputedUpdateAttestation': wrap['precomputedUpdateAttestation'],
 }
+private_quads = json.loads(sys.argv[5])
+if private_quads:
+    body['privateQuads'] = private_quads
 print(json.dumps(body))
-" "$seal" "$kc" "$cg" "$quads_json"
+" "$seal" "$kc" "$cg" "$quads_json" "$private_quads_json"
 }

--- a/scripts/devnet-update-helpers.sh
+++ b/scripts/devnet-update-helpers.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for devnet scripts that call POST /api/update with
+# rc.12 owner-sealed updates (precomputedUpdateAttestation).
+#
+# Usage: source after setting REPO_ROOT, DEVNET_DIR, NUM_NODES (optional).
+#
+#   source "$SCRIPT_DIR/devnet-update-helpers.sh"
+#   body=$(build_update_body 1 "$kaId" "$cg" "$quads_json") || exit 1
+#
+: "${REPO_ROOT:?REPO_ROOT must be set}"
+: "${DEVNET_DIR:?DEVNET_DIR must be set}"
+
+NUM_NODES="${NUM_NODES:-6}"
+CONTRACTS_JSON="${CONTRACTS_JSON:-$REPO_ROOT/packages/evm-module/deployments/localhost_contracts.json}"
+export CONTRACTS_JSON
+UPDATE_SEAL="${UPDATE_SEAL:-node $REPO_ROOT/scripts/devnet-update-seal.mjs}"
+CHAIN_CALL="${CHAIN_CALL:-node $REPO_ROOT/scripts/devnet-chain-call.mjs}"
+
+ka_owner_key() {
+  local kc=$1
+  local owner addr key
+  owner=$($CHAIN_CALL DKGKnowledgeAssets ownerOf --json "[\"$kc\"]" 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result','') or '')" 2>/dev/null)
+  [ -z "$owner" ] && return 1
+  python3 - "$DEVNET_DIR" "$owner" "$NUM_NODES" <<'PY'
+import json, os, sys
+devnet_dir = sys.argv[1]
+target = sys.argv[2].lower()
+max_node = int(sys.argv[3])
+for n in range(1, max_node + 1):
+    for fname in ("publisher-wallets.json", "wallets.json"):
+        p = os.path.join(devnet_dir, f"node{n}", fname)
+        if not os.path.exists(p):
+            continue
+        try:
+            data = json.load(open(p))
+        except Exception:
+            continue
+        wallets = data["wallets"] if isinstance(data, dict) and "wallets" in data else data
+        if not isinstance(wallets, list):
+            continue
+        for w in wallets:
+            a = (w.get("address") or "").lower()
+            if a == target:
+                print(w.get("address", "") + "\t" + w.get("privateKey", ""))
+                sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# Args: node_num kaId contextGraphId quads_json_array_string
+build_update_body() {
+  local node=$1 kc=$2 cg=$3 quads_json=$4 key seal owner_line
+  owner_line=$(ka_owner_key "$kc") || return 1
+  key="${owner_line##*$'\t'}"
+  [ -z "$key" ] && return 1
+  seal=$($UPDATE_SEAL --key "$key" --ka-id "$kc" --quads-json "$quads_json") || return 1
+  python3 -c "
+import json, sys
+wrap = json.loads(sys.argv[1])
+if not wrap.get('ok'):
+    sys.stderr.write(wrap.get('error','seal failed') + '\n')
+    sys.exit(1)
+body = {
+    'kaId': sys.argv[2],
+    'contextGraphId': sys.argv[3],
+    'quads': json.loads(sys.argv[4]),
+    'precomputedUpdateAttestation': wrap['precomputedUpdateAttestation'],
+}
+print(json.dumps(body))
+" "$seal" "$kc" "$cg" "$quads_json"
+}

--- a/scripts/devnet-update-seal.mjs
+++ b/scripts/devnet-update-seal.mjs
@@ -6,7 +6,7 @@
  * this helper mirrors packages/publisher/test/_helpers/seal.ts#buildUpdateSeal.
  *
  * Usage:
- *   node devnet-update-seal.mjs --key 0x... --ka-id <id> --quads-json '<quad-array>'
+ *   node devnet-update-seal.mjs --key 0x... --ka-id <id> --quads-json '<quad-array>' [--private-quads-json '<quad-array>']
  *
  * Output: one JSON line { ok, precomputedUpdateAttestation?, error? }
  *   Wire format matches agent-chat.ts parsePrecomputedUpdateAttestation.
@@ -85,11 +85,13 @@ async function main() {
   let key = null;
   let kaId = null;
   let quadsJson = null;
+  let privateQuadsJson = null;
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--key') key = argv[++i];
     else if (argv[i] === '--ka-id') kaId = argv[++i];
     else if (argv[i] === '--quads-json') quadsJson = argv[++i];
+    else if (argv[i] === '--private-quads-json') privateQuadsJson = argv[++i];
   }
   if (!key || kaId == null || !quadsJson) {
     out({ ok: false, error: 'usage: --key 0x.. --ka-id <id> --quads-json <json-array>' });
@@ -113,11 +115,20 @@ async function main() {
   }
 
   let quads;
+  let privateQuads;
   try {
     quads = JSON.parse(quadsJson);
   } catch (e) {
     out({ ok: false, error: `invalid quads JSON: ${e.message}` });
     process.exit(1);
+  }
+  if (privateQuadsJson) {
+    try {
+      privateQuads = JSON.parse(privateQuadsJson);
+    } catch (e) {
+      out({ ok: false, error: `invalid private quads JSON: ${e.message}` });
+      process.exit(1);
+    }
   }
 
   const provider = new ethers.JsonRpcProvider(RPC);
@@ -126,6 +137,7 @@ async function main() {
     const seal = await buildUpdateSeal({
       kaId,
       quads,
+      privateQuads,
       author,
       kav10Address: kav10,
       provider,

--- a/scripts/v10-rc-validation.sh
+++ b/scripts/v10-rc-validation.sh
@@ -210,21 +210,19 @@ if [ "$PUB_STATUS" = "confirmed" ] || [ "$PUB_STATUS" = "finalized" ]; then
 ]
 JSON
 )
-  UPD_BODY=$(build_update_body 1 "$PUB_KCID" "$CG" "$QUADS_JSON") || UPD_BODY=""
+  PRIVATE_QUADS_JSON=$(node -e "
+    const s = process.argv[1];
+    console.log(JSON.stringify([
+      { subject: s, predicate: 'http://schema.org/email', object: '\"bob@secret.test\"', graph: '' },
+      { subject: s, predicate: 'http://schema.org/telephone', object: '\"+1-555-PRIVATE\"', graph: '' },
+    ]));
+  " "$BOB_URI")
+  UPD_BODY=$(build_update_body 1 "$PUB_KCID" "$CG" "$QUADS_JSON" "$PRIVATE_QUADS_JSON") || UPD_BODY=""
   if [ -z "$UPD_BODY" ]; then
     fail "Private update: could not build precomputedUpdateAttestation for kaId=$PUB_KCID (is Hardhat up and contracts deployed?)"
     PRIV_RESULT=""
   else
-    PRIV_PAYLOAD=$(node -e "
-      const body = JSON.parse(process.argv[1]);
-      const s = process.argv[2];
-      body.privateQuads = [
-        { subject: s, predicate: 'http://schema.org/email', object: '\"bob@secret.test\"', graph: '' },
-        { subject: s, predicate: 'http://schema.org/telephone', object: '\"+1-555-PRIVATE\"', graph: '' },
-      ];
-      console.log(JSON.stringify(body));
-    " "$UPD_BODY" "$BOB_URI")
-    PRIV_RESULT=$(post 9201 /api/update -H "Content-Type: application/json" -d "$PRIV_PAYLOAD")
+    PRIV_RESULT=$(post 9201 /api/update -H "Content-Type: application/json" -d "$UPD_BODY")
   fi
   PRIV_STATUS=$(echo "$PRIV_RESULT" | pyfield "d.get('status','?')")
   if [ "$PRIV_STATUS" = "confirmed" ] || [ "$PRIV_STATUS" = "finalized" ]; then

--- a/scripts/v10-rc-validation.sh
+++ b/scripts/v10-rc-validation.sh
@@ -30,7 +30,11 @@ set -uo pipefail
 # work only by accident (and fail loudly with 401s on every POST after a
 # clean restart, which is exactly the trap this fallback path avoids).
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+NUM_NODES="${NUM_NODES:-6}"
+# shellcheck source=devnet-update-helpers.sh
+source "$SCRIPT_DIR/devnet-update-helpers.sh"
 if [ -n "${DKG_AUTH:-}" ]; then
   AUTH="$DKG_AUTH"
 elif [ -n "${AUTH_TOKEN:-}" ]; then
@@ -199,22 +203,29 @@ section "4. PUBLISH WITH PRIVATE TRIPLES (via /api/update)"
 
 if [ "$PUB_STATUS" = "confirmed" ] || [ "$PUB_STATUS" = "finalized" ]; then
   BOB_URI="urn:v10:bob-$RUN_TAG"
-  UPD_BODY=$(cat <<JSON
-{
-  "kaId": "$PUB_KCID",
-  "contextGraphId": "$CG",
-  "quads": [
-    $(q "$BOB_URI" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://schema.org/Person"),
-    $(ql "$BOB_URI" "http://schema.org/name" "Bob V10 $RUN_TAG")
-  ],
-  "privateQuads": [
-    $(ql "$BOB_URI" "http://schema.org/email" "bob@secret.test"),
-    $(ql "$BOB_URI" "http://schema.org/telephone" "+1-555-PRIVATE")
-  ]
-}
+  QUADS_JSON=$(cat <<JSON
+[
+  $(q "$BOB_URI" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://schema.org/Person"),
+  $(ql "$BOB_URI" "http://schema.org/name" "Bob V10 $RUN_TAG")
+]
 JSON
 )
-  PRIV_RESULT=$(post 9201 /api/update -H "Content-Type: application/json" -d "$UPD_BODY")
+  UPD_BODY=$(build_update_body 1 "$PUB_KCID" "$CG" "$QUADS_JSON") || UPD_BODY=""
+  if [ -z "$UPD_BODY" ]; then
+    fail "Private update: could not build precomputedUpdateAttestation for kaId=$PUB_KCID (is Hardhat up and contracts deployed?)"
+    PRIV_RESULT=""
+  else
+    PRIV_PAYLOAD=$(node -e "
+      const body = JSON.parse(process.argv[1]);
+      const s = process.argv[2];
+      body.privateQuads = [
+        { subject: s, predicate: 'http://schema.org/email', object: '\"bob@secret.test\"', graph: '' },
+        { subject: s, predicate: 'http://schema.org/telephone', object: '\"+1-555-PRIVATE\"', graph: '' },
+      ];
+      console.log(JSON.stringify(body));
+    " "$UPD_BODY" "$BOB_URI")
+    PRIV_RESULT=$(post 9201 /api/update -H "Content-Type: application/json" -d "$PRIV_PAYLOAD")
+  fi
   PRIV_STATUS=$(echo "$PRIV_RESULT" | pyfield "d.get('status','?')")
   if [ "$PRIV_STATUS" = "confirmed" ] || [ "$PRIV_STATUS" = "finalized" ]; then
     ok "Update with private triples confirmed, status=$PRIV_STATUS"


### PR DESCRIPTION
## Summary
- Adds `scripts/devnet-update-helpers.sh` (`ka_owner_key` + `build_update_body`) for rc.12 owner-sealed updates.
- Updates `v10-rc-validation.sh` §4 to attach `precomputedUpdateAttestation` before POST `/api/update`.

## Test plan
- [ ] Fresh devnet up
- [ ] `./scripts/v10-rc-validation.sh` — §4 private update confirms


Made with [Cursor](https://cursor.com)