### PR TITLE
chore(release): v10.0.0-rc.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
+## [10.0.0-rc.13] - 2026-06-02
+
+**Off-chain stabilization release.** No Solidity changes since rc.12 — the Base Sepolia (chainId 84532) deployment in `packages/evm-module/deployments/base_sepolia_v10_contracts.json` is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. Nodes upgrade in place; no local-state wipe. This release lands the core-preferred sync + chain-driven VM reconciliation work, the Kafka route-plugin MVP, and a batch of publish/SWM runtime hardening and Node UI fixes accumulated on top of rc.12.
+
+### Added — Core-preferred sync + chain-driven VM reconciliation (#927)
+
+- **Core-preferred sync + chain-driven verified-memory reconciliation** (PR #927, `packages/agent/src`, `packages/core/src`; supersedes #906/#908/#910/#911/#912/#914): the sync path now prefers Core peers and reconciles verified-memory against on-chain state, including host-mode catch-up. Closes the long-running sync/catch-up workstream tracked across the superseded PRs.
+
+### Added — Kafka route-plugin MVP (#607)
+
+- **`@origintrail-official/kafka-plugin`** (PR #607, `packages/kafka-plugin`, `demo/kafka-streams`): new route-plugin consumer package that ingests from Kafka topics into the DKG publish path. Added to `pnpm-workspace.yaml` and the runtime build set.
+
+### Changed — Default publish lifetime is now 12 epochs (#926)
+
+- **`random-sampling` default epochs** (PR #926): the default publish lifetime is set to **12 epochs**. Publishes that don't specify a lifetime now default to 12 instead of the previous default.
+
+### Fixed — Publish / SWM / sync runtime hardening
+
+- **Single-root SWM publish boundary** (PR #925, `packages/publisher/src`): enforce a single-root boundary on shared-working-memory publishes (multi-root publish flow correctness).
+- **SWM plaintext for on-chain-public CGs with an allowed-agent list** (PR #884, `packages/agent/src`): keep SWM payloads plaintext for context graphs that are on-chain-public but carry an allowed-agent list.
+- **Sub-graph SWM in catch-up + approve-time race** (PR #885, `packages/agent/src`): cover sub-graph SWM during catch-up and close a late-joiner / approve-time race (`scripts/devnet-test-swm-late-joiner-subgraph.sh`).
+- **SWM Sender Key setup after joined-CG approval** (PR #900, `packages/agent/src`): fix sender-key setup that was missed after a joined-CG approval; parallel fan-out correctness.
+- **rc.12 publish ACK / allowance races + SPARQL parse-error classifier** (PR #896, addresses #887/#888/#889): resolve publish ACK and allowance race conditions and add a SPARQL parse-error classifier.
+- **Stabilize V10 publish runtime paths** (PR #899): runtime fixes across the V10 publish path.
+- **Harden context-graph registration RPC handling** (PR #883, #883/orch): tolerate RPC 429s on context-graph register.
+- **Per-publish allowance auto-replenish** (PR #876, `packages/chain/src`): auto-replenish the per-publish allowance floor (#870).
+- **Skip recovery `getIdentityId` on boot chain-timeout** (PR #903): don't run identity recovery when the boot-time chain call times out.
+- **Artifact read-gate for public CGs** (PR #879, forward of #872).
+
+### Fixed — Forward-ports from rc.12 hotfix line
+
+- **Rich error when promote finds an empty assertion graph** (PR #898, forward-port of #874, `packages/publisher`, `packages/node-ui`).
+- **Respect explicit `accessPolicy="public"` over allowlist heuristic** (PR #897, forward-port of #873, `packages/agent`).
+
+### Fixed — Node UI
+
+- **Unified render-correct triple derivation via `useCanonicalTriples`** (PR #847, GH #819, `packages/node-ui/src`).
+- **WM Assertions subtab empty after #844** (PR #877): derive the list from `_meta`.
+- **4 QA-found UI bugs** (PR #924, addresses #904/#905/#913/#915).
+- **Markdown import root-children partitioning** (PR #920): fix markdown section root partitioning.
+- **Post-#847 follow-ups** (PR #890): GH #881 fused-counts helper + GH #882 hydrating tooltip.
+- **Settings page cleanup** (PR #855): remove stale sections, sleeker cards, accessibility fixes.
+- **Selected `DKG_HOME` daemon status detection** (PR #878, orch).
+
+### Added — Test coverage
+
+- **Node UI e2e against a real node** (PR #918, `packages/node-ui/e2e`).
+- **`core-peers-features` devnet suite** (`devnet/core-peers-features`).
+- **Build unblock**: augment `NodeJS.ProcessEnv` with `DKG_HOME` (PR #892); resolve 3 #892-surfaced test regressions (PR #901, addresses #893/#894/#895).
+
 ### Added — Operator observability for per-publish 1-wei allowance floor (#871)
 
 - **Diagnostic log line in `EVMChainAdapter.ensureV10ApproveTrac`** (`packages/chain/src/evm-adapter.ts`): when the V10 publish/update path emits its per-publish floor approval (`targetAllowance == V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE` and `chain.approvalPolicy.mode == 'per-publish'`), the daemon now logs a single `console.warn` line identifying that the resulting 1-wei allowance is the intentional `#720` workaround (the contract's `transferFrom(..., 1n)` minimum on zero-cost publishes) and is not a stuck or ghosted approval. This closes a reportability gap surfaced by [#871](https://github.com/OriginTrail/dkg/issues/871), where an operator manually inspected `allowance()` against the wrong (typo'd) spender address and read the daemon's pre-existing 1-wei floor as a daemon-side bug. Investigation note: [`docs/investigations/871-curator-wallet-allowance-ghosting.md`](docs/investigations/871-curator-wallet-allowance-ghosting.md). No behaviour change for any caller — only the diagnostic line is new; the underlying floor logic and the `effectivePublishAllowance` / `computeApprovalAction` invariants are unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.12",
+  "version": "10.0.0-rc.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release: v10.0.0-rc.13

Cuts **v10.0.0-rc.13** from `main` (base: rc.12 tag `v10.0.0-rc.12`, +224 commits / 20 merged PRs).

### What this PR does
- Bumps `version` on the root + 17 workspace packages `10.0.0-rc.12` → `10.0.0-rc.13`.
- Adds the `[10.0.0-rc.13]` CHANGELOG section.

No code/runtime changes — every feature/fix below already landed on `main`; this is the version + changelog bump to tag the release.

### Contracts: no redeploy required
- **Zero `.sol` changes** since `v10.0.0-rc.12`.
- `packages/evm-module/deployments/base_sepolia_v10_contracts.json` (Base Sepolia, chainId 84532) is **unchanged**.
- `network/testnet.json` `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01` — **no chain reset, no local-state wipe**. Nodes upgrade in place.
- (The only deployment-dir delta vs rc.12 is regenerated `localhost_contracts.json` hardhat metadata — local devnet only.)

### Highlights since rc.12
- **Core-preferred sync + chain-driven VM reconciliation** (#927, supersedes #906/#908/#910/#911/#912/#914).
- **Kafka route-plugin MVP** — `@origintrail-official/kafka-plugin` (#607).
- **Default publish lifetime → 12 epochs** (#926).
- Publish/SWM runtime hardening: #925, #884, #885, #900, #896, #899, #883, #876, #903, #879.
- Forward-ports of rc.12 hotfixes: #898 (#874), #897 (#873).
- Node UI fixes: #847, #877, #924, #920, #890, #855, #878.
- Test coverage: real-node e2e (#918), `core-peers-features` devnet suite, build unblock (#892/#901).

Full details in `CHANGELOG.md`.

### Release steps
1. Merge this PR.
2. Tag the merge commit `v10.0.0-rc.13` and publish the GitHub release (matches the rc.12 process — no testnet deploy step this round).

### Test plan
- [ ] CI green on this branch.
- [ ] `pnpm install` resolves with bumped versions (workspace-protocol deps, lockfile unaffected).
- [ ] Optional: rc.13 devnet release-validation run before tagging.

> Note: stale `codex/rc13-runtime-fixes` / `codex/rc13-devnet-validation` branches exist (127 commits behind `main`, pre-core-sync-vm) — appear superseded by merged PRs; confirm before deleting.

Made with [Cursor](https://cursor.com)