### PR TITLE
fix(node-ui): keep scoped GRAPH variables top-level in WM layer queries

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -818,6 +818,12 @@ export async function listAssertions(
   //     the allow-list to the assertion partitions so these counts populate.
   // Counts are merged by graph URI; a WM graph with no count row simply
   // renders without a triple badge (the badge is `!= null`-guarded).
+  // The two queries fire in parallel, but the count is BEST-EFFORT: it feeds
+  // only the triple-count badge, so a count failure (timeout, a future
+  // scoped-query edge case) must not reject the whole listing and regress the
+  // promote flow back to "no assertions". Its rejection is swallowed to `null`
+  // (rows then render with `tripleCount: undefined`); the membership query
+  // stays authoritative and its rejection still propagates.
   const listSparql = `SELECT ?g WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
   }`;
@@ -827,7 +833,8 @@ export async function listAssertions(
   } GROUP BY ?g`;
   const [listData, countData] = await Promise.all([
     postQueryDeduped({ sparql: listSparql, contextGraphId, includeContextGraphPartitions: true }),
-    postQueryDeduped({ sparql: countSparql, contextGraphId, includeContextGraphPartitions: true }),
+    postQueryDeduped({ sparql: countSparql, contextGraphId, includeContextGraphPartitions: true })
+      .catch(() => null),
   ]);
   const bindings: any[] = listData?.result?.bindings ?? [];
   const countByGraph = new Map<string, number>();

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -789,16 +789,41 @@ export async function listAssertions(
   // the data graph is genuinely empty (fresh create with no writes
   // yet), matching the prior listing semantics for that case.
   const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-  const sparql = `SELECT ?g (COUNT(?s) AS ?cnt) WHERE {
+  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  // Two scoped queries instead of a single `OPTIONAL { GRAPH ?g { … } }`.
+  // The OPTIONAL nested a GRAPH *variable* below the top level of the
+  // WHERE block, which the scoped local-query path
+  // (`constrainGraphVariablesToAllowedSet`, PR #749) rejects with
+  // "GRAPH variables must appear at the top level of scoped local
+  // queries". Split the concern:
+  //   • `listSparql`  — authoritative WM membership from the fixed
+  //     `_meta` graph (no GRAPH variable at all). Includes assertions
+  //     whose data partition is still empty (fresh create, no writes),
+  //     preserving the prior listing semantics the OPTIONAL existed for.
+  //   • `countSparql` — per-partition triple counts with the GRAPH
+  //     variable at the top level (guard-safe). In the UI
+  //     `includeContextGraphPartitions: true` expands the allow-list to
+  //     the assertion partitions so these counts populate.
+  // Counts are merged by graph URI; a WM graph with no count row simply
+  // renders without a triple badge (the badge is `!= null`-guarded).
+  const listSparql = `SELECT ?g WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
-    OPTIONAL { GRAPH ?g { ?s ?p ?o } }
+  }`;
+  const countSparql = `SELECT ?g (COUNT(*) AS ?cnt) WHERE {
+    GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgPrefix}"))
   } GROUP BY ?g`;
-  const data = await postQueryDeduped({
-    sparql,
-    contextGraphId,
-    includeContextGraphPartitions: true,
-  });
-  const bindings: any[] = data?.result?.bindings ?? [];
+  const [listData, countData] = await Promise.all([
+    postQueryDeduped({ sparql: listSparql, contextGraphId, includeContextGraphPartitions: true }),
+    postQueryDeduped({ sparql: countSparql, contextGraphId, includeContextGraphPartitions: true }),
+  ]);
+  const bindings: any[] = listData?.result?.bindings ?? [];
+  const countByGraph = new Map<string, number>();
+  for (const b of (countData?.result?.bindings ?? [])) {
+    const g = typeof b.g === 'string' ? b.g : b.g?.value;
+    const cntRaw = typeof b.cnt === 'string' ? b.cnt : b.cnt?.value;
+    const cnt = cntRaw != null ? parseInt(cntRaw, 10) : NaN;
+    if (g && Number.isFinite(cnt)) countByGraph.set(g, cnt);
+  }
   // #706 fix — the prior `startsWith('did:dkg:context-graph:<cg>/assertion/')`
   // shape silently dropped sub-graph-scoped WM assertions, whose graph
   // URI is `did:dkg:context-graph:<cg>/<sg>/assertion/<agent>/<name>`
@@ -813,7 +838,6 @@ export async function listAssertions(
   // would silently miss otherwise. The cgId itself is treated as
   // opaque (it may contain `/assertion/` as a literal substring,
   // per `validateContextGraphId`).
-  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
   const result: AssertionInfo[] = [];
   for (const b of bindings) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
@@ -831,8 +855,8 @@ export async function listAssertions(
       continue;
     }
     if (!name) continue;
-    const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
-    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined, subGraph });
+    const cnt = countByGraph.get(g);
+    result.push({ name, graphUri: g, tripleCount: cnt, subGraph });
   }
   return result;
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -580,8 +580,15 @@ export const executeQuery = (
   includeSharedMemory?: boolean,
   graphSuffix?: '_shared_memory',
   view?: 'verified-memory' | 'shared-working-memory',
+  // Opt the CG-scoped allow-list into the assertion partitions. Without it the
+  // daemon restricts `GRAPH ?g { … }` to the static set
+  // { <cg>, <cg>/_meta, <cg>/_shared_memory_meta } (see the long note on
+  // `listWmAssertions`), so a `GRAPH ?g` enumeration of WM content comes back
+  // empty. Callers that read raw partition triples (e.g. the WM layer view)
+  // pass `true`.
+  includeContextGraphPartitions?: boolean,
 ) =>
-  postQueryDeduped({ sparql, contextGraphId, includeSharedMemory, graphSuffix, view });
+  postQueryDeduped({ sparql, contextGraphId, includeSharedMemory, graphSuffix, view, includeContextGraphPartitions });
 
 // --- Publish (assertion-lifecycle: RFC-001 §9.x sign-at-creation) ---
 //
@@ -801,16 +808,22 @@ export async function listAssertions(
   //     whose data partition is still empty (fresh create, no writes),
   //     preserving the prior listing semantics the OPTIONAL existed for.
   //   • `countSparql` — per-partition triple counts with the GRAPH
-  //     variable at the top level (guard-safe). In the UI
-  //     `includeContextGraphPartitions: true` expands the allow-list to
-  //     the assertion partitions so these counts populate.
+  //     variable at the top level (guard-safe). Both GRAPH clauses are
+  //     siblings at the top of the WHERE block, so the `?g` variable
+  //     stays top-level and the guard passes. The leading fixed-graph
+  //     join restricts counting to the WM-marked assertion graphs only —
+  //     without it the count fanned out over *every* partition under the
+  //     CG (SWM/VM/meta included), turning a small WM listing into a full
+  //     CG scan. In the UI `includeContextGraphPartitions: true` expands
+  //     the allow-list to the assertion partitions so these counts populate.
   // Counts are merged by graph URI; a WM graph with no count row simply
   // renders without a triple badge (the badge is `!= null`-guarded).
   const listSparql = `SELECT ?g WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
   }`;
   const countSparql = `SELECT ?g (COUNT(*) AS ?cnt) WHERE {
-    GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgPrefix}"))
+    GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
+    GRAPH ?g { ?s ?p ?o }
   } GROUP BY ?g`;
   const [listData, countData] = await Promise.all([
     postQueryDeduped({ sparql: listSparql, contextGraphId, includeContextGraphPartitions: true }),

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -824,12 +824,23 @@ export async function listAssertions(
   // promote flow back to "no assertions". Its rejection is swallowed to `null`
   // (rows then render with `tripleCount: undefined`); the membership query
   // stays authoritative and its rejection still propagates.
+  // Exclude the reserved `meta` namespace. Profile / query-catalog artifacts
+  // (prof:Profile, prof:SavedQuery, …) are published as WM-marked assertions
+  // under `<cg>/meta/assertion/<addr>/<name>`, so a bare `memoryLayer "WM"`
+  // join scoops them in alongside real user knowledge. Since this listing
+  // feeds the assertions table + bulk-promote, those UI-config drafts would
+  // otherwise be promotable into SWM. Mirror the meta-exclusion policy
+  // `useMemoryEntities.wmSparql` already enforces (`STR(?g) != "<cg>/meta"`,
+  // `!CONTAINS("/meta/")`, `!STRENDS("/_meta")`).
+  const metaFilter = `FILTER(STR(?g) != "${cgPrefix}meta" && !CONTAINS(STR(?g), "/meta/") && !STRENDS(STR(?g), "/_meta"))`;
   const listSparql = `SELECT ?g WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
+    ${metaFilter}
   }`;
   const countSparql = `SELECT ?g (COUNT(*) AS ?cnt) WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
     GRAPH ?g { ?s ?p ?o }
+    ${metaFilter}
   } GROUP BY ?g`;
   const [listData, countData] = await Promise.all([
     postQueryDeduped({ sparql: listSparql, contextGraphId, includeContextGraphPartitions: true }),
@@ -875,6 +886,12 @@ export async function listAssertions(
       continue;
     }
     if (!name) continue;
+    // Defense-in-depth for the meta-namespace exclusion above: the reserved
+    // `meta` sub-graph (`<cg>/meta/assertion/…` profile/query-catalog drafts)
+    // is UI configuration, not user knowledge, and must never reach the
+    // assertions table or the bulk-promote flow. The SPARQL `metaFilter`
+    // already drops these daemon-side; this guards the parser too.
+    if (subGraph === 'meta') continue;
     const cnt = countByGraph.get(g);
     result.push({ name, graphUri: g, tripleCount: cnt, subGraph });
   }

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -113,7 +113,15 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
       const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-      return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}")) } } LIMIT 1000`;
+      // GRAPH variable must stay at the top level of the WHERE block: the
+      // scoped local-query path (`constrainGraphVariablesToAllowedSet`,
+      // PR #749) rejects a `GRAPH ?g` nested inside `UNION`/`OPTIONAL`/a
+      // sub-group with "GRAPH variables must appear at the top level of
+      // scoped local queries". The dropped `{ ?s ?p ?o }` default-graph
+      // UNION branch was also an unscoped read — in V10 all context-graph
+      // content lives in named partitions, so the named-graph branch alone
+      // returns the WM triples.
+      return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}")) } LIMIT 1000`;
     }
     if (layer === 'vm') {
       return buildVerifiedMemorySearchQuery({

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -138,10 +138,16 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
   const graphSuffix = layer === 'swm' ? '_shared_memory' as const : undefined;
   const includeShared = layer === 'swm';
   const queryView = layer === 'vm' ? 'verified-memory' as const : undefined;
+  // WM content lives in the CG's assertion partitions, which sit outside the
+  // daemon's static `GRAPH ?g` allow-list. Without this opt-in the WM view's
+  // `GRAPH ?g { ?s ?p ?o }` enumeration resolves against only
+  // { <cg>, <cg>/_meta, <cg>/_shared_memory_meta } and renders empty. SWM/VM
+  // use their own `view`-routed scopes and don't need it.
+  const includePartitions = layer === 'wm';
 
   const { data, loading, error, refresh } = useFetch(
-    () => executeQuery(sparql, contextGraphId, includeShared, graphSuffix, queryView),
-    [sparql, contextGraphId, includeShared, graphSuffix, queryView],
+    () => executeQuery(sparql, contextGraphId, includeShared, graphSuffix, queryView, includePartitions),
+    [sparql, contextGraphId, includeShared, graphSuffix, queryView, includePartitions],
     0
   );
   useMemoryGraphEvents(contextGraphId, refresh, { layers: [layer] });

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -112,16 +112,22 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
 
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
-      const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-      // GRAPH variable must stay at the top level of the WHERE block: the
-      // scoped local-query path (`constrainGraphVariablesToAllowedSet`,
-      // PR #749) rejects a `GRAPH ?g` nested inside `UNION`/`OPTIONAL`/a
-      // sub-group with "GRAPH variables must appear at the top level of
-      // scoped local queries". The dropped `{ ?s ?p ?o }` default-graph
-      // UNION branch was also an unscoped read — in V10 all context-graph
-      // content lives in named partitions, so the named-graph branch alone
-      // returns the WM triples.
-      return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}")) } LIMIT 1000`;
+      const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+      // Two constraints shape this query:
+      //  1. The GRAPH variable must stay at the TOP LEVEL of the WHERE block.
+      //     The scoped local-query path (`constrainGraphVariablesToAllowedSet`,
+      //     PR #749) rejects a `GRAPH ?g` nested inside `UNION`/`OPTIONAL`/a
+      //     sub-group ("GRAPH variables must appear at the top level of scoped
+      //     local queries"). Both GRAPH clauses below are WHERE-block siblings,
+      //     so `?g` stays top-level and the guard passes.
+      //  2. `?g` must be restricted to WM-marked partitions. The view runs with
+      //     `includeContextGraphPartitions: true` (see below), which widens the
+      //     allow-list to every same-CG partition — including `/_shared_memory`,
+      //     `/_verified_memory/*`, and metadata graphs. A bare prefix FILTER
+      //     would let SWM/VM triples bleed into the WM tab, so we gate `?g` on
+      //     the `<cg>/_meta` `dkg:memoryLayer "WM"` lifecycle marker (the same
+      //     authority `listWmAssertions` uses) and read only those graphs.
+      return `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" } GRAPH ?g { ?s ?p ?o } } LIMIT 1000`;
     }
     if (layer === 'vm') {
       return buildVerifiedMemorySearchQuery({

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -149,7 +149,14 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
   // `GRAPH ?g { ?s ?p ?o }` enumeration resolves against only
   // { <cg>, <cg>/_meta, <cg>/_shared_memory_meta } and renders empty. SWM/VM
   // use their own `view`-routed scopes and don't need it.
-  const includePartitions = layer === 'wm';
+  //
+  // Scope the opt-in to the *built-in* WM query only (`sparql === defaultSparql`):
+  // that query constrains `?g` to WM-marked graphs via the `_meta` join, so the
+  // widened allow-list stays layer-correct. A custom query typed into the WM tab
+  // must NOT get the opt-in — otherwise an advanced `GRAPH ?g { … }` could
+  // enumerate SWM/VM/meta partitions and silently escape the WM scope. Custom
+  // queries fall back to the daemon's default static allow-list.
+  const includePartitions = layer === 'wm' && sparql === defaultSparql;
 
   const { data, loading, error, refresh } = useFetch(
     () => executeQuery(sparql, contextGraphId, includeShared, graphSuffix, queryView, includePartitions),

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -127,7 +127,12 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
       //     would let SWM/VM triples bleed into the WM tab, so we gate `?g` on
       //     the `<cg>/_meta` `dkg:memoryLayer "WM"` lifecycle marker (the same
       //     authority `listWmAssertions` uses) and read only those graphs.
-      return `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" } GRAPH ?g { ?s ?p ?o } } LIMIT 1000`;
+      //  3. Exclude the reserved `meta` namespace (`<cg>/meta/assertion/…`
+      //     profile/query-catalog drafts are WM-marked but are UI config, not
+      //     user knowledge), mirroring `listWmAssertions` + the
+      //     `useMemoryEntities.wmSparql` meta-exclusion policy.
+      const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+      return `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" } GRAPH ?g { ?s ?p ?o } FILTER(STR(?g) != "${cgPrefix}meta" && !CONTAINS(STR(?g), "/meta/") && !STRENDS(STR(?g), "/_meta")) } LIMIT 1000`;
     }
     if (layer === 'vm') {
       return buildVerifiedMemorySearchQuery({

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -218,6 +218,20 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(countBody.sparql).toContain('COUNT');
   });
 
+  it('still lists WM assertions when the (best-effort) count query fails', async () => {
+    // Codex #944 — the triple-count query feeds only the badge, so a count
+    // failure must NOT drop the whole WM list and regress promote to "no
+    // assertions". The membership query (call[0]) resolves; the count query
+    // (call[1]) rejects. Rows must still surface, with tripleCount undefined.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ result: { bindings: [bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5)] } }),
+    );
+    fetchMock.mockRejectedValueOnce(new Error('count query timed out'));
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: 'notes', tripleCount: undefined });
+  });
+
   it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {
     // PR #710 reviewer guard — `validateContextGraphId` permits
     // slashes, so a cgId can literally contain `/assertion/` as a

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -207,6 +207,15 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(body.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
     expect(body.sparql).toContain('http://dkg.io/ontology/memoryLayer');
     expect(body.sparql).toContain('"WM"');
+    // The count query (call[1]) must ALSO gate on the `_meta` WM marker —
+    // counting only WM-marked partitions instead of scanning every graph
+    // under the CG (SWM/VM/meta included). Pins the Codex #944 perf fix.
+    const [, countInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const countBody = JSON.parse(String(countInit.body));
+    expect(countBody.sparql).toContain('did:dkg:context-graph:cg-A/_meta');
+    expect(countBody.sparql).toContain('http://dkg.io/ontology/memoryLayer');
+    expect(countBody.sparql).toContain('"WM"');
+    expect(countBody.sparql).toContain('COUNT');
   });
 
   it('scopes the /assertion/ discriminator to the tail when cgId itself contains "/assertion/"', async () => {

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -218,6 +218,30 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(countBody.sparql).toContain('COUNT');
   });
 
+  it('excludes the reserved meta sub-graph from the WM assertions list (Codex #944)', async () => {
+    // `<cg>/meta/assertion/…` graphs are profile / query-catalog drafts — UI
+    // configuration, not user knowledge — and must never reach the assertions
+    // table or the bulk-promote flow even though they carry a WM lifecycle
+    // marker. (The SPARQL also filters these daemon-side; this pins the
+    // parser-level defense.)
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/meta/assertion/0xabc/profile', 8),
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('notes');
+  });
+
+  it('SPARQL excludes the meta namespace in both the list and count queries (Codex #944)', async () => {
+    setBindings([bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5)]);
+    await listAssertions('cg-A', 'wm');
+    const [, listInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, countInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(String(listInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+    expect(JSON.parse(String(countInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+  });
+
   it('still lists WM assertions when the (best-effort) count query fails', async () => {
     // Codex #944 — the triple-count query feeds only the badge, so a count
     // failure must NOT drop the whole WM list and regress promote to "no

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -46,9 +46,16 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
   });
 
   function setBindings(bindings: unknown[]) {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({ result: { bindings } }),
-    );
+    // `listAssertions(wm)` now issues two scoped queries in parallel
+    // (membership from `<cg>/_meta`, then a top-level `GRAPH ?g` triple
+    // count) instead of one OPTIONAL-nested query — the latter tripped
+    // the scoped-graph-variable guard (PR #749). Feed the same fixture
+    // rows to both: the membership query reads `?g`, the count query
+    // reads `?g` + `?cnt`, and the parser merges counts back by graph
+    // URI. Order matches the Promise.all array: call[0] = membership,
+    // call[1] = count.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ result: { bindings } }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ result: { bindings } }));
   }
 
   it('parses root-bucket assertion: name extracted, subGraph undefined', async () => {
@@ -167,15 +174,20 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
       bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5),
     ]);
     await listAssertions('cg-A', 'wm');
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(String(url)).toContain('/api/query');
-    const body = JSON.parse(String(init.body));
-    expect(body).toMatchObject({
-      contextGraphId: 'cg-A',
-      includeContextGraphPartitions: true,
-    });
-    expect(typeof body.sparql).toBe('string');
+    // Two scoped queries now: membership (call[0]) + triple count
+    // (call[1]). Both must keep the partition opt-in so `GRAPH ?g`
+    // expansion reaches the assertion data partitions.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      const [url, init] = call as [string, RequestInit];
+      expect(String(url)).toContain('/api/query');
+      const body = JSON.parse(String(init.body));
+      expect(body).toMatchObject({
+        contextGraphId: 'cg-A',
+        includeContextGraphPartitions: true,
+      });
+      expect(typeof body.sparql).toBe('string');
+    }
   });
 
   it('SPARQL gates WM membership on dkg:memoryLayer "WM" in <cg>/_meta (#898 Codex)', async () => {

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -477,6 +477,10 @@ describe('memory layer custom query execution', () => {
     //     `GRAPH ?g` typed into the WM tab could enumerate SWM/VM/meta
     //     partitions and escape the WM scope.
     expect(memoryLayerView).toContain("layer === 'wm' && sparql === defaultSparql");
+    //  4. Exclude the reserved `meta` namespace (profile/query-catalog drafts
+    //     are WM-marked but are UI config, not user knowledge), mirroring the
+    //     listWmAssertions + useMemoryEntities meta-exclusion policy.
+    expect(memoryLayerView).toContain('!CONTAINS(STR(?g), "/meta/")');
   });
 });
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -457,16 +457,21 @@ describe('memory layer custom query execution', () => {
     expect(memoryLayerView).toContain('<button className="v10-mlv-run-btn" onClick={runQuery}>');
   });
 
-  it('keeps the WM default query GRAPH variable at the top level (scoped-query guard, PR #749)', () => {
-    // Regression guard: the scoped local-query path rejects a GRAPH
-    // *variable* nested in UNION/OPTIONAL/a sub-group with "GRAPH
-    // variables must appear at the top level of scoped local queries".
-    // The WM default query must read named partitions via a top-level
-    // `GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(...))` and must NOT wrap
-    // `GRAPH ?g` inside a UNION (the prior shape that broke the WM layer
-    // view + WM→SWM promote flow).
+  it('keeps the WM default query GRAPH variable top-level AND WM-scoped (scoped-query guard #749 + Codex #944)', () => {
+    // Two regressions pinned here:
+    //  1. The scoped local-query path rejects a GRAPH *variable* nested in
+    //     UNION/OPTIONAL/a sub-group ("GRAPH variables must appear at the top
+    //     level of scoped local queries"), so `GRAPH ?g` must never be wrapped
+    //     in a UNION/OPTIONAL (the prior shape that broke the WM layer view +
+    //     WM→SWM promote flow).
     expect(memoryLayerView).not.toMatch(/UNION\s*\{\s*GRAPH\s+\?/);
-    expect(memoryLayerView).toContain('GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g),');
+    expect(memoryLayerView).not.toMatch(/OPTIONAL\s*\{\s*GRAPH\s+\?/);
+    //  2. With `includeContextGraphPartitions` on, a bare prefix FILTER would
+    //     let SWM/VM partitions bleed into the WM tab. `?g` must be gated on
+    //     the `<cg>/_meta` `dkg:memoryLayer "WM"` marker and read via a
+    //     top-level `GRAPH ?g { ?s ?p ?o }`.
+    expect(memoryLayerView).toContain('<http://dkg.io/ontology/memoryLayer> "WM"');
+    expect(memoryLayerView).toContain('GRAPH ?g { ?s ?p ?o }');
   });
 });
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -472,6 +472,11 @@ describe('memory layer custom query execution', () => {
     //     top-level `GRAPH ?g { ?s ?p ?o }`.
     expect(memoryLayerView).toContain('<http://dkg.io/ontology/memoryLayer> "WM"');
     expect(memoryLayerView).toContain('GRAPH ?g { ?s ?p ?o }');
+    //  3. The partition opt-in must be gated to the built-in WM query only.
+    //     If it leaked to custom queries (just `layer === 'wm'`), an advanced
+    //     `GRAPH ?g` typed into the WM tab could enumerate SWM/VM/meta
+    //     partitions and escape the WM scope.
+    expect(memoryLayerView).toContain("layer === 'wm' && sparql === defaultSparql");
   });
 });
 

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -456,6 +456,18 @@ describe('memory layer custom query execution', () => {
     expect(memoryLayerView).toContain("onKeyDown={(e) => { if (e.key === 'Enter') runQuery(); }}");
     expect(memoryLayerView).toContain('<button className="v10-mlv-run-btn" onClick={runQuery}>');
   });
+
+  it('keeps the WM default query GRAPH variable at the top level (scoped-query guard, PR #749)', () => {
+    // Regression guard: the scoped local-query path rejects a GRAPH
+    // *variable* nested in UNION/OPTIONAL/a sub-group with "GRAPH
+    // variables must appear at the top level of scoped local queries".
+    // The WM default query must read named partitions via a top-level
+    // `GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(...))` and must NOT wrap
+    // `GRAPH ?g` inside a UNION (the prior shape that broke the WM layer
+    // view + WM→SWM promote flow).
+    expect(memoryLayerView).not.toMatch(/UNION\s*\{\s*GRAPH\s+\?/);
+    expect(memoryLayerView).toContain('GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g),');
+  });
 });
 
 /* ══════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes a **rc.14 regression**: the WM memory-layer view and the WM→SWM promote flow fail with:

> ✕ Scoped query violation: GRAPH variables must appear at the top level of scoped local queries

Root cause: two node-ui queries nested a `GRAPH ?g` **variable** inside `UNION`/`OPTIONAL`, below the top level of the WHERE block. The scoped local-query path (`constrainGraphVariablesToAllowedSet`, introduced in #749) injects `VALUES ?g { <allowed…> }` at the top level and therefore requires GRAPH variables to be top-level — it rejects nested ones rather than risk an unscoped read. The guard is correct; the queries were not.

- `MemoryLayerView.tsx` WM default query: dropped the unscoped `{ ?s ?p ?o }` default-graph `UNION` branch and read named partitions via a single top-level `GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), <cgUri>))`. In V10 all context-graph content lives in named partitions, so the dropped branch returned nothing useful anyway (and was itself an unscoped default-graph read).
- `api.ts` `listWmAssertions`: split the `OPTIONAL { GRAPH ?g { … } }` query into two guard-safe scoped queries run in parallel and merged by graph URI:
  - WM membership from the fixed `<cg>/_meta` graph (no GRAPH variable) — keeps empty WM assertions visible and preserves the #898 lifecycle-gated semantics.
  - a top-level `GRAPH ?g` triple count (populated via `includeContextGraphPartitions`).
  - No behavior regression: listing, the `_meta`/`"WM"` gate, and the per-assertion triple-count badge are all preserved.

## Verification

- Reproduced live on a testnet node (rc.14): old query → the exact error; both replacement queries → pass.
- `tsc --noEmit` clean; no lint errors.
- Updated `list-assertions.test.ts` for the two-query shape (10/10 pass) and added a regression guard in `ui-compat.test.ts` pinning the WM query to a top-level `GRAPH` variable (no `UNION { GRAPH … }`).

## Test plan

- [ ] Open the WM layer of a context graph in the node UI → triples load (no scoped-query violation).
- [ ] Click "Promote to Shared Working Memory" → succeeds.
- [ ] WM assertion list still shows assertions (incl. freshly-created empty ones) with their triple-count badges.

Made with [Cursor](https://cursor.com)