### PR TITLE
fix(devnet): rc.13 follow-up — fail single-root publish on non-success status

### DIFF
--- a/scripts/devnet-publish-helpers.sh
+++ b/scripts/devnet-publish-helpers.sh
@@ -256,6 +256,18 @@ devnet_publish_swm_all_roots() {
   probe_code=$(devnet_json_field "$probe" '.code')
 
   if [ "$probe_code" != "MULTI_ROOT_PUBLISH_NOT_ATOMIC" ]; then
+    # Not the multi-root sentinel. The only other response we may treat as a
+    # single-root publish is a genuinely successful one. Any other error
+    # (empty SWM, auto-register failure, malformed extra fields, …) must fail
+    # loudly here instead of being persisted as a successful single-root
+    # publish — otherwise the later verify steps run against a payload that
+    # was never published and a real publish regression passes as green.
+    local probe_status
+    probe_status=$(devnet_json_field "$probe" '.status')
+    if ! _devnet_publish_status_ok "$probe_status"; then
+      printf '%s' "$probe" >&2
+      return 1
+    fi
     local single_arr single_roots
     single_arr=$(printf '%s' "$probe" | node -e '
       let d=""; process.stdin.on("data",c=>d+=c);


### PR DESCRIPTION
## Summary

Follow-up to the rc.13 candidate PRs (#916, #917, #928, #932) capturing the review feedback that was still open after they merged.

After auditing **every** unresolved review thread across the four PRs, almost all of the feedback was already addressed on `main` by the merged work. This PR lands the one remaining, statically-verifiable correctness bug:

- **`scripts/devnet-publish-helpers.sh`** — `devnet_publish_swm_all_roots` treated *any* probe response other than the `MULTI_ROOT_PUBLISH_NOT_ATOMIC` sentinel as a successful single-root publish and persisted it to the state file. A genuine error (empty SWM, auto-register failure, malformed extra fields, …) was therefore recorded as a "success", so the later `verify-batch` / KCS read-back steps ran against a payload that was never published and a real publish regression could pass as green. Now the single-root branch validates the probe status via `_devnet_publish_status_ok` before persisting — mirroring the per-root status gate already present in the multi-root path.

## Triage of the unresolved threads (for the record)

**#916 — already addressed on `main`:**
- Host-mode persistence key mismatch (store-key + await-queue-key): `enqueueHostModePersistence`/`awaitHostModePersistence` both canonicalize via `canonicalSwmHostModeKey` (→ wire-hash) and the store mutation goes through `hostModePersistenceStoreKey` (→ cleartext). Mark/unmark across id shapes now collapse onto one `.meta` file.
- `assertion.ts` SWM linkage fallback: no longer `LIMIT 1` — selects all rows and uses `singletonMetadataBinding`, which throws `409` on conflicting `sourceFile`/`markdownForm` values (fail-closed, matching the `_meta` path).
- Beacon-curator signer threads: refactored — `getBeaconCatchupSigner` removed; `getWorkspaceGossipSigningAgent()` now sits behind a `callerScopedSigner ??` precedence so multi-agent nodes sign with the caller's agent.

**#917 — already addressed / not a static fix:**
- Unclean-restart catchup now fails on per-peer `swmError`/`durableError` (`assert_catchup_clean`), not just logs.
- The node-ui e2e `pickWritableContextGraph`/`synced` helper referenced in the thread no longer exists in that form.
- Scale/LU-8 "single-root drops large-batch coverage" is a test-coverage trade-off (the scripts still write 50 triples); changing the publish shape needs live-devnet validation, so it's intentionally out of scope here.

**#928 — substantially reworked on `main`; one gap fixed here:**
- Parent-stable (`$$`) state file (not `BASHPID`), structured `.code` detection (not grep), `tentative` accepted, fail-fast root→batch lookups, all-roots iteration, and merkleRoot read from the publish node to avoid the chain-sync race are all already in.
- Remaining gap (this PR): single-root branch did not validate publish status.

**#932 — no unresolved threads.**

## Test plan
- [x] `bash -n scripts/devnet-publish-helpers.sh` (syntax)
- [ ] Devnet harness run exercising a single-root publish path (e.g. `devnet-test-rfc38-*`) to confirm a failed probe now aborts instead of recording a phantom success — requires a live devnet.

Made with [Cursor](https://cursor.com)