### PR TITLE
chore(release): v10.0.0-rc.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,39 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
-### Added — Store read-latency benchmark (regression guard for #939)
+## [10.0.0-rc.15] - 2026-06-03
 
-- **`bench/store-read-latency.bench.ts`** — a new esbench suite that measures real Oxigraph read latency for the two shapes that hung on a saturated node (issue #939): a trivial `SELECT … LIMIT 1` scan and the production `getTotalTriples` `COUNT(*)` aggregate, on an idle store. On the embedded **`worker` backend** (the single-writer store) it additionally measures those reads **under concurrent write load**, quantifying the read-starvation that drove the rc.13 regression and giving a baseline to measure the MVCC `oxigraph-server` backend (now the default for new installs) against. Contention is worker-only by design — the in-process store is single-threaded/synchronous and cannot exhibit true read/write overlap, so it runs the idle baselines only. Backends via `DKG_BENCH_STORE_BACKENDS` (`inprocess` always; `worker` auto-added when its compiled artefact is built, e.g. in CI), sizes via `DKG_BENCH_STORE_SIZES`. Run with `pnpm bench:store-read`; participates in `pnpm bench` / `bench:baseline` / `bench:compare` like the existing suites.
+**Off-chain runtime release.** No Solidity changes since rc.13 — the Base Sepolia (chainId 84532) deployment is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. The sync protocol ID is **unchanged** (`/dkg/10.0.2/sync`), so rc.15 nodes interoperate with rc.14 peers — nodes upgrade in place with **no local-state wipe**. This release makes `oxigraph-server` the default store backend for **new** installs, fixes the Node UI Working-Memory scoped-query violation (and the SWM/VM bleed + reserved-meta false-positives it surfaced), reclaims the `node-ui.db` WAL on a running node, splits the `DKGAgent` god class into subsystem mixin holders, and lands typed publisher errors plus CI/bench hardening.
 
 ### Changed — `oxigraph-server` is now the default triple-store backend for new installs
 
-- **`dkg init` defaults to `oxigraph-server`** (`packages/cli/src/store-wizard.ts`): the store-backend menu now lists `oxigraph-server` (daemon-managed local RocksDB server) as the first, recommended option and the default answer; the embedded in-process worker (`oxigraph`) moves to option 2 for minimal-footprint / single-reader nodes. A fresh `dkg init` — or one that accepts the default — writes an explicit `"store": { "backend": "oxigraph-server" }` block, so new nodes get MVCC concurrent reads + incremental persistence out of the box.
+- **`dkg init` defaults to `oxigraph-server`** (PR #946, `packages/cli/src/store-wizard.ts`): the store-backend menu now lists `oxigraph-server` (daemon-managed local RocksDB server) as the first, recommended option and the default answer; the embedded in-process worker (`oxigraph`) moves to option 2 for minimal-footprint / single-reader nodes. A fresh `dkg init` — or one that accepts the default — writes an explicit `"store": { "backend": "oxigraph-server" }` block, so new nodes get MVCC concurrent reads + incremental persistence out of the box.
 - **The existing fleet is unaffected on auto-update.** The runtime fallback for a config with **no** `store` block stays `oxigraph-worker`, and auto-update never re-runs `dkg init` — so existing nodes keep booting on the embedded worker unchanged. A re-init only flips a **block-less** node (an explicitly-chosen local backend — `oxigraph` / `oxigraph-worker` / `oxigraph-persistent` — is preserved on Enter-through), and even then the daemon's `STORE-SWITCH` guard makes the switch an opt-in (it refuses to start until `DKG_ACCEPT_STORE_RESET=1`) rather than a silent store reset.
 - **Platform note:** new installs fetch the prebuilt `oxigraph` v0.5.8 binary on first boot. The Linux artifacts are glibc-only, so musl hosts (Alpine/distroless) should pick option 2 (`oxigraph`) or an external `sparql-http` endpoint at the `dkg init` prompt.
+
+### Fixed — Node UI Working-Memory layer scoped-query violation
+
+- **Keep scoped `GRAPH` variables top-level in WM layer queries** (PR #944, `packages/node-ui/src/ui/api.ts`, `views/MemoryLayerView.tsx`): the WM layer view and `listWmAssertions` nested `GRAPH ?g` inside a `UNION`, which the scoped local-query guard (PR #749, `constrainGraphVariablesToAllowedSet`) rejects with "GRAPH variables must appear at the top level of scoped local queries". Surfaced as a *"Scoped query violation"* during WM→SWM promotion. The queries now keep both `GRAPH` clauses as top-level WHERE-block siblings and opt into the CG-scoped assertion partitions via `includeContextGraphPartitions`.
+- **No SWM/VM bleed into the WM tab**: widening the allow-list to the assertion partitions also exposes `/_shared_memory` and `/_verified_memory/*`, so `?g` is gated on the `<cg>/_meta` `dkg:memoryLayer "WM"` lifecycle marker (the same authority `listWmAssertions` uses), and the partition opt-in is scoped to the built-in WM query only — not user-typed custom SPARQL.
+- **WM triple-count is best-effort**: a failing count query no longer collapses the whole assertion list to "no assertions"; counts degrade independently.
+- **Match the reserved meta bucket by path shape, not `/_meta` suffix** (PR #948, follow-up to #944): exclude UI-config drafts via `FILTER(!CONTAINS(STR(?g), "/meta/assertion/"))` (plus a parser-level guard) so a legitimate user assertion *named* `_meta` is no longer dropped.
+
+### Fixed — Reclaim `node-ui.db` WAL on a running node
+
+- **WAL reclaim** (PR #945, `packages/node-ui/src/db.ts`): the multi-GB `node-ui.db` WAL left behind by the pre-rc.14 messenger-substrate sync bloat is now reclaimed on a running node, complementing the rc.14 fix that stopped the growth at the source.
+
+### Changed — Internal refactors (no behavior change)
+
+- **`DKGAgent` god class split into subsystem mixin holders** (PR #941, `packages/agent/src/dkg-agent-*.ts`): the monolithic `dkg-agent.ts` is decomposed into per-subsystem mixin modules (boot, lifecycle, publish, query, join, registry, crypto, diagnostics, …) applied via `dkg-agent-apply-mixins.ts`. Pure structural refactor; runtime behavior unchanged.
+- **Typed publisher errors** (PR #949, `packages/publisher/src/errors.ts`): publisher error classes extracted into a dedicated `errors.ts` module.
+
+### Added — Store read-latency benchmark (regression guard for #939)
+
+- **`bench/store-read-latency.bench.ts`** (PR #943) — a new esbench suite that measures real Oxigraph read latency for the two shapes that hung on a saturated node (issue #939): a trivial `SELECT … LIMIT 1` scan and the production `getTotalTriples` `COUNT(*)` aggregate, on an idle store. On the embedded **`worker` backend** (the single-writer store) it additionally measures those reads **under concurrent write load**, quantifying the read-starvation that drove the rc.13 regression and giving a baseline to measure the MVCC `oxigraph-server` backend (now the default for new installs) against. Contention is worker-only by design — the in-process store is single-threaded/synchronous and cannot exhibit true read/write overlap, so it runs the idle baselines only. Backends via `DKG_BENCH_STORE_BACKENDS` (`inprocess` always; `worker` auto-added when its compiled artefact is built, e.g. in CI), sizes via `DKG_BENCH_STORE_SIZES`. Run with `pnpm bench:store-read`; participates in `pnpm bench` / `bench:baseline` / `bench:compare` like the existing suites.
+
+### Changed — Test / CI hardening
+
+- **e2e devnet preconditions fail in CI instead of skipping** (PR #942, `packages/node-ui/e2e`): missing devnet preconditions now fail the job rather than silently skipping, and the suite rejects a 207 partial VM publish by default.
 
 ## [10.0.0-rc.14] - 2026-06-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.14",
+  "version": "10.0.0-rc.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release: v10.0.0-rc.15

Cuts **v10.0.0-rc.15** from `main` (base: rc.14 tag `v10.0.0-rc.14`).

### What this PR does
- Bumps `version` on the root + 18 workspace packages `10.0.0-rc.14` → `10.0.0-rc.15`.
- Adds the `[10.0.0-rc.15]` CHANGELOG section.

No code/runtime changes — every feature/fix below already landed on `main`; this is the version + changelog bump to tag the release.

### Contracts: no redeploy required
- **Zero `.sol` / deployment / abi changes** since `v10.0.0-rc.14` (verified `git diff v10.0.0-rc.14..main` touches no `evm-module` / `*.sol` / `deployments/` paths).
- Base Sepolia (chainId 84532) deployment is **unchanged**; `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01` — **no chain reset, no local-state wipe**. Nodes upgrade in place.

### Wire compatibility: rc.15 ↔ rc.14 interoperate
- The sync protocol ID is **unchanged** (`/dkg/10.0.2/sync`), so — unlike the rc.13→rc.14 hard cutover — rc.15 and rc.14 nodes sync normally. No staged rollout required.

### Included since rc.14 (already merged to `main`)
- **#946** `oxigraph-server` is now the default store backend for **new** installs (existing fleet unaffected; runtime fallback stays `oxigraph-worker`).
- **#944** + **#948** Node UI Working-Memory scoped-query violation fix (top-level `GRAPH` vars; no SWM/VM bleed; best-effort count; reserved-meta matched by path shape).
- **#945** reclaim `node-ui.db` WAL on a running node.
- **#941** split `DKGAgent` god class into subsystem mixin holders (internal refactor).
- **#949** typed publisher errors (`errors.ts`) (internal refactor).
- **#943** real-store read-latency benchmark (regression guard for #939).
- **#942** e2e devnet preconditions fail in CI instead of skipping.

Full details in `CHANGELOG.md`.

### Release steps
1. Merge this PR.
2. Tag the merge commit `v10.0.0-rc.15` and publish the GitHub release.
3. `npm publish` (matches the rc.14 process — no testnet deploy step this round).

### Test plan
- [ ] CI green on this branch.
- [ ] `pnpm install` resolves with bumped versions (workspace-protocol deps; lockfile unaffected — 0 version refs in `pnpm-lock.yaml`).
- [ ] Optional: rc.15 devnet release-validation run before tagging.

Made with [Cursor](https://cursor.com)