### PR TITLE
fix(node-ui): reclaim node-ui.db WAL file on a running node

### DIFF
--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -110,6 +110,15 @@ export class DashboardDB {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
+    // Cap the persisted WAL file. A PASSIVE autocheckpoint resets WAL
+    // frames but leaves the -wal file at its high-water mark, so a node
+    // that once took a heavy write burst (e.g. the pre-rc.14 sync-page
+    // idempotency firehose) keeps a multi-GB -wal on disk forever. With
+    // journal_size_limit set, checkpoints truncate the file back to this
+    // cap. Per-connection setting (not persisted), so it is re-applied on
+    // every open. 64 MiB leaves headroom above the ~4 MiB default
+    // autocheckpoint while bounding the worst case.
+    this.db.pragma('journal_size_limit = 67108864');
     this.migrate();
     this.loadRetentionSetting();
     this.prune();
@@ -772,6 +781,20 @@ export class DashboardDB {
         // VACUUM requires an exclusive lock. If another connection is
         // holding the DB open we skip and retry on the next prune.
       }
+    }
+
+    // Return the WAL file itself to the OS. journal_size_limit bounds it
+    // in steady state, but a TRUNCATE checkpoint here shrinks it promptly
+    // on the prune cadence (~6h) and immediately after the VACUUM above,
+    // which rewrites the whole DB through the WAL and momentarily grows
+    // it. Runs unconditionally — independent of the VACUUM gate — because
+    // an idle node still wants its -wal reclaimed. Best-effort: a
+    // concurrent reader can leave the checkpoint `busy` (no truncate),
+    // which is harmless and retried on the next prune.
+    try {
+      this.db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      // Same rationale as the VACUUM skip above — never block prune.
     }
   }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -788,13 +788,27 @@ export class DashboardDB {
     // on the prune cadence (~6h) and immediately after the VACUUM above,
     // which rewrites the whole DB through the WAL and momentarily grows
     // it. Runs unconditionally — independent of the VACUUM gate — because
-    // an idle node still wants its -wal reclaimed. Best-effort: a
-    // concurrent reader can leave the checkpoint `busy` (no truncate),
-    // which is harmless and retried on the next prune.
+    // an idle node still wants its -wal reclaimed.
     try {
-      this.db.pragma('wal_checkpoint(TRUNCATE)');
+      // wal_checkpoint signals reader contention through its result row
+      // (`busy = 1`), NOT by throwing — so a busy checkpoint leaves the
+      // WAL un-truncated while looking like success. With better-sqlite3's
+      // single synchronous connection this should not happen, but surface
+      // it if it ever does so a silently-failing reclaim is observable
+      // rather than indistinguishable from a real one.
+      const [checkpoint] = this.db.pragma('wal_checkpoint(TRUNCATE)') as Array<{
+        busy: number;
+        log: number;
+        checkpointed: number;
+      }>;
+      if (checkpoint?.busy) {
+        console.warn(
+          `[DashboardDB] wal_checkpoint(TRUNCATE) busy — WAL not reclaimed this prune ` +
+            `(log=${checkpoint.log}, checkpointed=${checkpoint.checkpointed}); retried next prune`,
+        );
+      }
     } catch {
-      // Same rationale as the VACUUM skip above — never block prune.
+      // The pragma itself throwing is unexpected; never block prune.
     }
   }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -807,8 +807,17 @@ export class DashboardDB {
             `(log=${checkpoint.log}, checkpointed=${checkpoint.checkpointed}); retried next prune`,
         );
       }
-    } catch {
-      // The pragma itself throwing is unexpected; never block prune.
+    } catch (err) {
+      // Reaching here means the pragma threw, which is distinct from the
+      // handled busy case above: contention surfaces as busy>0, not an
+      // exception. Log it (don't swallow) so that if a future SQLite /
+      // better-sqlite3 change turns lock or I/O errors into throws, the
+      // stalled WAL reclaim is visible in the daemon log instead of only
+      // showing up later as unexplained disk growth. Never block prune.
+      console.warn(
+        `[DashboardDB] wal_checkpoint(TRUNCATE) failed — WAL not reclaimed this prune: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -644,9 +644,13 @@ describe('DashboardDB — WAL reclaim', () => {
 
       walDb.prune();
 
+      // No competing readers in this test, so wal_checkpoint(TRUNCATE)
+      // must fully reclaim the file (busy = 0). Assert it is truncated to
+      // empty rather than merely "smaller" — a partial checkpoint that
+      // only shaved a few pages (the regression we want to catch) would
+      // still leave multiple MB here.
       const afterWal = statSync(walPath).size;
-      expect(afterWal).toBeLessThan(beforeWal);
-      expect(afterWal).toBeLessThanOrEqual(67108864);
+      expect(afterWal).toBe(0);
     } finally {
       walDb.close();
       rmSync(walDir, { recursive: true, force: true });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
@@ -603,6 +603,53 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
       expect(afterPrune).toBeLessThan(1_000);
     } finally {
       vacuumDb.close();
+    }
+  });
+});
+
+describe('DashboardDB — WAL reclaim', () => {
+  it('caps the WAL with journal_size_limit = 64 MiB on open', () => {
+    const walDir = mkdtempSync(join(tmpdir(), 'dkg-db-wal-limit-'));
+    const walDb = new DashboardDB({ dataDir: walDir });
+    try {
+      expect(Number(walDb.db.pragma('journal_size_limit', { simple: true }))).toBe(67108864);
+    } finally {
+      walDb.close();
+      rmSync(walDir, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates the -wal file on prune() even when the VACUUM gate stays closed', () => {
+    const walDir = mkdtempSync(join(tmpdir(), 'dkg-db-wal-trunc-'));
+    // retentionDays high so prune() deletes no rows and the VACUUM gate
+    // (logsDeleted / freelist thresholds) never trips — isolating the
+    // unconditional wal_checkpoint(TRUNCATE) added at the end of prune().
+    const walDb = new DashboardDB({ dataDir: walDir, retentionDays: 365 });
+    const walPath = join(walDir, 'node-ui.db-wal');
+    try {
+      // Disable autocheckpoint so the WAL grows unbounded as we write,
+      // reproducing the high-water-mark the fix targets.
+      walDb.db.pragma('wal_autocheckpoint = 0');
+      walDb.db.exec(`CREATE TABLE wal_fixture (payload BLOB NOT NULL);`);
+      const insert = walDb.db.prepare(
+        `INSERT INTO wal_fixture (payload) VALUES (zeroblob(4096))`,
+      );
+      const fillFixture = walDb.db.transaction(() => {
+        for (let i = 0; i < 5_000; i += 1) insert.run();
+      });
+      fillFixture();
+
+      const beforeWal = statSync(walPath).size;
+      expect(beforeWal).toBeGreaterThan(5 * 1024 * 1024);
+
+      walDb.prune();
+
+      const afterWal = statSync(walPath).size;
+      expect(afterWal).toBeLessThan(beforeWal);
+      expect(afterWal).toBeLessThanOrEqual(67108864);
+    } finally {
+      walDb.close();
+      rmSync(walDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

A PASSIVE SQLite autocheckpoint resets WAL frames but leaves the `node-ui.db-wal` file at its **high-water mark**. After a heavy write burst (notably the pre-rc.14 sync-page `message_idempotency` firehose, fixed in rc.14), the `-wal` file stayed **multi-GB on disk indefinitely** even once logically empty — observed at ~2.4–3.3 GB on a long-lived testnet node, contributing to slow writes / hung MCP calls.

This is the follow-up "Part B" to the rc.14 sync-off-substrate fix: rc.14 stopped *writing* the junk; this makes the WAL file actually return to disk.

### Changes (`packages/node-ui/src/db.ts`)
- Set `journal_size_limit = 64 MiB` on every `DashboardDB` open, so checkpoints truncate the WAL file back to a bounded cap. It's a per-connection pragma, so it's applied on each open.
- Run an **unconditional** `wal_checkpoint(TRUNCATE)` at the end of `prune()`, **outside** the gated `VACUUM` block, so the WAL file is reclaimed on the ~6h prune cadence (+ at boot) even on an idle node where the VACUUM thresholds never trip. Best-effort: a `busy` checkpoint (concurrent reader) is harmless and retried on the next prune. It runs after `VACUUM`, which itself rewrites the whole DB through the WAL.

No schema change (`SCHEMA_VERSION` unchanged; pragmas are connection settings).

## Test plan
- [x] `packages/node-ui` unit suite green (`vitest run test/db.test.ts`, 73 passed).
- [x] New `DashboardDB — WAL reclaim` tests:
  - `journal_size_limit` reads `67108864` on open.
  - A grown `-wal` (autocheckpoint disabled, 5k blob rows) is truncated by `prune()` with the VACUUM gate closed.
- [ ] Optional manual: on a bloated node, after this patch + restart, `~/.dkg/node-ui.db-wal` stays bounded across a prune cycle.

Made with [Cursor](https://cursor.com)