### PR TITLE
Rename autoPartition → skolemizeByEntity (OT-RFC-44 §4)

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-ccl.ts
+++ b/packages/agent/src/dkg-agent-ccl.ts
@@ -101,7 +101,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -100,7 +100,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-endorse.ts
+++ b/packages/agent/src/dkg-agent-endorse.ts
@@ -100,7 +100,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-helpers.ts
+++ b/packages/agent/src/dkg-agent-helpers.ts
@@ -21,7 +21,7 @@
 import { ethers } from 'ethers';
 import { join } from 'node:path';
 import {
-  autoPartition,
+  skolemizeByEntity,
   FileWorkspacePublicSnapshotStore,
   type LiftRequestAuthorSeal,
   type SharedMemoryPublicSnapshotStorageConfig,
@@ -79,9 +79,9 @@ export function partitionPublishAsyncQuads(publicQuads: Quad[], privateQuads: Qu
   privateQuadsByRoot: Map<string, Quad[]>;
   roots: string[];
 } {
-  const privateByRoot = autoPartition(privateQuads);
+  const privateByRoot = skolemizeByEntity(privateQuads);
   let stagedPublicQuads = [...publicQuads];
-  let publicByRoot = autoPartition(stagedPublicQuads);
+  let publicByRoot = skolemizeByEntity(stagedPublicQuads);
 
   for (const rootEntity of privateByRoot.keys()) {
     if (!publicByRoot.has(rootEntity)) {
@@ -94,7 +94,7 @@ export function partitionPublishAsyncQuads(publicQuads: Quad[], privateQuads: Qu
     }
   }
 
-  publicByRoot = autoPartition(stagedPublicQuads);
+  publicByRoot = skolemizeByEntity(stagedPublicQuads);
   const roots = [...publicByRoot.keys()];
   if (roots.length === 0) {
     throw new InvalidContentError('Content produced no publishable root entities');

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -101,7 +101,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -101,7 +101,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,
@@ -1521,7 +1521,7 @@ export class PublishMethods extends DKGAgentBase {
     //    `buildAssertionSealQuads` rejects unsafe roots at the seal
     //    boundary. This guard surfaces the same failure earlier
     //    with a more actionable message.
-    const kaMap = autoPartition(quads);
+    const kaMap = skolemizeByEntity(quads);
     const allRootEntities = [...kaMap.keys()];
     const unsafeRootEntities = allRootEntities.filter((r) => !isSafeIri(r));
     if (unsafeRootEntities.length > 0) {
@@ -1541,7 +1541,7 @@ export class PublishMethods extends DKGAgentBase {
     }
     const allSkolemizedQuads = [...kaMap.values()].flat();
     const merkleRoot = computeFlatKCRoot(allSkolemizedQuads, []);
-    // 3b. Capture rootEntities from the SAME `autoPartition` call that
+    // 3b. Capture rootEntities from the SAME `skolemizeByEntity` call that
     //     drives the merkle leaves. The seal binds these so
     //     `publishFromFinalizedAssertion` can scope its SWM CONSTRUCT
     //     instead of bundling everything currently sitting in shared
@@ -1550,7 +1550,7 @@ export class PublishMethods extends DKGAgentBase {
     const rootEntities = allRootEntities;
     if (rootEntities.length === 0) {
       throw new Error(
-        `Cannot finalize assertion <${assertionUri}>: autoPartition produced ` +
+        `Cannot finalize assertion <${assertionUri}>: skolemizeByEntity produced ` +
           `no root entities. The assertion has no quads; add at least one ` +
           `user-authored quad on a non-reserved subject before finalizing.`,
       );
@@ -1865,7 +1865,7 @@ export class PublishMethods extends DKGAgentBase {
       );
     }
 
-    const kaMap = autoPartition(quads);
+    const kaMap = skolemizeByEntity(quads);
     const allSkolemizedQuads = [...kaMap.values()].flat();
     // Mirror the publisher's per-rootEntity private partition + root
     // derivation (see `dkg-publisher.ts:1526-1570`). Each public root
@@ -2505,7 +2505,7 @@ export class PublishMethods extends DKGAgentBase {
     //    in shared memory into the same KC; the publisher's recompute
     //    would then disagree with the seal's `expectedMerkleRoot` and
     //    flip to `tentative kaId: "0"`. The seal's rootEntities were
-    //    captured at finalize time from the same `autoPartition` call
+    //    captured at finalize time from the same `skolemizeByEntity` call
     //    that drove the merkle leaves, so this selection deterministically
     //    yields the post-promote SWM slice the seal commits to.
     const result = await this.publishFromSharedMemory(

--- a/packages/agent/src/dkg-agent-query.ts
+++ b/packages/agent/src/dkg-agent-query.ts
@@ -100,7 +100,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -101,7 +101,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -102,7 +102,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/dkg-agent-utils.ts
+++ b/packages/agent/src/dkg-agent-utils.ts
@@ -19,7 +19,7 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { Logger, OperationContext } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
-  autoPartition,
+  skolemizeByEntity,
 } from '@origintrail-official/dkg-publisher';
 
 export type JsonLdDocument = Record<string, unknown> | Record<string, unknown>[];
@@ -120,7 +120,7 @@ export async function getJsonld() {
  * Replace blank node identifiers with deterministic uuid: URIs.
  *
  * JSON-LD documents without explicit @id produce blank nodes (_:b0, _:b1, etc.)
- * which autoPartition cannot use as root entities. This function assigns a stable
+ * which skolemizeByEntity cannot use as root entities. This function assigns a stable
  * uuid: URI to each unique blank node, matching dkg.js v8's generateMissingIdsForBlankNodes.
  *
  * Mutates the array in place.
@@ -292,7 +292,7 @@ export function verifySyncedData(
   }
 
   // Partition data triples by root entity
-  const partitioned = autoPartition(dataQuads);
+  const partitioned = skolemizeByEntity(dataQuads);
 
   // Verify each KC
   const verifiedKcUals = new Set<string>();

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -91,7 +91,7 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -11,7 +11,7 @@ import {
 import { GraphManager, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
-  computeFlatKCRootV10 as computeFlatKCRoot, autoPartition,
+  computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
   generateConfirmedFullMetadata, getTentativeStatusQuad,
   generateSubGraphRegistration,
   shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
@@ -999,7 +999,7 @@ export class FinalizationHandler {
     const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msgRootEntities, subGraphName);
     const merkleRoot = computeFlatKCRoot(canonicalQuads, privateRoots);
 
-    const partitioned = autoPartition(canonicalQuads);
+    const partitioned = skolemizeByEntity(canonicalQuads);
     const localRootSet = new Set(partitioned.keys());
 
     const rootEntities = msgRootEntities.length > 0

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -9,7 +9,7 @@ import {
 import { GraphManager, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, autoPartition,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
   generateTentativeMetadata, getTentativeStatusQuad, getConfirmedStatusQuad,
   validatePublishRequest, parseSimpleNQuads, generateSubGraphRegistration,
   type KAMetadata,
@@ -306,7 +306,7 @@ export class GossipPublishHandler {
           .map(ka => new Uint8Array(ka.privateMerkleRoot));
         const merkleRoot = computeFlatKCRoot(normalized, privateRoots);
 
-        const partitioned = autoPartition(normalized);
+        const partitioned = skolemizeByEntity(normalized);
         const kaMetadata: KAMetadata[] = [];
 
         let metadataTokenId = 1n;

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -1,5 +1,5 @@
 import { parentPort } from 'node:worker_threads';
-import { computeFlatKCRootV10 as computeFlatKCRoot, autoPartition } from '@origintrail-official/dkg-publisher';
+import { computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 
@@ -91,7 +91,7 @@ function verifySyncedData(
     for (const kcUal of kcUals) overlappingKCs.add(kcUal);
   }
 
-  const partitioned = autoPartition(dataQuads);
+  const partitioned = skolemizeByEntity(dataQuads);
   const verifiedKcUals = new Set<string>();
   let rejected = 0;
 

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -3084,11 +3084,11 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       // root entity is prevented by a subject-prefix filter in
       // `packages/publisher/src/dkg-publisher.ts` `assertionPromote` that
       // excludes both `urn:dkg:file:` and `urn:dkg:extraction:` subjects
-      // from the partition before `autoPartition` runs. Row 1 (whose
+      // from the partition before `skolemizeByEntity` runs. Row 1 (whose
       // subject is the doc entity, not the file URN) is preserved through
       // promote; rows 4-13 are WM-only by design. See Codex Bug 8 Round 4
       // reconciled ruling — Round 3 tried blank-node subjects, but an
-      // `autoPartition` audit showed they silently drop the prov block on
+      // `skolemizeByEntity` audit showed they silently drop the prov block on
       // promote, which was a correctness smell. See `19_MARKDOWN_CONTENT_TYPE.md
       // §10.2` for the normative rule.
       const fileUri = `urn:dkg:file:${fileStoreEntry.keccak256}`;

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -59,7 +59,7 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
-import { autoPartition, findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions, type PublishResult } from '@origintrail-official/dkg-publisher';
+import { skolemizeByEntity, findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions, type PublishResult } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
   DashboardDB,
@@ -410,7 +410,7 @@ async function resolvePublishRootEntities(
   const quads: Quad[] = result.type === "quads"
     ? result.quads.filter((quad) => quad.predicate !== WORKSPACE_OWNER_PREDICATE)
     : [];
-  return [...autoPartition(quads).keys()];
+  return [...skolemizeByEntity(quads).keys()];
 }
 
 function publishResponsePayload(

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -82,7 +82,7 @@ export interface MarkdownExtractInput {
    * blank-node subjects. See `19_MARKDOWN_CONTENT_TYPE.md §10.2` for the
    * normative rule and spec-engineer's reconciled ruling on Codex Bug 8
    * for the history (Round 3 tried blank nodes; Round 4 reverted to URI
-   * subjects + promote-time filter after an `autoPartition` audit showed
+   * subjects + promote-time filter after an `skolemizeByEntity` audit showed
    * the blank-node approach silently drops the ExtractionProvenance
    * block, which is a correctness smell).
    */
@@ -529,9 +529,9 @@ function frontmatterKeyToPredicate(key: string): string | null {
  * Cross-assertion promote contention on that subject is prevented by a
  * subject-prefix filter in `packages/publisher/src/dkg-publisher.ts`
  * `assertionPromote` that excludes `urn:dkg:file:` and `urn:dkg:extraction:`
- * subjects from the partition before `autoPartition` runs. See Codex
+ * subjects from the partition before `skolemizeByEntity` runs. See Codex
  * Bug 8 Round 4 reconciled ruling for the history — Round 3 tried blank
- * nodes but an `autoPartition` audit showed they silently drop the
+ * nodes but an `skolemizeByEntity` audit showed they silently drop the
  * ExtractionProvenance block on promote, which was a correctness smell.
  *
  * `resolvedRootEntity` follows the §19.10.1:508 precedence rules:

--- a/packages/core/src/assertion-seal.ts
+++ b/packages/core/src/assertion-seal.ts
@@ -49,7 +49,7 @@ export const ASSERTION_SEAL_PREDICATES = {
    * time so that `publishFromFinalizedAssertion` can scope the SWM
    * SPARQL CONSTRUCT to exactly this assertion's quads instead of
    * bundling everything currently in shared memory. The set is
-   * derived from `autoPartition(filteredQuads).keys()` over the same
+   * derived from `skolemizeByEntity(filteredQuads).keys()` over the same
    * reserved-subject-filtered quads `assertionPromote` writes, so the
    * post-promote SWM lookup produces the same merkle leaves the seal
    * was signed over. IRI literal — emitted as `<rootEntity>` (object

--- a/packages/publisher/src/auto-partition.ts
+++ b/packages/publisher/src/auto-partition.ts
@@ -2,16 +2,22 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import { skolemize, isSkolemizedUri, rootEntityFromSkolemized, isBlankNode } from './skolemize.js';
 
 /**
- * Auto-partitions quads into Knowledge Assets.
+ * Skolemizes blank nodes under their parent entity and INDEXES the result by
+ * entity. It does NOT partition into Knowledge Assets — the name `autoPartition`
+ * was a misnomer that led readers (and patches) to treat the entity index as a
+ * list of KAs (OT-RFC-44 §4 / OT-RFC-43 §10.4). Under Design B one file = one KA
+ * whose member entities are exactly the keys of this map.
  *
  * 1. Identifies root entities (non-blank, non-skolemized subjects)
- * 2. Skolemizes blank nodes under their parent root entity
- * 3. Groups triples: each rootEntity defines a KA, skolemized children belong
- *    to the KA whose rootEntity is their URI prefix
+ * 2. Skolemizes blank nodes under their parent entity (`<entity>/.well-known/genid/N`)
+ * 3. Groups triples by entity: skolemized children belong to the entity whose
+ *    URI is their prefix
  *
- * Returns a Map of rootEntity → Quad[].
+ * The skolemization is load-bearing for consensus (canonical subject hashes for
+ * the flat Merkle, validation, the SWM gather, and the RS prover); the grouping
+ * is just an index. Returns a Map of entity → Quad[].
  */
-export function autoPartition(quads: Quad[]): Map<string, Quad[]> {
+export function skolemizeByEntity(quads: Quad[]): Map<string, Quad[]> {
   // Phase 1: Find root entities (non-blank, non-skolemized unique subjects)
   const rootEntities = new Set<string>();
   for (const q of quads) {
@@ -78,3 +84,11 @@ export function autoPartition(quads: Quad[]): Map<string, Quad[]> {
 
   return rootQuadsMap;
 }
+
+/**
+ * @deprecated Misnomer — this skolemizes and indexes by entity; it does not
+ * partition into Knowledge Assets (OT-RFC-44 §4). Use {@link skolemizeByEntity}.
+ * Kept as an alias for one release so external consumers (test fixtures,
+ * scripts) can migrate; will be removed once no callers reference it.
+ */
+export const autoPartition = skolemizeByEntity;

--- a/packages/publisher/src/canonical-publish-payload.ts
+++ b/packages/publisher/src/canonical-publish-payload.ts
@@ -4,7 +4,7 @@
 // the same bytes the publisher submits.
 
 import type { Quad } from '@origintrail-official/dkg-storage';
-import { autoPartition } from './auto-partition.js';
+import { skolemizeByEntity } from './auto-partition.js';
 import { computeFlatKCRootV10, computePrivateRootV10 } from './merkle.js';
 
 export interface CanonicalManifestEntry {
@@ -25,7 +25,7 @@ export function canonicalPublishPayload(
   quads: Quad[],
   privateQuads: Quad[] = [],
 ): CanonicalPublishPayload {
-  const kaMap = autoPartition(quads);
+  const kaMap = skolemizeByEntity(quads);
 
   const manifestEntries: CanonicalManifestEntry[] = [];
   for (const [rootEntity, publicForRoot] of kaMap) {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3270,6 +3270,14 @@ export class DKGPublisher implements Publisher {
     }));
   }
 
+  /**
+   * @deprecated Use {@link skolemizeByEntity}. Kept as a one-release
+   * compatibility alias for callers that use the public instance method.
+   */
+  autoPartition(quads: Quad[]): KAManifestEntry[] {
+    return this.skolemizeByEntity(quads);
+  }
+
   skolemize(rootEntity: string, quads: Quad[]): Quad[] {
     return skolemize(rootEntity, quads);
   }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -5,7 +5,7 @@ import type { EventBus, OperationContext } from '@origintrail-official/dkg-core'
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
-import { autoPartition } from './auto-partition.js';
+import { skolemizeByEntity } from './auto-partition.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
 import { skolemize } from './skolemize.js';
@@ -799,7 +799,7 @@ export class DKGPublisher implements Publisher {
 
     await this.graphManager.ensureContextGraph(contextGraphId);
 
-    const kaMap = autoPartition(quads);
+    const kaMap = skolemizeByEntity(quads);
     const manifestEntries: { rootEntity: string; privateMerkleRoot?: Uint8Array; privateTripleCount: number }[] = [];
     for (const [rootEntity, publicQuads] of kaMap) {
       const privRoot = undefined;
@@ -1223,7 +1223,7 @@ export class DKGPublisher implements Publisher {
     // that payload may contain N root entities and still publish as ONE KA in a
     // single transaction. Higher-level selection endpoints keep their
     // unrelated-root guard until they can identify that one lifecycle boundary.
-    const rootEntities = [...autoPartition(quads).keys()];
+    const rootEntities = [...skolemizeByEntity(quads).keys()];
 
     const ctxGraphId = options?.publishContextGraphId;
     const chainCgId = options?.onChainContextGraphId ?? ctxGraphId;
@@ -1447,7 +1447,7 @@ export class DKGPublisher implements Publisher {
     if (publishResult.status === 'confirmed') {
       const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(contextGraphId, options?.subGraphName);
       const swmOwnershipKey = options?.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
-      const kaMap = autoPartition(quads);
+      const kaMap = skolemizeByEntity(quads);
       let ownerDeletedTotal = 0;
       for (const rootEntity of kaMap.keys()) {
         await this.store.deleteByPattern({ graph: swmGraph, subject: rootEntity });
@@ -2801,7 +2801,7 @@ export class DKGPublisher implements Publisher {
 
     onPhase?.('prepare', 'start');
     onPhase?.('prepare:partition', 'start');
-    const kaMap = autoPartition(quads);
+    const kaMap = skolemizeByEntity(quads);
     onPhase?.('prepare:partition', 'end');
 
     onPhase?.('prepare:manifest', 'start');
@@ -3261,8 +3261,8 @@ export class DKGPublisher implements Publisher {
     return this.publisherNodeIdentityId;
   }
 
-  autoPartition(quads: Quad[]): KAManifestEntry[] {
-    const kaMap = autoPartition(quads);
+  skolemizeByEntity(quads: Quad[]): KAManifestEntry[] {
+    const kaMap = skolemizeByEntity(quads);
     let tokenId = 1n;
     return [...kaMap.keys()].map((rootEntity) => ({
       tokenId: tokenId++,
@@ -4055,7 +4055,7 @@ export class DKGPublisher implements Publisher {
     // §10.2 linkage table) and the `<urn:dkg:extraction:<uuid>>`
     // ExtractionProvenance block (rows 9-13) are subordinate metadata
     // about the extraction RUN, not semantic knowledge about an Entity.
-    // Without this filter, `autoPartition` below would treat
+    // Without this filter, `skolemizeByEntity` below would treat
     // `<urn:dkg:file:keccak256:abc>` as a root entity and cross-assertion
     // ownership would contend when two different assertions reference
     // the same file content (same keccak256 → same URN → same
@@ -4077,7 +4077,7 @@ export class DKGPublisher implements Publisher {
     //
     // See `19_MARKDOWN_CONTENT_TYPE.md §10.2` for the normative rule
     // and Codex Bug 8 Round 4 reconciled ruling for the history (Round
-    // 3 tried blank-node subjects but an `autoPartition` audit showed
+    // 3 tried blank-node subjects but an `skolemizeByEntity` audit showed
     // they silently drop rows 9-13 on promote, which was worse).
     // Round 12 Bug 35: source the prefix list from `RESERVED_SUBJECT_PREFIXES`
     // instead of hardcoding the two literals inline. If the reserved
@@ -4112,7 +4112,7 @@ export class DKGPublisher implements Publisher {
     const operationId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Skolemize blank nodes so local SWM and gossip peers store identical data.
-    const kaMap = autoPartition(quadsToPromote);
+    const kaMap = skolemizeByEntity(quadsToPromote);
     if (kaMap.size === 0) {
       throw new Error(
         'Cannot promote assertion: no root entities found. ' +

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -1,7 +1,7 @@
 export * from './publisher.js';
 export { skolemize, isBlankNode, isSkolemizedUri, rootEntityFromSkolemized } from './skolemize.js';
 export { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
-export { autoPartition } from './auto-partition.js';
+export { skolemizeByEntity, autoPartition } from './auto-partition.js';
 export {
   canonicalPublishPayload,
   type CanonicalPublishPayload,

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -21,7 +21,7 @@ import {
   getConfirmedStatusQuad,
   type KAMetadata,
 } from './metadata.js';
-import { autoPartition } from './auto-partition.js';
+import { skolemizeByEntity } from './auto-partition.js';
 import { PublishJournal, type JournalEntry } from './publish-journal.js';
 
 interface PendingPublish {
@@ -242,7 +242,7 @@ export class PublishHandler {
         .map(ka => new Uint8Array(ka.privateMerkleRoot));
       const computedMerkleRoot = computeFlatKCRoot(quads, privateRoots);
 
-      const partitioned = autoPartition(quads);
+      const partitioned = skolemizeByEntity(quads);
 
       // ── UAL consistency ──
       const startKAId = protoToBigInt(request.startKAId);

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -337,5 +337,7 @@ export interface Publisher {
   publish(options: PublishOptions): Promise<PublishResult>;
   update(kaId: bigint, options: PublishOptions): Promise<PublishResult>;
   skolemizeByEntity(quads: Quad[]): KAManifestEntry[];
+  /** @deprecated Use skolemizeByEntity. */
+  autoPartition(quads: Quad[]): KAManifestEntry[];
   skolemize(rootEntity: string, quads: Quad[]): Quad[];
 }

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -271,7 +271,7 @@ export interface PublishOptions {
    * The caller has already:
    *   1. Computed `expectedMerkleRoot` over the same quads it is
    *      now asking the publisher to publish (computed via
-   *      `computeFlatKCRoot` / `autoPartition` semantics).
+   *      `computeFlatKCRoot` / `skolemizeByEntity` semantics).
    *   2. Signed (or collected a signature for) the typed data
    *      `buildAuthorAttestationTypedData({ chainId, kav10Address,
    *      contextGraphId, merkleRoot: expectedMerkleRoot,
@@ -336,6 +336,6 @@ export interface PublishResult {
 export interface Publisher {
   publish(options: PublishOptions): Promise<PublishResult>;
   update(kaId: bigint, options: PublishOptions): Promise<PublishResult>;
-  autoPartition(quads: Quad[]): KAManifestEntry[];
+  skolemizeByEntity(quads: Quad[]): KAManifestEntry[];
   skolemize(rootEntity: string, quads: Quad[]): Quad[];
 }

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -5,7 +5,7 @@ import type { ChainAdapter, KAUpdateVerification } from '@origintrail-official/d
 import { Logger, createOperationContext, DKGEvent, sparqlInt, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { decodeKAUpdateRequest } from '@origintrail-official/dkg-core';
 import { parseSimpleNQuads } from './publish-handler.js';
-import { autoPartition } from './auto-partition.js';
+import { skolemizeByEntity } from './auto-partition.js';
 import { computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot } from './merkle.js';
 import {
   promoteUpdatedKaToPerCgId,
@@ -174,7 +174,7 @@ export class UpdateHandler {
         .map((r) => new Uint8Array(r));
       const computedRoot = computeFlatKCRoot(quads, privateRoots);
 
-      const partitioned = autoPartition(quads);
+      const partitioned = skolemizeByEntity(quads);
       const manifestRoots = new Set(manifest.map((m) => m.rootEntity));
       for (const payloadRoot of partitioned.keys()) {
         if (!manifestRoots.has(payloadRoot)) {

--- a/packages/publisher/test/dkg-publisher-compat.test.ts
+++ b/packages/publisher/test/dkg-publisher-compat.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  TypedEventBus,
+  generateEd25519Keypair,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+
+function q(s: string, p: string, o: string): Quad {
+  return {
+    subject: s,
+    predicate: p,
+    object: o,
+    graph: 'did:dkg:context-graph:test',
+  };
+}
+
+async function makePublisher(): Promise<DKGPublisher> {
+  return new DKGPublisher({
+    store: new OxigraphStore(),
+    chain: new NoChainAdapter(),
+    eventBus: new TypedEventBus(),
+    keypair: await generateEd25519Keypair(),
+  });
+}
+
+describe('DKGPublisher compatibility aliases', () => {
+  it('keeps autoPartition as a deprecated alias for skolemizeByEntity', async () => {
+    const publisher = await makePublisher();
+    const quads = [
+      q('urn:compat:one', 'http://schema.org/name', '"One"'),
+      q('urn:compat:two', 'http://schema.org/name', '"Two"'),
+    ];
+
+    expect(publisher.autoPartition(quads)).toEqual(publisher.skolemizeByEntity(quads));
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'test/trust-metadata.test.ts',
+      'test/dkg-publisher-compat.test.ts',
       'test/shared-memory-publish-boundary.test.ts',
       'test/storage-ack-roster-and-verify-mofn-extra.test.ts',
       'test/verification-metadata.test.ts',


### PR DESCRIPTION
## What & why

Renames the misnamed `autoPartition` function to `skolemizeByEntity`. It never partitioned into Knowledge Assets — it **skolemizes blank nodes under their parent entity and indexes the result by entity** (`Map<entity, Quad[]>`). The "autoPartition" name is the misnomer that repeatedly led readers (and patches) to treat the entity index as a list of KAs and conclude "kill autoPartition" — re-entrenching the entity-count == KA-count bug that Design B (#968) removes.

**No behavior change.** Pure rename + doc fix.

## What changed

- `auto-partition.ts`: export renamed to `skolemizeByEntity`; the misleading JSDoc fixed (it indexes by entity — the skolemization is consensus-load-bearing for the flat Merkle / validation / SWM gather / RS prover; the grouping is just an index). `autoPartition` kept as a `@deprecated` alias for one release so external test/script consumers can migrate.
- `index.ts`: exports both names.
- ~29 internal call sites (publisher, agent, cli, core) migrated to the new name; tests keep working through the alias.

## Verification

Agent build closure green; publisher tests (dkg-publisher, metadata, boundary, pure-functions, canonical-publish-payload, publish-lifecycle, ka-update) all pass.

## Notes

- **Stacked on #968** (Design B). Base is `feat/v10-file-ka`; review/merge after #968, or retarget to `main` once #968 lands.
- Filename `auto-partition.ts` left unchanged to avoid import-path churn; can rename in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)