### PR TITLE
fix(devnet): parse scoped notification API meta as objects

### DIFF
--- a/scripts/devnet-test-reject-flow.sh
+++ b/scripts/devnet-test-reject-flow.sh
@@ -233,16 +233,19 @@ while :; do
   hit=$(api "$N2" GET /api/notifications | python3 -c "
 import sys,json
 d=json.load(sys.stdin)
-cg = '$CG_ID'
+cg = sys.argv[1]
 for x in d.get('notifications',[]):
-    if x.get('type')=='join_rejected':
-        meta = x.get('meta')
-        try: meta = json.loads(meta) if isinstance(meta,str) else meta
-        except: meta = {}
-        if (meta or {}).get('contextGraphId')==cg:
-            print(json.dumps({'ts':x.get('ts'),'title':x.get('title'),'message':x.get('message'),'meta':meta}))
-            break
-")
+    if x.get('type')!='join_rejected':
+        continue
+    meta = x.get('meta') or {}
+    if isinstance(meta, str):
+        try: meta = json.loads(meta)
+        except Exception: meta = {}
+    row_cg = x.get('contextGraphId') or meta.get('contextGraphId') or ''
+    if row_cg == cg:
+        print(json.dumps({'ts':x.get('ts'),'title':x.get('title'),'message':x.get('message'),'meta':meta}))
+        break
+" "$CG_ID")
   if [ -n "$hit" ]; then
     ok "N2 received join_rejected notification"
     echo "$hit" | python3 -m json.tool

--- a/scripts/devnet-test-sharing.sh
+++ b/scripts/devnet-test-sharing.sh
@@ -777,15 +777,21 @@ N1_NOTIFS=$(c "http://127.0.0.1:9201/api/notifications?limit=5")
 N1_JOIN_NOTIF=$(echo "$N1_NOTIFS" | python3 -c '
 import sys,json
 d=json.load(sys.stdin)
+target_cg = sys.argv[1]
 for n in d.get("notifications",[]):
-  if n.get("type")=="join_request":
-    meta=json.loads(n.get("meta","{}")) if n.get("meta") else {}
-    if "'"$CG2_ID"'" in meta.get("contextGraphId",""):
-      print("found")
-      break
+  if n.get("type")!="join_request":
+    continue
+  meta = n.get("meta") or {}
+  if isinstance(meta, str):
+    try: meta = json.loads(meta)
+    except Exception: meta = {}
+  cg = n.get("contextGraphId") or meta.get("contextGraphId") or ""
+  if cg == target_cg:
+    print("found")
+    break
 else:
   print("missing")
-' 2>/dev/null)
+' "$CG2_ID" 2>/dev/null)
 check "Join-request notification created on Node 1" "$N1_JOIN_NOTIF" "found"
 
 echo "--- 13h: Node 1 approves Node 4 ---"


### PR DESCRIPTION
## Summary
- Fixes `devnet-test-reject-flow.sh` and `devnet-test-sharing.sh` notification polling to handle scoped `/api/notifications` wire rows where `meta` is already a JSON object (not a string).
- Matches `contextGraphId` on the top-level row field as well as inside `meta`.

## Test plan
- [ ] `./scripts/devnet-test-reject-flow.sh`
- [ ] `./scripts/devnet-test-sharing.sh` (§13g join-request notification)


Made with [Cursor](https://cursor.com)