### PR TITLE
fix(node-ui): match reserved meta bucket by path shape (follow-up to #944)

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -829,10 +829,12 @@ export async function listAssertions(
   // under `<cg>/meta/assertion/<addr>/<name>`, so a bare `memoryLayer "WM"`
   // join scoops them in alongside real user knowledge. Since this listing
   // feeds the assertions table + bulk-promote, those UI-config drafts would
-  // otherwise be promotable into SWM. Mirror the meta-exclusion policy
-  // `useMemoryEntities.wmSparql` already enforces (`STR(?g) != "<cg>/meta"`,
-  // `!CONTAINS("/meta/")`, `!STRENDS("/_meta")`).
-  const metaFilter = `FILTER(STR(?g) != "${cgPrefix}meta" && !CONTAINS(STR(?g), "/meta/") && !STRENDS(STR(?g), "/_meta"))`;
+  // otherwise be promotable into SWM. Match the reserved bucket by its path
+  // SHAPE (`/meta/assertion/`) rather than a `/_meta` suffix: a raw suffix
+  // match would also drop a perfectly valid WM assertion whose *name* is
+  // `_meta` (names may start with `_`). The parser below keys on the parsed
+  // sub-graph segment (`=== 'meta'`), which is fully name-safe.
+  const metaFilter = `FILTER(!CONTAINS(STR(?g), "/meta/assertion/"))`;
   const listSparql = `SELECT ?g WHERE {
     GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" }
     ${metaFilter}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -129,10 +129,10 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
       //     authority `listWmAssertions` uses) and read only those graphs.
       //  3. Exclude the reserved `meta` namespace (`<cg>/meta/assertion/…`
       //     profile/query-catalog drafts are WM-marked but are UI config, not
-      //     user knowledge), mirroring `listWmAssertions` + the
-      //     `useMemoryEntities.wmSparql` meta-exclusion policy.
-      const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
-      return `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" } GRAPH ?g { ?s ?p ?o } FILTER(STR(?g) != "${cgPrefix}meta" && !CONTAINS(STR(?g), "/meta/") && !STRENDS(STR(?g), "/_meta")) } LIMIT 1000`;
+      //     user knowledge), mirroring `listWmAssertions`. Match the bucket by
+      //     its path SHAPE (`/meta/assertion/`), not a `/_meta` suffix, so a
+      //     valid WM assertion named `_meta` isn't dropped.
+      return `SELECT ?s ?p ?o WHERE { GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "WM" } GRAPH ?g { ?s ?p ?o } FILTER(!CONTAINS(STR(?g), "/meta/assertion/")) } LIMIT 1000`;
     }
     if (layer === 'vm') {
       return buildVerifiedMemorySearchQuery({

--- a/packages/node-ui/test/list-assertions.test.ts
+++ b/packages/node-ui/test/list-assertions.test.ts
@@ -233,13 +233,28 @@ describe('listAssertions (WM) — URI parse + cg-scoped filter', () => {
     expect(out[0].name).toBe('notes');
   });
 
-  it('SPARQL excludes the meta namespace in both the list and count queries (Codex #944)', async () => {
+  it('SPARQL excludes the meta namespace by path shape in both queries (Codex #944)', async () => {
     setBindings([bRow('did:dkg:context-graph:cg-A/assertion/0xabc/notes', 5)]);
     await listAssertions('cg-A', 'wm');
     const [, listInit] = fetchMock.mock.calls[0] as [string, RequestInit];
     const [, countInit] = fetchMock.mock.calls[1] as [string, RequestInit];
-    expect(JSON.parse(String(listInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
-    expect(JSON.parse(String(countInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/")');
+    // Path-shape match, not a `/_meta` suffix (which would drop assertions
+    // named `_meta`).
+    expect(JSON.parse(String(listInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/assertion/")');
+    expect(JSON.parse(String(countInit.body)).sparql).toContain('!CONTAINS(STR(?g), "/meta/assertion/")');
+    expect(JSON.parse(String(listInit.body)).sparql).not.toContain('STRENDS(STR(?g), "/_meta")');
+  });
+
+  it('keeps a WM assertion whose name is "_meta" (Codex #944 — no /_meta suffix match)', async () => {
+    // Assertion names may start with `_`, so `<cg>/assertion/<addr>/_meta` is a
+    // valid root WM assertion. The reserved-meta exclusion must be by sub-graph
+    // shape, not a `/_meta` suffix, or this draft becomes impossible to promote.
+    setBindings([
+      bRow('did:dkg:context-graph:cg-A/assertion/0xabc/_meta', 2),
+    ]);
+    const out = await listAssertions('cg-A', 'wm');
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: '_meta', subGraph: undefined });
   });
 
   it('still lists WM assertions when the (best-effort) count query fails', async () => {

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -477,10 +477,12 @@ describe('memory layer custom query execution', () => {
     //     `GRAPH ?g` typed into the WM tab could enumerate SWM/VM/meta
     //     partitions and escape the WM scope.
     expect(memoryLayerView).toContain("layer === 'wm' && sparql === defaultSparql");
-    //  4. Exclude the reserved `meta` namespace (profile/query-catalog drafts
-    //     are WM-marked but are UI config, not user knowledge), mirroring the
-    //     listWmAssertions + useMemoryEntities meta-exclusion policy.
-    expect(memoryLayerView).toContain('!CONTAINS(STR(?g), "/meta/")');
+    //  4. Exclude the reserved `meta` namespace by path SHAPE (the profile /
+    //     query-catalog drafts live at `<cg>/meta/assertion/…`). Must match the
+    //     `/meta/assertion/` bucket, NOT a `/_meta` suffix — the latter would
+    //     also drop a valid WM assertion whose name is `_meta`.
+    expect(memoryLayerView).toContain('!CONTAINS(STR(?g), "/meta/assertion/")');
+    expect(memoryLayerView).not.toContain('STRENDS(STR(?g), "/_meta")');
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #944 (merged). The final Codex review on #944 landed one second after that PR was merged, so this last fix didn't make it into the merge — this PR carries it to `main`.

**Codex finding:** #944's reserved-`meta` exclusion used `!STRENDS(STR(?g), "/_meta")`, which would also drop a perfectly valid WM assertion whose **name** is `_meta` (assertion names may start with `_`, e.g. `<cg>/assertion/<addr>/_meta`). That draft would silently disappear from the assertions list and become impossible to promote from the UI.

**Fix:** match the reserved profile/query-catalog bucket by its path **shape** (`/meta/assertion/`) instead of a `/_meta` suffix, in both `listWmAssertions` and the `MemoryLayerView` WM default query. The parser-level guard already keys on the parsed sub-graph segment (`=== 'meta'`), which is inherently name-safe.

## Changes
- `api.ts` `listWmAssertions`: `metaFilter` → `!CONTAINS(STR(?g), "/meta/assertion/")` (list + count SPARQL).
- `MemoryLayerView.tsx`: same FILTER in the WM default query.
- Tests: assert the path-shape filter (and the absence of the `/_meta` suffix match) in both queries + the WM view guard; add a regression test that an assertion named `_meta` stays listed.

## Verification
- `tsc --noEmit` clean; 97 node-ui tests pass (incl. the new `_meta`-name regression).

## Test plan
- [ ] In the node UI, create a WM assertion named `_meta` → it appears in the assertions list and can be promoted.
- [ ] Profile / query-catalog drafts (`<cg>/meta/assertion/…`) still do NOT appear in the WM assertions list or the WM layer view.

Made with [Cursor](https://cursor.com)