### PR TITLE
test(node-ui): fail e2e devnet preconditions in CI instead of skipping

### DIFF
--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -253,7 +253,7 @@ export async function publishToVm(opts: {
   assertionName: string;
   nodeNum?: number;
   clearAfter?: boolean;
-}): Promise<{ status?: string; kaId?: string; txHash?: string }> {
+}): Promise<{ httpStatus: number; status?: string; kaId?: string; txHash?: string; contextGraphError?: string }> {
   const res = await devnetApiFetch('/api/shared-memory/publish', {
     method: 'POST',
     nodeNum: opts.nodeNum ?? 1,
@@ -266,14 +266,20 @@ export async function publishToVm(opts: {
   if (!res.ok) {
     throw new Error(`publish failed: ${res.status} ${await res.text()}`);
   }
-  return (await res.json()) as { status?: string; kaId?: string; txHash?: string };
+  // NB: `res.ok` is true for 207 too. The daemon returns 207 when the SWM/VM
+  // publish itself succeeded but the context-graph mirror failed
+  // (`result.contextGraphError`) — a PARTIAL publish. We surface both the raw
+  // http status and the error string so callers that care (the full-pipeline
+  // verifier) can reject a 207 instead of treating it as a clean pass.
+  const body = (await res.json()) as { status?: string; kaId?: string; txHash?: string; contextGraphError?: string };
+  return { httpStatus: res.status, ...body };
 }
 
 export async function runWmSwmVmPipeline(opts: {
   contextGraphId: string;
   stamp?: number;
   nodeNum?: number;
-}): Promise<{ assertionName: string; label: string; kaId?: string }> {
+}): Promise<{ assertionName: string; label: string; kaId?: string; httpStatus?: number; contextGraphError?: string }> {
   const stamp = opts.stamp ?? Date.now();
   const assertionName = `e2e-ui-pipeline-${stamp}`;
   const label = `E2E Pipeline ${stamp}`;
@@ -309,7 +315,7 @@ export async function runWmSwmVmPipeline(opts: {
       nodeNum: opts.nodeNum,
     });
 
-    return { assertionName, label, kaId: vm.kaId };
+    return { assertionName, label, kaId: vm.kaId, httpStatus: vm.httpStatus, contextGraphError: vm.contextGraphError };
   });
 }
 

--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -253,6 +253,14 @@ export async function publishToVm(opts: {
   assertionName: string;
   nodeNum?: number;
   clearAfter?: boolean;
+  /**
+   * Tolerate a 207 partial publish (SWM/VM landed but the context-graph mirror
+   * failed). OFF by default — see the 207 handling below. No current caller
+   * needs this; it exists as a deliberate, greppable escape hatch so a future
+   * spec that specifically exercises the partial-publish path can opt in rather
+   * than silently inheriting it.
+   */
+  allowPartial?: boolean;
 }): Promise<{ httpStatus: number; status?: string; kaId?: string; txHash?: string; contextGraphError?: string }> {
   const res = await devnetApiFetch('/api/shared-memory/publish', {
     method: 'POST',
@@ -266,12 +274,20 @@ export async function publishToVm(opts: {
   if (!res.ok) {
     throw new Error(`publish failed: ${res.status} ${await res.text()}`);
   }
-  // NB: `res.ok` is true for 207 too. The daemon returns 207 when the SWM/VM
-  // publish itself succeeded but the context-graph mirror failed
-  // (`result.contextGraphError`) — a PARTIAL publish. We surface both the raw
-  // http status and the error string so callers that care (the full-pipeline
-  // verifier) can reject a 207 instead of treating it as a clean pass.
   const body = (await res.json()) as { status?: string; kaId?: string; txHash?: string; contextGraphError?: string };
+  // `res.ok` is true for 207 too. The daemon returns 207 when the SWM/VM publish
+  // itself succeeded but the context-graph mirror failed (`contextGraphError`) —
+  // a PARTIAL publish. That is exactly the kind of false-green this lane is meant
+  // to catch, so REJECT it here by default: a centralized throw protects every
+  // caller (the global-setup VM seed, the conviction + messaging specs, …) at
+  // once, instead of relying on each one to remember to inspect `httpStatus`.
+  // Callers that genuinely want a partial publish pass `allowPartial: true`.
+  if (res.status === 207 && !opts.allowPartial) {
+    throw new Error(
+      `publish partial (HTTP 207) — SWM/VM publish landed but the context-graph ` +
+        `mirror failed: ${body.contextGraphError ?? 'unknown contextGraphError'}`,
+    );
+  }
   return { httpStatus: res.status, ...body };
 }
 

--- a/packages/node-ui/e2e/helpers/devnet.ts
+++ b/packages/node-ui/e2e/helpers/devnet.ts
@@ -134,19 +134,33 @@ export async function waitForConnectedPeers(
 
 const IS_CI = !!process.env.CI;
 
+// How many devnet nodes the lane booted. Mirrors the default in
+// `playwright.config.ts` / `real-node.ts` (read from the same env var) so a
+// node-availability gate can tell "node down" (a real failure) apart from "node
+// is outside the booted topology" (genuinely not applicable — e.g. node2 on a
+// `PLAYWRIGHT_DEVNET_NUM_NODES=1` run). Read from env rather than importing
+// real-node.ts to keep this low-level helper dependency-light.
+const CONFIGURED_NUM_NODES = Number(process.env.PLAYWRIGHT_DEVNET_NUM_NODES) || 3;
+
 type SkippableTest = { skip: (condition: boolean, description: string) => void };
 
 /**
- * Gate a devnet spec on a precondition (node reachable, ≥1 context graph, …).
+ * Gate a devnet spec on an ALREADY-RESOLVED boolean precondition (e.g. a
+ * just-fetched `cgs.length === 0`).
  *
- * These preconditions are genuinely OPTIONAL for a local run with no devnet up —
+ * Such preconditions are genuinely OPTIONAL for a local run with no devnet up —
  * there we just skip so `pnpm test:e2e` stays usable without a cluster. But in
  * CI the devnet is bootstrapped by `bootstrap-devnet.ts` and gated to a SETTLED
  * mesh + a registered PRIMARY_CG by `global-setup.ts` BEFORE any spec runs. So a
  * failing precondition in CI is NOT "not applicable" — it's a real, currently
- * MASKED failure (a flaked node, a partitioned mesh, a dropped CG). Skipping it
- * would turn a broken devnet into a false green on the most valuable protocol
- * tests. So in CI we THROW (turning the lane red) instead of skipping.
+ * MASKED failure (a partitioned mesh, a dropped CG). Skipping it would turn a
+ * broken devnet into a false green on the most valuable protocol tests. So in CI
+ * we THROW (turning the lane red) instead of skipping.
+ *
+ * NOTE: for *node liveness* use `requireDevnetNode` instead — `isDevnetAvailable`
+ * is a single 2s curl, so feeding `!isDevnetAvailable(n)` straight into this
+ * sync gate would turn one transiently-slow `/api/status` into a CI false-red.
+ * `requireDevnetNode` retries (via `waitForDevnetStatus`) before failing.
  *
  * Use this for environment/setup preconditions only. Genuine run-state guards
  * (e.g. "a prior serial test in this file didn't produce data") should keep
@@ -159,17 +173,40 @@ export function requireDevnetPrecondition(test: SkippableTest, unmet: boolean, d
     throw new Error(
       `[devnet-precondition] ${description}. In CI the devnet is bootstrapped and gated ` +
         `by global-setup before any spec runs, so an unmet precondition here is a real ` +
-        `failure (flaked node / partitioned mesh / missing context graph), not a skip.`,
+        `failure (partitioned mesh / missing context graph), not a skip.`,
     );
   }
   test.skip(true, description);
 }
 
+/**
+ * Gate a devnet spec on node `nodeNum` being live.
+ *
+ *   - Node OUTSIDE the booted topology (`nodeNum > CONFIGURED_NUM_NODES`, e.g.
+ *     node2 on a 1-node run): genuinely not applicable → skip EVERYWHERE,
+ *     including CI. This keeps the node2 messaging specs from hard-failing a
+ *     deliberately small `PLAYWRIGHT_DEVNET_NUM_NODES=1` lane.
+ *   - Node in-topology but the fast `isDevnetAvailable` probe (one 2s curl)
+ *     misses: locally we skip; in CI we DON'T fail on that single probe — we
+ *     fall back to `waitForDevnetStatus`, which retries for `timeoutMs` and only
+ *     throws (red) on a genuine outage. This avoids turning a transiently-slow
+ *     `/api/status` into a false-red while still failing a truly-down node.
+ */
+export async function requireDevnetNode(test: SkippableTest, nodeNum = 1, timeoutMs = 60_000): Promise<void> {
+  if (nodeNum > CONFIGURED_NUM_NODES) {
+    test.skip(true, `node${nodeNum} is outside this ${CONFIGURED_NUM_NODES}-node devnet topology — not applicable`);
+    return;
+  }
+  if (isDevnetAvailable(nodeNum)) return;
+  if (IS_CI) {
+    // Retries internally; throws a clear error (→ red) only on a real outage.
+    await waitForDevnetStatus(nodeNum, timeoutMs);
+    return;
+  }
+  test.skip(true, `Devnet node${nodeNum} not running — start with ./scripts/devnet.sh start ${CONFIGURED_NUM_NODES}`);
+}
+
 /** Skip helper for devnet-only specs — call at start of test. */
-export function skipUnlessDevnet(test: SkippableTest, nodeNum = 1) {
-  requireDevnetPrecondition(
-    test,
-    !isDevnetAvailable(nodeNum),
-    `Devnet node${nodeNum} not running — start with ./scripts/devnet.sh start 6`,
-  );
+export async function skipUnlessDevnet(test: SkippableTest, nodeNum = 1) {
+  await requireDevnetNode(test, nodeNum);
 }

--- a/packages/node-ui/e2e/helpers/devnet.ts
+++ b/packages/node-ui/e2e/helpers/devnet.ts
@@ -132,7 +132,44 @@ export async function waitForConnectedPeers(
   );
 }
 
+const IS_CI = !!process.env.CI;
+
+type SkippableTest = { skip: (condition: boolean, description: string) => void };
+
+/**
+ * Gate a devnet spec on a precondition (node reachable, ≥1 context graph, …).
+ *
+ * These preconditions are genuinely OPTIONAL for a local run with no devnet up —
+ * there we just skip so `pnpm test:e2e` stays usable without a cluster. But in
+ * CI the devnet is bootstrapped by `bootstrap-devnet.ts` and gated to a SETTLED
+ * mesh + a registered PRIMARY_CG by `global-setup.ts` BEFORE any spec runs. So a
+ * failing precondition in CI is NOT "not applicable" — it's a real, currently
+ * MASKED failure (a flaked node, a partitioned mesh, a dropped CG). Skipping it
+ * would turn a broken devnet into a false green on the most valuable protocol
+ * tests. So in CI we THROW (turning the lane red) instead of skipping.
+ *
+ * Use this for environment/setup preconditions only. Genuine run-state guards
+ * (e.g. "a prior serial test in this file didn't produce data") should keep
+ * using `test.skip(...)` directly — the upstream failure is already red, and the
+ * dependent skip just avoids cascading noise.
+ */
+export function requireDevnetPrecondition(test: SkippableTest, unmet: boolean, description: string): void {
+  if (!unmet) return;
+  if (IS_CI) {
+    throw new Error(
+      `[devnet-precondition] ${description}. In CI the devnet is bootstrapped and gated ` +
+        `by global-setup before any spec runs, so an unmet precondition here is a real ` +
+        `failure (flaked node / partitioned mesh / missing context graph), not a skip.`,
+    );
+  }
+  test.skip(true, description);
+}
+
 /** Skip helper for devnet-only specs — call at start of test. */
-export function skipUnlessDevnet(test: { skip: (condition: boolean, description: string) => void }, nodeNum = 1) {
-  test.skip(!isDevnetAvailable(nodeNum), `Devnet node${nodeNum} not running — start with ./scripts/devnet.sh start 6`);
+export function skipUnlessDevnet(test: SkippableTest, nodeNum = 1) {
+  requireDevnetPrecondition(
+    test,
+    !isDevnetAvailable(nodeNum),
+    `Devnet node${nodeNum} not running — start with ./scripts/devnet.sh start 6`,
+  );
 }

--- a/packages/node-ui/e2e/specs/devnet/cg-variants.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/cg-variants.devnet.spec.ts
@@ -2,13 +2,13 @@
  * Context graph variant matrix on devnet — edge vs core node roles.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, waitForDevnetStatus, devnetApiFetch } from '../../helpers/devnet.js';
+import { isDevnetAvailable, waitForDevnetStatus, devnetApiFetch, requireDevnetPrecondition } from '../../helpers/devnet.js';
 import { listContextGraphs, buildTestQuads, createWmAssertion } from '../../helpers/devnet-publish.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
@@ -38,7 +38,7 @@ test.describe('CG variants — core nodes', () => {
 
   test('core node (node1) can create WM assertion', async () => {
     const cgs = await listContextGraphs(1);
-    test.skip(cgs.length === 0, 'No CGs on core');
+    requireDevnetPrecondition(test, cgs.length === 0, 'No CGs on core');
     const cgId = cgs[0]!.id;
     const stamp = Date.now();
     const res = await createWmAssertion({

--- a/packages/node-ui/e2e/specs/devnet/cg-variants.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/cg-variants.devnet.spec.ts
@@ -2,13 +2,13 @@
  * Context graph variant matrix on devnet — edge vs core node roles.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, waitForDevnetStatus, devnetApiFetch, requireDevnetPrecondition } from '../../helpers/devnet.js';
+import { isDevnetAvailable, waitForDevnetStatus, devnetApiFetch, requireDevnetPrecondition, requireDevnetNode } from '../../helpers/devnet.js';
 import { listContextGraphs, buildTestQuads, createWmAssertion } from '../../helpers/devnet-publish.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 

--- a/packages/node-ui/e2e/specs/devnet/conviction-publishing.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/conviction-publishing.devnet.spec.ts
@@ -3,12 +3,12 @@
  * Full conviction discount flows live in devnet/conviction-lazy-settle/.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
+import { devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition, requireDevnetNode } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 

--- a/packages/node-ui/e2e/specs/devnet/conviction-publishing.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/conviction-publishing.devnet.spec.ts
@@ -3,12 +3,12 @@
  * Full conviction discount flows live in devnet/conviction-lazy-settle/.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus } from '../../helpers/devnet.js';
+import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
@@ -27,7 +27,7 @@ test.describe('Conviction NFT (PCA) API', () => {
   test('publish without PCA registration uses standard shared-memory path', async () => {
     const { runWmSwmVmPipeline, listContextGraphs } = await import('../../helpers/devnet-publish.js');
     const cgs = await listContextGraphs(1);
-    test.skip(cgs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, cgs.length === 0, 'No CGs');
     const result = await runWmSwmVmPipeline({ contextGraphId: cgs[0]!.id });
     expect(result.assertionName).toBeTruthy();
   });
@@ -37,7 +37,7 @@ test.describe('Non-conviction publishing (baseline)', () => {
   test('shared-memory publish endpoint responds for devnet CG', async () => {
     const cgsRes = await devnetApiFetch('/api/context-graphs');
     const { contextGraphs } = (await cgsRes.json()) as { contextGraphs: Array<{ id: string }> };
-    test.skip(contextGraphs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, contextGraphs.length === 0, 'No CGs');
     const { createWmAssertion, promoteAssertion, publishToVm, buildTestQuads } = await import('../../helpers/devnet-publish.js');
     const { withSwmLock } = await import('../../helpers/swm-lock.js');
     const cgId = contextGraphs[0]!.id;

--- a/packages/node-ui/e2e/specs/devnet/mcp-tools.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/mcp-tools.devnet.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
+import { devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition, requireDevnetNode } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 

--- a/packages/node-ui/e2e/specs/devnet/mcp-tools.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/mcp-tools.devnet.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus } from '../../helpers/devnet.js';
+import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
@@ -33,7 +33,7 @@ test.describe('MCP server tools (devnet API smoke)', () => {
   test('SPARQL query endpoint returns bindings for devnet CG', async () => {
     const cgs = await devnetApiFetch('/api/context-graphs');
     const { contextGraphs } = (await cgs.json()) as { contextGraphs: Array<{ id: string }> };
-    test.skip(contextGraphs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, contextGraphs.length === 0, 'No CGs');
     const cgId = contextGraphs[0]!.id;
     const res = await devnetApiFetch('/api/query', {
       method: 'POST',
@@ -51,7 +51,7 @@ test.describe('MCP server tools (devnet API smoke)', () => {
   test('context graph manifest endpoint responds', async () => {
     const cgs = await devnetApiFetch('/api/context-graphs');
     const { contextGraphs } = (await cgs.json()) as { contextGraphs: Array<{ id: string }> };
-    test.skip(contextGraphs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, contextGraphs.length === 0, 'No CGs');
     const cgId = contextGraphs[0]!.id;
     const res = await devnetApiFetch(`/api/context-graph/${encodeURIComponent(cgId)}/manifest`);
     expect([200, 404]).toContain(res.status);

--- a/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
@@ -6,6 +6,7 @@ import {
   isDevnetAvailable,
   devnetApiFetch,
   waitForDevnetStatus,
+  requireDevnetPrecondition,
 } from '../../helpers/devnet.js';
 import {
   listContextGraphs,
@@ -16,13 +17,13 @@ import {
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
 test.describe('Prolonged inter-node messaging soak', () => {
   test('agents peer count stable over 30s polling window', async () => {
-    test.skip(!isDevnetAvailable(2), 'Devnet node2 not running');
+    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
     const samples: number[] = [];
     let okResponses = 0;
     for (let i = 0; i < 15; i++) {
@@ -40,7 +41,7 @@ test.describe('Prolonged inter-node messaging soak', () => {
 
   test('status endpoint stays healthy across nodes during soak', async () => {
     for (const nodeNum of [1, 2]) {
-      test.skip(!isDevnetAvailable(nodeNum), `Devnet node${nodeNum} not running`);
+      requireDevnetPrecondition(test, !isDevnetAvailable(nodeNum), `Devnet node${nodeNum} not running`);
       const res = await devnetApiFetch('/api/status', { nodeNum });
       expect(res.ok).toBe(true);
     }
@@ -50,7 +51,7 @@ test.describe('Prolonged inter-node messaging soak', () => {
 test.describe('Ownership transfer + delegated KA update (API)', () => {
   test('curator can list and mutate participants on owned CG', async () => {
     const cgs = await listContextGraphs(1);
-    test.skip(cgs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, cgs.length === 0, 'No CGs');
     const cgId = cgs[0]!.id;
     const list = await devnetApiFetch(`/api/context-graph/${encodeURIComponent(cgId)}/participants`);
     expect(list.ok).toBe(true);
@@ -58,7 +59,7 @@ test.describe('Ownership transfer + delegated KA update (API)', () => {
 
   test('KA update endpoint accepts quads after WM→VM pipeline', async () => {
     const cgs = await listContextGraphs(1);
-    test.skip(cgs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, cgs.length === 0, 'No CGs');
     const cgId = cgs[0]!.id;
     await runWmSwmVmPipeline({ contextGraphId: cgId });
     const stamp = Date.now();
@@ -73,7 +74,7 @@ test.describe('Ownership transfer + delegated KA update (API)', () => {
   });
 
   test('second agent registration succeeds on devnet node2', async () => {
-    test.skip(!isDevnetAvailable(2), 'Devnet node2 not running');
+    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
     const { registerAgent } = await import('../../helpers/devnet-publish.js');
     const agent = await registerAgent(2, 'delegated');
     expect(agent.agentAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);

--- a/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
@@ -3,10 +3,10 @@
  */
 import { test, expect } from '../../fixtures/base.js';
 import {
-  isDevnetAvailable,
   devnetApiFetch,
   waitForDevnetStatus,
   requireDevnetPrecondition,
+  requireDevnetNode,
 } from '../../helpers/devnet.js';
 import {
   listContextGraphs,
@@ -17,13 +17,13 @@ import {
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 
 test.describe('Prolonged inter-node messaging soak', () => {
   test('agents peer count stable over 30s polling window', async () => {
-    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
+    await requireDevnetNode(test, 2);
     const samples: number[] = [];
     let okResponses = 0;
     for (let i = 0; i < 15; i++) {
@@ -41,7 +41,7 @@ test.describe('Prolonged inter-node messaging soak', () => {
 
   test('status endpoint stays healthy across nodes during soak', async () => {
     for (const nodeNum of [1, 2]) {
-      requireDevnetPrecondition(test, !isDevnetAvailable(nodeNum), `Devnet node${nodeNum} not running`);
+      await requireDevnetNode(test, nodeNum);
       const res = await devnetApiFetch('/api/status', { nodeNum });
       expect(res.ok).toBe(true);
     }
@@ -74,7 +74,7 @@ test.describe('Ownership transfer + delegated KA update (API)', () => {
   });
 
   test('second agent registration succeeds on devnet node2', async () => {
-    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
+    await requireDevnetNode(test, 2);
     const { registerAgent } = await import('../../helpers/devnet-publish.js');
     const agent = await registerAgent(2, 'delegated');
     expect(agent.agentAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);

--- a/packages/node-ui/e2e/specs/devnet/messaging-ownership.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/messaging-ownership.devnet.spec.ts
@@ -1,23 +1,23 @@
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus } from '../../helpers/devnet.js';
+import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
 test.describe('Inter-node messaging (devnet API)', () => {
   test('node2 is reachable when 6-node devnet is running', async () => {
-    test.skip(!isDevnetAvailable(2), 'Devnet node2 not running');
+    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
     await waitForDevnetStatus(2);
     const res = await devnetApiFetch('/api/status', { nodeNum: 2 });
     expect(res.ok).toBe(true);
   });
 
   test('agents endpoint lists connected peers over prolonged polling window', async () => {
-    test.skip(!isDevnetAvailable(2), 'Devnet node2 not running');
+    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
     let maxPeers = 0;
     let okResponses = 0;
     for (let i = 0; i < 6; i++) {
@@ -44,7 +44,7 @@ test.describe('Ownership transfer UI prerequisites (devnet API)', () => {
   test('participants list is readable for first context graph', async () => {
     const cgs = await devnetApiFetch('/api/context-graphs');
     const { contextGraphs } = (await cgs.json()) as { contextGraphs: Array<{ id: string }> };
-    test.skip(contextGraphs.length === 0, 'No CGs');
+    requireDevnetPrecondition(test, contextGraphs.length === 0, 'No CGs');
     const cgId = contextGraphs[0]!.id;
     const res = await devnetApiFetch(`/api/context-graph/${encodeURIComponent(cgId)}/participants`);
     expect(res.ok).toBe(true);

--- a/packages/node-ui/e2e/specs/devnet/messaging-ownership.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/messaging-ownership.devnet.spec.ts
@@ -1,23 +1,23 @@
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
+import { devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition, requireDevnetNode } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 
 test.describe('Inter-node messaging (devnet API)', () => {
   test('node2 is reachable when 6-node devnet is running', async () => {
-    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
+    await requireDevnetNode(test, 2);
     await waitForDevnetStatus(2);
     const res = await devnetApiFetch('/api/status', { nodeNum: 2 });
     expect(res.ok).toBe(true);
   });
 
   test('agents endpoint lists connected peers over prolonged polling window', async () => {
-    requireDevnetPrecondition(test, !isDevnetAvailable(2), 'Devnet node2 not running');
+    await requireDevnetNode(test, 2);
     let maxPeers = 0;
     let okResponses = 0;
     for (let i = 0; i < 6; i++) {

--- a/packages/node-ui/e2e/specs/devnet/publishing-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/publishing-lifecycle.devnet.spec.ts
@@ -4,12 +4,12 @@
  * `scripts/devnet.sh start` is required.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus } from '../../helpers/devnet.js';
+import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
 });
 
@@ -34,7 +34,7 @@ test.describe('Publishing lifecycle (devnet)', () => {
     expect(cgs.ok).toBe(true);
     const body = (await cgs.json()) as { contextGraphs: Array<{ id: string; name: string }> };
     const cg = body.contextGraphs[0];
-    test.skip(!cg, 'No context graphs on devnet');
+    requireDevnetPrecondition(test, !cg, 'No context graphs on devnet');
 
     const stamp = Date.now();
     const res = await devnetApiFetch('/api/assertion/create', {

--- a/packages/node-ui/e2e/specs/devnet/publishing-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/publishing-lifecycle.devnet.spec.ts
@@ -4,12 +4,12 @@
  * `scripts/devnet.sh start` is required.
  */
 import { test, expect } from '../../fixtures/base.js';
-import { isDevnetAvailable, devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition } from '../../helpers/devnet.js';
+import { devnetApiFetch, waitForDevnetStatus, requireDevnetPrecondition, requireDevnetNode } from '../../helpers/devnet.js';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
 });
 

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
@@ -5,10 +5,10 @@
  */
 import { test, expect } from '../../fixtures/base.js';
 import {
-  isDevnetAvailable,
   waitForDevnetStatus,
   devnetApiFetch,
   requireDevnetPrecondition,
+  requireDevnetNode,
 } from '../../helpers/devnet.js';
 import {
   listContextGraphs,
@@ -23,7 +23,7 @@ test.describe.configure({ mode: 'serial' });
 const run: { cgId?: string; cgName?: string; label?: string; assertionName?: string; kaId?: string } = {};
 
 test.beforeAll(async () => {
-  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
+  await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
   const cgs = await listContextGraphs(1);
   requireDevnetPrecondition(test, cgs.length === 0, 'No context graphs on devnet');
@@ -58,20 +58,32 @@ test.describe('WM → SWM → VM API pipeline', () => {
     expect(promote.ok).toBe(true);
   });
 
-  test('full WM → SWM → VM pipeline returns kaId', async () => {
+  test('full WM → SWM → VM pipeline mints a confirmed on-chain kaId', async () => {
     const result = await runWmSwmVmPipeline({ contextGraphId: run.cgId! });
     expect(result.assertionName).toBeTruthy();
     run.label = result.label;
     run.assertionName = result.assertionName;
     run.kaId = result.kaId;
-    // A successful VM publish (HTTP 200) ALWAYS carries a kaId — the daemon's
-    // publishResponsePayload returns `kaId: String(result.kaId)` and publishToVm
-    // throws on any non-2xx. So this is an unconditional contract, NOT a soft
-    // "assert only if present" check: a 200 with a missing/zero kaId means the
-    // on-chain KA mint silently regressed, which is exactly what this test exists
-    // to catch. The previous `if (result.kaId)` guard let that slip through green.
-    expect(result.kaId, 'VM publish returned 200 but minted no on-chain kaId').toBeTruthy();
-    expect(BigInt(result.kaId!)).toBeGreaterThan(0n);
+
+    // 207 = the SWM/VM publish landed but the context-graph mirror failed
+    // (`contextGraphError`) — a PARTIAL publish. publishToVm only gates on
+    // `res.ok`, which is true for 207 too, so without this the full-pipeline
+    // verifier would treat a partial publish as a clean pass.
+    expect(result.contextGraphError, `VM publish was partial (HTTP ${result.httpStatus}): ${result.contextGraphError}`).toBeFalsy();
+    expect(result.httpStatus, 'VM publish should be a clean 200, not a 207 partial').toBe(200);
+
+    // The daemon sends `kaId: String(result.kaId)`, so it always reaches us as a
+    // numeric string ("0", "42", …) — never empty/undefined. A bare
+    // `toBeTruthy()` would therefore pass even on "0", so assert the SHAPE
+    // (clean message + guards BigInt() from throwing if the payload ever becomes
+    // a UAL/DID string) and then the value.
+    expect(result.kaId, 'VM publish returned 2xx but no numeric kaId — KA mint regressed').toMatch(/^\d+$/);
+    // kaId 0 means the publish downgraded to a *tentative* local result
+    // (`onChainResult?.batchId ?? 0n` in dkg-publisher). On the e2e devnet the
+    // chain is live and quorum was confirmed by global-setup, so a confirmed
+    // on-chain mint (kaId > 0) is the contract — a 0 here is a real regression,
+    // not an expected outcome.
+    expect(BigInt(result.kaId!), 'kaId is 0 — publish did not mint on-chain (tentative downgrade)').toBeGreaterThan(0n);
   });
 });
 

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
@@ -8,6 +8,7 @@ import {
   isDevnetAvailable,
   waitForDevnetStatus,
   devnetApiFetch,
+  requireDevnetPrecondition,
 } from '../../helpers/devnet.js';
 import {
   listContextGraphs,
@@ -22,10 +23,10 @@ test.describe.configure({ mode: 'serial' });
 const run: { cgId?: string; cgName?: string; label?: string; assertionName?: string; kaId?: string } = {};
 
 test.beforeAll(async () => {
-  test.skip(!isDevnetAvailable(1), 'Devnet node1 not running');
+  requireDevnetPrecondition(test, !isDevnetAvailable(1), 'Devnet node1 not running');
   await waitForDevnetStatus(1);
   const cgs = await listContextGraphs(1);
-  test.skip(cgs.length === 0, 'No context graphs on devnet');
+  requireDevnetPrecondition(test, cgs.length === 0, 'No context graphs on devnet');
   run.cgId = cgs[0]!.id;
   run.cgName = cgs[0]!.name;
 });
@@ -63,9 +64,14 @@ test.describe('WM → SWM → VM API pipeline', () => {
     run.label = result.label;
     run.assertionName = result.assertionName;
     run.kaId = result.kaId;
-    if (result.kaId) {
-      expect(BigInt(result.kaId)).toBeGreaterThan(0n);
-    }
+    // A successful VM publish (HTTP 200) ALWAYS carries a kaId — the daemon's
+    // publishResponsePayload returns `kaId: String(result.kaId)` and publishToVm
+    // throws on any non-2xx. So this is an unconditional contract, NOT a soft
+    // "assert only if present" check: a 200 with a missing/zero kaId means the
+    // on-chain KA mint silently regressed, which is exactly what this test exists
+    // to catch. The previous `if (result.kaId)` guard let that slip through green.
+    expect(result.kaId, 'VM publish returned 200 but minted no on-chain kaId').toBeTruthy();
+    expect(BigInt(result.kaId!)).toBeGreaterThan(0n);
   });
 });
 

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
@@ -66,9 +66,11 @@ test.describe('WM → SWM → VM API pipeline', () => {
     run.kaId = result.kaId;
 
     // 207 = the SWM/VM publish landed but the context-graph mirror failed
-    // (`contextGraphError`) — a PARTIAL publish. publishToVm only gates on
-    // `res.ok`, which is true for 207 too, so without this the full-pipeline
-    // verifier would treat a partial publish as a clean pass.
+    // (`contextGraphError`) — a PARTIAL publish. publishToVm now REJECTS a 207 by
+    // default (it would have thrown above before returning), so reaching this
+    // point already guarantees a clean publish. We assert it here too as an
+    // explicit, readable contract for this headline pipeline test — and as a
+    // tripwire if anyone ever flips the helper's default to tolerate partials.
     expect(result.contextGraphError, `VM publish was partial (HTTP ${result.httpStatus}): ${result.contextGraphError}`).toBeFalsy();
     expect(result.httpStatus, 'VM publish should be a clean 200, not a 207 partial').toBe(200);
 


### PR DESCRIPTION
## Summary

Hardens the `node-ui` Playwright real-node devnet e2e lane so it can't report a **false green**. Two changes, both surfaced by an in-depth reliability review of the suite:

1. **CI-mode preconditions now fail instead of skip.** The devnet specs guarded themselves with `test.skip(!isDevnetAvailable(n))` / `test.skip(cgs.length === 0)`. A skip is green — so a transient node blip or a missing context graph at a spec's `beforeAll` silently dropped the most valuable protocol tests (publish pipeline, messaging, peer connectivity) while the lane still passed. In CI the devnet is bootstrapped by `bootstrap-devnet.ts` and gated to a *settled* mesh + registered `PRIMARY_CG` by `global-setup.ts` **before any spec runs**, so an unmet precondition there is a real (currently masked) failure, not "not applicable".

   New helper `requireDevnetPrecondition(test, unmet, description)` in `e2e/helpers/devnet.ts`:
   - **In CI** (`process.env.CI`): throws → turns the lane red.
   - **Locally**: skips, so `pnpm test:e2e` stays usable without a cluster.

   All environment/setup skips across the 7 devnet specs route through it. Genuine **run-state** guards (a prior serial test didn't produce data) keep using `test.skip` — the upstream failure is already red, so the dependent skip just avoids cascading noise.

2. **Unconditional `kaId` assertion in the WM→SWM→VM pipeline test.** The old `if (result.kaId)` guard meant the on-chain KA mint was only soft-checked: a 200 response that minted no `kaId` would still pass. A successful VM publish always carries a `kaId` (`publishResponsePayload` returns `kaId: String(result.kaId)`; `publishToVm` throws on non-2xx), so the absence of one is a real regression. Now asserted unconditionally.

## Test plan

- [x] `tsc --noEmit` over the full `e2e/` tree — clean.
- [x] No lint errors on changed files.
- [x] Confirmed only the two legitimate run-state `test.skip`s remain in `e2e/specs/devnet`.
- [ ] CI `Kosava: node-ui e2e (Playwright real-node devnet)` lane stays green (preconditions are guaranteed by bootstrap + global-setup, so the new CI-fail path should not trigger on a healthy run).

## Notes

A third review finding (CI `retries: 2` masking flakes) is intentionally **not** addressed here — retries are reasonable for a heavy real-node lane; the recommendation was to track retry-only passes over time, which is a separate observability change.

Made with [Cursor](https://cursor.com)