### PR TITLE
fix(node-ui): harden replication route input parsing

### DIFF
--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -180,18 +180,19 @@ export async function handleNodeUIRequest(
   // --- Replication (chain-driven VM reconciliation) — Phase F ---
 
   if (req.method === 'GET' && path === '/api/replication/summary') {
-    const periodMs = parseInt(url.searchParams.get('periodMs') ?? String(86_400_000), 10);
+    const periodMs = parsePeriodMs(url.searchParams.get('periodMs') ?? '24h');
     return json(res, 200, db.getReplicationSummary(periodMs));
   }
 
   if (req.method === 'GET' && path === '/api/replication/per-cg') {
-    const periodMs = parseInt(url.searchParams.get('periodMs') ?? String(86_400_000), 10);
+    const periodMs = parsePeriodMs(url.searchParams.get('periodMs') ?? '24h');
     return json(res, 200, { rows: db.getReplicationPerCg(periodMs) });
   }
 
   if (req.method === 'GET' && path === '/api/replication/timeline') {
-    const periodMs = parseInt(url.searchParams.get('periodMs') ?? String(86_400_000), 10);
-    const bucketMs = parseInt(url.searchParams.get('bucketMs') ?? String(3_600_000), 10);
+    const periodMs = parsePeriodMs(url.searchParams.get('periodMs') ?? '24h');
+    const rawBucket = parseInt(url.searchParams.get('bucketMs') ?? '', 10);
+    const bucketMs = Number.isFinite(rawBucket) && rawBucket > 0 ? rawBucket : autoBucketMs(periodMs);
     const contextGraphId = url.searchParams.get('cg') ?? undefined;
     return json(res, 200, { buckets: db.getReplicationTimeline({ periodMs, bucketMs, contextGraphId }) });
   }
@@ -203,7 +204,8 @@ export async function handleNodeUIRequest(
   if (req.method === 'GET' && path === '/api/replication/events') {
     const cg = url.searchParams.get('cg');
     if (!cg) return json(res, 400, { error: 'Missing cg query param' });
-    const limit = parseInt(url.searchParams.get('limit') ?? '100', 10);
+    const rawLimit = parseInt(url.searchParams.get('limit') ?? '', 10);
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 100;
     return json(res, 200, { events: db.getReplicationEventsForCg(cg, limit) });
   }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1015,6 +1015,11 @@ export class DashboardDB {
    * Recent raw events for a CG (the per-CG timeline drawer). Newest first.
    */
   getReplicationEventsForCg(contextGraphId: string, limit = 100): ReplicationEventRow[] {
+    // Guard against a non-finite limit (e.g. ?limit=foo → NaN upstream): Math.min/max
+    // propagate NaN, which would bind `LIMIT NaN` and make SQLite throw a 500.
+    const safeLimit = Number.isFinite(limit)
+      ? Math.max(1, Math.min(1000, Math.trunc(limit)))
+      : 100;
     return this.db.prepare(`
       SELECT ts, context_graph_id, on_chain_cg_id, action, ual, ordinal, ka_id,
              from_watermark, to_watermark, head, reconciled, pending, detail
@@ -1022,7 +1027,7 @@ export class DashboardDB {
       WHERE context_graph_id = ?
       ORDER BY ts DESC
       LIMIT ?
-    `).all(contextGraphId, Math.max(1, Math.min(1000, limit))) as ReplicationEventRow[];
+    `).all(contextGraphId, safeLimit) as ReplicationEventRow[];
   }
 
   /**

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -668,4 +668,24 @@ describe('handleNodeUIRequest replication routes (Phase F)', () => {
     expect(body.events.length).toBe(3);
     expect(body.events[0].action).toBe('cursor-advance'); // newest first
   });
+
+  it('GET /api/replication/summary accepts a unit-suffixed period (e.g. 24h)', async () => {
+    harness.setArgs(args());
+    // Raw parseInt('24h') === 24 (24ms window → excludes everything). parsePeriodMs
+    // must read this as 24 hours so the recent events stay in range.
+    const res = await fetch(`${baseUrl}/api/replication/summary?periodMs=24h`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.promotes).toBe(1);
+    expect(body.fetches).toBe(1);
+  });
+
+  it('GET /api/replication/events tolerates a non-numeric limit', async () => {
+    harness.setArgs(args());
+    // ?limit=foo previously bound `LIMIT NaN` and surfaced a SQLite 500.
+    const res = await fetch(`${baseUrl}/api/replication/events?cg=mfacts&limit=foo`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events.length).toBe(3);
+  });
 });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -1481,6 +1481,19 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     expect(events[0].ts).toBe(now);
   });
 
+  it('per-cg event stream coerces a non-finite limit to the default (no LIMIT NaN)', () => {
+    // ?limit=foo → parseInt → NaN. Math.min/max propagate NaN, so binding it
+    // straight into `LIMIT ?` made SQLite throw. The limit must fall back safely.
+    for (let i = 0; i < 3; i++) {
+      db.insertReplicationEvent({ ts: now - i * 1000, context_graph_id: 'cgN', action: 'promote', ordinal: 3 - i });
+    }
+    expect(() => db.getReplicationEventsForCg('cgN', NaN)).not.toThrow();
+    expect(db.getReplicationEventsForCg('cgN', NaN).length).toBe(3);
+    // Out-of-range values are clamped, not rejected.
+    expect(db.getReplicationEventsForCg('cgN', 0).length).toBe(1);
+    expect(db.getReplicationEventsForCg('cgN', 99_999).length).toBe(3);
+  });
+
   it('V18 migration creates replication_events on an upgraded DB', () => {
     db.close();
     const raw = new Database(join(dir, 'node-ui.db'));


### PR DESCRIPTION
## Summary

Follow-up to the chain-driven VM reconciliation work merged in #927. These are the two **cheap, high-value** robustness fixes from the PR-review audit of the (now-closed) stacked PRs.

- **#20 — `periodMs` parsing.** The replication `summary` / `per-cg` / `timeline` routes parsed `periodMs` with raw `parseInt`, so a unit-suffixed value like `24h` was read as `24` (ms) and silently excluded the entire window. They now route through the existing `parsePeriodMs` helper (consistent with the operation-stats routes). The timeline route also falls back to `autoBucketMs` for a missing/invalid `bucketMs`.
- **#21 — NaN `limit`.** `GET /api/replication/events?limit=foo` produced `NaN`; `Math.min/Math.max` propagate `NaN`, so it bound `LIMIT NaN` and SQLite returned a 500. The limit is now sanitized at the route and clamped defensively inside `getReplicationEventsForCg` (`Number.isFinite` → default 100, clamp 1..1000).

## Test plan

- [x] `node-ui` `db.test.ts` — new case: `getReplicationEventsForCg(NaN)` no longer throws and falls back to the default; out-of-range values clamp.
- [x] `node-ui` `api-routes.test.ts` — new cases: `?periodMs=24h` keeps recent events in range; `?limit=foo` returns 200 with the full stream.
- [x] Full `db.test.ts` + `api-routes.test.ts` suites green (102 tests).
- [x] Lint clean on changed files.

Made with [Cursor](https://cursor.com)