### PR TITLE
fix(agent): sync off the messenger substrate (node-ui.db bloat) + sync reconciler backoff [rc.14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
+## [10.0.0-rc.14] - 2026-06-02
+
+**Off-chain runtime release.** No Solidity changes since rc.13 — the Base Sepolia (chainId 84532) deployment is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. Nodes upgrade in place; no local-state wipe. This release fixes the multi-GB `node-ui.db` bloat by taking the sync RPC off the Universal Messenger substrate, and adds per-peer exponential backoff to the sync reconciler.
+
+> **Wire-compatibility note (hard cutover):** the sync protocol ID is bumped `/dkg/10.0.1/sync` → `/dkg/10.0.2/sync`. An rc.14 node will **not** sync with an rc.13 (or earlier) node and vice versa — mixed-version peers cleanly skip each other (`waitForSyncProtocol`). Because sync is a self-healing eventual-consistency catch-up net (not a primary data path), the brief mixed-version window during a network rollout is **no-data-loss**: once both ends are on rc.14 the next reconnect/reconciler tick backfills.
+
+### Fixed — `node-ui.db` bloat: sync RPC taken off the Universal Messenger substrate
+
+- **Sync no longer writes to `message_idempotency`** (`packages/agent/src/dkg-agent.ts`, `packages/agent/src/sync/responder/sync-handler.ts`, `packages/core/src/constants.ts`). rc.9 PR-E had routed sync through the Universal Messenger substrate "for receiver-side dedup", but the sync requester mints a **fresh `messageId` per attempt**, so the dedup key never repeats — the cache-hit rate is structurally zero while every large, never-reused sync page response was being cached on **both** sides of the `message_idempotency` table. On a long-lived node this grew `node-ui.db` to multiple GB (≈3.1 GB observed, plus a same-size WAL). The responder now registers on the **raw `ProtocolRouter`** and the requester sends via `messenger.sendToPeer` (raw pass-through) instead of `messenger.sendReliable`. Sync already carries its own `withRetry`, a 90s auth-freshness TTL, and per-`requestId` replay protection, so it needs none of the substrate's idempotency/outbox machinery. A regression test pins that `PROTOCOL_SYNC` is registered off the substrate.
+
+### Added — Per-peer exponential backoff for the sync reconciler
+
+- **Sync reconciler backoff** (`packages/agent/src/dkg-agent.ts`, `packages/agent/src/dkg-agent-constants.ts`): a peer that can never be synced (dead, NAT-stuck, or persistently stream-resetting) never stamps `lastSuccessfulSyncAt`, so it read as perpetually stale and was dialed on **every** reconciler tick forever. The reconciler now applies per-peer exponential backoff — `SYNC_BACKOFF_BASE_MS * 2^(failures-1)`, capped at `SYNC_BACKOFF_MAX_MS`, with ±`SYNC_BACKOFF_JITTER` randomisation — that resets the instant a sync succeeds and is cleared on `connection:close`. Only the **periodic reconciler** is gated; `connection:open` and `peer:update` still trigger an immediate attempt, so a newly-reachable peer is never delayed.
+
 ## [10.0.0-rc.13] - 2026-06-02
 
 **Off-chain stabilization release.** No Solidity changes since rc.12 — the Base Sepolia (chainId 84532) deployment in `packages/evm-module/deployments/base_sepolia_v10_contracts.json` is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. Nodes upgrade in place; no local-state wipe. This release lands the core-preferred sync + chain-driven VM reconciliation work, the Kafka route-plugin MVP, and a batch of publish/SWM runtime hardening and Node UI fixes accumulated on top of rc.12.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -133,6 +133,22 @@ export const SYNC_RECONCILER_INTERVAL_MS = 5 * 60_000;
  * the event-driven path time to win the race in the common case.
  */
 export const SYNC_STALENESS_THRESHOLD_MS = 10 * 60_000;
+/**
+ * Per-peer exponential backoff for the sync reconciler. Without it, a
+ * peer that can never be synced (dead, NAT-stuck, or persistently
+ * stream-resetting) is retried on EVERY reconciler tick forever:
+ * `lastSuccessfulSyncAt` never gets stamped, so the peer reads as
+ * perpetually stale and is dialed every `SYNC_RECONCILER_INTERVAL_MS`.
+ * The backoff grows the per-peer retry gap as
+ * `SYNC_BACKOFF_BASE_MS * 2^(failures-1)` (capped at
+ * `SYNC_BACKOFF_MAX_MS`, ±`SYNC_BACKOFF_JITTER` to de-correlate peers)
+ * and resets the instant a sync succeeds. Only the periodic reconciler
+ * is gated — connection:open and peer:update still trigger an immediate
+ * attempt, so new information is never delayed.
+ */
+export const SYNC_BACKOFF_BASE_MS = 5 * 60_000;
+export const SYNC_BACKOFF_MAX_MS = 60 * 60_000;
+export const SYNC_BACKOFF_JITTER = 0.25;
 export const RANDOM_SAMPLING_BIND_RETRY_MS = 30_000;
 export const STORAGE_ACK_REGISTRATION_RETRY_MS = 30_000;
 

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -449,6 +449,7 @@ export interface PeerDiagnostics {
    */
   syncStatus: {
     capable: boolean;
+    capability: 'supported' | 'unsupported' | 'unknown';
     lastSuccessfulSyncAt: number | null;
     stale: boolean;
     backoff: {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -410,9 +410,9 @@ export interface PeerDiagnostics {
    *
    * `byProtocol` (rc.9 PR-E codex follow-up #10) breaks out queued
    * entries per libp2p protocol id so post-substrate-migration
-   * traffic (sync, SWM, future protocols) is visible to operator
-   * diagnostics — without it, a peer stuck on sync catch-up reports
-   * `pendingCount=0` and looks healthy.
+   * substrate traffic (SWM, access, future protocols) is visible to
+   * operator diagnostics. Raw sync catch-up state lives in
+   * `syncStatus` because sync is no longer on the substrate.
    */
   outbox: {
     /** Pending count for the chat protocol specifically (rc.8 contract). */
@@ -442,6 +442,21 @@ export interface PeerDiagnostics {
   protocols: string[];
   /** Convenience flag — peer speaks `PROTOCOL_SYNC`. */
   syncCapable: boolean;
+  /**
+   * Raw sync catch-up health. Sync no longer lives on the messenger
+   * substrate, so stuck catch-up is exposed here instead of in
+   * `outbox.byProtocol`.
+   */
+  syncStatus: {
+    capable: boolean;
+    lastSuccessfulSyncAt: number | null;
+    stale: boolean;
+    backoff: {
+      failures: number;
+      nextRetryAt: number;
+      retryInMs: number;
+    } | null;
+  };
 }
 
 /**

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -440,7 +440,7 @@ export interface PeerDiagnostics {
   health: PeerHealth | null;
   /** Protocols this peer's identify-handshake advertised. */
   protocols: string[];
-  /** Convenience flag — peer speaks `/dkg/10.0.0/sync`. */
+  /** Convenience flag — peer speaks `PROTOCOL_SYNC`. */
   syncCapable: boolean;
 }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3566,7 +3566,11 @@ export class DKGAgent {
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           if (err instanceof SyncOnConnectPostSyncError) {
-            this.log.warn(ctx, `Sync reconciler post-sync step failed for ${shortPeer}; retrying without growing peer backoff: ${message}`);
+            if (err.backoffEligible) {
+              this.recordSyncReconcilerFailure(peerId, probe);
+            }
+            const backoffNote = err.backoffEligible ? 'growing peer backoff' : 'retrying without growing peer backoff';
+            this.log.warn(ctx, `Sync reconciler post-sync step failed for ${shortPeer}; ${backoffNote}: ${message}`);
             return;
           }
           this.recordSyncReconcilerFailure(peerId, probe);
@@ -21521,8 +21525,6 @@ export class DKGAgent {
     } catch {
       rawConns = [];
     }
-    const connected = rawConns.length > 0;
-
     // libp2p's peerId-keyed lookup. See `getConnectionsReturnsForPeer`
     // JSDoc — divergence from `rawConns.length` is the Window D signature.
     let keyedConns: LibConnection[] = [];
@@ -21531,6 +21533,14 @@ export class DKGAgent {
     } catch {
       keyedConns = [];
     }
+
+    let peerListHasPeer = false;
+    try {
+      peerListHasPeer = libp2p.getPeers().some((p: unknown) => p?.toString?.() === peerKey);
+    } catch {
+      peerListHasPeer = false;
+    }
+    const connected = rawConns.length > 0 || keyedConns.length > 0 || peerListHasPeer;
 
     const connections: PeerConnectionSnapshot[] = rawConns.map((c) => {
       const remoteAddr = c.remoteAddr?.toString() ?? null;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -390,6 +390,18 @@ export type {
   DKGAgentConfig,
 };
 
+type SyncReconcilerBackoff = {
+  failures: number;
+  nextRetryAt: number;
+  protocolsKey?: string | null;
+  connectionKey?: string | null;
+};
+
+type SyncReconcilerProbe = {
+  protocolsKey: string | null;
+  connectionKey: string | null;
+};
+
 /**
  * High-level facade that ties together all DKG agent capabilities:
  * identity, networking, publishing, querying, discovery, and messaging.
@@ -1229,7 +1241,7 @@ export class DKGAgent {
    * `connection:close`. Bounded by the connected-peer set (one entry per
    * peer, cleared on disconnect). See `SYNC_BACKOFF_BASE_MS`.
    */
-  private readonly syncReconcilerBackoff = new Map<string, { failures: number; nextRetryAt: number }>();
+  private readonly syncReconcilerBackoff = new Map<string, SyncReconcilerBackoff>();
   private syncReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   /** A.4-lite+: periodic warm/pinned Core-connection reconcile (opt-in). */
   private warmCoreTimer: ReturnType<typeof setInterval> | null = null;
@@ -3529,7 +3541,10 @@ export class DKGAgent {
       // peer:update still fire an immediate attempt, so newly-reachable
       // peers are never delayed.
       const backoff = this.syncReconcilerBackoff.get(peerId);
-      if (backoff && now < backoff.nextRetryAt) continue;
+      const probe = await this.getSyncReconcilerProbe(peerId);
+      if (backoff && now < backoff.nextRetryAt && !this.hasSyncReconcilerProbeChanged(backoff, probe)) {
+        continue;
+      }
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       this.trySyncFromPeer(peerId)
@@ -3545,11 +3560,11 @@ export class DKGAgent {
           // reconciler tick, so a missed identify update cannot stretch into
           // a 5/10/20/60-minute delay.
           if (this.lastSuccessfulSyncAt.get(peerId) === lastOk) {
-            this.recordSyncReconcilerFailure(peerId);
+            this.recordSyncReconcilerFailure(peerId, probe);
           }
         })
         .catch((err: unknown) => {
-          this.recordSyncReconcilerFailure(peerId);
+          this.recordSyncReconcilerFailure(peerId, probe);
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
         });
@@ -3564,7 +3579,41 @@ export class DKGAgent {
    * de-correlate retries across peers. Reset to absent on success
    * (`onPeerSynced`) or disconnect (`connection:close`).
    */
-  private recordSyncReconcilerFailure(peerId: string): void {
+  private async getSyncReconcilerProbe(peerId: string): Promise<SyncReconcilerProbe> {
+    let protocolsKey: string | null = null;
+    try {
+      const protocols = await this.getPeerProtocols(peerId);
+      protocolsKey = [...protocols].sort().join('\n');
+    } catch {
+      protocolsKey = null;
+    }
+    return {
+      protocolsKey,
+      connectionKey: this.getSyncReconcilerConnectionKey(peerId),
+    };
+  }
+
+  private getSyncReconcilerConnectionKey(peerId: string): string | null {
+    try {
+      const entries = this.node.libp2p.getConnections()
+        .filter((conn) => conn.remotePeer?.toString?.() === peerId)
+        .map((conn) => [
+          conn.direction,
+          conn.timeline?.open ?? 0,
+          conn.remoteAddr?.toString?.() ?? '',
+        ].join(':'))
+        .sort();
+      return entries.length > 0 ? entries.join('|') : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private hasSyncReconcilerProbeChanged(backoff: SyncReconcilerBackoff, probe: SyncReconcilerProbe): boolean {
+    return backoff.protocolsKey !== probe.protocolsKey || backoff.connectionKey !== probe.connectionKey;
+  }
+
+  private recordSyncReconcilerFailure(peerId: string, probe: SyncReconcilerProbe): void {
     if (!this.started || !this.isPeerConnectedForSyncBackoff(peerId)) return;
     const failures = (this.syncReconcilerBackoff.get(peerId)?.failures ?? 0) + 1;
     // Clamp the exponent so `2 ** exp` can never overflow before the cap.
@@ -3574,6 +3623,8 @@ export class DKGAgent {
     this.syncReconcilerBackoff.set(peerId, {
       failures,
       nextRetryAt: Date.now() + jittered,
+      protocolsKey: probe.protocolsKey,
+      connectionKey: probe.connectionKey,
     });
   }
 
@@ -21430,6 +21481,7 @@ export class DKGAgent {
         syncCapable: false,
         syncStatus: {
           capable: false,
+          capability: 'unknown',
           lastSuccessfulSyncAt: null,
           stale: false,
           backoff: null,
@@ -21465,6 +21517,7 @@ export class DKGAgent {
     } catch {
       rawConns = [];
     }
+    const connected = rawConns.length > 0;
 
     // libp2p's peerId-keyed lookup. See `getConnectionsReturnsForPeer`
     // JSDoc — divergence from `rawConns.length` is the Window D signature.
@@ -21581,17 +21634,26 @@ export class DKGAgent {
     // cutover — peers on the older `/sync` wire ID are no longer
     // compatible and intentionally report syncCapable=false.
     const syncCapable = protocols.includes(PROTOCOL_SYNC);
+    const syncCapability: PeerDiagnostics['syncStatus']['capability'] = peerStoreSnapshot == null
+      ? 'unknown'
+      : syncCapable
+        ? 'supported'
+        : 'unsupported';
     const now = Date.now();
     const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(peerKey) ?? null;
     const backoff = this.syncReconcilerBackoff.get(peerKey) ?? null;
-    const syncStale = syncCapable && (
-      lastSuccessfulSync == null || (now - lastSuccessfulSync) >= SYNC_STALENESS_THRESHOLD_MS
+    const syncHealthObservable = connected && (syncCapability === 'supported' || syncCapability === 'unknown');
+    const syncStale = syncHealthObservable && (
+      backoff != null ||
+      lastSuccessfulSync == null ||
+      (now - lastSuccessfulSync) >= SYNC_STALENESS_THRESHOLD_MS
     );
     const syncStatus = {
       capable: syncCapable,
+      capability: syncCapability,
       lastSuccessfulSyncAt: lastSuccessfulSync,
       stale: syncStale,
-      backoff: syncCapable && backoff
+      backoff: syncHealthObservable && backoff
         ? {
             failures: backoff.failures,
             nextRetryAt: backoff.nextRetryAt,
@@ -21602,7 +21664,7 @@ export class DKGAgent {
 
     return {
       peerId: peerKey,
-      connected: rawConns.length > 0,
+      connected,
       rawConnectionCount: rawConns.length,
       getConnectionsReturnsForPeer: keyedConns.length,
       connections,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3436,11 +3436,12 @@ export class DKGAgent {
    * them into our local store. Used on peer:connect for initial catch-up,
    * with a per-peer guard to avoid overlapping sync storms.
    */
-  private async trySyncFromPeer(remotePeer: string): Promise<void> {
+  private async trySyncFromPeer(remotePeer: string): Promise<'attempted' | 'skipped-no-sync' | 'not-started'> {
     if (!this.started) {
-      return;
+      return 'not-started';
     }
-    return runSyncOnConnect({
+    let skippedNoSync = false;
+    await runSyncOnConnect({
       remotePeer,
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
@@ -3453,6 +3454,7 @@ export class DKGAgent {
       syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
+        skippedNoSync = true;
         this.skippedNoSyncPeers.add(peerId);
       },
       onPeerSynced: (peerId) => {
@@ -3461,6 +3463,7 @@ export class DKGAgent {
         this.syncReconcilerBackoff.delete(peerId);
       },
     });
+    return skippedNoSync ? 'skipped-no-sync' : 'attempted';
   }
 
   /**
@@ -3530,11 +3533,17 @@ export class DKGAgent {
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       this.trySyncFromPeer(peerId)
-        .then(() => {
+        .then((outcome) => {
+          if (outcome === 'skipped-no-sync') {
+            return;
+          }
           // `onPeerSynced` clears the backoff on a real success. If the
           // attempt resolved WITHOUT advancing `lastSuccessfulSyncAt`
-          // (e.g. peer didn't advertise PROTOCOL_SYNC, or no progress),
-          // treat it as a failure so the backoff grows.
+          // (e.g. no progress), treat it as a genuine sync failure so the
+          // backoff grows. A peer that still does not advertise
+          // PROTOCOL_SYNC is handled above and remains eligible on every
+          // reconciler tick, so a missed identify update cannot stretch into
+          // a 5/10/20/60-minute delay.
           if (this.lastSuccessfulSyncAt.get(peerId) === lastOk) {
             this.recordSyncReconcilerFailure(peerId);
           }
@@ -21422,7 +21431,7 @@ export class DKGAgent {
         syncStatus: {
           capable: false,
           lastSuccessfulSyncAt: null,
-          stale: true,
+          stale: false,
           backoff: null,
         },
       };
@@ -21575,11 +21584,14 @@ export class DKGAgent {
     const now = Date.now();
     const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(peerKey) ?? null;
     const backoff = this.syncReconcilerBackoff.get(peerKey) ?? null;
+    const syncStale = syncCapable && (
+      lastSuccessfulSync == null || (now - lastSuccessfulSync) >= SYNC_STALENESS_THRESHOLD_MS
+    );
     const syncStatus = {
       capable: syncCapable,
       lastSuccessfulSyncAt: lastSuccessfulSync,
-      stale: lastSuccessfulSync == null || (now - lastSuccessfulSync) >= SYNC_STALENESS_THRESHOLD_MS,
-      backoff: backoff
+      stale: syncStale,
+      backoff: syncCapable && backoff
         ? {
             failures: backoff.failures,
             nextRetryAt: backoff.nextRetryAt,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -202,7 +202,7 @@ import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
-import { runSyncOnConnect, type SyncOnConnectOutcome } from './sync/on-connect/sync-on-connect.js';
+import { runSyncOnConnect, SyncOnConnectPostSyncError, type SyncOnConnectOutcome } from './sync/on-connect/sync-on-connect.js';
 import {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,
   ensureWorkspaceEncryptionKey,
@@ -3564,8 +3564,12 @@ export class DKGAgent {
           }
         })
         .catch((err: unknown) => {
-          this.recordSyncReconcilerFailure(peerId, probe);
           const message = err instanceof Error ? err.message : String(err);
+          if (err instanceof SyncOnConnectPostSyncError) {
+            this.log.warn(ctx, `Sync reconciler post-sync step failed for ${shortPeer}; retrying without growing peer backoff: ${message}`);
+            return;
+          }
+          this.recordSyncReconcilerFailure(peerId, probe);
           this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
         });
     }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -273,6 +273,9 @@ import {
   CATCHUP_ON_CONNECT_COOLDOWN_MS,
   SYNC_RECONCILER_INTERVAL_MS,
   SYNC_STALENESS_THRESHOLD_MS,
+  SYNC_BACKOFF_BASE_MS,
+  SYNC_BACKOFF_MAX_MS,
+  SYNC_BACKOFF_JITTER,
   RANDOM_SAMPLING_BIND_RETRY_MS,
   STORAGE_ACK_REGISTRATION_RETRY_MS,
   JOIN_APPROVAL_RETRY_TICK_MS,
@@ -1218,6 +1221,15 @@ export class DKGAgent {
    * connected peer.
    */
   private readonly lastSuccessfulSyncAt = new Map<string, number>();
+  /**
+   * Per-peer sync-reconciler backoff. `failures` is the count of
+   * consecutive reconciler attempts that did NOT produce a successful
+   * sync; `nextRetryAt` is the epoch-ms before which the reconciler
+   * skips this peer. Reset on a successful sync (`onPeerSynced`) and on
+   * `connection:close`. Bounded by the connected-peer set (one entry per
+   * peer, cleared on disconnect). See `SYNC_BACKOFF_BASE_MS`.
+   */
+  private readonly syncReconcilerBackoff = new Map<string, { failures: number; nextRetryAt: number }>();
   private syncReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   /** A.4-lite+: periodic warm/pinned Core-connection reconcile (opt-in). */
   private warmCoreTimer: ReturnType<typeof setInterval> | null = null;
@@ -2640,14 +2652,17 @@ export class DKGAgent {
       }
     }
 
-    // rc.9 PR-E: bind to messenger.register so the /dkg/10.0.1/sync
-    // handler receives envelope-unwrapped payload + benefits from
-    // receiver-side idempotency dedup. Pre-PR-E this registered on
-    // the raw router, so the constant bump on its own (commit at
-    // PROTOCOL_SYNC declaration) gave the new protocol ID none of
-    // the substrate semantics — Codex review #569 caught the gap.
+    // Sync registers on the RAW ProtocolRouter (not messenger.register):
+    // /dkg/10.0.2/sync is deliberately off the Universal Messenger
+    // substrate so its large, never-reused page responses are not cached
+    // in message_idempotency (the ~2.9 GB node-ui.db bloat). The raw
+    // router passes the bare payload — exactly the auth envelope
+    // parseSyncRequest expects — and the adapter re-exposes the string
+    // peerId contract registerSyncHandler relies on. (Reverts rc.9 PR-E
+    // for sync only; other substrate protocols keep their dedup.)
     registerSyncHandler({
-      register: this.messenger.register.bind(this.messenger),
+      register: (protocol, handler) =>
+        this.router.register(protocol, (data, peerIdObj) => handler(data, peerIdObj.toString())),
       protocolSync: PROTOCOL_SYNC,
       syncDeniedResponse: SYNC_DENIED_RESPONSE,
       syncPageSize: SYNC_PAGE_SIZE,
@@ -3086,6 +3101,7 @@ export class DKGAgent {
       this.catchupOnConnectAt.delete(remotePeer);
       this.skippedNoSyncPeers.delete(remotePeer);
       this.lastSuccessfulSyncAt.delete(remotePeer);
+      this.syncReconcilerBackoff.delete(remotePeer);
     });
 
     // Event-driven sync-retry: libp2p emits `peer:update` whenever a
@@ -3442,6 +3458,7 @@ export class DKGAgent {
       onPeerSynced: (peerId) => {
         this.lastSuccessfulSyncAt.set(peerId, Date.now());
         this.skippedNoSyncPeers.delete(peerId);
+        this.syncReconcilerBackoff.delete(peerId);
       },
     });
   }
@@ -3501,13 +3518,53 @@ export class DKGAgent {
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
       const stale = lastOk == null || (now - lastOk) >= SYNC_STALENESS_THRESHOLD_MS;
       if (!stale) continue;
+      // Per-peer exponential backoff: a peer that can never be synced
+      // (dead / NAT-stuck / persistently stream-resetting) never stamps
+      // `lastSuccessfulSyncAt`, so it reads as perpetually stale. Without
+      // this gate it would be dialed on every tick forever. The gate
+      // applies ONLY to the periodic reconciler — connection:open and
+      // peer:update still fire an immediate attempt, so newly-reachable
+      // peers are never delayed.
+      const backoff = this.syncReconcilerBackoff.get(peerId);
+      if (backoff && now < backoff.nextRetryAt) continue;
       const shortPeer = peerId.slice(-8);
-      this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`})`);
-      this.trySyncFromPeer(peerId).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
-      });
+      this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
+      this.trySyncFromPeer(peerId)
+        .then(() => {
+          // `onPeerSynced` clears the backoff on a real success. If the
+          // attempt resolved WITHOUT advancing `lastSuccessfulSyncAt`
+          // (e.g. peer didn't advertise PROTOCOL_SYNC, or no progress),
+          // treat it as a failure so the backoff grows.
+          if (this.lastSuccessfulSyncAt.get(peerId) === lastOk) {
+            this.recordSyncReconcilerFailure(peerId);
+          }
+        })
+        .catch((err: unknown) => {
+          this.recordSyncReconcilerFailure(peerId);
+          const message = err instanceof Error ? err.message : String(err);
+          this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
+        });
     }
+  }
+
+  /**
+   * Grow the per-peer sync-reconciler backoff after an attempt that did
+   * not produce a successful sync. `nextRetryAt` advances by
+   * `SYNC_BACKOFF_BASE_MS * 2^(failures-1)` (capped at
+   * `SYNC_BACKOFF_MAX_MS`) with ±`SYNC_BACKOFF_JITTER` randomisation to
+   * de-correlate retries across peers. Reset to absent on success
+   * (`onPeerSynced`) or disconnect (`connection:close`).
+   */
+  private recordSyncReconcilerFailure(peerId: string): void {
+    const failures = (this.syncReconcilerBackoff.get(peerId)?.failures ?? 0) + 1;
+    // Clamp the exponent so `2 ** exp` can never overflow before the cap.
+    const exp = Math.min(failures - 1, 30);
+    const delay = Math.min(SYNC_BACKOFF_BASE_MS * 2 ** exp, SYNC_BACKOFF_MAX_MS);
+    const jittered = delay * (1 + (Math.random() * 2 - 1) * SYNC_BACKOFF_JITTER);
+    this.syncReconcilerBackoff.set(peerId, {
+      failures,
+      nextRetryAt: Date.now() + jittered,
+    });
   }
 
   /**
@@ -3790,68 +3847,20 @@ export class DKGAgent {
         }
         return this.getOrCreateSyncVerifyWorker().parseAndFilter(nquadsText, targetGraphUri, targetContextGraphId);
       },
-      // rc.9 PR-E: route page fetches through `messenger.sendReliable`
-      // so the sync RPC gets the same ReliableEnvelope wrapping +
-      // outbox + (best-effort) sender-side idempotency cache as the
-      // other migrated protocols (chat, access, query-remote,
-      // storage-ack, verify-proposal, join-request). Pre-PR-E this
-      // used `messenger.sendToPeer` — the raw pass-through — which
-      // gave the new /dkg/10.0.1/sync wire ID none of the substrate
-      // semantics it was named for.
-      //
-      // Sync RPC is synchronous-by-contract: the caller needs the
-      // page bytes back NOW to advance pagination. `queued=true`
-      // means the request landed in the durable outbox but no
-      // response is available yet — the page-fetch layer treats
-      // that as a hard failure for this attempt; the surrounding
-      // `withRetry` (in sync-transport.ts) handles the retry +
-      // backoff loop.
-      //
-      // `messageId` is freshly minted on every retry attempt by
-      // sync-transport.ts (codex review on #569 follow-ups #1-#8
-      // explored stable messageIds and found that every variant
-      // either defeated dedup OR enabled silent replay of stale
-      // responses past sync's app-layer freshness gate; fresh
-      // per-attempt is the only design that holds under all timing
-      // scenarios). The trade-off is no sender-side dedup of
-      // retry-storms — the responder may run a SPARQL page query
-      // up to `syncPageRetryAttempts` times if all attempts
-      // succeed at the receiver but the responses are lost in
-      // transit. Bounded waste, app-layer idempotent, acceptable.
-      //
-      // Known residual concern (codex review #569 follow-up #10,
-      // deferred): recoverable sync send failures land in the
-      // Messenger's shared outbox with the default 24h max-age.
-      // Sync envelopes carry their own 90s freshness TTL
-      // (`SYNC_AUTH_MAX_AGE_MS`), so any outbox-delivered envelope
-      // past that window is denied by the receiver — wasted tick
-      // work, but NOT a correctness problem because fresh
-      // messageIds prevent the cached denial from ever replaying
-      // onto a different attempt. A per-call `maxAgeMs` was
-      // explored, but `Messenger.sendReliable`'s
-      // `enqueueFailure` path doesn't currently read
-      // `opts.maxAgeMs` (only the instance-wide setting at
-      // construction time), so wiring it through is out of scope
-      // for this PR. Also out of scope: extending
-      // `getPeerDiagnostics()` to include per-protocol queued
-      // counts so stuck sync catch-up is observable in the MCP
-      // health endpoint (today only `PROTOCOL_MESSAGE` queued
-      // entries are reported there). Both follow-ups are tracked
-      // for rc.10.
-      send: async (peerId, protocolId, data, sendTimeoutMs, messageId) => {
-        const result = await this.messenger.sendReliable(peerId, protocolId, data, {
-          timeoutMs: sendTimeoutMs,
-          messageId,
-        });
-        if (!result.delivered) {
-          throw new Error(
-            `Sync send to ${peerId} ${
-              result.queued ? 'queued (not synchronously deliverable)' : 'failed'
-            }: ${result.error ?? 'unknown'}`,
-          );
-        }
-        return result.response;
-      },
+      // Sync sends via the raw `messenger.sendToPeer` pass-through
+      // (ProtocolRouter.send), NOT `sendReliable`: /dkg/10.0.2/sync is
+      // off the Universal Messenger substrate so its large, never-reused
+      // page responses are not cached in message_idempotency (the
+      // ~2.9 GB node-ui.db bloat — see PROTOCOL_SYNC declaration). Sync
+      // RPC is synchronous-by-contract (the caller needs the page bytes
+      // back NOW to advance pagination); `sendToPeer` returns the
+      // response bytes directly, and sync's own `withRetry`
+      // (sync-transport.ts) handles retry + backoff. The per-attempt
+      // `messageId` minted by sync-transport.ts is now unused by this
+      // adapter — harmless, left in place to keep the transport surface
+      // stable (reverts rc.9 PR-E for sync only).
+      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId) =>
+        this.messenger.sendToPeer(peerId, protocolId, data, { timeoutMs: sendTimeoutMs }),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),
@@ -21507,14 +21516,13 @@ export class DKGAgent {
     // consumers expect. Preserved as-is so we don't break that
     // contract.
     //
-    // The new `byProtocol` map (rc.9 PR-E codex follow-up #10)
-    // surfaces queued entries for EVERY protocol the substrate
-    // now carries, including sync (`/dkg/10.0.1/sync` migrated in
-    // this PR). Without it, stuck sync catch-up — or any future
-    // protocol-substrate migration — would be invisible in
-    // operator diagnostics. Each per-protocol summary mirrors the
-    // top-level summary's shape so tooling can render a per-
-    // protocol view with zero extra plumbing.
+    // The `byProtocol` map surfaces queued entries for EVERY protocol
+    // the substrate carries (chat, swm-*, access, etc.). Note sync is
+    // NOT on the substrate (it runs raw over /dkg/10.0.2/sync), so it
+    // never appears here — stuck sync catch-up is observed via the
+    // reconciler/backoff path, not the outbox. Each per-protocol summary
+    // mirrors the top-level summary's shape so tooling can render a
+    // per-protocol view with zero extra plumbing.
     const peerEntries = this.messenger
       .listOutbox()
       .filter((entry) => entry.peer === peerKey)
@@ -21543,12 +21551,11 @@ export class DKGAgent {
     };
 
     const protocols = peerStoreSnapshot?.protocols ?? [];
-    // rc.9 PR-E: tracks the active `PROTOCOL_SYNC` constant rather
-    // than the literal `/dkg/10.0.0/sync`, so a node running rc.9+
-    // (advertising `/dkg/10.0.1/sync`) is correctly reported as
-    // sync-capable. Hard cutover — legacy `/dkg/10.0.0/sync`-only
-    // peers are no longer compatible and intentionally report
-    // syncCapable=false.
+    // Tracks the active `PROTOCOL_SYNC` constant (now `/dkg/10.0.2/sync`
+    // after sync moved off the messenger substrate), so a node
+    // advertising the current protocol is reported sync-capable. Hard
+    // cutover — peers on the older `/sync` wire ID are no longer
+    // compatible and intentionally report syncCapable=false.
     const syncCapable = protocols.includes(PROTOCOL_SYNC);
 
     return {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3556,6 +3556,7 @@ export class DKGAgent {
    * (`onPeerSynced`) or disconnect (`connection:close`).
    */
   private recordSyncReconcilerFailure(peerId: string): void {
+    if (!this.started || !this.isPeerConnectedForSyncBackoff(peerId)) return;
     const failures = (this.syncReconcilerBackoff.get(peerId)?.failures ?? 0) + 1;
     // Clamp the exponent so `2 ** exp` can never overflow before the cap.
     const exp = Math.min(failures - 1, 30);
@@ -3565,6 +3566,14 @@ export class DKGAgent {
       failures,
       nextRetryAt: Date.now() + jittered,
     });
+  }
+
+  private isPeerConnectedForSyncBackoff(peerId: string): boolean {
+    try {
+      return this.node.libp2p.getPeers().some((pid) => pid.toString() === peerId);
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -21410,6 +21419,12 @@ export class DKGAgent {
         health: null,
         protocols: [],
         syncCapable: false,
+        syncStatus: {
+          capable: false,
+          lastSuccessfulSyncAt: null,
+          stale: true,
+          backoff: null,
+        },
       };
     }
 
@@ -21557,6 +21572,21 @@ export class DKGAgent {
     // cutover — peers on the older `/sync` wire ID are no longer
     // compatible and intentionally report syncCapable=false.
     const syncCapable = protocols.includes(PROTOCOL_SYNC);
+    const now = Date.now();
+    const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(peerKey) ?? null;
+    const backoff = this.syncReconcilerBackoff.get(peerKey) ?? null;
+    const syncStatus = {
+      capable: syncCapable,
+      lastSuccessfulSyncAt: lastSuccessfulSync,
+      stale: lastSuccessfulSync == null || (now - lastSuccessfulSync) >= SYNC_STALENESS_THRESHOLD_MS,
+      backoff: backoff
+        ? {
+            failures: backoff.failures,
+            nextRetryAt: backoff.nextRetryAt,
+            retryInMs: Math.max(0, backoff.nextRetryAt - now),
+          }
+        : null,
+    };
 
     return {
       peerId: peerKey,
@@ -21569,6 +21599,7 @@ export class DKGAgent {
       health: this.peerHealth.get(peerKey) ?? null,
       protocols,
       syncCapable,
+      syncStatus,
     };
   }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -202,7 +202,7 @@ import { runSharedMemorySync } from './sync/requester/shared-memory-sync.js';
 import { buildSyncRequestEnvelope, type SyncPhase } from './sync/auth/request-build.js';
 import { authorizePrivateSyncRequest } from './sync/auth/request-authorize.js';
 import { registerSyncHandler } from './sync/responder/sync-handler.js';
-import { runSyncOnConnect } from './sync/on-connect/sync-on-connect.js';
+import { runSyncOnConnect, type SyncOnConnectOutcome } from './sync/on-connect/sync-on-connect.js';
 import {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,
   ensureWorkspaceEncryptionKey,
@@ -3448,12 +3448,11 @@ export class DKGAgent {
    * them into our local store. Used on peer:connect for initial catch-up,
    * with a per-peer guard to avoid overlapping sync storms.
    */
-  private async trySyncFromPeer(remotePeer: string): Promise<'attempted' | 'skipped-no-sync' | 'not-started'> {
+  private async trySyncFromPeer(remotePeer: string): Promise<SyncOnConnectOutcome | 'not-started'> {
     if (!this.started) {
       return 'not-started';
     }
-    let skippedNoSync = false;
-    await runSyncOnConnect({
+    return runSyncOnConnect({
       remotePeer,
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
@@ -3466,7 +3465,6 @@ export class DKGAgent {
       syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
-        skippedNoSync = true;
         this.skippedNoSyncPeers.add(peerId);
       },
       onPeerSynced: (peerId) => {
@@ -3475,7 +3473,6 @@ export class DKGAgent {
         this.syncReconcilerBackoff.delete(peerId);
       },
     });
-    return skippedNoSync ? 'skipped-no-sync' : 'attempted';
   }
 
   /**
@@ -3542,14 +3539,17 @@ export class DKGAgent {
       // peers are never delayed.
       const backoff = this.syncReconcilerBackoff.get(peerId);
       const probe = await this.getSyncReconcilerProbe(peerId);
-      if (backoff && now < backoff.nextRetryAt && !this.hasSyncReconcilerProbeChanged(backoff, probe)) {
-        continue;
+      if (backoff && now < backoff.nextRetryAt) {
+        if (!this.hasSyncReconcilerProbeChanged(backoff, probe)) {
+          continue;
+        }
+        this.syncReconcilerBackoff.delete(peerId);
       }
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       this.trySyncFromPeer(peerId)
         .then((outcome) => {
-          if (outcome === 'skipped-no-sync') {
+          if (outcome === 'skipped-no-sync' || outcome === 'already-syncing' || outcome === 'not-started') {
             return;
           }
           // `onPeerSynced` clears the backoff on a real success. If the

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -39,12 +39,14 @@ export type SyncOnConnectOutcome = 'synced' | 'skipped-no-sync' | 'already-synci
 
 export class SyncOnConnectPostSyncError extends Error {
   readonly originalError: unknown;
+  readonly backoffEligible: boolean;
 
-  constructor(remotePeer: string, originalError: unknown) {
+  constructor(remotePeer: string, originalError: unknown, options: { backoffEligible: boolean }) {
     const detail = originalError instanceof Error ? originalError.message : String(originalError);
     super(`post-sync step failed for peer ${remotePeer.slice(-8)}: ${detail}`);
     this.name = 'SyncOnConnectPostSyncError';
     this.originalError = originalError;
+    this.backoffEligible = options.backoffEligible;
   }
 }
 
@@ -74,7 +76,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     try {
       return await step();
     } catch (err) {
-      throw new SyncOnConnectPostSyncError(remotePeer, err);
+      throw new SyncOnConnectPostSyncError(remotePeer, err, { backoffEligible: false });
     }
   };
 
@@ -133,7 +135,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       throw err;
     }
     if (durableSyncCompleted) {
-      throw new SyncOnConnectPostSyncError(remotePeer, err);
+      throw new SyncOnConnectPostSyncError(remotePeer, err, { backoffEligible: true });
     }
     throw err;
   } finally {

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -70,6 +70,14 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
   syncingPeers.add(remotePeer);
 
   let durableSyncCompleted = false;
+  const runNonTransportStep = async <T>(step: () => Promise<T>): Promise<T> => {
+    try {
+      return await step();
+    } catch (err) {
+      throw new SyncOnConnectPostSyncError(remotePeer, err);
+    }
+  };
+
   try {
     const protocols = await getPeerProtocols(remotePeer);
 
@@ -89,7 +97,6 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(getSyncContextGraphs() ?? []);
     const synced = await syncFromPeer(remotePeer);
-    durableSyncCompleted = true;
     logInfo(ctx, `Synced ${synced} data triples from peer ${shortPeer}`);
 
     const syncScope = new Set<string>([
@@ -97,9 +104,9 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
       ...(getSyncContextGraphs() ?? []),
     ]);
-    await refreshMetaSyncedFlags(syncScope);
+    await runNonTransportStep(() => refreshMetaSyncedFlags(syncScope));
 
-    await discoverContextGraphsFromStore();
+    await runNonTransportStep(() => discoverContextGraphsFromStore());
 
     const allCgsAfter = getSyncContextGraphs() ?? [];
     const newlyDiscovered = allCgsAfter.filter((id) => !knownCgsBefore.has(id));
@@ -107,9 +114,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Discovered ${newlyDiscovered.length} new CG(s) — syncing durable data from ${shortPeer}`);
       const discoverSynced = await syncFromPeer(remotePeer, newlyDiscovered);
       logInfo(ctx, `Synced ${discoverSynced} durable triples for newly discovered CG(s) from ${shortPeer}`);
-      await refreshMetaSyncedFlags(newlyDiscovered);
+      await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));
     }
 
+    durableSyncCompleted = true;
     const wsContextGraphIds = getSyncContextGraphs() ?? [];
     if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
@@ -121,6 +129,9 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     context.onPeerSynced?.(remotePeer);
     return 'synced';
   } catch (err) {
+    if (err instanceof SyncOnConnectPostSyncError) {
+      throw err;
+    }
     if (durableSyncCompleted) {
       throw new SyncOnConnectPostSyncError(remotePeer, err);
     }

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -37,6 +37,17 @@ interface SyncOnConnectContext {
 
 export type SyncOnConnectOutcome = 'synced' | 'skipped-no-sync' | 'already-syncing';
 
+export class SyncOnConnectPostSyncError extends Error {
+  readonly originalError: unknown;
+
+  constructor(remotePeer: string, originalError: unknown) {
+    const detail = originalError instanceof Error ? originalError.message : String(originalError);
+    super(`post-sync step failed for peer ${remotePeer.slice(-8)}: ${detail}`);
+    this.name = 'SyncOnConnectPostSyncError';
+    this.originalError = originalError;
+  }
+}
+
 export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnConnectOutcome> {
   const {
     remotePeer,
@@ -58,6 +69,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
   if (syncingPeers.has(remotePeer)) return 'already-syncing';
   syncingPeers.add(remotePeer);
 
+  let durableSyncCompleted = false;
   try {
     const protocols = await getPeerProtocols(remotePeer);
 
@@ -77,6 +89,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
     const knownCgsBefore = new Set(getSyncContextGraphs() ?? []);
     const synced = await syncFromPeer(remotePeer);
+    durableSyncCompleted = true;
     logInfo(ctx, `Synced ${synced} data triples from peer ${shortPeer}`);
 
     const syncScope = new Set<string>([
@@ -107,6 +120,11 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
 
     context.onPeerSynced?.(remotePeer);
     return 'synced';
+  } catch (err) {
+    if (durableSyncCompleted) {
+      throw new SyncOnConnectPostSyncError(remotePeer, err);
+    }
+    throw err;
   } finally {
     syncingPeers.delete(remotePeer);
   }

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -35,7 +35,9 @@ interface SyncOnConnectContext {
   onPeerSynced?: (peerId: string) => void;
 }
 
-export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<void> {
+export type SyncOnConnectOutcome = 'synced' | 'skipped-no-sync' | 'already-syncing';
+
+export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<SyncOnConnectOutcome> {
   const {
     remotePeer,
     syncingPeers,
@@ -53,7 +55,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<v
   const ctx = createOperationContext('sync');
   const shortPeer = remotePeer.slice(-8);
 
-  if (syncingPeers.has(remotePeer)) return;
+  if (syncingPeers.has(remotePeer)) return 'already-syncing';
   syncingPeers.add(remotePeer);
 
   try {
@@ -69,7 +71,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<v
     if (!hasSync) {
       logInfo(ctx, `Peer ${shortPeer} does not support sync protocol (protocols: ${protocols.join(', ')})`);
       context.onPeerSkippedNoSync?.(remotePeer, protocols);
-      return;
+      return 'skipped-no-sync';
     }
 
     logInfo(ctx, `Syncing from peer ${shortPeer}...`);
@@ -104,6 +106,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<v
     }
 
     context.onPeerSynced?.(remotePeer);
+    return 'synced';
   } finally {
     syncingPeers.delete(remotePeer);
   }

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -51,16 +51,18 @@ interface FetchSyncPagesParams {
   sinceBatchId?: string;
   parseAndFilter: (nquadsText: string, graphUri: string, contextGraphId: string) => Promise<{ quads: Quad[]; totalQuads: number }>;
   /**
-   * Per-attempt send hook. The substrate-backed implementation
-   * (`DKGAgent`'s adapter routing through `messenger.sendReliable`)
-   * receives a fresh `messageId` on EVERY retry attempt. Stable
-   * messageIds were explored on this PR (codex review #569
-   * follow-ups #1, #4, #5, #6, #7, #8) but every variant either
-   * defeated sender-side dedup OR enabled silent replay of stale
-   * cached responses past sync's app-layer freshness gate
-   * (`SYNC_AUTH_MAX_AGE_MS`). Fresh-per-attempt is the only design
-   * that holds under all timing scenarios — see jsdoc on
-   * `sendSyncRequest` for the full rationale.
+   * Per-attempt send hook. `DKGAgent`'s production adapter sends raw
+   * via `messenger.sendToPeer` (ProtocolRouter pass-through), not
+   * `messenger.sendReliable`, because sync is intentionally off the
+   * Universal Messenger substrate. `sendSyncRequest` still mints a
+   * fresh `messageId` per retry attempt for transport-surface
+   * stability and older test adapters that record it. Stable IDs were
+   * explored on this PR (codex review #569 follow-ups #1, #4, #5,
+   * #6, #7, #8) but every variant either defeated sender-side dedup OR
+   * enabled silent replay of stale cached responses past sync's
+   * app-layer freshness gate (`SYNC_AUTH_MAX_AGE_MS`). Fresh-per-
+   * attempt is the only design that holds under all timing scenarios —
+   * see jsdoc on `sendSyncRequest` for the full rationale.
    */
   send: (
     peerId: string,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -6,23 +6,18 @@ import type { SyncRequestEnvelope } from '../auth/request-build.js';
 
 interface RegisterSyncHandlerParams {
   /**
-   * Substrate `register` callable. In production this is bound to
-   * `Messenger.register`, so the wrapped handler receives an
-   * envelope-unwrapped payload + a string `peerId` and benefits from
-   * receiver-side idempotency dedup + envelope versioning (rc.9
-   * PR-E migration to `/dkg/10.0.1/sync`).
+   * `register` callable. In production this is bound to the RAW
+   * ProtocolRouter (via an adapter that re-exposes the string `peerId`),
+   * NOT `Messenger.register`: sync runs off the Universal Messenger
+   * substrate on `/dkg/10.0.2/sync` so its large, never-reused page
+   * responses are not cached in message_idempotency (the node-ui.db
+   * bloat fix). The handler receives the bare payload — exactly the
+   * auth envelope `parseSyncRequest` expects — and returns the response
+   * bytes for the router to send.
    *
    * In tests this can be any callable matching the signature; the
    * caller doesn't need to provide a real ProtocolRouter or full
    * Messenger.
-   *
-   * Before PR-E this was `router: { register }` with a peerId
-   * `{ toString(): string }` object — Codex caught that bumping the
-   * advertised `/sync` protocol ID without also moving the sender/
-   * receiver onto the substrate left the new ID without
-   * ReliableEnvelope/dedup/outbox semantics. Migrating the handler
-   * here is half of the fix (the other half is the requester-side
-   * `sendReliable` swap in dkg-agent.ts:fetchSyncPages).
    */
   register: (
     protocolId: string,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -8,8 +8,8 @@ interface RegisterSyncHandlerParams {
   /**
    * `register` callable. In production this is bound to the RAW
    * ProtocolRouter (via an adapter that re-exposes the string `peerId`),
-   * NOT `Messenger.register`: sync runs off the Universal Messenger
-   * substrate on `/dkg/10.0.2/sync` so its large, never-reused page
+   * NOT `Messenger.register`: sync runs outside the Universal Messenger
+   * substrate as raw `/dkg/10.0.2/sync` so its large, never-reused page
    * responses are not cached in message_idempotency (the node-ui.db
    * bloat fix). The handler receives the bare payload — exactly the
    * auth envelope `parseSyncRequest` expects — and returns the response

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -94,7 +94,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       // received zero bytes of any sub-graph SWM the responder had
       // locally, so a late joiner who joined AFTER the curator had
       // published into a sub-graph could not backfill that history
-      // through `/dkg/10.0.1/sync` — see the SWM late-joiner backfill
+      // through `PROTOCOL_SYNC` — see the SWM late-joiner backfill
       // gap (urn:dkg:finding:swm-gap-2-subgraph-blind-spot). Filter
       // by URI shape under the CG prefix and emit `?g` per binding so
       // the requester reconstructs the correct graph at write time.

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -85,6 +85,7 @@ function makeAgentLike({
   health,
   lastSuccessfulSyncAt,
   syncReconcilerBackoff,
+  peerIds,
 }: {
   rawConnections: StubConnection[];
   keyedConnectionsByPeer?: Map<string, StubConnection[]>;
@@ -109,6 +110,7 @@ function makeAgentLike({
   health?: Map<string, any>;
   lastSuccessfulSyncAt?: Map<string, number>;
   syncReconcilerBackoff?: Map<string, { failures: number; nextRetryAt: number }>;
+  peerIds?: string[];
 }): any {
   return {
     node: {
@@ -118,6 +120,7 @@ function makeAgentLike({
           const key = (arg as { toString: () => string }).toString();
           return keyedConnectionsByPeer?.get(key) ?? [];
         }),
+        getPeers: vi.fn(() => (peerIds ?? []).map((id) => ({ toString: () => id }))),
         peerStore: {
           get: vi.fn(async (pid: any) => {
             const key = pid.toString();
@@ -387,6 +390,44 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         expect(diag.syncStatus).toEqual({
           capable: false,
           capability: 'unknown',
+          lastSuccessfulSyncAt: null,
+          stale: true,
+          backoff: {
+            failures: 2,
+            nextRetryAt: 1_010_000,
+            retryInMs: 10_000,
+          },
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('keeps sync health observable when getPeers shows a live peer without raw connections', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        const agentLike = makeAgentLike({
+          rawConnections: [],
+          peerIds: [PEER_A],
+          peerStoreEntries: new Map([
+            [
+              PEER_A,
+              {
+                addresses: [],
+                protocols: [PROTOCOL_SYNC],
+              },
+            ],
+          ]),
+          syncReconcilerBackoff: new Map([[PEER_A, { failures: 2, nextRetryAt: 1_010_000 }]]),
+        });
+        const diag = await callDiagnostics(agentLike, PEER_A);
+
+        expect(diag.connected).toBe(true);
+        expect(diag.rawConnectionCount).toBe(0);
+        expect(diag.getConnectionsReturnsForPeer).toBe(0);
+        expect(diag.syncStatus).toEqual({
+          capable: true,
+          capability: 'supported',
           lastSuccessfulSyncAt: null,
           stale: true,
           backoff: {

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -272,7 +272,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       // (`/dkg/10.0.2/sync` after sync left the messenger substrate).
       // A peer advertising the current protocol is reported sync-capable.
       const agentLike = makeAgentLike({
-        rawConnections: [],
+        rawConnections: [makeStubConn(PEER_A)],
         peerStoreEntries: new Map([
           [
             PEER_A,
@@ -290,7 +290,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       expect(diag.peerStore).toEqual({
         knownMultiaddrCount: 2,
         multiaddrs: ['/ip4/1.2.3.4/tcp/4001', `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}`],
-        protocols: ['/dkg/10.0.2/sync', '/dkg/10.0.1/message'],
+        protocols: [PROTOCOL_SYNC, PROTOCOL_MESSAGE],
         // No `metadata` provided in the stub → identify hasn't run
         // → both version fields null (rc.11 follow-up).
         nodeVersion: null,
@@ -300,6 +300,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       expect(diag.syncCapable).toBe(true);
       expect(diag.syncStatus).toEqual({
         capable: true,
+        capability: 'supported',
         lastSuccessfulSyncAt: null,
         stale: true,
         backoff: null,
@@ -310,7 +311,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
       try {
         const agentLike = makeAgentLike({
-          rawConnections: [],
+          rawConnections: [makeStubConn(PEER_A)],
           peerStoreEntries: new Map([
             [
               PEER_A,
@@ -327,6 +328,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         expect(diag.syncCapable).toBe(false);
         expect(diag.syncStatus).toEqual({
           capable: false,
+          capability: 'unsupported',
           lastSuccessfulSyncAt: null,
           stale: false,
           backoff: null,
@@ -340,7 +342,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
       try {
         const agentLike = makeAgentLike({
-          rawConnections: [],
+          rawConnections: [makeStubConn(PEER_A)],
           peerStoreEntries: new Map([
             [
               PEER_A,
@@ -356,6 +358,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         const diag = await callDiagnostics(agentLike, PEER_A);
         expect(diag.syncStatus).toEqual({
           capable: true,
+          capability: 'supported',
           lastSuccessfulSyncAt: 100_000,
           stale: true,
           backoff: {
@@ -368,6 +371,60 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       } finally {
         nowSpy.mockRestore();
       }
+    });
+
+    it('keeps connected cold-cache peers observable as unknown sync capability', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        const agentLike = makeAgentLike({
+          rawConnections: [makeStubConn(PEER_A)],
+          peerStoreEntries: new Map(),
+          syncReconcilerBackoff: new Map([[PEER_A, { failures: 2, nextRetryAt: 1_010_000 }]]),
+        });
+        const diag = await callDiagnostics(agentLike, PEER_A);
+
+        expect(diag.syncCapable).toBe(false);
+        expect(diag.syncStatus).toEqual({
+          capable: false,
+          capability: 'unknown',
+          lastSuccessfulSyncAt: null,
+          stale: true,
+          backoff: {
+            failures: 2,
+            nextRetryAt: 1_010_000,
+            retryInMs: 10_000,
+          },
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('does not report disconnected peers as stale from cached sync protocols alone', async () => {
+      const agentLike = makeAgentLike({
+        rawConnections: [],
+        peerStoreEntries: new Map([
+          [
+            PEER_A,
+            {
+              addresses: [],
+              protocols: [PROTOCOL_SYNC],
+            },
+          ],
+        ]),
+        lastSuccessfulSyncAt: new Map([[PEER_A, Date.now() - 20 * 60_000]]),
+        syncReconcilerBackoff: new Map([[PEER_A, { failures: 2, nextRetryAt: Date.now() + 100_000 }]]),
+      });
+      const diag = await callDiagnostics(agentLike, PEER_A);
+
+      expect(diag.connected).toBe(false);
+      expect(diag.syncStatus).toEqual({
+        capable: true,
+        capability: 'supported',
+        lastSuccessfulSyncAt: expect.any(Number),
+        stale: false,
+        backoff: null,
+      });
     });
 
     // rc.11 follow-up to the "version on the wire" gap surfaced during
@@ -624,6 +681,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         syncCapable: false,
         syncStatus: {
           capable: false,
+          capability: 'unknown',
           lastSuccessfulSyncAt: null,
           stale: false,
           backoff: null,

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -18,7 +18,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DKGAgent } from '../src/dkg-agent.js';
-import { PROTOCOL_MESSAGE, type ProtocolOutboxEntry } from '@origintrail-official/dkg-core';
+import { PROTOCOL_MESSAGE, PROTOCOL_SYNC, type ProtocolOutboxEntry } from '@origintrail-official/dkg-core';
 
 interface StubOutboxEntry {
   peer: string;
@@ -281,7 +281,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
                 { multiaddr: { toString: () => '/ip4/1.2.3.4/tcp/4001' } },
                 { multiaddr: { toString: () => `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}` } },
               ],
-              protocols: ['/dkg/10.0.2/sync', '/dkg/10.0.1/message'],
+              protocols: [PROTOCOL_SYNC, PROTOCOL_MESSAGE],
             },
           ],
         ]),
@@ -296,7 +296,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         nodeVersion: null,
         protocolVersion: null,
       });
-      expect(diag.protocols).toEqual(['/dkg/10.0.2/sync', '/dkg/10.0.1/message']);
+      expect(diag.protocols).toEqual([PROTOCOL_SYNC, PROTOCOL_MESSAGE]);
       expect(diag.syncCapable).toBe(true);
       expect(diag.syncStatus).toEqual({
         capable: true,
@@ -304,6 +304,36 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         stale: true,
         backoff: null,
       });
+    });
+
+    it('does not mark peers that lack the current sync protocol as stale', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        const agentLike = makeAgentLike({
+          rawConnections: [],
+          peerStoreEntries: new Map([
+            [
+              PEER_A,
+              {
+                addresses: [],
+                protocols: ['/dkg/10.0.1/sync'],
+              },
+            ],
+          ]),
+          syncReconcilerBackoff: new Map([[PEER_A, { failures: 2, nextRetryAt: 1_010_000 }]]),
+        });
+        const diag = await callDiagnostics(agentLike, PEER_A);
+
+        expect(diag.syncCapable).toBe(false);
+        expect(diag.syncStatus).toEqual({
+          capable: false,
+          lastSuccessfulSyncAt: null,
+          stale: false,
+          backoff: null,
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it('surfaces raw sync status separately from substrate outbox state', async () => {
@@ -316,7 +346,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
               PEER_A,
               {
                 addresses: [],
-                protocols: ['/dkg/10.0.2/sync'],
+                protocols: [PROTOCOL_SYNC],
               },
             ],
           ]),
@@ -595,7 +625,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         syncStatus: {
           capable: false,
           lastSuccessfulSyncAt: null,
-          stale: true,
+          stale: false,
           backoff: null,
         },
       });

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -83,6 +83,8 @@ function makeAgentLike({
   peerStoreEntries,
   outboxEntries,
   health,
+  lastSuccessfulSyncAt,
+  syncReconcilerBackoff,
 }: {
   rawConnections: StubConnection[];
   keyedConnectionsByPeer?: Map<string, StubConnection[]>;
@@ -105,6 +107,8 @@ function makeAgentLike({
   >;
   outboxEntries?: StubOutboxEntry[];
   health?: Map<string, any>;
+  lastSuccessfulSyncAt?: Map<string, number>;
+  syncReconcilerBackoff?: Map<string, { failures: number; nextRetryAt: number }>;
 }): any {
   return {
     node: {
@@ -126,6 +130,8 @@ function makeAgentLike({
     },
     messenger: makeOutboxStub(outboxEntries ?? []),
     peerHealth: health ?? new Map(),
+    lastSuccessfulSyncAt: lastSuccessfulSyncAt ?? new Map(),
+    syncReconcilerBackoff: syncReconcilerBackoff ?? new Map(),
   };
 }
 
@@ -292,6 +298,46 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       });
       expect(diag.protocols).toEqual(['/dkg/10.0.2/sync', '/dkg/10.0.1/message']);
       expect(diag.syncCapable).toBe(true);
+      expect(diag.syncStatus).toEqual({
+        capable: true,
+        lastSuccessfulSyncAt: null,
+        stale: true,
+        backoff: null,
+      });
+    });
+
+    it('surfaces raw sync status separately from substrate outbox state', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        const agentLike = makeAgentLike({
+          rawConnections: [],
+          peerStoreEntries: new Map([
+            [
+              PEER_A,
+              {
+                addresses: [],
+                protocols: ['/dkg/10.0.2/sync'],
+              },
+            ],
+          ]),
+          lastSuccessfulSyncAt: new Map([[PEER_A, 100_000]]),
+          syncReconcilerBackoff: new Map([[PEER_A, { failures: 3, nextRetryAt: 1_010_000 }]]),
+        });
+        const diag = await callDiagnostics(agentLike, PEER_A);
+        expect(diag.syncStatus).toEqual({
+          capable: true,
+          lastSuccessfulSyncAt: 100_000,
+          stale: true,
+          backoff: {
+            failures: 3,
+            nextRetryAt: 1_010_000,
+            retryInMs: 10_000,
+          },
+        });
+        expect(diag.outbox.byProtocol).toEqual({});
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     // rc.11 follow-up to the "version on the wire" gap surfaced during
@@ -546,6 +592,12 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         peerStore: null,
         protocols: [],
         syncCapable: false,
+        syncStatus: {
+          capable: false,
+          lastSuccessfulSyncAt: null,
+          stale: true,
+          backoff: null,
+        },
       });
     });
 

--- a/packages/agent/test/dkg-agent-diagnostics.test.ts
+++ b/packages/agent/test/dkg-agent-diagnostics.test.ts
@@ -262,9 +262,9 @@ describe('DKGAgent.getPeerDiagnostics', () => {
     });
 
     it('extracts multiaddrs + protocols from a populated peerStore entry', async () => {
-      // rc.9 PR-E: `syncCapable` now tracks the current PROTOCOL_SYNC
-      // wire ID (`/dkg/10.0.1/sync`), not the legacy `/dkg/10.0.0/sync`.
-      // A peer advertising the bumped protocol is reported sync-capable.
+      // `syncCapable` tracks the current PROTOCOL_SYNC wire ID
+      // (`/dkg/10.0.2/sync` after sync left the messenger substrate).
+      // A peer advertising the current protocol is reported sync-capable.
       const agentLike = makeAgentLike({
         rawConnections: [],
         peerStoreEntries: new Map([
@@ -275,7 +275,7 @@ describe('DKGAgent.getPeerDiagnostics', () => {
                 { multiaddr: { toString: () => '/ip4/1.2.3.4/tcp/4001' } },
                 { multiaddr: { toString: () => `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}` } },
               ],
-              protocols: ['/dkg/10.0.1/sync', '/dkg/10.0.1/message'],
+              protocols: ['/dkg/10.0.2/sync', '/dkg/10.0.1/message'],
             },
           ],
         ]),
@@ -284,13 +284,13 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       expect(diag.peerStore).toEqual({
         knownMultiaddrCount: 2,
         multiaddrs: ['/ip4/1.2.3.4/tcp/4001', `/ip4/5.6.7.8/tcp/4001/p2p/${PEER_A}`],
-        protocols: ['/dkg/10.0.1/sync', '/dkg/10.0.1/message'],
+        protocols: ['/dkg/10.0.2/sync', '/dkg/10.0.1/message'],
         // No `metadata` provided in the stub → identify hasn't run
         // → both version fields null (rc.11 follow-up).
         nodeVersion: null,
         protocolVersion: null,
       });
-      expect(diag.protocols).toEqual(['/dkg/10.0.1/sync', '/dkg/10.0.1/message']);
+      expect(diag.protocols).toEqual(['/dkg/10.0.2/sync', '/dkg/10.0.1/message']);
       expect(diag.syncCapable).toBe(true);
     });
 
@@ -437,11 +437,12 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         // 2x chat (newer + older)
         makeOutboxEntry({ peer: PEER_A, messageId: 'chat-1', attempts: 1, firstFailureAt: 2000 }),
         makeOutboxEntry({ peer: PEER_A, messageId: 'chat-2', attempts: 2, firstFailureAt: 1000 }),
-        // 1x sync (the migration this PR ships)
+        // 1x swm-update (a protocol still carried by the substrate;
+        // sync itself is no longer on the substrate so it can't appear here)
         makeOutboxEntry({
           peer: PEER_A,
-          protocol: '/dkg/10.0.1/sync',
-          messageId: 'sync-1',
+          protocol: '/dkg/10.0.1/swm-update',
+          messageId: 'swm-update-1',
           attempts: 3,
           firstFailureAt: 1500,
         }),
@@ -456,8 +457,8 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         // PEER_B entry — must NOT appear in PEER_A's per-protocol view.
         makeOutboxEntry({
           peer: PEER_B,
-          protocol: '/dkg/10.0.1/sync',
-          messageId: 'sync-other-peer',
+          protocol: '/dkg/10.0.1/swm-update',
+          messageId: 'swm-update-other-peer',
           attempts: 7,
           firstFailureAt: 100,
         }),
@@ -474,9 +475,9 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       expect(Object.keys(diag.outbox.byProtocol).sort()).toEqual([
         '/dkg/10.0.1/message',
         '/dkg/10.0.1/swm-sender-key',
-        '/dkg/10.0.1/sync',
+        '/dkg/10.0.1/swm-update',
       ]);
-      expect(diag.outbox.byProtocol['/dkg/10.0.1/sync']).toEqual({
+      expect(diag.outbox.byProtocol['/dkg/10.0.1/swm-update']).toEqual({
         pendingCount: 1,
         oldestFirstFailureAt: 1500,
         attempts: [3],
@@ -491,23 +492,24 @@ describe('DKGAgent.getPeerDiagnostics', () => {
         oldestFirstFailureAt: 1000,
         attempts: [2, 1],
       });
-      // PEER_B sync entry MUST NOT bleed into PEER_A's per-protocol view.
-      expect(diag.outbox.byProtocol['/dkg/10.0.1/sync'].attempts).not.toContain(7);
+      // PEER_B entry MUST NOT bleed into PEER_A's per-protocol view.
+      expect(diag.outbox.byProtocol['/dkg/10.0.1/swm-update'].attempts).not.toContain(7);
     });
 
     /**
-     * Regression for the exact bug Codex described: "sync catch-up
-     * gets stuck and is invisible in the diagnostics surface". A peer
-     * with ONLY sync queued (no chat) used to report
-     * `outbox.pendingCount=0` and looked healthy. Now sync is visible
-     * in `byProtocol` so operators can tell the difference.
+     * Regression for the diagnostics gap Codex described: a non-chat
+     * substrate protocol stuck in the outbox used to report
+     * `outbox.pendingCount=0` and looked healthy. The per-protocol
+     * `byProtocol` view makes it visible. (Originally written for sync;
+     * sync has since left the substrate, so this uses swm-update — any
+     * substrate protocol exercises the same aggregation path.)
      */
-    it('makes a sync-only stuck peer visible in diagnostics (was invisible pre-rc.9 PR-E)', async () => {
+    it('makes a non-chat-only stuck peer visible in diagnostics', async () => {
       const outboxEntries: StubOutboxEntry[] = [
         makeOutboxEntry({
           peer: PEER_A,
-          protocol: '/dkg/10.0.1/sync',
-          messageId: 'sync-stuck',
+          protocol: '/dkg/10.0.1/swm-update',
+          messageId: 'swm-update-stuck',
           attempts: 4,
           firstFailureAt: 7000,
         }),
@@ -520,9 +522,9 @@ describe('DKGAgent.getPeerDiagnostics', () => {
       expect(diag.outbox.pendingCount).toBe(0);
       expect(diag.outbox.oldestFirstFailureAt).toBeNull();
 
-      // But the per-protocol view tells operators that sync IS stuck.
+      // But the per-protocol view tells operators the protocol IS stuck.
       expect(diag.outbox.byProtocol).toEqual({
-        '/dkg/10.0.1/sync': {
+        '/dkg/10.0.1/swm-update': {
           pendingCount: 1,
           oldestFirstFailureAt: 7000,
           attempts: [4],

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -26,7 +26,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 const REMOTE_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 const CG_ID = 'urn:test:cg';
 const GRAPH_URI = `urn:test:cg/graph`;
-const PROTOCOL_ID = '/dkg/10.0.1/sync';
+const PROTOCOL_ID = '/dkg/10.0.2/sync';
 
 function noopLog(): void {}
 function makeCtx(): OperationContext {

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -120,6 +120,7 @@ describe('runSyncOnConnect callbacks', () => {
 
     expect(caught).toBeInstanceOf(SyncOnConnectPostSyncError);
     expect((caught as SyncOnConnectPostSyncError).originalError).toBe(laterError);
+    expect((caught as SyncOnConnectPostSyncError).backoffEligible).toBe(false);
     expect(synced).toEqual([]);
     expect(syncingPeers.has(remotePeer)).toBe(false);
   });
@@ -594,9 +595,9 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     }
   });
 
-  it('does not back off post-sync phase failures', async () => {
+  it('does not back off local post-sync bookkeeping failures', async () => {
     const agent = await DKGAgent.create({
-      name: 'ReconcilerPostSyncFailureNoBackoff',
+      name: 'ReconcilerLocalPostSyncFailureNoBackoff',
       listenHost: '127.0.0.1',
       chainAdapter: new MockChainAdapter(),
     });
@@ -610,13 +611,43 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       );
       vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
       vi.spyOn(agent as any, 'trySyncFromPeer').mockRejectedValue(
-        new SyncOnConnectPostSyncError(peerA, new Error('shared memory failed')),
+        new SyncOnConnectPostSyncError(peerA, new Error('discovery failed'), { backoffEligible: false }),
       );
 
       await (agent as any).reconcileSyncFromConnectedPeers();
       await flushMicrotasks();
 
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('backs off post-sync peer catch-up failures', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerPeerPostSyncFailureBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
+      vi.spyOn(agent as any, 'trySyncFromPeer').mockRejectedValue(
+        new SyncOnConnectPostSyncError(peerA, new Error('shared memory failed'), { backoffEligible: true }),
+      );
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      const backoff = (agent as any).syncReconcilerBackoff.get(peerA);
+      expect(backoff?.failures).toBe(1);
+      expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { PROTOCOL_SYNC, PROTOCOL_ACCESS } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
@@ -329,10 +329,72 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       await agent.stop().catch(() => {});
     }
   });
+
+  it('backs off a never-successful peer exponentially and skips it until the retry window elapses', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+
+      const calls: string[] = [];
+      // Resolve WITHOUT stamping lastSuccessfulSyncAt: the reconciler
+      // then treats every attempt as a failure (mirrors a dead /
+      // stream-resetting peer that never completes a sync).
+      (agent as any).trySyncFromPeer = async (peerId: string) => {
+        calls.push(peerId);
+      };
+
+      const backoffMap = (agent as any).syncReconcilerBackoff as Map<
+        string,
+        { failures: number; nextRetryAt: number }
+      >;
+
+      // Tick 1: never synced → fires once and records failure #1.
+      const t1 = Date.now();
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await new Promise(r => setTimeout(r, 50));
+      expect(calls).toEqual([peerA]);
+      const b1 = backoffMap.get(peerA)!;
+      expect(b1.failures).toBe(1);
+      const delay1 = b1.nextRetryAt - t1;
+      expect(delay1).toBeGreaterThan(0);
+
+      // Tick 2 immediately: still inside the backoff window → skipped.
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await new Promise(r => setTimeout(r, 50));
+      expect(calls).toEqual([peerA]);
+      expect(backoffMap.get(peerA)!.failures).toBe(1);
+
+      // Force the window to have elapsed, then tick again → fires and
+      // records failure #2 with a strictly larger window (exponential).
+      backoffMap.set(peerA, { failures: 1, nextRetryAt: Date.now() - 1 });
+      const t2 = Date.now();
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await new Promise(r => setTimeout(r, 50));
+      expect(calls).toEqual([peerA, peerA]);
+      const b2 = backoffMap.get(peerA)!;
+      expect(b2.failures).toBe(2);
+      const delay2 = b2.nextRetryAt - t2;
+      // failure-2 window (~10min ±25%) strictly exceeds the failure-1
+      // window (~5min ±25%) even at worst-case jitter (7.5min > 6.25min).
+      expect(delay2).toBeGreaterThan(delay1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });
 
 describe('DKGAgent sync state lifecycle', () => {
-  it('clears skippedNoSyncPeers and lastSuccessfulSyncAt on connection:close', async () => {
+  it('clears skippedNoSyncPeers, lastSuccessfulSyncAt and sync backoff on connection:close', async () => {
     const agent = await DKGAgent.create({
       name: 'ConnectionCloseClearsState',
       listenHost: '127.0.0.1',
@@ -344,6 +406,7 @@ describe('DKGAgent sync state lifecycle', () => {
       const remotePeer = freshPeerIdString();
       (agent as any).skippedNoSyncPeers.add(remotePeer);
       (agent as any).lastSuccessfulSyncAt.set(remotePeer, Date.now());
+      (agent as any).syncReconcilerBackoff.set(remotePeer, { failures: 3, nextRetryAt: Date.now() + 100_000 });
 
       // Stub getPeers so the close handler considers the peer fully gone.
       vi.spyOn(agent.node.libp2p, 'getPeers').mockReturnValue([]);
@@ -359,6 +422,38 @@ describe('DKGAgent sync state lifecycle', () => {
 
       expect((agent as any).skippedNoSyncPeers.has(remotePeer)).toBe(false);
       expect((agent as any).lastSuccessfulSyncAt.has(remotePeer)).toBe(false);
+      expect((agent as any).syncReconcilerBackoff.has(remotePeer)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+});
+
+describe('DKGAgent sync transport — off the messenger substrate (node-ui.db bloat fix)', () => {
+  it('registers PROTOCOL_SYNC on the raw ProtocolRouter, NOT the Messenger substrate', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SyncOffSubstrate',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const messengerHandlers = (agent as any).messenger.handlers as Map<string, unknown>;
+      const routerHandlers = (agent as any).router.handlers as Map<string, unknown>;
+
+      // Regression guard: routing sync through `messenger.register` /
+      // `sendReliable` is exactly what cached large, never-reused sync
+      // page responses into `message_idempotency` (the ~2.9 GB
+      // node-ui.db bloat). Sync MUST live on the raw router so no
+      // idempotency rows are ever written for it.
+      expect(messengerHandlers.has(PROTOCOL_SYNC)).toBe(false);
+      expect(routerHandlers.has(PROTOCOL_SYNC)).toBe(true);
+
+      // Sanity: a genuine substrate protocol (private-access) IS still
+      // registered through the Messenger, so the assertion above is
+      // meaningful and not vacuously true.
+      expect(messengerHandlers.has(PROTOCOL_ACCESS)).toBe(true);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -398,6 +398,45 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     }
   });
 
+  it('bypasses pending backoff when the live protocol fingerprint changes', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerBackoffFingerprint',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
+      const trySync = vi.spyOn(agent as any, 'trySyncFromPeer').mockResolvedValue(undefined);
+
+      const backoffMap = (agent as any).syncReconcilerBackoff as Map<
+        string,
+        { failures: number; nextRetryAt: number; protocolsKey?: string | null; connectionKey?: string | null }
+      >;
+      backoffMap.set(peerA, {
+        failures: 1,
+        nextRetryAt: Date.now() + 100_000,
+        protocolsKey: '/dkg/old/sync',
+        connectionKey: null,
+      });
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(trySync).toHaveBeenCalledTimes(1);
+      expect(backoffMap.get(peerA)?.failures).toBe(2);
+      expect(backoffMap.get(peerA)?.protocolsKey).toBe(PROTOCOL_SYNC);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not back off a peer that still does not advertise PROTOCOL_SYNC', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerNoSyncNoBackoff',
@@ -415,6 +454,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       const getPeerProtocols = vi
         .spyOn(agent as any, 'getPeerProtocols')
         .mockResolvedValue(['/ipfs/id/1.0.0']);
+      const trySync = vi.spyOn(agent as any, 'trySyncFromPeer');
 
       const backoffMap = (agent as any).syncReconcilerBackoff as Map<
         string,
@@ -426,7 +466,8 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       await (agent as any).reconcileSyncFromConnectedPeers();
       await flushMicrotasks();
 
-      expect(getPeerProtocols).toHaveBeenCalledTimes(2);
+      expect(trySync).toHaveBeenCalledTimes(2);
+      expect(getPeerProtocols.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect((agent as any).skippedNoSyncPeers.has(peerA)).toBe(true);
       expect(backoffMap.has(peerA)).toBe(false);
     } finally {

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -398,6 +398,42 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
     }
   });
 
+  it('does not back off a peer that still does not advertise PROTOCOL_SYNC', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerNoSyncNoBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      const getPeerProtocols = vi
+        .spyOn(agent as any, 'getPeerProtocols')
+        .mockResolvedValue(['/ipfs/id/1.0.0']);
+
+      const backoffMap = (agent as any).syncReconcilerBackoff as Map<
+        string,
+        { failures: number; nextRetryAt: number }
+      >;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(getPeerProtocols).toHaveBeenCalledTimes(2);
+      expect((agent as any).skippedNoSyncPeers.has(peerA)).toBe(true);
+      expect(backoffMap.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not recreate backoff after the peer disconnects while an attempt is in flight', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerBackoffDisconnectRace',

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -391,6 +391,45 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       await agent.stop().catch(() => {});
     }
   });
+
+  it('does not recreate backoff after the peer disconnects while an attempt is in flight', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerBackoffDisconnectRace',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      let connectedPeers = [peerIdFromString(peerA)];
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(() => connectedPeers);
+
+      let resolveAttempt!: () => void;
+      const calls: string[] = [];
+      (agent as any).trySyncFromPeer = (peerId: string) => {
+        calls.push(peerId);
+        return new Promise<void>((resolve) => {
+          resolveAttempt = resolve;
+        });
+      };
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await new Promise(r => setTimeout(r, 0));
+      expect(calls).toEqual([peerA]);
+
+      // Simulate connection:close winning the race before the
+      // fire-and-forget sync attempt resolves without progress.
+      connectedPeers = [];
+      (agent as any).syncReconcilerBackoff.delete(peerA);
+      resolveAttempt();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });
 
 describe('DKGAgent sync state lifecycle', () => {

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -3,7 +3,7 @@ import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
-import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
+import { runSyncOnConnect, SyncOnConnectPostSyncError } from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 /**
@@ -89,6 +89,39 @@ describe('runSyncOnConnect callbacks', () => {
     expect(outcome).toBe('synced');
     expect(skipped).toEqual([]);
     expect(synced).toEqual([remotePeer]);
+  });
+
+  it('tags failures that happen after durable sync completes', async () => {
+    const remotePeer = freshPeerIdString();
+    const syncingPeers = new Set<string>();
+    const laterError = new Error('discovery failed');
+    const synced: string[] = [];
+    let caught: unknown;
+
+    try {
+      await runSyncOnConnect({
+        remotePeer,
+        syncingPeers,
+        getPeerProtocols: async () => [PROTOCOL_SYNC],
+        knownCorePeerIds: new Set(),
+        getSyncContextGraphs: () => [],
+        syncFromPeer: async () => 7,
+        refreshMetaSyncedFlags: async () => {},
+        discoverContextGraphsFromStore: async () => {
+          throw laterError;
+        },
+        syncSharedMemoryFromPeer: async () => 0,
+        logInfo: noopLog,
+        onPeerSynced: (peerId) => synced.push(peerId),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(SyncOnConnectPostSyncError);
+    expect((caught as SyncOnConnectPostSyncError).originalError).toBe(laterError);
+    expect(synced).toEqual([]);
+    expect(syncingPeers.has(remotePeer)).toBe(false);
   });
 
   it('can skip shared-memory catch-up on connect while still running durable sync', async () => {
@@ -516,6 +549,34 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       );
       vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
       vi.spyOn(agent as any, 'trySyncFromPeer').mockResolvedValue('already-syncing');
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not back off post-sync phase failures', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerPostSyncFailureNoBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
+      vi.spyOn(agent as any, 'trySyncFromPeer').mockRejectedValue(
+        new SyncOnConnectPostSyncError(peerA, new Error('shared memory failed')),
+      );
 
       await (agent as any).reconcileSyncFromConnectedPeers();
       await flushMicrotasks();

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -124,6 +124,41 @@ describe('runSyncOnConnect callbacks', () => {
     expect(syncingPeers.has(remotePeer)).toBe(false);
   });
 
+  it('leaves newly discovered durable sync failures eligible for peer backoff', async () => {
+    const remotePeer = freshPeerIdString();
+    let contextGraphs = ['cg-a'];
+    const secondDurableError = new Error('newly discovered durable sync failed');
+    const syncFromPeer = vi.fn()
+      .mockResolvedValueOnce(7)
+      .mockRejectedValueOnce(secondDurableError);
+    let caught: unknown;
+
+    try {
+      await runSyncOnConnect({
+        remotePeer,
+        syncingPeers: new Set(),
+        getPeerProtocols: async () => [PROTOCOL_SYNC],
+        knownCorePeerIds: new Set(),
+        getSyncContextGraphs: () => contextGraphs,
+        syncFromPeer,
+        refreshMetaSyncedFlags: async () => {},
+        discoverContextGraphsFromStore: async () => {
+          contextGraphs = ['cg-a', 'cg-b'];
+          return 1;
+        },
+        syncSharedMemoryFromPeer: async () => 0,
+        logInfo: noopLog,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(secondDurableError);
+    expect(caught).not.toBeInstanceOf(SyncOnConnectPostSyncError);
+    expect(syncFromPeer).toHaveBeenCalledWith(remotePeer);
+    expect(syncFromPeer).toHaveBeenCalledWith(remotePeer, ['cg-b']);
+  });
+
   it('can skip shared-memory catch-up on connect while still running durable sync', async () => {
     const remotePeer = freshPeerIdString();
     const syncFromPeer = vi.fn().mockResolvedValue(3);

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -41,7 +41,7 @@ describe('runSyncOnConnect callbacks', () => {
     const synced: string[] = [];
     const syncFromPeer = vi.fn().mockResolvedValue(0);
 
-    await runSyncOnConnect({
+    const outcome = await runSyncOnConnect({
       remotePeer,
       syncingPeers: new Set(),
       getPeerProtocols: async () => ['/ipfs/id/1.0.0', '/meshsub/1.1.0'],
@@ -60,6 +60,7 @@ describe('runSyncOnConnect callbacks', () => {
       },
     });
 
+    expect(outcome).toBe('skipped-no-sync');
     expect(skipped).toEqual([{ peerId: remotePeer, protocols: ['/ipfs/id/1.0.0', '/meshsub/1.1.0'] }]);
     expect(synced).toEqual([]);
     expect(syncFromPeer).not.toHaveBeenCalled();
@@ -70,7 +71,7 @@ describe('runSyncOnConnect callbacks', () => {
     const skipped: string[] = [];
     const synced: string[] = [];
 
-    await runSyncOnConnect({
+    const outcome = await runSyncOnConnect({
       remotePeer,
       syncingPeers: new Set(),
       getPeerProtocols: async () => [PROTOCOL_SYNC],
@@ -85,6 +86,7 @@ describe('runSyncOnConnect callbacks', () => {
       onPeerSynced: (peerId) => synced.push(peerId),
     });
 
+    expect(outcome).toBe('synced');
     expect(skipped).toEqual([]);
     expect(synced).toEqual([remotePeer]);
   });
@@ -95,7 +97,7 @@ describe('runSyncOnConnect callbacks', () => {
     const syncSharedMemoryFromPeer = vi.fn().mockResolvedValue(11);
     const synced: string[] = [];
 
-    await runSyncOnConnect({
+    const outcome = await runSyncOnConnect({
       remotePeer,
       syncingPeers: new Set(),
       getPeerProtocols: async () => [PROTOCOL_SYNC],
@@ -110,9 +112,32 @@ describe('runSyncOnConnect callbacks', () => {
       onPeerSynced: (peerId) => synced.push(peerId),
     });
 
+    expect(outcome).toBe('synced');
     expect(syncFromPeer).toHaveBeenCalledOnce();
     expect(syncSharedMemoryFromPeer).not.toHaveBeenCalled();
     expect(synced).toEqual([remotePeer]);
+  });
+
+  it('returns already-syncing without running duplicate work', async () => {
+    const remotePeer = freshPeerIdString();
+    const syncingPeers = new Set([remotePeer]);
+    const syncFromPeer = vi.fn().mockResolvedValue(0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers,
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => [],
+      syncFromPeer,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('already-syncing');
+    expect(syncFromPeer).not.toHaveBeenCalled();
   });
 });
 
@@ -430,7 +455,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       await flushMicrotasks();
 
       expect(trySync).toHaveBeenCalledTimes(1);
-      expect(backoffMap.get(peerA)?.failures).toBe(2);
+      expect(backoffMap.get(peerA)?.failures).toBe(1);
       expect(backoffMap.get(peerA)?.protocolsKey).toBe(PROTOCOL_SYNC);
     } finally {
       await agent.stop().catch(() => {});
@@ -470,6 +495,32 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       expect(getPeerProtocols.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect((agent as any).skippedNoSyncPeers.has(peerA)).toBe(true);
       expect(backoffMap.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not back off when the attempt reports already-syncing', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerAlreadySyncingNoBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+
+      const peerA = freshPeerIdString();
+      const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+      vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+        () => [...origGetPeers(), peerIdFromString(peerA)],
+      );
+      vi.spyOn(agent as any, 'getPeerProtocols').mockResolvedValue([PROTOCOL_SYNC]);
+      vi.spyOn(agent as any, 'trySyncFromPeer').mockResolvedValue('already-syncing');
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { PROTOCOL_SYNC, PROTOCOL_ACCESS } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
@@ -27,6 +27,12 @@ function freshPeerIdString(): string {
 }
 
 const noopLog = (_ctx: OperationContext, _message: string) => {};
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('runSyncOnConnect callbacks', () => {
   it('fires onPeerSkippedNoSync when the peer does not advertise PROTOCOL_SYNC', async () => {
@@ -253,7 +259,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
 
       await (agent as any).reconcileSyncFromConnectedPeers();
       // trySyncFromPeer is fire-and-forget inside the reconciler.
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
 
       expect(calls.sort()).toEqual([peerA, peerB].sort());
     } finally {
@@ -289,7 +295,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       };
 
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
 
       expect(calls).toEqual([stalePeer]);
     } finally {
@@ -322,7 +328,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       };
 
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
 
       expect(calls).toEqual([]);
     } finally {
@@ -361,7 +367,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       // Tick 1: never synced → fires once and records failure #1.
       const t1 = Date.now();
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
       expect(calls).toEqual([peerA]);
       const b1 = backoffMap.get(peerA)!;
       expect(b1.failures).toBe(1);
@@ -370,7 +376,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
 
       // Tick 2 immediately: still inside the backoff window → skipped.
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
       expect(calls).toEqual([peerA]);
       expect(backoffMap.get(peerA)!.failures).toBe(1);
 
@@ -379,7 +385,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       backoffMap.set(peerA, { failures: 1, nextRetryAt: Date.now() - 1 });
       const t2 = Date.now();
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
       expect(calls).toEqual([peerA, peerA]);
       const b2 = backoffMap.get(peerA)!;
       expect(b2.failures).toBe(2);
@@ -415,7 +421,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       };
 
       await (agent as any).reconcileSyncFromConnectedPeers();
-      await new Promise(r => setTimeout(r, 0));
+      await flushMicrotasks();
       expect(calls).toEqual([peerA]);
 
       // Simulate connection:close winning the race before the
@@ -423,7 +429,7 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       connectedPeers = [];
       (agent as any).syncReconcilerBackoff.delete(peerA);
       resolveAttempt();
-      await new Promise(r => setTimeout(r, 50));
+      await flushMicrotasks();
 
       expect((agent as any).syncReconcilerBackoff.has(peerA)).toBe(false);
     } finally {
@@ -493,6 +499,39 @@ describe('DKGAgent sync transport — off the messenger substrate (node-ui.db bl
       // registered through the Messenger, so the assertion above is
       // meaningful and not vacuously true.
       expect(messengerHandlers.has(PROTOCOL_ACCESS)).toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('fetches sync pages via sendToPeer and never sendReliable', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SyncRequesterOffSubstrate',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      const sendToPeer = vi.fn(async () => new Uint8Array(0));
+      const sendReliable = vi.fn(async () => {
+        throw new Error('sync requester must not use sendReliable');
+      });
+      (agent as any).messenger = { sendToPeer, sendReliable };
+      (agent as any).buildSyncRequest = vi.fn(async () => new Uint8Array([1, 2, 3]));
+
+      const result = await (agent as any).fetchSyncPages(
+        createOperationContext('sync'),
+        freshPeerIdString(),
+        'sync-requester-transport',
+        false,
+        'data',
+        'urn:dkg:test:data',
+        Date.now() + 5000,
+      );
+
+      expect(result.quads).toEqual([]);
+      expect(sendToPeer).toHaveBeenCalledTimes(1);
+      expect(sendToPeer.mock.calls[0][1]).toBe(PROTOCOL_SYNC);
+      expect(sendReliable).not.toHaveBeenCalled();
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/cli/scripts/swm-triple-volume-benchmark.cjs
+++ b/packages/cli/scripts/swm-triple-volume-benchmark.cjs
@@ -28,8 +28,8 @@ const DIAGNOSTIC_LOG_PATTERNS = [
   { name: 'syncingFromPeer', text: 'Syncing from peer' },
   { name: 'syncTimeout', text: 'Sync timeout' },
   { name: 'syncFailed', text: 'Sync from ' },
-  // rc.9 PR-E: sync protocol bumped /dkg/10.0.0/sync → /dkg/10.0.1/sync.
-  { name: 'protocolSyncSend', text: 'send /dkg/10.0.1/sync' },
+  // sync protocol is /dkg/10.0.2/sync (off the messenger substrate).
+  { name: 'protocolSyncSend', text: 'send /dkg/10.0.2/sync' },
   { name: 'skippedSwmSync', text: 'Skipping shared memory sync' },
   { name: 'rsTick', text: '[rs.tick' },
   { name: 'rsLoopError', text: '[rs.loop.tick-threw]' },

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -272,7 +272,7 @@ export class ApiClient {
     remoteAddrs: Array<string | null>;
     protocols: string[];
     syncCapable: boolean;
-    syncStatus: {
+    syncStatus?: {
       capable: boolean;
       capability?: 'supported' | 'unsupported' | 'unknown';
       lastSuccessfulSyncAt: number | null;

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -274,6 +274,7 @@ export class ApiClient {
     syncCapable: boolean;
     syncStatus: {
       capable: boolean;
+      capability?: 'supported' | 'unsupported' | 'unknown';
       lastSuccessfulSyncAt: number | null;
       stale: boolean;
       backoff: {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -272,6 +272,16 @@ export class ApiClient {
     remoteAddrs: Array<string | null>;
     protocols: string[];
     syncCapable: boolean;
+    syncStatus: {
+      capable: boolean;
+      lastSuccessfulSyncAt: number | null;
+      stale: boolean;
+      backoff: {
+        failures: number;
+        nextRetryAt: number;
+        retryInMs: number;
+      } | null;
+    };
     lastSeen: number | null;
     latencyMs: number | null;
   }> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1297,8 +1297,11 @@ program
       const syncBackoff = info.syncStatus.backoff
         ? `, backoff failures=${info.syncStatus.backoff.failures}, retry in ${Math.round(info.syncStatus.backoff.retryInMs / 1000)}s`
         : '';
-      const syncState = info.syncStatus.capable
+      const syncCapability = info.syncStatus.capability ?? (info.syncStatus.capable ? 'supported' : 'unsupported');
+      const syncState = syncCapability === 'supported'
         ? (info.syncStatus.stale ? 'stale' : 'fresh')
+        : syncCapability === 'unknown'
+          ? (info.syncStatus.stale ? 'unknown/stale' : 'unknown')
         : 'unsupported';
       console.log(`Sync Status:   ${syncState} (last success: ${syncLastOk}${syncBackoff})`);
       if (info.transports.length > 0) console.log(`Transports:    ${info.transports.join(', ')}`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1297,7 +1297,10 @@ program
       const syncBackoff = info.syncStatus.backoff
         ? `, backoff failures=${info.syncStatus.backoff.failures}, retry in ${Math.round(info.syncStatus.backoff.retryInMs / 1000)}s`
         : '';
-      console.log(`Sync Status:   ${info.syncStatus.stale ? 'stale' : 'fresh'} (last success: ${syncLastOk}${syncBackoff})`);
+      const syncState = info.syncStatus.capable
+        ? (info.syncStatus.stale ? 'stale' : 'fresh')
+        : 'unsupported';
+      console.log(`Sync Status:   ${syncState} (last success: ${syncLastOk}${syncBackoff})`);
       if (info.transports.length > 0) console.log(`Transports:    ${info.transports.join(', ')}`);
       if (info.directions.length > 0) console.log(`Directions:    ${info.directions.join(', ')}`);
       if (info.remoteAddrs.length > 0) console.log(`Remote Addrs:  ${info.remoteAddrs.filter(Boolean).join(', ')}`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1291,6 +1291,13 @@ program
       console.log(`Connected:     ${info.connected ? 'yes' : 'no'}`);
       console.log(`Connections:   ${info.connectionCount}`);
       console.log(`Sync Capable:  ${info.syncCapable ? 'yes' : 'no'}`);
+      const syncLastOk = info.syncStatus.lastSuccessfulSyncAt
+        ? new Date(info.syncStatus.lastSuccessfulSyncAt).toISOString()
+        : 'never';
+      const syncBackoff = info.syncStatus.backoff
+        ? `, backoff failures=${info.syncStatus.backoff.failures}, retry in ${Math.round(info.syncStatus.backoff.retryInMs / 1000)}s`
+        : '';
+      console.log(`Sync Status:   ${info.syncStatus.stale ? 'stale' : 'fresh'} (last success: ${syncLastOk}${syncBackoff})`);
       if (info.transports.length > 0) console.log(`Transports:    ${info.transports.join(', ')}`);
       if (info.directions.length > 0) console.log(`Directions:    ${info.directions.join(', ')}`);
       if (info.remoteAddrs.length > 0) console.log(`Remote Addrs:  ${info.remoteAddrs.filter(Boolean).join(', ')}`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1291,17 +1291,24 @@ program
       console.log(`Connected:     ${info.connected ? 'yes' : 'no'}`);
       console.log(`Connections:   ${info.connectionCount}`);
       console.log(`Sync Capable:  ${info.syncCapable ? 'yes' : 'no'}`);
-      const syncLastOk = info.syncStatus.lastSuccessfulSyncAt
-        ? new Date(info.syncStatus.lastSuccessfulSyncAt).toISOString()
+      const syncStatus = info.syncStatus ?? {
+        capable: info.syncCapable,
+        capability: info.syncCapable ? 'supported' as const : 'unknown' as const,
+        lastSuccessfulSyncAt: null,
+        stale: false,
+        backoff: null,
+      };
+      const syncLastOk = syncStatus.lastSuccessfulSyncAt
+        ? new Date(syncStatus.lastSuccessfulSyncAt).toISOString()
         : 'never';
-      const syncBackoff = info.syncStatus.backoff
-        ? `, backoff failures=${info.syncStatus.backoff.failures}, retry in ${Math.round(info.syncStatus.backoff.retryInMs / 1000)}s`
+      const syncBackoff = syncStatus.backoff
+        ? `, backoff failures=${syncStatus.backoff.failures}, retry in ${Math.round(syncStatus.backoff.retryInMs / 1000)}s`
         : '';
-      const syncCapability = info.syncStatus.capability ?? (info.syncStatus.capable ? 'supported' : 'unsupported');
+      const syncCapability = syncStatus.capability ?? (syncStatus.capable ? 'supported' : 'unsupported');
       const syncState = syncCapability === 'supported'
-        ? (info.syncStatus.stale ? 'stale' : 'fresh')
+        ? (syncStatus.stale ? 'stale' : 'fresh')
         : syncCapability === 'unknown'
-          ? (info.syncStatus.stale ? 'unknown/stale' : 'unknown')
+          ? (syncStatus.stale ? 'unknown/stale' : 'unknown')
         : 'unsupported';
       console.log(`Sync Status:   ${syncState} (last success: ${syncLastOk}${syncBackoff})`);
       if (info.transports.length > 0) console.log(`Transports:    ${info.transports.join(', ')}`);

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -669,6 +669,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       // `health` for callers that want the typed snapshot.
       protocols: diag.protocols,
       syncCapable: diag.syncCapable,
+      syncStatus: diag.syncStatus,
       lastSeen: diag.health?.lastSeen ?? null,
       latencyMs: diag.health?.latencyMs ?? null,
       health: diag.health,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,18 +3,23 @@
 export const PROTOCOL_PUBLISH = '/dkg/10.0.0/publish';
 export const PROTOCOL_QUERY = '/dkg/10.0.0/query';
 export const PROTOCOL_DISCOVER = '/dkg/10.0.0/discover';
-// rc.9 PR-E (SWM reliable fan-out plan, Step 2): bumped from
-// /dkg/10.0.0/sync to /dkg/10.0.1/sync. The sync RPC is the eventual-
-// consistency safety net for SWM share delivery (runSyncOnConnect →
-// syncSharedMemoryFromPeer when peers reconnect). Pre-rc.9 the
-// safety net itself ran over an un-migrated transport: no envelope
-// versioning, no idempotency, no durable outbox — a stream reset
-// mid-sync was unrecoverable except by the next reconnect. Bumping
-// onto the /dkg/10.0.1/ prefix gives the safety net the same
-// reliability primitives as chat / access / query-remote / etc.
-// Hard cutover, consistent with the rc.9 protocol migration model:
-// rc.8 nodes cannot sync from rc.9 nodes and vice versa.
-export const PROTOCOL_SYNC = '/dkg/10.0.1/sync';
+// Bumped /dkg/10.0.1/sync -> /dkg/10.0.2/sync: sync is taken BACK OFF
+// the Universal Messenger substrate (raw ProtocolRouter register/send,
+// no ReliableEnvelope, no idempotency, no outbox). rc.9 PR-E had routed
+// sync through the substrate "for receiver-side dedup", but the sync
+// requester mints a fresh messageId per attempt, so the dedup key never
+// repeats — the cache hit rate is structurally zero while every large,
+// never-reused page response was cached on both sides of
+// message_idempotency (the ~2.9 GB node-ui.db bloat). Sync already has
+// its own retry (withRetry), 90s auth-freshness TTL, and per-requestId
+// replay protection, so it needs none of the substrate's machinery.
+// Going raw changes the wire bytes (bare auth-envelope vs
+// ReliableEnvelope), so the protocol ID MUST bump or mixed-version peers
+// mis-decode. Hard cutover, consistent with the rc.9 migration model:
+// mixed-version peers cleanly skip each other via waitForSyncProtocol
+// (sync is a self-healing catch-up net, so the brief mixed-version
+// window during auto-update is no-data-loss).
+export const PROTOCOL_SYNC = '/dkg/10.0.2/sync';
 // Universal Messenger pilot protocol (rc.9 PR-3). Bumped from
 // /dkg/10.0.0/message to /dkg/10.0.1/message to opt into the
 // reliability substrate (ReliableEnvelope wrapper, sender +

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -66,7 +66,6 @@ describe('V10 protocol stream IDs', () => {
   // follow-up signal, not a synchronous request.
   it('substrate-migrated protocols use /dkg/10.0.1/ prefix', () => {
     expect(PROTOCOL_MESSAGE).toBe('/dkg/10.0.1/message');
-    expect(PROTOCOL_SYNC).toBe('/dkg/10.0.1/sync');
     expect(PROTOCOL_ACCESS).toBe('/dkg/10.0.1/private-access');
     expect(PROTOCOL_QUERY_REMOTE).toBe('/dkg/10.0.1/query-remote');
     expect(PROTOCOL_SWM_SENDER_KEY).toBe('/dkg/10.0.1/swm-sender-key');
@@ -75,6 +74,10 @@ describe('V10 protocol stream IDs', () => {
     expect(PROTOCOL_VERIFY_PROPOSAL).toBe('/dkg/10.0.1/verify-proposal');
     expect(PROTOCOL_VERIFY_APPROVAL).toBe('/dkg/10.0.0/verify-approval');
     expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');
+  });
+
+  it('sync uses the /dkg/10.0.2/ prefix (taken back OFF the messenger substrate)', () => {
+    expect(PROTOCOL_SYNC).toBe('/dkg/10.0.2/sync');
   });
 
   it('DHT protocol is unchanged', () => {

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -136,8 +136,9 @@ export interface PeerInfo {
      * Per-protocol pending breakdown. Empty object when this peer
      * has no pending entries on the substrate at all.
      *
-     * Keys are libp2p protocol ids (e.g. `/dkg/10.0.1/sync`,
-     * `/dkg/10.0.1/message`).
+     * Keys are libp2p protocol ids (e.g. `/dkg/10.0.1/message`,
+     * `/dkg/10.0.1/swm-update`). Sync is off the substrate so it does
+     * not appear here.
      */
     byProtocol: Record<
       string,

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -155,6 +155,7 @@ export interface PeerInfo {
   syncCapable: boolean;
   syncStatus: {
     capable: boolean;
+    capability?: 'supported' | 'unsupported' | 'unknown';
     lastSuccessfulSyncAt: number | null;
     stale: boolean;
     backoff: {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -122,8 +122,10 @@ export interface PeerInfo {
    * {@link byProtocol} (rc.9 PR-E codex follow-up #10 — daemon
    * shipped in b3dd4db4) breaks out queued entries per libp2p
    * protocol id so the per-protocol substrate-outbox state
-   * (sync, SWM, future protocols) is visible to MCP consumers.
-   * Each per-protocol summary mirrors the top-level shape.
+   * (SWM, access, future protocols) is visible to MCP consumers.
+   * Raw sync catch-up state lives in `syncStatus` because sync is
+   * off the substrate. Each per-protocol summary mirrors the
+   * top-level shape.
    */
   outbox: {
     /** Chat-protocol pending count (rc.8 contract). */
@@ -151,6 +153,16 @@ export interface PeerInfo {
   };
   protocols: string[];
   syncCapable: boolean;
+  syncStatus: {
+    capable: boolean;
+    lastSuccessfulSyncAt: number | null;
+    stale: boolean;
+    backoff: {
+      failures: number;
+      nextRetryAt: number;
+      retryInMs: number;
+    } | null;
+  };
   lastSeen: number | null;
   latencyMs: number | null;
   health: {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -153,7 +153,7 @@ export interface PeerInfo {
   };
   protocols: string[];
   syncCapable: boolean;
-  syncStatus: {
+  syncStatus?: {
     capable: boolean;
     capability?: 'supported' | 'unsupported' | 'unknown';
     lastSuccessfulSyncAt: number | null;

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -386,8 +386,9 @@ export class FakeClient {
       syncCapable: false,
       syncStatus: {
         capable: false,
+        capability: 'unknown',
         lastSuccessfulSyncAt: null,
-        stale: true,
+        stale: false,
         backoff: null,
       },
       lastSeen: null,

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -384,6 +384,12 @@ export class FakeClient {
       outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [], byProtocol: {} },
       protocols: [],
       syncCapable: false,
+      syncStatus: {
+        capable: false,
+        lastSuccessfulSyncAt: null,
+        stale: true,
+        backoff: null,
+      },
       lastSeen: null,
       latencyMs: null,
       health: null,

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -50,9 +50,9 @@ describe('health tools', () => {
             openedAt: 1715670000000,
           },
         ],
-        peerStore: { knownMultiaddrCount: 1, multiaddrs: ['/ip4/1.2.3.4/tcp/4001'], protocols: ['/dkg/10.0.1/sync'] },
+        peerStore: { knownMultiaddrCount: 1, multiaddrs: ['/ip4/1.2.3.4/tcp/4001'], protocols: ['/dkg/10.0.2/sync'] },
         outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [], byProtocol: {} },
-        protocols: ['/dkg/10.0.1/sync'],
+        protocols: ['/dkg/10.0.2/sync'],
         syncCapable: true,
         lastSeen: 1715670010000,
         latencyMs: 42,
@@ -69,8 +69,8 @@ describe('health tools', () => {
       expect(body).toContain(PEER_A);
       expect(body).toContain('"connected": true');
       expect(body).toContain('"getConnectionsReturnsForPeer": 1');
-      // rc.9 PR-E: protocol bump to /dkg/10.0.1/sync.
-      expect(body).toContain('/dkg/10.0.1/sync');
+      // sync protocol is /dkg/10.0.2/sync (off the messenger substrate).
+      expect(body).toContain('/dkg/10.0.2/sync');
     });
 
     // The Window D bug surface — when the two counts diverge, an

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -158,6 +158,36 @@ describe('health tools', () => {
       expect(result.content[0].text).toMatch(/daemon offline/);
     });
 
+    it('accepts older peer-info payloads without syncStatus', async () => {
+      const client = new FakeClient({
+        getPeerInfo: async () => ({
+          peerId: PEER_A,
+          connected: false,
+          rawConnectionCount: 0,
+          getConnectionsReturnsForPeer: 0,
+          connections: [],
+          peerStore: null,
+          outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [], byProtocol: {} },
+          protocols: [],
+          syncCapable: false,
+          lastSeen: null,
+          latencyMs: null,
+          health: null,
+          connectionCount: 0,
+          transports: [],
+          directions: [],
+          remoteAddrs: [],
+        }),
+      });
+      const localServer = new FakeServer();
+      registerHealthTools(localServer.asMcpServer(), client.asDkgClient(), makeConfig());
+      const result = await localServer.call('dkg_peer_info', { peerId: PEER_A });
+      expect(result.isError).toBeFalsy();
+      const body = result.content[0].text;
+      expect(body).toContain('"syncCapable": false');
+      expect(body).not.toContain('"syncStatus"');
+    });
+
     // User review on PR #533: `PeerInfo.remoteAddrs` was typed as
     // `string[]` but the runtime JSON contains `null` entries when
     // libp2p doesn't expose a multiaddr for a given connection.

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -11,6 +11,12 @@ import { registerHealthTools } from '../src/tools/health.js';
 import { FakeServer, FakeClient, makeConfig } from './harness.js';
 
 const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
+const STALE_SYNC_STATUS = {
+  capable: false,
+  lastSuccessfulSyncAt: null,
+  stale: true,
+  backoff: null,
+};
 
 describe('health tools', () => {
   let server: FakeServer;
@@ -54,6 +60,12 @@ describe('health tools', () => {
         outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [], byProtocol: {} },
         protocols: ['/dkg/10.0.2/sync'],
         syncCapable: true,
+        syncStatus: {
+          capable: true,
+          lastSuccessfulSyncAt: 1715670005000,
+          stale: false,
+          backoff: null,
+        },
         lastSeen: 1715670010000,
         latencyMs: 42,
         health: null,
@@ -69,6 +81,7 @@ describe('health tools', () => {
       expect(body).toContain(PEER_A);
       expect(body).toContain('"connected": true');
       expect(body).toContain('"getConnectionsReturnsForPeer": 1');
+      expect(body).toContain('"syncStatus"');
       // sync protocol is /dkg/10.0.2/sync (off the messenger substrate).
       expect(body).toContain('/dkg/10.0.2/sync');
     });
@@ -110,6 +123,7 @@ describe('health tools', () => {
         },
         protocols: [],
         syncCapable: false,
+        syncStatus: STALE_SYNC_STATUS,
         lastSeen: null,
         latencyMs: null,
         health: null,
@@ -170,6 +184,7 @@ describe('health tools', () => {
           outbox: { pendingCount: 0, oldestFirstFailureAt: null, attempts: [], byProtocol: {} },
           protocols: [],
           syncCapable: false,
+          syncStatus: STALE_SYNC_STATUS,
           lastSeen: null,
           latencyMs: null,
           health: null,

--- a/packages/mcp-dkg/test/health-tools.test.ts
+++ b/packages/mcp-dkg/test/health-tools.test.ts
@@ -13,6 +13,7 @@ import { FakeServer, FakeClient, makeConfig } from './harness.js';
 const PEER_A = '12D3KooWFq5KMnSMyYr8Z8t8a6Vh1Y6N6KkF5UZjLpCqUkBJsAaa';
 const STALE_SYNC_STATUS = {
   capable: false,
+  capability: 'unknown' as const,
   lastSuccessfulSyncAt: null,
   stale: true,
   backoff: null,
@@ -62,6 +63,7 @@ describe('health tools', () => {
         syncCapable: true,
         syncStatus: {
           capable: true,
+          capability: 'supported',
           lastSuccessfulSyncAt: 1715670005000,
           stale: false,
           backoff: null,

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.13",
+  "version": "10.0.0-rc.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -2,6 +2,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CORE_CONSTANTS_TS="$SCRIPT_DIR/../packages/core/src/constants.ts"
 if [[ -n "${DKG_AUTH:-}" ]]; then
   AUTH="$DKG_AUTH"
 elif [[ -f "$SCRIPT_DIR/../.devnet/node1/auth.token" ]]; then
@@ -118,6 +119,11 @@ except: print('__ERR__')
 check() {
   local desc="$1" actual="$2" expected="$3"
   if [[ "$actual" == "$expected" ]]; then ok "$desc"; else fail "$desc (expected=$expected, got=$actual)"; fi
+}
+
+protocol_const() {
+  local const_name="$1"
+  sed -nE "s|^export const ${const_name} = '([^']+)';$|\1|p" "$CORE_CONSTANTS_TS" 2>/dev/null | head -n 1
 }
 
 # P1-3: Safe count helper. Replaces the pervasive
@@ -3012,27 +3018,34 @@ fi
 section_done
 
 #------------------------------------------------------------
-section_start "SECTION 33: rc.9 — substrate protocols negotiated on the wire (/dkg/10.0.1/*)"
+section_start "SECTION 33: rc.9/rc.14 — wire protocols negotiated"
 # rc.9 bumped 8+ short-message protocols from /dkg/10.0.0/* to
-# /dkg/10.0.1/*. A devnet-wide mismatch (one node still on 10.0.0)
-# would manifest as silently queued substrate messages. The peerStore
-# protocols list returned by /api/peer-info?peerId=<X> proves the
-# identify handshake advertised the rc.9 prefix on both sides.
+# /dkg/10.0.1/*; rc.14 bumps PROTOCOL_SYNC again when sync leaves the
+# messenger substrate. A devnet-wide mismatch (one node still on an
+# older wire ID) would manifest as silently queued substrate messages
+# or skipped sync. The peerStore protocols list returned by
+# /api/peer-info?peerId=<X> proves the identify handshake advertised
+# the expected protocol IDs on both sides.
 if [[ "$SKIP_RC9_SUBSTRATE" == "1" ]]; then
   skip "SECTION 33: skipped via SKIP_RC9_SUBSTRATE=1"
 elif [[ "$NUM_NODES" -lt 2 ]]; then
   skip "SECTION 33: need ≥2 nodes (have $NUM_NODES)"
 else
-  # rc.9 substrate protocol IDs we expect to see on every healthy
+  # Wire protocol IDs we expect to see on every healthy
   # peer. PROTOCOL_ACCESS (/dkg/10.0.1/private-access) is registered
   # unconditionally by DKGAgent.start() — round-3 Codex fix corrects
   # the earlier mistaken comment that claimed it was conditional.
   # /dkg/10.0.1/storage-ack is core-only — DKGAgent.start() registers
   # it under `if (effectiveRole === 'core')` (round-4 Codex fix), so
   # it's expected only when the TARGET is a core node.
+  PROTOCOL_SYNC_EXPECTED="$(protocol_const PROTOCOL_SYNC)"
+  if [[ -z "$PROTOCOL_SYNC_EXPECTED" ]]; then
+    fail "PROTOCOL_SYNC unreadable from packages/core/src/constants.ts — cannot verify sync protocol advertisement"
+    PROTOCOL_SYNC_EXPECTED="__MISSING_PROTOCOL_SYNC__"
+  fi
   EXPECTED_UNIVERSAL=(
     "/dkg/10.0.1/message"
-    "/dkg/10.0.1/sync"
+    "$PROTOCOL_SYNC_EXPECTED"
     "/dkg/10.0.1/swm-update"
     "/dkg/10.0.1/swm-share-ack"
     "/dkg/10.0.1/swm-sender-key"
@@ -3126,7 +3139,7 @@ except Exception:
         fi
       done
       if [[ ${#missing[@]} -eq 0 ]]; then
-        ok "N$((i+1)) ($observer_port) sees N$((j+1)) ($target_port, $target_role) advertising all ${#expected_for_target[@]} substrate protocols"
+        ok "N$((i+1)) ($observer_port) sees N$((j+1)) ($target_port, $target_role) advertising all ${#expected_for_target[@]} expected wire protocols"
       else
         fail "N$((i+1)) ($observer_port) does NOT see N$((j+1)) ($target_port, $target_role) advertising: ${missing[*]} (peerStore.protocols mismatch — possible wire-prefix drift)"
       fi

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -3083,7 +3083,7 @@ else
     target_peer=${TARGET_PEER_IDS[$j]}
     target_role=${TARGET_NODE_ROLES[$j]}
     if [[ -z "$target_peer" || "$target_peer" == "__NONE__" || "$target_peer" == "__ERR__" ]]; then
-      fail "N$((j+1)) ($target_port) peerId unreadable via /api/info — cannot verify substrate protocol advertisements"
+      fail "N$((j+1)) ($target_port) peerId unreadable via /api/info — cannot verify wire protocol advertisements"
     fi
     if [[ -z "$target_role" || "$target_role" == "__NONE__" || "$target_role" == "__ERR__" ]]; then
       fail "N$((j+1)) ($target_port) nodeRole unreadable via /api/info — cannot decide expected core-only protocols"


### PR DESCRIPTION
## Summary

Release 1 of the scaling quick-wins. Two single-node fixes, both shippable independently:

1. **`node-ui.db` bloat fix — sync RPC taken off the Universal Messenger substrate.** rc.9 PR-E routed sync through the substrate "for receiver-side dedup", but the sync requester mints a **fresh `messageId` per attempt**, so the idempotency key never repeats — cache-hit rate is structurally zero while every large, never-reused sync page response was cached on **both** sides of `message_idempotency`. On a long-lived node this grew `node-ui.db` to multiple GB (~3.1 GB observed + same-size WAL). Sync now registers on the **raw `ProtocolRouter`** and sends via `messenger.sendToPeer` instead of `sendReliable`. Sync already has its own `withRetry`, a 90s auth-freshness TTL, and per-`requestId` replay protection, so it needs none of the substrate's machinery.
   - **Wire hard cutover:** `PROTOCOL_SYNC` bumped `/dkg/10.0.1/sync` → `/dkg/10.0.2/sync`. Mixed-version peers cleanly skip each other (`waitForSyncProtocol`); sync is a self-healing catch-up net so the rollout window is no-data-loss.

2. **Per-peer exponential backoff for the sync reconciler.** A peer that can never be synced (dead / NAT-stuck / stream-resetting) never stamps `lastSuccessfulSyncAt`, so it read as perpetually stale and was dialed on **every** reconciler tick forever. Now backs off `base * 2^(failures-1)` (capped, jittered), resets on success, cleared on disconnect. Only the periodic reconciler is gated — `connection:open` / `peer:update` still fire immediately.

No Solidity changes — no contract redeploy, `chainResetMarker` unchanged. Workspace bumped to `10.0.0-rc.14`.

## Changes
- `core/constants.ts`: `PROTOCOL_SYNC` → `/dkg/10.0.2/sync` (+ rationale).
- `agent/dkg-agent.ts`: responder on raw router; requester via `sendToPeer`; per-peer backoff state + gating + `recordSyncReconcilerFailure`.
- `agent/dkg-agent-constants.ts`: `SYNC_BACKOFF_BASE_MS` / `SYNC_BACKOFF_MAX_MS` / `SYNC_BACKOFF_JITTER`.
- `agent/sync/responder/sync-handler.ts`, `mcp-dkg/client.ts`, `cli/.../swm-triple-volume-benchmark.cjs`: stale-comment/log-matcher updates.
- Tests: protocol-ID bumps; diagnostics outbox examples retargeted (sync no longer transits the outbox); off-substrate regression test; backoff unit test.
- CHANGELOG + 19 package.json version bumps to `10.0.0-rc.14`.

## Test plan
- [x] `core/test/v10-constants.test.ts` (36 pass)
- [x] `agent/test/{sync-on-connect-retry,dkg-agent-diagnostics,sync-fresh-per-attempt}.test.ts` (36 pass) — backoff + off-substrate regression covered
- [x] `mcp-dkg/test/health-tools.test.ts` (6 pass)
- [x] `pnpm build:packages` clean (20/20)
- [ ] Full agent suite under Hardhat (CI)
- [ ] Devnet RFC-38 sync regression (CI / devnet)
- [ ] Rollout: auto-update a node, confirm `message_idempotency` stops growing for sync and reconciler backoff is active

Made with [Cursor](https://cursor.com)