### PR TITLE
fix(cli,core): allow `dkg init` on monorepo checkouts + default adapter/MCP setups to oxigraph-server (#960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ## [Unreleased]
 
+### Fixed — `dkg init` on monorepo checkouts + oxigraph-server default for adapter/MCP setups (#960)
+
+- **`dkg init` runs from a monorepo / checkout clone again** (`packages/cli/src/cli.ts`). PR #753 (RFC-41 Bundle B1c) hard-refused `dkg init` from a monorepo checkout; that was over-strict — the CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`) already routes a clone to `~/.dkg-dev` (kept separate from an npm install's `~/.dkg`), the same home the local dev daemon resolves, so there was no real risk of divergence. The hard refusal (and its non-functional `DKG_HOME` escape) is replaced by a one-line notice showing which home is being written. Restores the pre-#753 dev workflow: a clone runs `dkg init` exactly like an npm install, differing only in the home directory.
+- **OpenClaw / Hermes / MCP setups now seed the `oxigraph-server` default on a fresh node** (`packages/core/src/ensure-dkg-node-config.ts`). The rc.15 `oxigraph-server` default previously reached only nodes set up via the `dkg init` store-wizard; the shared `ensureDkgNodeConfig` helper (used by `dkg openclaw/hermes/mcp setup`) left `store` unset, so those nodes fell back to `oxigraph-worker`. It now adopts `oxigraph-server` on a **fresh** install (no existing config) with no explicit store — matching the wizard default — while never rewriting an existing node's backend (which would force a store reset) and preserving any explicit `store` block.
+
 ## [10.0.0-rc.15] - 2026-06-03
 
 **Off-chain runtime release.** No Solidity changes since rc.13 — the Base Sepolia (chainId 84532) deployment is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. The sync protocol ID is **unchanged** (`/dkg/10.0.2/sync`), so rc.15 nodes interoperate with rc.14 peers — nodes upgrade in place with **no local-state wipe**. This release makes `oxigraph-server` the default store backend for **new** installs, fixes the Node UI Working-Memory scoped-query violation (and the SWM/VM bleed + reserved-meta false-positives it surfaced), reclaims the `node-ui.db` WAL on a running node, splits the `DKGAgent` god class into subsystem mixin holders, and lands typed publisher errors plus CI/bench hardening.

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -672,8 +672,20 @@ export async function runHermesSetup(req: HermesSetupRequest): Promise<HermesSet
   // setup-entrypoint-contract.md §2 Open Question 1 + H-AC-58.
   warnPortConflict(req, warnings);
 
-  // Step 2: bootstrap `~/.dkg/config.json` when missing.
-  if (!dryRun && !existsSync(join(resolveDkgConfigHome({ startDir: __dirname }), 'config.json'))) {
+  // Step 2: bootstrap `~/.dkg/config.json` when no daemon config exists yet.
+  // Honor BOTH `config.json` AND `config.yaml`: `resolveDkgConfigHome` and the
+  // daemon's `loadConfig` both treat a YAML-only home as a valid existing node
+  // (see the "detect both config.json AND config.yaml" rule in core/dkg-home.ts),
+  // so a node configured purely via `config.yaml` must NOT be re-bootstrapped.
+  // Writing a fresh `config.json` would shadow the operator's YAML config and —
+  // post-issue #960 — risk steering them onto a different store backend than the
+  // one they chose. Gating on `config.json` alone (the pre-#960 behavior) misses
+  // the YAML-only install.
+  const dkgConfigHome = resolveDkgConfigHome({ startDir: __dirname });
+  const dkgConfigExists =
+    existsSync(join(dkgConfigHome, 'config.json')) ||
+    existsSync(join(dkgConfigHome, 'config.yaml'));
+  if (!dryRun && !dkgConfigExists) {
     try {
       await bootstrapDkgNodeConfig(profile, setupOptions, warnings);
     } catch (err: any) {
@@ -1818,7 +1830,8 @@ function loadHermesNetworkConfig(warnings: string[]): FundWalletsNetworkConfig &
     cliDir = null;
   }
   // testnet.json is the default network — operators with a custom env can
-  // pre-write `~/.dkg/config.json` and `runHermesSetup` will skip bootstrap.
+  // pre-write `~/.dkg/config.json` (or `config.yaml`) and `runHermesSetup`
+  // will skip bootstrap.
   const candidates: string[] = [];
   if (cliDir) candidates.push(join(cliDir, 'network', 'testnet.json'));
   candidates.push(resolve(__dirname, '..', '..', '..', 'network', 'testnet.json'));

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -1110,6 +1110,73 @@ assert config["allow_context_graph_admin_tools"] is False, config
     expect(body.transport.bridgeUrl).toBeUndefined();
   });
 
+  // issue #960 — end-to-end YAML-only Hermes path. A daemon home that has
+  // only a `config.yaml` (no `config.json`) is a valid existing node:
+  // `resolveDkgConfigHome` and the daemon's `loadConfig` both honor it. The
+  // Hermes bootstrap step must treat such a home as already configured and
+  // NOT write a fresh `config.json` — doing so would shadow the operator's
+  // YAML config and could seed a store backend they never chose.
+  it('honors an existing config.yaml DKG home during setup and does not write a shadowing config.json (issue #960)', async () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const dkgHome = mkdtempSync(join(tmpdir(), 'dkg-home-yaml-'));
+    const yamlBefore = 'name: yaml-only-node\napiPort: 9201\nnodeRole: edge\n';
+    writeFileSync(join(dkgHome, 'config.yaml'), yamlBefore);
+
+    // Registration probe fires regardless of `start` (decoupled per #386),
+    // so stub fetch to keep the orchestrator offline-safe.
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const oldDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      await runSetup({ hermesHome, verify: false, start: false, fund: false });
+    } finally {
+      if (oldDkgHome === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = oldDkgHome;
+    }
+
+    // Bootstrap skipped — no shadowing config.json written.
+    expect(existsSync(join(dkgHome, 'config.json'))).toBe(false);
+    // The operator's YAML config is left byte-for-byte intact.
+    expect(readFileSync(join(dkgHome, 'config.yaml'), 'utf-8')).toBe(yamlBefore);
+  });
+
+  // issue #960 — positive control for the test above: a genuinely fresh DKG
+  // home (no config.json AND no config.yaml) DOES get bootstrapped, and the
+  // written config adopts the `oxigraph-server` store default. This proves the
+  // bootstrap write path is live in this test environment, so the YAML-only
+  // test above is meaningfully guarding the gate (not passing vacuously).
+  it('bootstraps a fresh DKG home with the oxigraph-server store default during setup (issue #960)', async () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const dkgHome = mkdtempSync(join(tmpdir(), 'dkg-home-fresh-'));
+
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const oldDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      await runSetup({ hermesHome, verify: false, start: false, fund: false });
+    } finally {
+      if (oldDkgHome === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = oldDkgHome;
+    }
+
+    const configPath = join(dkgHome, 'config.json');
+    expect(existsSync(configPath)).toBe(true);
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(written.store).toEqual({ backend: 'oxigraph-server' });
+  });
+
   it('uses the shared monorepo DKG home when DKG_HOME is unset for setup daemon registration', async () => {
     const homeRoot = mkdtempSync(join(tmpdir(), 'hermes-dkg-home-'));
     const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,7 +27,7 @@ import {
   apiPortPath,
   loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
   releasesDir, activeSlot, swapSlot,
-  slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
+  slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
   readNodeRoleFromConfigSync,
   type AutoUpdateConfig,
@@ -604,34 +604,35 @@ program
     // checkout, exactly like an npm install — the only difference is the home
     // directory. The CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`)
     // routes a clone to `~/.dkg-dev` (kept separate from an npm install's
-    // `~/.dkg`), the SAME home the local dev daemon resolves, so init writes the
-    // dev config with no risk of the two diverging.
-    //
-    // The one case Bundle B1c (PR #753) was right to guard: when an npm-installed
-    // node already owns `~/.dkg`, the resolver intentionally falls back to
-    // `~/.dkg`, and a checkout `dkg init` would then overwrite that installed
-    // node's config. We refuse only that stomping case (and only when the user
-    // hasn't explicitly chosen a home via DKG_HOME); otherwise we proceed into
-    // the dev home and surface where we're writing.
-    if (isDkgMonorepo() && !process.env.DKG_HOME?.trim()) {
-      const npmHome = join(homedir(), '.dkg');
-      const npmNodeConfigExists =
-        existsSync(join(npmHome, 'config.json')) || existsSync(join(npmHome, 'config.yaml'));
-      if (npmNodeConfigExists) {
-        console.error(
-          '\n[dkg init] Refusing: an npm-installed node config already exists at ~/.dkg, and\n' +
-            '  running `dkg init` from this monorepo checkout would overwrite it. To bootstrap a\n' +
-            '  separate dev config without touching the installed node, point DKG_HOME at a\n' +
-            '  dev/scratch home:\n' +
-            '\n' +
-            '    DKG_HOME=~/.dkg-dev dkg init\n',
+    // `~/.dkg`), the SAME home the local dev daemon resolves. We never block:
+    // we only NOTE the dev home, or WARN if the resolver fell back to a
+    // pre-existing `~/.dkg` (which *might* be an npm-installed node — but config
+    // presence isn't proof of npm ownership, and a dev may use `~/.dkg`
+    // intentionally, so a hard refusal would be wrong). See `classifyMonorepoInit`.
+    // (PR #753 / Bundle B1c hard-refused all monorepo inits; that was over-strict.)
+    switch (classifyMonorepoInit({
+      isMonorepo: isDkgMonorepo(),
+      dkgHomeEnv: process.env.DKG_HOME,
+      resolvedHome: dkgDir(),
+      npmHome: join(homedir(), '.dkg'),
+    })) {
+      case 'dev-home':
+        console.log(
+          `[dkg init] Monorepo checkout detected — writing dev config to ${dkgDir()} ` +
+            `(set DKG_HOME to override).`,
         );
-        process.exit(1);
-      }
-      console.log(
-        `[dkg init] Monorepo checkout detected — writing dev config to ${dkgDir()} ` +
-          `(set DKG_HOME to override).`,
-      );
+        break;
+      case 'shared-npm-home':
+        console.warn(
+          `\n[dkg init] Note: writing to the existing ~/.dkg config home (${dkgDir()}), not a\n` +
+            `  separate dev home, because a config already exists there. If ~/.dkg belongs to an\n` +
+            `  npm-installed node you don't want this checkout to modify, re-run with a dev home:\n` +
+            `\n` +
+            `    DKG_HOME=~/.dkg-dev dkg init\n`,
+        );
+        break;
+      default:
+        break;
     }
 
     await ensureDkgDir();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { spawn, execSync } from 'node:child_process';
 import { createReadStream } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 import { readFile, writeFile, unlink, appendFile } from 'node:fs/promises';
 import { ethers } from 'ethers';
 import { resolveRpcUrls } from '@origintrail-official/dkg-chain';
@@ -602,13 +603,31 @@ program
     // OT-RFC-41 follow-up (issue #960): `dkg init` runs normally from a monorepo
     // checkout, exactly like an npm install — the only difference is the home
     // directory. The CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`)
-    // already routes a clone to `~/.dkg-dev` (kept separate from an npm
-    // install's `~/.dkg`), which is the SAME home the local dev daemon resolves
-    // — so init writes the dev config with no risk of the two diverging. We
-    // surface which home is being written so it's obvious in a checkout.
-    // (PR #753 / Bundle B1c previously hard-refused here; that was over-strict —
-    // the home resolution, not a refusal, is what keeps dev and npm state apart.)
-    if (isDkgMonorepo()) {
+    // routes a clone to `~/.dkg-dev` (kept separate from an npm install's
+    // `~/.dkg`), the SAME home the local dev daemon resolves, so init writes the
+    // dev config with no risk of the two diverging.
+    //
+    // The one case Bundle B1c (PR #753) was right to guard: when an npm-installed
+    // node already owns `~/.dkg`, the resolver intentionally falls back to
+    // `~/.dkg`, and a checkout `dkg init` would then overwrite that installed
+    // node's config. We refuse only that stomping case (and only when the user
+    // hasn't explicitly chosen a home via DKG_HOME); otherwise we proceed into
+    // the dev home and surface where we're writing.
+    if (isDkgMonorepo() && !process.env.DKG_HOME?.trim()) {
+      const npmHome = join(homedir(), '.dkg');
+      const npmNodeConfigExists =
+        existsSync(join(npmHome, 'config.json')) || existsSync(join(npmHome, 'config.yaml'));
+      if (npmNodeConfigExists) {
+        console.error(
+          '\n[dkg init] Refusing: an npm-installed node config already exists at ~/.dkg, and\n' +
+            '  running `dkg init` from this monorepo checkout would overwrite it. To bootstrap a\n' +
+            '  separate dev config without touching the installed node, point DKG_HOME at a\n' +
+            '  dev/scratch home:\n' +
+            '\n' +
+            '    DKG_HOME=~/.dkg-dev dkg init\n',
+        );
+        process.exit(1);
+      }
       console.log(
         `[dkg init] Monorepo checkout detected — writing dev config to ${dkgDir()} ` +
           `(set DKG_HOME to override).`,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,7 +27,7 @@ import {
   apiPortPath,
   loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
   releasesDir, activeSlot, swapSlot,
-  slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit,
+  slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit, sharedHomeInitGate,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
   readNodeRoleFromConfigSync,
   type AutoUpdateConfig,
@@ -599,17 +599,25 @@ program
     '--store-url <url>',
     'Pre-fill the SPARQL endpoint URL prompt for external backends.',
   )
+  .option(
+    '-y, --yes',
+    'Skip the confirmation prompt when running from a monorepo checkout into an existing ~/.dkg home (non-interactive opt-in to modifying it).',
+  )
   .action(async (opts: ActionOpts) => {
     // OT-RFC-41 follow-up (issue #960): `dkg init` runs normally from a monorepo
     // checkout, exactly like an npm install — the only difference is the home
     // directory. The CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`)
     // routes a clone to `~/.dkg-dev` (kept separate from an npm install's
-    // `~/.dkg`), the SAME home the local dev daemon resolves. We never block:
-    // we only NOTE the dev home, or WARN if the resolver fell back to a
-    // pre-existing `~/.dkg` (which *might* be an npm-installed node — but config
-    // presence isn't proof of npm ownership, and a dev may use `~/.dkg`
-    // intentionally, so a hard refusal would be wrong). See `classifyMonorepoInit`.
-    // (PR #753 / Bundle B1c hard-refused all monorepo inits; that was over-strict.)
+    // `~/.dkg`), the SAME home the local dev daemon resolves. (PR #753 /
+    // Bundle B1c hard-refused all monorepo inits; that was over-strict.)
+    //
+    // The one risky case is `shared-npm-home`: a clone with no `DKG_HOME` where
+    // the resolver fell back to a pre-existing `~/.dkg` (which *might* be an
+    // npm-installed node). We must neither silently proceed (a missed warning
+    // would mutate that node's config) nor hard-block (config presence isn't
+    // proof of ownership, and a dev may target `~/.dkg` on purpose), so we
+    // require an explicit opt-in via `sharedHomeInitGate`: confirm interactively
+    // or pass `--yes`. See `classifyMonorepoInit` + `sharedHomeInitGate`.
     switch (classifyMonorepoInit({
       isMonorepo: isDkgMonorepo(),
       dkgHomeEnv: process.env.DKG_HOME,
@@ -622,15 +630,45 @@ program
             `(set DKG_HOME to override).`,
         );
         break;
-      case 'shared-npm-home':
+      case 'shared-npm-home': {
+        const home = dkgDir();
+        const gate = sharedHomeInitGate({
+          yes: opts.yes === true,
+          isTty: Boolean(process.stdin.isTTY),
+        });
+        if (gate === 'refuse') {
+          console.error(
+            `\n[dkg init] Refusing to modify the existing config home ${home} non-interactively.\n` +
+              `  A config already exists there and this is a monorepo checkout, so it may belong\n` +
+              `  to an npm-installed node. To proceed, choose one:\n` +
+              `    • re-run interactively and confirm at the prompt, or\n` +
+              `    • pass --yes to opt in explicitly, or\n` +
+              `    • keep this checkout isolated:  DKG_HOME=~/.dkg-dev dkg init\n`,
+          );
+          process.exit(1);
+        }
+        if (gate === 'prompt') {
+          const confirmRl = createInterface({ input: process.stdin, output: process.stdout });
+          const confirmed = await new Promise<boolean>(resolve => {
+            confirmRl.question(
+              `\n[dkg init] ⚠️  ${home} already contains a DKG config and this is a monorepo\n` +
+                `  checkout — it may belong to an npm-installed node. Continuing will read and\n` +
+                `  may OVERWRITE it. (Use DKG_HOME=~/.dkg-dev to keep this checkout isolated.)\n` +
+                `  Continue and modify ${home}? [y/N]: `,
+              answer => resolve(/^y(es)?$/i.test(answer.trim())),
+            );
+          }).finally(() => confirmRl.close());
+          if (!confirmed) {
+            console.error(`\n[dkg init] Aborted — ${home} left unchanged.\n`);
+            process.exit(1);
+          }
+        }
         console.warn(
-          `\n[dkg init] Note: writing to the existing ~/.dkg config home (${dkgDir()}), not a\n` +
-            `  separate dev home, because a config already exists there. If ~/.dkg belongs to an\n` +
-            `  npm-installed node you don't want this checkout to modify, re-run with a dev home:\n` +
-            `\n` +
-            `    DKG_HOME=~/.dkg-dev dkg init\n`,
+          `[dkg init] Proceeding into existing ${home}` +
+            `${opts.yes === true ? ' (--yes)' : ' (confirmed)'}.`,
         );
         break;
+      }
       default:
         break;
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -599,34 +599,21 @@ program
     'Pre-fill the SPARQL endpoint URL prompt for external backends.',
   )
   .action(async (opts: ActionOpts) => {
-    // OT-RFC-41 Bundle B1c: monorepo guard. `dkg init` from a
-    // contributor checkout is almost always a mistake — the
-    // monorepo dev workflow is `pnpm dev` against the local CLI,
-    // not a globally-installed config. Surface this loudly so
-    // contributors don't accidentally write an Edge-style
-    // ~/.dkg/config.json that then disagrees with the binary on
-    // their $PATH.
+    // OT-RFC-41 follow-up (issue #960): `dkg init` runs normally from a monorepo
+    // checkout, exactly like an npm install — the only difference is the home
+    // directory. The CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`)
+    // already routes a clone to `~/.dkg-dev` (kept separate from an npm
+    // install's `~/.dkg`), which is the SAME home the local dev daemon resolves
+    // — so init writes the dev config with no risk of the two diverging. We
+    // surface which home is being written so it's obvious in a checkout.
+    // (PR #753 / Bundle B1c previously hard-refused here; that was over-strict —
+    // the home resolution, not a refusal, is what keeps dev and npm state apart.)
     if (isDkgMonorepo()) {
-      console.error(
-        '\n[dkg init] Refusing to run from a DKG monorepo checkout.\n' +
-          '\n' +
-          '  Detected monorepo root: ' + (repoDir() ?? '(unknown)') + '\n' +
-          '\n' +
-          "  Monorepo dev workflow uses 'pnpm dev' against the local CLI build; ~/.dkg/config.json\n" +
-          "  is for npm-installed nodes (`npm install -g @origintrail-official/dkg`). Writing one\n" +
-          '  here would diverge from how the local CLI resolves its own working state.\n' +
-          '\n' +
-          '  If you really want to bootstrap a config for testing from this checkout, set\n' +
-          '  DKG_HOME to a scratch directory:\n' +
-          '\n' +
-          '    DKG_HOME=/tmp/dkg-test dkg init\n' +
-          '\n' +
-          '  RFC: https://github.com/OriginTrail/dkgv10-spec/blob/main/rfcs/OT-RFC-41-edge-node-npm-only-install-and-update.md\n' +
-          '\n',
+      console.log(
+        `[dkg init] Monorepo checkout detected — writing dev config to ${dkgDir()} ` +
+          `(set DKG_HOME to override).`,
       );
-      process.exit(1);
     }
-
 
     await ensureDkgDir();
     const existing = await loadConfig();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -992,6 +992,42 @@ export function isDkgMonorepo(): boolean {
   return _isDkgMonorepo;
 }
 
+export type MonorepoInitTarget = 'not-monorepo' | 'explicit-home' | 'dev-home' | 'shared-npm-home';
+
+/**
+ * Classify what `dkg init`'s config-home resolution means for a given run, so
+ * the command can notify the operator without hard-blocking (issue #960). Pure
+ * + fully injectable so the three meaningful branches are unit-testable.
+ *
+ *  - `not-monorepo`    — an npm install; init behaves normally, no notice.
+ *  - `explicit-home`   — the user set `DKG_HOME`; their explicit choice, no notice.
+ *  - `dev-home`        — monorepo checkout, no `DKG_HOME`, resolves to the
+ *                        separate dev home (`~/.dkg-dev`); safe — informational
+ *                        notice only.
+ *  - `shared-npm-home` — monorepo checkout, no `DKG_HOME`, but a config already
+ *                        exists at `~/.dkg` so `resolveDkgConfigHome` falls back
+ *                        to it; init would write the shared `~/.dkg` home (which
+ *                        *might* be an npm-installed node). We only **warn** —
+ *                        config presence is not proof of npm ownership, and a
+ *                        dev may intentionally use `~/.dkg`, so blocking would be
+ *                        wrong.
+ *
+ * `resolvedHome === npmHome` is the signal for the fallback: `dkgDir()` returns
+ * `~/.dkg` (rather than `~/.dkg-dev`) only when the resolver's own
+ * config-existence check (`config.json` OR `config.yaml`) matched, so the YAML
+ * case is handled here for free.
+ */
+export function classifyMonorepoInit(params: {
+  isMonorepo: boolean;
+  dkgHomeEnv: string | undefined;
+  resolvedHome: string;
+  npmHome: string;
+}): MonorepoInitTarget {
+  if (!params.isMonorepo) return 'not-monorepo';
+  if (params.dkgHomeEnv?.trim()) return 'explicit-home';
+  return params.resolvedHome === params.npmHome ? 'shared-npm-home' : 'dev-home';
+}
+
 /**
  * Resolve the repo root from the compiled code location.
  * Works from packages/cli/dist/ (compiled) or packages/cli/src/ (dev).

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1006,11 +1006,14 @@ export type MonorepoInitTarget = 'not-monorepo' | 'explicit-home' | 'dev-home' |
  *                        notice only.
  *  - `shared-npm-home` — monorepo checkout, no `DKG_HOME`, but a config already
  *                        exists at `~/.dkg` so `resolveDkgConfigHome` falls back
- *                        to it; init would write the shared `~/.dkg` home (which
- *                        *might* be an npm-installed node). We only **warn** —
- *                        config presence is not proof of npm ownership, and a
- *                        dev may intentionally use `~/.dkg`, so blocking would be
- *                        wrong.
+ *                        to it; init would read and may OVERWRITE the shared
+ *                        `~/.dkg` home (which *might* be an npm-installed node).
+ *                        The command must NOT silently proceed (that can mutate
+ *                        an installed node's config if the operator misses the
+ *                        warning) and must NOT hard-block (config presence isn't
+ *                        proof of npm ownership, and a dev may intentionally use
+ *                        `~/.dkg`). The caller gates this case behind an explicit
+ *                        opt-in via {@link sharedHomeInitGate}.
  *
  * `resolvedHome === npmHome` is the signal for the fallback: `dkgDir()` returns
  * `~/.dkg` (rather than `~/.dkg-dev`) only when the resolver's own
@@ -1026,6 +1029,33 @@ export function classifyMonorepoInit(params: {
   if (!params.isMonorepo) return 'not-monorepo';
   if (params.dkgHomeEnv?.trim()) return 'explicit-home';
   return params.resolvedHome === params.npmHome ? 'shared-npm-home' : 'dev-home';
+}
+
+export type SharedHomeInitGate = 'proceed' | 'prompt' | 'refuse';
+
+/**
+ * Decide how `dkg init` should gate the {@link classifyMonorepoInit}
+ * `shared-npm-home` case — running from a monorepo checkout into a pre-existing
+ * `~/.dkg` that may belong to an npm-installed node (issue #960, round-3
+ * review). A plain warn-and-proceed is a regression: a contributor who misses
+ * the warning silently mutates the installed node's config. A hard refusal is
+ * also wrong (a dev may intentionally target `~/.dkg`). So we require an
+ * **explicit opt-in**:
+ *
+ *  - `proceed` — the operator passed `--yes`; honor the explicit opt-in.
+ *  - `prompt`  — interactive TTY; ask for confirmation before touching `~/.dkg`.
+ *  - `refuse`  — non-interactive and no `--yes`; we can't ask and must not
+ *                silently overwrite, so abort with guidance (re-run with
+ *                `--yes`, or set `DKG_HOME`).
+ *
+ * Pure + injectable so all three branches are unit-testable without a TTY.
+ */
+export function sharedHomeInitGate(params: {
+  yes: boolean;
+  isTty: boolean;
+}): SharedHomeInitGate {
+  if (params.yes) return 'proceed';
+  return params.isTty ? 'prompt' : 'refuse';
 }
 
 /**

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -21,6 +21,7 @@ import {
   isDkgMonorepo,
   dkgDir,
   classifyMonorepoInit,
+  sharedHomeInitGate,
   repoDir,
   resolveAutoUpdateSource,
   resolveApprovalPolicy,
@@ -51,9 +52,24 @@ describe('classifyMonorepoInit (dkg init monorepo home guard — issue #960)', (
       .toBe('dev-home');
   });
 
-  it('monorepo, ~/.dkg config present → shared-npm-home (resolver fell back to ~/.dkg): warn, not block', () => {
+  it('monorepo, ~/.dkg config present → shared-npm-home (resolver fell back to ~/.dkg): gated opt-in', () => {
     expect(classifyMonorepoInit({ isMonorepo: true, dkgHomeEnv: undefined, resolvedHome: npmHome, npmHome }))
       .toBe('shared-npm-home');
+  });
+});
+
+describe('sharedHomeInitGate (dkg init shared ~/.dkg opt-in — issue #960 round-3)', () => {
+  it('--yes → proceed (explicit non-interactive opt-in, regardless of TTY)', () => {
+    expect(sharedHomeInitGate({ yes: true, isTty: false })).toBe('proceed');
+    expect(sharedHomeInitGate({ yes: true, isTty: true })).toBe('proceed');
+  });
+
+  it('interactive TTY, no --yes → prompt (ask before touching ~/.dkg)', () => {
+    expect(sharedHomeInitGate({ yes: false, isTty: true })).toBe('prompt');
+  });
+
+  it('non-interactive, no --yes → refuse (cannot ask; must not silently overwrite)', () => {
+    expect(sharedHomeInitGate({ yes: false, isTty: false })).toBe('refuse');
   });
 });
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -20,11 +20,42 @@ import {
   readNodeRoleFromConfigSync,
   isDkgMonorepo,
   dkgDir,
+  classifyMonorepoInit,
   repoDir,
   resolveAutoUpdateSource,
   resolveApprovalPolicy,
   resolveChainConfig,
 } from '../src/config.js';
+
+describe('classifyMonorepoInit (dkg init monorepo home guard — issue #960)', () => {
+  const npmHome = '/home/u/.dkg';
+  const devHome = '/home/u/.dkg-dev';
+
+  it('npm install (not a monorepo) → not-monorepo (no notice)', () => {
+    expect(classifyMonorepoInit({ isMonorepo: false, dkgHomeEnv: undefined, resolvedHome: npmHome, npmHome }))
+      .toBe('not-monorepo');
+  });
+
+  it('explicit DKG_HOME → explicit-home (user choice, bypass)', () => {
+    expect(classifyMonorepoInit({ isMonorepo: true, dkgHomeEnv: '/tmp/scratch', resolvedHome: '/tmp/scratch', npmHome }))
+      .toBe('explicit-home');
+  });
+
+  it('whitespace-only DKG_HOME is treated as unset', () => {
+    expect(classifyMonorepoInit({ isMonorepo: true, dkgHomeEnv: '   ', resolvedHome: devHome, npmHome }))
+      .toBe('dev-home');
+  });
+
+  it('monorepo, no ~/.dkg config → dev-home (resolves to ~/.dkg-dev): proceed', () => {
+    expect(classifyMonorepoInit({ isMonorepo: true, dkgHomeEnv: undefined, resolvedHome: devHome, npmHome }))
+      .toBe('dev-home');
+  });
+
+  it('monorepo, ~/.dkg config present → shared-npm-home (resolver fell back to ~/.dkg): warn, not block', () => {
+    expect(classifyMonorepoInit({ isMonorepo: true, dkgHomeEnv: undefined, resolvedHome: npmHome, npmHome }))
+      .toBe('shared-npm-home');
+  });
+});
 
 describe('removePid / removeApiPort (catch path)', () => {
   it('removePid does not throw when pid file does not exist (ENOENT)', async () => {

--- a/packages/core/src/ensure-dkg-node-config.ts
+++ b/packages/core/src/ensure-dkg-node-config.ts
@@ -107,8 +107,11 @@ export function ensureDkgNodeConfig(opts: EnsureDkgNodeConfigOptions): void {
   const dir = dkgDir();
   const configPath = join(dir, 'config.json');
   // A pre-existing config gates the store-default seeding below (issue #960):
-  // we only adopt the new default on a genuinely fresh install.
-  const configExisted = existsSync(configPath);
+  // we only adopt the new default on a genuinely fresh install. Check BOTH
+  // `config.json` and `config.yaml` — `loadConfig` / `resolveDkgConfigHome`
+  // both treat a YAML-only config as a valid existing node, so a YAML node must
+  // not be misread as fresh and silently flipped onto a new backend.
+  const configExisted = existsSync(configPath) || existsSync(join(dir, 'config.yaml'));
   mkdirSync(dir, { recursive: true });
 
   // Explicit CLI overrides (--name, --port) take precedence over existing

--- a/packages/core/src/ensure-dkg-node-config.ts
+++ b/packages/core/src/ensure-dkg-node-config.ts
@@ -30,7 +30,7 @@
  * user-visible output is unchanged from pre-extraction.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveDkgConfigHome } from './dkg-home.js';
@@ -106,6 +106,9 @@ export function ensureDkgNodeConfig(opts: EnsureDkgNodeConfigOptions): void {
 
   const dir = dkgDir();
   const configPath = join(dir, 'config.json');
+  // A pre-existing config gates the store-default seeding below (issue #960):
+  // we only adopt the new default on a genuinely fresh install.
+  const configExisted = existsSync(configPath);
   mkdirSync(dir, { recursive: true });
 
   // Explicit CLI overrides (--name, --port) take precedence over existing
@@ -150,6 +153,18 @@ export function ensureDkgNodeConfig(opts: EnsureDkgNodeConfigOptions): void {
   // running.
   if (!existing.autoUpdate && network.autoUpdate?.enabled !== undefined) {
     config.autoUpdate = { enabled: network.autoUpdate.enabled };
+  }
+
+  // issue #960: on a FRESH install (no config yet) with no explicit store
+  // backend, adopt the `oxigraph-server` default — the same recommended choice
+  // the `dkg init` store-wizard offers — so the OpenClaw / Hermes / MCP setups
+  // (and any other caller of this helper) bootstrap a node with MVCC concurrent
+  // reads out of the box, matching a wizard-driven install. We seed ONLY on a
+  // fresh config: an existing node is never rewritten onto a new backend here
+  // (that would force a store reset on its next boot), and an explicit existing
+  // `store` block is preserved by the `...existing` spread above.
+  if (!configExisted && config.store === undefined) {
+    config.store = { backend: 'oxigraph-server' };
   }
 
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');

--- a/packages/core/test/ensure-dkg-node-config.test.ts
+++ b/packages/core/test/ensure-dkg-node-config.test.ts
@@ -47,6 +47,19 @@ describe('ensureDkgNodeConfig — store-backend default (issue #960)', () => {
     expect(readWritten().store).toBeUndefined();
   });
 
+  it('treats a YAML-only existing node as existing (does NOT seed)', () => {
+    // loadConfig / resolveDkgConfigHome accept config.yaml as a valid config, so
+    // a YAML-only node must not be misclassified as fresh and flipped.
+    writeFileSync(join(tempHome, 'config.yaml'), 'name: node-a\nnodeRole: edge\n');
+    ensureDkgNodeConfig({
+      agentName: 'node-a',
+      network: NETWORK,
+      apiPort: 9200,
+      existing: { name: 'node-a', nodeRole: 'edge' },
+    });
+    expect(readWritten().store).toBeUndefined();
+  });
+
   it('preserves an explicit existing store block (even on a fresh write)', () => {
     const store = { backend: 'blazegraph', options: { url: 'http://localhost:9999/blazegraph' } };
     ensureDkgNodeConfig({ agentName: 'node-a', network: NETWORK, apiPort: 9200, existing: { store } });

--- a/packages/core/test/ensure-dkg-node-config.test.ts
+++ b/packages/core/test/ensure-dkg-node-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureDkgNodeConfig } from '../src/ensure-dkg-node-config.js';
+
+// `dkgDir()` inside ensureDkgNodeConfig resolves via `resolveDkgConfigHome`,
+// where an explicit `DKG_HOME` wins — so pointing it at a temp dir lets us
+// assert the written config without touching the real `~/.dkg-dev`.
+const NETWORK = { networkName: 'Test Net', defaultNodeRole: 'edge', defaultContextGraphs: [] as string[] };
+
+describe('ensureDkgNodeConfig — store-backend default (issue #960)', () => {
+  let tempHome: string;
+  const originalEnv = process.env.DKG_HOME;
+
+  beforeEach(() => {
+    tempHome = join(tmpdir(), `dkg-ensure-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempHome, { recursive: true });
+    process.env.DKG_HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalEnv;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  const readWritten = (): Record<string, any> =>
+    JSON.parse(readFileSync(join(tempHome, 'config.json'), 'utf-8'));
+
+  it('seeds the oxigraph-server default on a fresh install with no explicit store', () => {
+    ensureDkgNodeConfig({ agentName: 'node-a', network: NETWORK, apiPort: 9200, existing: {} });
+    expect(readWritten().store).toEqual({ backend: 'oxigraph-server' });
+  });
+
+  it('does NOT flip an existing (block-less) node onto a new backend', () => {
+    // Simulate an existing node: a config.json is already on disk (it had been
+    // running on the oxigraph-worker runtime fallback). Re-running setup must
+    // not silently switch its backend (which would force a store reset).
+    writeFileSync(join(tempHome, 'config.json'), JSON.stringify({ name: 'node-a', nodeRole: 'edge' }) + '\n');
+    ensureDkgNodeConfig({
+      agentName: 'node-a',
+      network: NETWORK,
+      apiPort: 9200,
+      existing: { name: 'node-a', nodeRole: 'edge' },
+    });
+    expect(readWritten().store).toBeUndefined();
+  });
+
+  it('preserves an explicit existing store block (even on a fresh write)', () => {
+    const store = { backend: 'blazegraph', options: { url: 'http://localhost:9999/blazegraph' } };
+    ensureDkgNodeConfig({ agentName: 'node-a', network: NETWORK, apiPort: 9200, existing: { store } });
+    expect(readWritten().store).toEqual(store);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #960 — two related fixes from the RFC-41 Bundle B (PR #753) follow-up:

1. **Unblock `dkg init` on monorepo / checkout clones.** PR #753 added a hard refusal (`process.exit(1)`) for `dkg init` from a monorepo, but it was over-strict: the CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`) already routes a clone to `~/.dkg-dev` (kept separate from an npm install's `~/.dkg`) — the same home the local dev daemon resolves — so init can run and write the dev config exactly as it did before #753. The refusal (and its **non-functional `DKG_HOME` escape**, which `isDkgMonorepo()` ignores) is replaced by a one-line notice showing which home is written.

2. **Default the OpenClaw / Hermes / MCP setups to `oxigraph-server`.** The rc.15 `oxigraph-server` default only reached nodes set up through the `dkg init` store-wizard; `ensureDkgNodeConfig` (the shared bootstrap used by the adapter/MCP setups) left `store` unset, so those nodes fell back to `oxigraph-worker`. It now seeds `oxigraph-server` on a **fresh** install with no explicit store — matching the wizard default — without flipping existing nodes.

Mapping to #960: **P1** (init unblock) + **P2** (broken `DKG_HOME` escape removed) + **P4** (oxigraph-server default reaches the setups). **P3** (init-vs-setup inconsistency) is resolved because init is no longer guarded. The other two desired-state items were already in place and need no change: edge nodes use no blue/green slots (only Core does), and `dkg init`'s store-wizard already lists `oxigraph-server` as the recommended default (verified — see Test plan).

## Related

- Fixes #960
- Regression introduced by **#753** (RFC-41 Bundle B). Related: #946 (oxigraph-server made default), #938 (managed oxigraph-server backend).

## Files changed

| File | What |
|------|------|
| `packages/cli/src/cli.ts` | Replace the `dkg init` monorepo hard-refusal with a non-fatal notice (init's home resolver already targets `~/.dkg-dev`). |
| `packages/core/src/ensure-dkg-node-config.ts` | Seed `store.backend: oxigraph-server` on a fresh install with no explicit store; preserve existing/explicit store; never flip an existing node. |
| `packages/core/test/ensure-dkg-node-config.test.ts` | New: fresh-seed / no-flip-existing / preserve-explicit. |
| `CHANGELOG.md` | `[Unreleased]` entry. |

## Test plan

- [x] `core` unit — new `ensure-dkg-node-config.test.ts`: **3/3** (fresh → `oxigraph-server`; existing config → store untouched; explicit store → preserved).
- [x] `adapter-openclaw` setup suite — **175 passed** (seed doesn't break setup).
- [x] `adapter-hermes` `hermes-adapter` — **88 passed**.
- [x] `cli` `mcp-setup` + `config` + `validate-store-config` — **176 passed**.
- [x] `pnpm --filter "@origintrail-official/dkg..." build` — clean (`cli.ts` compiles).
- [x] Empirical: `dkg init` from this monorepo checkout is **no longer refused** — it prints `[dkg init] Monorepo checkout detected — writing dev config to <home>` and proceeds into setup, with the store prompt listing `oxigraph-server` as the recommended default (option 1). Confirms P1 + the init oxigraph-server default.
- [ ] CI.
- [ ] (post-merge) Confirm on an npm install that a full `dkg init` writes `store.backend: oxigraph-server` by default, and that `dkg openclaw setup` on a fresh node writes `oxigraph-server`.

## Notes / decisions

- **Fresh-only store seeding (safety):** `ensureDkgNodeConfig` seeds `oxigraph-server` only when no config exists yet. It deliberately does **not** rewrite an existing (even block-less) node's store — that would force a store reset on its next boot. Existing nodes keep their runtime fallback (`oxigraph-worker`); an explicit `store` block is always preserved by the `...existing` spread.
- **Bare `dkg start` auto-bootstrap** still runs on `oxigraph-worker` (it never writes a config). Defaulting it to `oxigraph-server` would require changing the runtime fallback, which flips every existing block-less node — intentionally out of scope here. The path to `oxigraph-server` is `dkg init` (now works on monorepo) or any adapter setup.
- **Edge blue/green slots** were already removed by #753 (Core-only); confirmed, no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
