### PR TITLE
GitHub-shaped /api/knowledge-assets HTTP surface (OT-RFC-43 §10.5)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1621,7 +1621,7 @@ export class DKGAgent extends DKGAgentBase {
         const row = entityResult.bindings[0];
         const stateStr = strip(row['state']) as AssertionState;
         const layerStr = strip(row['memoryLayer']);
-        const graphUri = row['assertionGraph'] ?? contextGraphAssertionUri(contextGraphId, addr, name);
+        const graphUri = row['assertionGraph'] ?? contextGraphAssertionUri(contextGraphId, addr, name, opts?.subGraphName);
 
         const sealResult = await agent.store.query(
           `SELECT ?authorAddress ?schemeVersion ?finalizedAt WHERE {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1623,6 +1623,21 @@ export class DKGAgent extends DKGAgentBase {
         const layerStr = strip(row['memoryLayer']);
         const graphUri = row['assertionGraph'] ?? contextGraphAssertionUri(contextGraphId, addr, name);
 
+        const sealResult = await agent.store.query(
+          `SELECT ?authorAddress ?schemeVersion ?finalizedAt WHERE {
+            GRAPH <${metaGraph}> {
+              <${graphUri}> <${DKG_NS}authorAddress> ?authorAddress .
+              OPTIONAL { <${graphUri}> <${DKG_NS}authorSchemeVersion> ?schemeVersion }
+              OPTIONAL { <${graphUri}> <${DKG_NS}assertionFinalizedAt> ?finalizedAt }
+            }
+          } LIMIT 1`,
+        );
+        const sealRow = sealResult.type === 'bindings' ? sealResult.bindings[0] : undefined;
+        const sealAuthorAddress = strip(sealRow?.['authorAddress']);
+        const sealSchemeVersionRaw = strip(sealRow?.['schemeVersion']);
+        const sealSchemeVersion = sealSchemeVersionRaw != null ? Number(sealSchemeVersionRaw) : undefined;
+        const sealFinalizedAtIso = strip(sealRow?.['finalizedAt']);
+
         // Query all prov:Activity events that acted on this assertion
         // (linked via prov:used or prov:generated)
         const eventsResult = await agent.store.query(
@@ -1678,6 +1693,13 @@ export class DKGAgent extends DKGAgentBase {
           state: stateStr,
           memoryLayer: (layerStr as MemoryLayer) ?? null,
           assertionGraph: graphUri,
+          ...(sealAuthorAddress ? {
+            seal: {
+              authorAddress: sealAuthorAddress,
+              ...(Number.isFinite(sealSchemeVersion) ? { schemeVersion: sealSchemeVersion } : {}),
+              ...(sealFinalizedAtIso ? { finalizedAtIso: sealFinalizedAtIso } : {}),
+            },
+          } : {}),
           events: [...eventMap.values()],
         };
       },

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -322,6 +322,7 @@ import { handleMemoryRoutes } from './routes/memory.js';
 import { handlePublisherRoutes } from './routes/publisher.js';
 import { handleContextGraphRoutes } from './routes/context-graph.js';
 import { handleAssertionRoutes } from './routes/assertion.js';
+import { handleKnowledgeAssetsRoutes } from './routes/knowledge-assets.js';
 import { handleQueryRoutes } from './routes/query.js';
 import { handleLocalAgentsRoutes } from './routes/local-agents.js';
 import { handleEpcisRoutes } from './routes/epcis.js';
@@ -427,6 +428,9 @@ export async function handleRequest(
   if (res.writableEnded) return;
 
   await handleContextGraphRoutes(ctx);
+  if (res.writableEnded) return;
+
+  await handleKnowledgeAssetsRoutes(ctx);
   if (res.writableEnded) return;
 
   await handleAssertionRoutes(ctx);

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -25,7 +25,8 @@
 // `(agent, number)` addressing is layered on by Option 1 later, on these same
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
-import { validateAssertionName } from "@origintrail-official/dkg-core";
+import { createOperationContext, validateAssertionName } from "@origintrail-official/dkg-core";
+import { resolveChainConfig } from "../../config.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
 import { recordAssertionActivity } from "../activity-notification.js";
 import {
@@ -35,12 +36,35 @@ import {
   resolveRequiredWriteContextGraphId,
   safeDecodeURIComponent,
   safeParseJson,
+  SMALL_BODY_BYTES,
   validateEntities,
   validateOptionalSubGraphName,
   validateRequiredContextGraphId,
 } from "../http-utils.js";
 
 const PREFIX = "/api/knowledge-assets";
+
+/**
+ * Body-size cap by `(layer, verb)` (codex PR #971 F21). The control verbs
+ * (`finalize`, `discard`, `pull-from`, `share`, `publish`) carry a handful
+ * of scalar fields — there is no legitimate reason for any of them to be
+ * larger than the legacy `SMALL_BODY_BYTES` cap their `/api/assertion/*` +
+ * `/api/shared-memory/*` ancestors used. `wm/write` is the only quad-bearing
+ * sub-route, so it keeps the default `MAX_BODY_BYTES`. The atomic create at
+ * `POST /api/knowledge-assets` also keeps the large cap because its body
+ * may include the same `quads` payload as `wm/write`.
+ */
+function postShapeMaxBytes(layer: string | undefined, verb: string | undefined): number | undefined {
+  if (layer === "wm" && verb === "write") return undefined; // default MAX_BODY_BYTES
+  if (
+    (layer === "wm" && (verb === "finalize" || verb === "discard" || verb === "pull-from")) ||
+    (layer === "swm" && verb === "share") ||
+    (layer === "vm" && verb === "publish")
+  ) {
+    return SMALL_BODY_BYTES;
+  }
+  return undefined;
+}
 
 function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
@@ -291,6 +315,70 @@ function clearSharedMemoryAfterForNamedPublish(opts: Record<string, unknown>): b
   return typeof opts.clearSharedMemoryAfter === "boolean" ? opts.clearSharedMemoryAfter : false;
 }
 
+/**
+ * Mirror the legacy `/api/shared-memory/publish` operation-tracker dance
+ * (codex PR #971 F22). Without this the new surface would publish without
+ * recording progress, tx hash, or gas/cost metadata in the daemon's
+ * operation history — a silent regression versus the route it replaces.
+ *
+ * `publishFromFinalizedAssertion` accepts `operationCtx` and threads it
+ * through the publisher's own phase markers, so the dashboard sees the
+ * same fine-grained timeline regardless of which HTTP surface initiated
+ * the publish. On exit:
+ *   - throws → `tracker.fail(opCtx, err)` then re-throw (caller's catch
+ *     maps to 400/500 as before);
+ *   - returns → `tracker.complete(opCtx, { tripleCount: kaManifest.length })`
+ *     unconditionally. Partial-success states (`tentative`/`failed` /
+ *     `contextGraphError`) are reflected in the HTTP status code (207)
+ *     by the caller — the operation row records a non-error completion
+ *     because the publish call itself completed, exactly mirroring the
+ *     legacy code path in `memory.ts` (`tracker.complete` runs even when
+ *     `result.contextGraphError` is set).
+ */
+async function publishWithTracker(
+  ctx: RequestContext,
+  contextGraphId: string,
+  name: string,
+  options: {
+    subGraphName?: string;
+    publishOptions: Record<string, unknown>;
+  },
+): Promise<any> {
+  const { tracker, agent, config, network } = ctx;
+  const opCtx = createOperationContext("publishFromSWM");
+  tracker.start(opCtx, {
+    contextGraphId,
+    details: {
+      source: "api",
+      assertionName: name,
+      ...(options.subGraphName ? { subGraphName: options.subGraphName } : {}),
+    },
+  });
+  try {
+    const result: any = await tracker.trackPhase(opCtx, "read-shared-memory", () =>
+      agent.publishFromFinalizedAssertion(contextGraphId, name, {
+        ...(options.subGraphName ? { subGraphName: options.subGraphName } : {}),
+        operationCtx: opCtx,
+        ...options.publishOptions,
+      }),
+    );
+    const chain = result?.onChainResult;
+    if (chain) {
+      tracker.setCost(opCtx, {
+        gasUsed: chain.gasUsed,
+        gasPrice: chain.effectiveGasPrice,
+      });
+      const chainId = resolveChainConfig(config, network)?.chainId;
+      tracker.setTxHash(opCtx, chain.txHash, chainId ? Number(chainId) : undefined);
+    }
+    tracker.complete(opCtx, { tripleCount: result?.kaManifest?.length ?? 0 });
+    return result;
+  } catch (err) {
+    tracker.fail(opCtx, err);
+    throw err;
+  }
+}
+
 function emitPublished(
   ctx: RequestContext,
   contextGraphId: string,
@@ -490,9 +578,13 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
       if (alsoPublishVm) {
         try {
-          const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
-            ...(subGraphName ? { subGraphName } : {}),
-            ...atomicPublishOptions,
+          // codex PR #971 F22: the atomic-create publish tail records into
+          // the same operation-tracker timeline as `/api/shared-memory/publish`
+          // and `/vm/publish`, so dashboards never lose visibility on a
+          // publish just because the caller chose the atomic surface.
+          const pub: any = await publishWithTracker(ctx, resolvedContextGraphId, name, {
+            subGraphName,
+            publishOptions: atomicPublishOptions,
           });
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
@@ -601,13 +693,26 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   // body, so an unknown shape (e.g. `/:name/foo/bar`) falls through to the
   // daemon's 404 instead of returning a body-dependent 400/500. `pull-from` is
   // a known shape (returns 501 below), so it stays in the supported set.
+  //
+  // codex PR #971 F20: require the EXACT segment count for each known POST
+  // shape. Without the `segs.length === 3` guard, a path like
+  // `/api/knowledge-assets/foo/vm/publish/extra` still matched
+  // `(layer="vm", verb="publish")` and ran the publish side effect instead
+  // of falling through to the daemon's 404. Every currently-supported POST
+  // shape is `<name>/<layer>/<verb>` (3 segments after the prefix); when
+  // future shapes add their own depth they will need their own segment
+  // count too.
   const isSupportedPostShape =
-    (layer === "wm" && (verb === "write" || verb === "finalize" || verb === "discard" || verb === "pull-from")) ||
-    (layer === "swm" && verb === "share") ||
-    (layer === "vm" && verb === "publish");
+    segs.length === 3 &&
+    ((layer === "wm" && (verb === "write" || verb === "finalize" || verb === "discard" || verb === "pull-from")) ||
+      (layer === "swm" && verb === "share") ||
+      (layer === "vm" && verb === "publish"));
   if (!isSupportedPostShape) return;
 
-  const parsed = safeParseJson(await readBody(req), res);
+  // codex PR #971 F21: pick the body-size cap up front from the matched
+  // shape so control verbs do not silently inherit the 10 MB default.
+  const verbMaxBytes = postShapeMaxBytes(layer, verb);
+  const parsed = safeParseJson(await readBody(req, verbMaxBytes), res);
   if (!parsed) return;
   const contextGraphId = parsed.contextGraphId;
   const subGraphName = parsed.subGraphName;
@@ -714,9 +819,12 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (layer === "vm" && verb === "publish") {
       const opts = resolveFinalizedPublishOptions(ctx, finalizedPublishOptionsInput(parsed));
       if (opts === null) return;
-      const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
-        ...(subGraphName ? { subGraphName } : {}),
-        ...opts,
+      // codex PR #971 F22: mirror the legacy operation-tracker dance from
+      // `/api/shared-memory/publish` so the daemon's operation history
+      // records progress / tx-hash / cost for KA publishes too.
+      const pub: any = await publishWithTracker(ctx, resolvedContextGraphId, name, {
+        subGraphName,
+        publishOptions: opts,
       });
       emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
       // Mirror the atomic path: non-throwing tentative/failed/contextGraphError

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -268,6 +268,27 @@ function actorFromFinalizeOptions(finalizeOptions: Record<string, unknown>): str
   return typeof preSigned?.address === "string" ? preSigned.address : undefined;
 }
 
+async function sealedAuthorFromAssertionHistory(
+  ctx: RequestContext,
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+): Promise<string | undefined> {
+  try {
+    const history = await ctx.agent.assertion.history(
+      contextGraphId,
+      name,
+      subGraphName ? { subGraphName } : undefined,
+    );
+    const seal = (history as { seal?: { authorAddress?: unknown } } | null)?.seal;
+    return typeof seal?.authorAddress === "string" && seal.authorAddress.length > 0
+      ? seal.authorAddress
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function recordActivity(
   ctx: RequestContext,
   contextGraphId: string,
@@ -800,6 +821,20 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       (layer === "vm" && verb === "publish"));
   if (!isSupportedPostShape) return;
 
+  if (layer === "wm" && verb === "pull-from") {
+    // Net-new primitive (the git-checkout equivalent): seed a fresh WM
+    // draft from the current SWM or VM state, with onConflict semantics
+    // for a dirty draft. Implemented in a focused follow-up — it needs the
+    // per-layer entity-scoped gather + conflict handling (OT-RFC-43 §10.5.3).
+    //
+    // Short-circuit before body/context validation so feature probes always
+    // receive the advertised 501, even with malformed JSON or a stale CG id.
+    return jsonResponse(res, 501, {
+      error: "wm/pull-from is not implemented yet (OT-RFC-43 §10.5.3 — follow-up)",
+      layer,
+    });
+  }
+
   // codex PR #971 F21: pick the body-size cap up front from the matched
   // shape so control verbs do not silently inherit the 10 MB default.
   const verbMaxBytes = postShapeMaxBytes(layer, verb);
@@ -871,13 +906,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         return jsonResponse(res, 200, { discarded: true });
       }
       if (verb === "pull-from") {
-        // Net-new primitive (the git-checkout equivalent): seed a fresh WM
-        // draft from the current SWM or VM state, with onConflict semantics
-        // for a dirty draft. Implemented in a focused follow-up — it needs the
-        // per-layer entity-scoped gather + conflict handling (OT-RFC-43 §10.5.3).
         return jsonResponse(res, 501, {
           error: "wm/pull-from is not implemented yet (OT-RFC-43 §10.5.3 — follow-up)",
-          layer: parsed.layer,
+          layer,
         });
       }
     }
@@ -890,6 +921,12 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         subGraphName,
       });
       if (share.promotedCount !== 0) {
+        const sealAuthorAddress = await sealedAuthorFromAssertionHistory(
+          ctx,
+          resolvedContextGraphId,
+          name,
+          subGraphName,
+        );
         emitMemoryGraphChanged?.({
           contextGraphId: resolvedContextGraphId,
           layers: ["wm", "swm"],
@@ -900,6 +937,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         });
         recordActivity(ctx, resolvedContextGraphId, "promoted", {
           subGraphName,
+          actorAgentAddress: sealAuthorAddress,
           tripleCount: share.promotedCount,
         });
       }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -134,6 +134,12 @@ function resolveFinalizeOptions(
   };
 }
 
+function actorFromFinalizeOptions(finalizeOptions: Record<string, unknown>): string | undefined {
+  if (typeof finalizeOptions.authorAgentAddress === "string") return finalizeOptions.authorAgentAddress;
+  const preSigned = finalizeOptions.preSignedAuthorAttestation as { address?: unknown } | undefined;
+  return typeof preSigned?.address === "string" ? preSigned.address : undefined;
+}
+
 function recordActivity(
   ctx: RequestContext,
   contextGraphId: string,
@@ -215,6 +221,14 @@ function resolveFinalizedPublishOptions(
   }
 
   const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
+  if (clearAfter !== undefined && typeof clearAfter !== "boolean") {
+    jsonResponse(res, 400, { error: '"clearAfter" must be a boolean when supplied' });
+    return null;
+  }
+  if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== "boolean") {
+    jsonResponse(res, 400, { error: '"clearSharedMemoryAfter" must be a boolean when supplied' });
+    return null;
+  }
   return {
     ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
     ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
@@ -345,46 +359,54 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         source: "api",
         counts: { triples: 0 },
       });
+      const finalizeActorAddress = actorFromFinalizeOptions(finalizeOptions);
       recordActivity(ctx, resolvedContextGraphId, "created", {
         subGraphName,
-        actorAgentAddress:
-          typeof finalizeOptions.authorAgentAddress === "string"
-            ? finalizeOptions.authorAgentAddress
-            : requestAgentAddress,
+        actorAgentAddress: finalizeActorAddress ?? requestAgentAddress,
       });
       const result: Record<string, unknown> = { name, assertionUri, status: "draft-open" };
 
       // autoFinalize: when quads are supplied, write + seal in the same call
       // (OT-RFC-43 §10.5.5). `also*` are opt-in layer transitions on top.
       if (Array.isArray(quads) && quads.length > 0) {
-        await agent.assertion.write(
-          resolvedContextGraphId,
-          name,
-          quads,
-          subGraphName ? { subGraphName } : undefined,
-        );
-        emitMemoryGraphChanged?.({
-          contextGraphId: resolvedContextGraphId,
-          layers: ["wm"],
-          subGraphName,
-          operation: "assertion_written",
-          source: "api",
-          counts: { triples: quads.length },
-        });
-        result.written = quads.length;
-        const seal = await agent.assertion.finalize(resolvedContextGraphId, name, {
-          ...(subGraphName ? { subGraphName } : {}),
-          ...finalizeOptions,
-        });
-        emitMemoryGraphChanged?.({
-          contextGraphId: resolvedContextGraphId,
-          layers: ["wm"],
-          subGraphName,
-          operation: "assertion_finalized",
-          source: "api",
-        });
-        result.merkleRoot = hex(seal.merkleRoot);
-        result.status = "wm-sealed";
+        try {
+          await agent.assertion.write(
+            resolvedContextGraphId,
+            name,
+            quads,
+            subGraphName ? { subGraphName } : undefined,
+          );
+          emitMemoryGraphChanged?.({
+            contextGraphId: resolvedContextGraphId,
+            layers: ["wm"],
+            subGraphName,
+            operation: "assertion_written",
+            source: "api",
+            counts: { triples: quads.length },
+          });
+          result.written = quads.length;
+          result.status = "wm-written";
+          const seal = await agent.assertion.finalize(resolvedContextGraphId, name, {
+            ...(subGraphName ? { subGraphName } : {}),
+            ...finalizeOptions,
+          });
+          emitMemoryGraphChanged?.({
+            contextGraphId: resolvedContextGraphId,
+            layers: ["wm"],
+            subGraphName,
+            operation: "assertion_finalized",
+            source: "api",
+          });
+          result.merkleRoot = hex(seal.merkleRoot);
+          result.status = "wm-sealed";
+        } catch (e: any) {
+          const phase = result.written === quads.length ? "wm-finalize" : "wm-write";
+          return jsonResponse(res, 207, {
+            created: true,
+            ...result,
+            errors: [{ phase, error: e?.message ?? String(e) }],
+          });
+        }
       }
 
       const errors: Array<{ phase: string; error: string }> = [];
@@ -409,6 +431,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
             });
             recordActivity(ctx, resolvedContextGraphId, "promoted", {
               subGraphName,
+              actorAgentAddress: finalizeActorAddress ?? requestAgentAddress,
               tripleCount: share.promotedCount,
             });
           }
@@ -485,13 +508,19 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     const cg = url.searchParams.get("contextGraphId");
     if (!validateRequiredContextGraphId(cg, res)) return;
     const normalizedContextGraphId = normalizeContextGraphIdOrUri(cg!);
+    const rawAgentAddress = url.searchParams.get("agentAddress") ?? undefined;
+    if (rawAgentAddress && !/^[\w:.\-]+$/.test(rawAgentAddress)) {
+      return jsonResponse(res, 400, { error: "Invalid agentAddress format" });
+    }
     const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
     if (!validateOptionalSubGraphName(subGraphName, res)) return;
     try {
       const hist = await agent.assertion.history(
         normalizedContextGraphId,
         name,
-        subGraphName ? { subGraphName } : undefined,
+        rawAgentAddress || subGraphName
+          ? { ...(rawAgentAddress ? { agentAddress: rawAgentAddress } : {}), ...(subGraphName ? { subGraphName } : {}) }
+          : undefined,
       );
       if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${normalizedContextGraphId}"` });
       return jsonResponse(res, 200, hist);
@@ -641,9 +670,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         ...opts,
       });
       emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
-      // Mirror the legacy publish route: a non-throwing `contextGraphError` is a
-      // partial success → 207, not 200.
-      const httpStatus = pub?.contextGraphError ? 207 : 200;
+      // Mirror the atomic path: non-throwing tentative/failed/contextGraphError
+      // results are partial successes, not confirmed publishes.
+      const httpStatus = pub?.status === "confirmed" && !pub?.contextGraphError ? 200 : 207;
       return jsonResponse(res, httpStatus, {
         kaId: pub?.kaId,
         status: pub?.status,

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -133,6 +133,14 @@ function validateFinalizedAssertionPublishRequest(
   const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
     ? parsed.options as Record<string, unknown>
     : undefined;
+  const assertionName = parsed.assertionName ?? nested?.assertionName;
+  if (assertionName !== undefined) {
+    jsonResponse(res, 400, {
+      error:
+        '"assertionName" is not accepted on /api/knowledge-assets/:name/vm/publish — the URL name selects the assertion.',
+    });
+    return false;
+  }
   const hasAuthorOverride =
     parsed.authorAgentAddress != null ||
     parsed.preSignedAuthorAttestation != null ||
@@ -570,8 +578,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (finalizeOptions === null) return;
     // Coerce/validate publish controls up front too — bad option values 400
     // before any assertion is created rather than after a durable seal.
-    const atomicPublishOptions = alsoPublishVm ? resolveFinalizedPublishOptions(ctx, alsoPublishVm) : {};
-    if (atomicPublishOptions === null) return;
+    let atomicPublishOptions: Record<string, unknown> = {};
+    if (alsoPublishVm) {
+      const publishOptionsInput = alsoPublishVmIsObject
+        ? finalizedPublishOptionsInput(alsoPublishVm as Record<string, unknown>, res)
+        : alsoPublishVm;
+      if (publishOptionsInput === null) return;
+      const resolvedAtomicPublishOptions = resolveFinalizedPublishOptions(ctx, publishOptionsInput);
+      if (resolvedAtomicPublishOptions === null) return;
+      atomicPublishOptions = resolvedAtomicPublishOptions;
+    }
     try {
       const assertionUri = await agent.assertion.create(
         resolvedContextGraphId,
@@ -720,9 +736,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   }
 
   // ── /api/knowledge-assets/:name[/{wm,swm,vm}[/verb]] ──
-  const rawSegs = path.slice(`${PREFIX}/`.length).split("/").filter(Boolean);
+  const rawSegs = path.slice(`${PREFIX}/`.length).split("/");
   const segs: string[] = [];
   for (const rawSeg of rawSegs) {
+    if (rawSeg === "") return;
     const decoded = safeDecodeURIComponent(rawSeg, res);
     if (decoded === null) return;
     segs.push(decoded);

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -25,7 +25,20 @@
 // `(agent, number)` addressing is layered on by Option 1 later, on these same
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
-import { jsonResponse, readBody, safeParseJson } from "../http-utils.js";
+import { validateAssertionName } from "@origintrail-official/dkg-core";
+import { validatePreSignedAuthorAttestation } from "./memory.js";
+import { recordAssertionActivity } from "../activity-notification.js";
+import {
+  jsonResponse,
+  normalizeContextGraphIdOrUri,
+  readBody,
+  resolveRequiredWriteContextGraphId,
+  safeDecodeURIComponent,
+  safeParseJson,
+  validateEntities,
+  validateOptionalSubGraphName,
+  validateRequiredContextGraphId,
+} from "../http-utils.js";
 
 const PREFIX = "/api/knowledge-assets";
 
@@ -33,29 +46,245 @@ function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
 }
 
+function routeError(res: RequestContext["res"], err: unknown): boolean {
+  const anyErr = err as any;
+  if (anyErr?.name === "AssertionNotPersistedError" || anyErr?.code === "ASSERTION_NOT_PERSISTED") {
+    jsonResponse(res, 409, {
+      error: anyErr.message,
+      code: "ASSERTION_NOT_PERSISTED",
+      contextGraphId: anyErr.contextGraphId,
+      assertionGraph: anyErr.assertionGraph,
+      expectedTripleCount: anyErr.expectedTripleCount,
+    });
+    return true;
+  }
+  const message = anyErr?.message ?? String(err);
+  if (
+    message.includes("already exists") ||
+    message.includes("not found") ||
+    message.includes("Invalid") ||
+    message.includes("Unsafe") ||
+    message.includes("not registered") ||
+    message.includes("mutually exclusive") ||
+    message.includes("not a registered local agent") ||
+    message.includes("signer mismatch") ||
+    message.includes("has no quads") ||
+    message.includes("different merkleRoot") ||
+    message.includes("reserved namespace") ||
+    anyErr?.name === "ReservedNamespaceError"
+  ) {
+    jsonResponse(res, 400, { error: message });
+    return true;
+  }
+  return false;
+}
+
+function resolveFinalizeOptions(
+  ctx: RequestContext,
+  parsed: Record<string, any>,
+): Record<string, unknown> | null {
+  const { res, agent, requestToken } = ctx;
+  const {
+    authorAgentAddress: bodyAuthorAgentAddress,
+    preSignedAuthorAttestation: bodyPreSignedAttestation,
+    schemeVersion,
+  } = parsed;
+  if (bodyAuthorAgentAddress != null && bodyPreSignedAttestation != null) {
+    jsonResponse(res, 400, {
+      error: '"authorAgentAddress" and "preSignedAuthorAttestation" are mutually exclusive',
+    });
+    return null;
+  }
+  let resolvedPreSignedAttestation:
+    | { address: string; signature: { r: Uint8Array; vs: Uint8Array } }
+    | undefined;
+  if (bodyPreSignedAttestation != null) {
+    const validated = validatePreSignedAuthorAttestation(bodyPreSignedAttestation, res);
+    if (validated === undefined) return null;
+    resolvedPreSignedAttestation = validated;
+  }
+  let resolvedAuthorAgentAddress: string | undefined;
+  if (resolvedPreSignedAttestation == null) {
+    if (typeof bodyAuthorAgentAddress === "string" && bodyAuthorAgentAddress.length > 0) {
+      if (!/^0x[0-9a-fA-F]{40}$/.test(bodyAuthorAgentAddress)) {
+        jsonResponse(res, 400, {
+          error: '"authorAgentAddress" must be a 0x-prefixed 20-byte EVM address',
+        });
+        return null;
+      }
+      resolvedAuthorAgentAddress = bodyAuthorAgentAddress;
+    } else {
+      const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
+      if (tokenAgentAddress != null) resolvedAuthorAgentAddress = tokenAgentAddress;
+    }
+  }
+  if (
+    schemeVersion != null &&
+    (typeof schemeVersion !== "number" || !Number.isInteger(schemeVersion) || schemeVersion < 1)
+  ) {
+    jsonResponse(res, 400, {
+      error: '"schemeVersion" must be a positive integer when supplied',
+    });
+    return null;
+  }
+  return {
+    ...(resolvedAuthorAgentAddress ? { authorAgentAddress: resolvedAuthorAgentAddress } : {}),
+    ...(resolvedPreSignedAttestation ? { preSignedAuthorAttestation: resolvedPreSignedAttestation } : {}),
+    ...(schemeVersion != null ? { schemeVersion } : {}),
+  };
+}
+
+function recordActivity(
+  ctx: RequestContext,
+  contextGraphId: string,
+  kind: "created" | "promoted" | "published",
+  opts: { subGraphName?: string; actorAgentAddress?: string; tripleCount?: number; entityCount?: number } = {},
+): void {
+  try {
+    recordAssertionActivity(ctx.dashDb, {
+      contextGraphId,
+      kind,
+      actorAgentAddress: opts.actorAgentAddress ?? ctx.requestAgentAddress,
+      subGraphName: opts.subGraphName,
+      tripleCount: opts.tripleCount,
+      entityCount: opts.entityCount,
+    });
+    ctx.emitNotification?.({ contextGraphId, type: "assertion_activity" });
+  } catch {
+    // Dashboard side effects must never break the write path.
+  }
+}
+
+function normalizeFinalizedPublishOptions(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const { clearAfter, clearSharedMemoryAfter, ...rest } = raw as Record<string, unknown>;
+  return {
+    ...rest,
+    ...(clearAfter !== undefined
+      ? { clearSharedMemoryAfter: clearAfter }
+      : clearSharedMemoryAfter !== undefined
+        ? { clearSharedMemoryAfter }
+        : {}),
+  };
+}
+
+function clearSharedMemoryAfterForNamedPublish(opts: Record<string, unknown>): boolean {
+  return typeof opts.clearSharedMemoryAfter === "boolean" ? opts.clearSharedMemoryAfter : false;
+}
+
+function emitPublished(
+  ctx: RequestContext,
+  contextGraphId: string,
+  result: any,
+  subGraphName?: string,
+  clearSharedMemoryAfter = false,
+): void {
+  const publicTripleCount = Array.isArray(result?.publicQuads) ? result.publicQuads.length : 0;
+  const rootCount = Array.isArray(result?.kaManifest) ? result.kaManifest.length : 0;
+  const publishedSwmCleaned = result?.status === "confirmed";
+  ctx.emitMemoryGraphChanged?.({
+    contextGraphId,
+    layers: publishedSwmCleaned ? ["swm", "vm"] : ["vm"],
+    subGraphName,
+    operation: "shared_memory_published",
+    source: "api",
+    clearSharedMemoryAfter,
+    status: typeof result?.status === "string" ? result.status : undefined,
+    counts: { roots: rootCount, triples: publicTripleCount },
+  });
+  recordActivity(ctx, contextGraphId, "published", {
+    subGraphName,
+    tripleCount: publicTripleCount,
+    entityCount: rootCount,
+  });
+}
+
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, url } = ctx;
+  const { req, res, agent, path, url, requestToken, requestAgentAddress, emitMemoryGraphChanged } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
   const method = req.method ?? "GET";
+  const writePreflightCallerAgentAddress = requestToken
+    ? agent.resolveAgentByToken(requestToken)
+    : undefined;
+  const writePreflightContextGraphOpts = {
+    callerAgentAddress: writePreflightCallerAgentAddress,
+    allowLocalExactFallback: !writePreflightCallerAgentAddress,
+  };
 
   // ── POST /api/knowledge-assets — create KA + open WM draft (atomic shortcut) ──
   if (method === "POST" && path === PREFIX) {
     const parsed = safeParseJson(await readBody(req), res);
     if (!parsed) return;
-    const { contextGraphId, name, subGraphName, quads, authorAgentAddress, alsoShareSwm, alsoPublishVm } = parsed;
-    if (!contextGraphId || !name) {
-      return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
+    const { contextGraphId, name, subGraphName, quads, alsoShareSwm, alsoPublishVm } = parsed;
+    if (!name) return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
+    const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
+      agent,
+      contextGraphId,
+      res,
+      writePreflightContextGraphOpts,
+    );
+    if (!resolvedContextGraphId) return;
+    if (typeof name !== "string") return jsonResponse(res, 400, { error: '"name" must be a string' });
+    const nameVal = validateAssertionName(name);
+    if (!nameVal.valid) return jsonResponse(res, 400, { error: `Invalid "name": ${nameVal.reason}` });
+    if (!validateOptionalSubGraphName(subGraphName, res)) return;
+    if (quads !== undefined && (!Array.isArray(quads) || quads.length === 0)) {
+      return jsonResponse(res, 400, { error: '"quads" must be a non-empty array when supplied' });
     }
+    const finalizeOptions = resolveFinalizeOptions(ctx, parsed);
+    if (finalizeOptions === null) return;
     try {
-      const assertionUri = await agent.assertion.create(contextGraphId, name, { subGraphName });
+      const assertionUri = await agent.assertion.create(
+        resolvedContextGraphId,
+        name,
+        subGraphName ? { subGraphName } : undefined,
+      );
+      emitMemoryGraphChanged?.({
+        contextGraphId: resolvedContextGraphId,
+        layers: ["wm"],
+        subGraphName,
+        operation: "assertion_created",
+        source: "api",
+        counts: { triples: 0 },
+      });
+      recordActivity(ctx, resolvedContextGraphId, "created", {
+        subGraphName,
+        actorAgentAddress:
+          typeof finalizeOptions.authorAgentAddress === "string"
+            ? finalizeOptions.authorAgentAddress
+            : requestAgentAddress,
+      });
       const result: Record<string, unknown> = { name, assertionUri, status: "draft-open" };
 
       // autoFinalize: when quads are supplied, write + seal in the same call
       // (OT-RFC-43 §10.5.5). `also*` are opt-in layer transitions on top.
       if (Array.isArray(quads) && quads.length > 0) {
-        await agent.assertion.write(contextGraphId, name, quads, { subGraphName });
+        await agent.assertion.write(
+          resolvedContextGraphId,
+          name,
+          quads,
+          subGraphName ? { subGraphName } : undefined,
+        );
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm"],
+          subGraphName,
+          operation: "assertion_written",
+          source: "api",
+          counts: { triples: quads.length },
+        });
         result.written = quads.length;
-        const seal = await agent.assertion.finalize(contextGraphId, name, { subGraphName, authorAgentAddress });
+        const seal = await agent.assertion.finalize(resolvedContextGraphId, name, {
+          ...(subGraphName ? { subGraphName } : {}),
+          ...finalizeOptions,
+        });
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm"],
+          subGraphName,
+          operation: "assertion_finalized",
+          source: "api",
+        });
         result.merkleRoot = hex(seal.merkleRoot);
         result.status = "wm-sealed";
       }
@@ -63,22 +292,44 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       const errors: Array<{ phase: string; error: string }> = [];
       if (alsoShareSwm) {
         try {
-          const share = await agent.assertion.promote(contextGraphId, name, { subGraphName });
+          const share = await agent.assertion.promote(
+            resolvedContextGraphId,
+            name,
+            subGraphName ? { subGraphName } : undefined,
+          );
           result.swmShared = true;
           result.promotedCount = share.promotedCount;
           result.status = "swm-shared";
+          if (share.promotedCount !== 0) {
+            emitMemoryGraphChanged?.({
+              contextGraphId: resolvedContextGraphId,
+              layers: ["wm", "swm"],
+              subGraphName,
+              operation: "assertion_promoted",
+              source: "api",
+              counts: { triples: share.promotedCount },
+            });
+            recordActivity(ctx, resolvedContextGraphId, "promoted", {
+              subGraphName,
+              tripleCount: share.promotedCount,
+            });
+          }
         } catch (e: any) {
           errors.push({ phase: "swm-share", error: e?.message ?? String(e) });
         }
       }
       if (alsoPublishVm) {
         try {
-          const opts = typeof alsoPublishVm === "object" && alsoPublishVm ? alsoPublishVm : {};
-          const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
+          const opts = normalizeFinalizedPublishOptions(alsoPublishVm);
+          const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
+            ...(subGraphName ? { subGraphName } : {}),
+            ...opts,
+          });
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
           result.status = "vm-confirmed";
+          emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
         } catch (e: any) {
           errors.push({ phase: "vm-publish", error: e?.message ?? String(e) });
         }
@@ -89,35 +340,66 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (errors.length > 0) return jsonResponse(res, 207, { created: true, ...result, errors });
       return jsonResponse(res, 201, result);
     } catch (e: any) {
+      if (routeError(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
     }
   }
 
   // ── /api/knowledge-assets/:name[/{wm,swm,vm}[/verb]] ──
-  const segs = path.slice(`${PREFIX}/`.length).split("/").filter(Boolean).map(decodeURIComponent);
+  const rawSegs = path.slice(`${PREFIX}/`.length).split("/").filter(Boolean);
+  const segs: string[] = [];
+  for (const rawSeg of rawSegs) {
+    const decoded = safeDecodeURIComponent(rawSeg, res);
+    if (decoded === null) return;
+    segs.push(decoded);
+  }
   if (segs.length === 0) return;
   const name = segs[0];
+  const nameVal = validateAssertionName(name);
+  if (!nameVal.valid) return jsonResponse(res, 400, { error: `Invalid "name": ${nameVal.reason}` });
   const layer = segs[1]; // wm | swm | vm | undefined
   const verb = segs[2];
 
   // GET /api/knowledge-assets/:name — KA metadata / lifecycle state
   if (method === "GET" && segs.length === 1) {
     const cg = url.searchParams.get("contextGraphId");
-    if (!cg) return jsonResponse(res, 400, { error: 'Missing "contextGraphId" query param' });
+    if (!validateRequiredContextGraphId(cg, res)) return;
+    const normalizedContextGraphId = normalizeContextGraphIdOrUri(cg!);
     const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
-    const hist = await agent.assertion.history(cg, name, { subGraphName });
-    if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${cg}"` });
-    return jsonResponse(res, 200, hist);
+    if (!validateOptionalSubGraphName(subGraphName, res)) return;
+    try {
+      const hist = await agent.assertion.history(
+        normalizedContextGraphId,
+        name,
+        subGraphName ? { subGraphName } : undefined,
+      );
+      if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${normalizedContextGraphId}"` });
+      return jsonResponse(res, 200, hist);
+    } catch (e: any) {
+      if (routeError(res, e)) return;
+      return jsonResponse(res, 500, { error: e?.message ?? String(e) });
+    }
   }
 
   // GET /api/knowledge-assets/:name/{wm,swm,vm} — per-layer status
   if (method === "GET" && (layer === "wm" || layer === "swm" || layer === "vm") && !verb) {
     const cg = url.searchParams.get("contextGraphId");
-    if (!cg) return jsonResponse(res, 400, { error: 'Missing "contextGraphId" query param' });
+    if (!validateRequiredContextGraphId(cg, res)) return;
+    const normalizedContextGraphId = normalizeContextGraphIdOrUri(cg!);
     const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
-    const hist = await agent.assertion.history(cg, name, { subGraphName });
-    if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}"` });
-    return jsonResponse(res, 200, { layer, ...hist });
+    if (!validateOptionalSubGraphName(subGraphName, res)) return;
+    try {
+      const hist = await agent.assertion.history(
+        normalizedContextGraphId,
+        name,
+        subGraphName ? { subGraphName } : undefined,
+      );
+      if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}"` });
+      return jsonResponse(res, 200, { layer, ...hist });
+    } catch (e: any) {
+      if (routeError(res, e)) return;
+      return jsonResponse(res, 500, { error: e?.message ?? String(e) });
+    }
   }
 
   if (method !== "POST") return;
@@ -126,27 +408,67 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   if (!parsed) return;
   const contextGraphId = parsed.contextGraphId;
   const subGraphName = parsed.subGraphName;
-  if (!contextGraphId) return jsonResponse(res, 400, { error: 'Missing "contextGraphId"' });
+  const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
+    agent,
+    contextGraphId,
+    res,
+    writePreflightContextGraphOpts,
+  );
+  if (!resolvedContextGraphId) return;
+  if (!validateOptionalSubGraphName(subGraphName, res)) return;
 
   try {
     // ── WM verbs (the only writable layer) ──
     if (layer === "wm") {
       if (verb === "write") {
-        if (!Array.isArray(parsed.quads)) return jsonResponse(res, 400, { error: 'Missing "quads"' });
-        await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });
+        if (!Array.isArray(parsed.quads) || parsed.quads.length === 0) {
+          return jsonResponse(res, 400, { error: 'Missing "quads"' });
+        }
+        await agent.assertion.write(
+          resolvedContextGraphId,
+          name,
+          parsed.quads,
+          subGraphName ? { subGraphName } : undefined,
+        );
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm"],
+          subGraphName,
+          operation: "assertion_written",
+          source: "api",
+          counts: { triples: parsed.quads.length },
+        });
         return jsonResponse(res, 200, { written: parsed.quads.length });
       }
       if (verb === "finalize") {
-        const seal = await agent.assertion.finalize(contextGraphId, name, {
+        const finalizeOptions = resolveFinalizeOptions(ctx, parsed);
+        if (finalizeOptions === null) return;
+        const seal = await agent.assertion.finalize(resolvedContextGraphId, name, {
+          ...(subGraphName ? { subGraphName } : {}),
+          ...finalizeOptions,
+        });
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm"],
           subGraphName,
-          authorAgentAddress: parsed.authorAgentAddress,
-          preSignedAuthorAttestation: parsed.preSignedAuthorAttestation,
-          schemeVersion: parsed.schemeVersion,
+          operation: "assertion_finalized",
+          source: "api",
         });
         return jsonResponse(res, 200, { merkleRoot: hex(seal.merkleRoot), eip712Digest: seal.eip712Digest });
       }
       if (verb === "discard") {
-        await agent.assertion.discard(contextGraphId, name, { subGraphName });
+        await agent.assertion.discard(
+          resolvedContextGraphId,
+          name,
+          subGraphName ? { subGraphName } : undefined,
+        );
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm"],
+          subGraphName,
+          operation: "assertion_discarded",
+          source: "api",
+        });
         return jsonResponse(res, 200, { discarded: true });
       }
       if (verb === "pull-from") {
@@ -163,14 +485,36 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── SWM verb: share (WM → SWM; OT-RFC-43 §10.6 renames promote → share) ──
     if (layer === "swm" && verb === "share") {
-      const share = await agent.assertion.promote(contextGraphId, name, { entities: parsed.entities, subGraphName });
+      if (!validateEntities(parsed.entities, res)) return;
+      const share = await agent.assertion.promote(resolvedContextGraphId, name, {
+        entities: parsed.entities ?? "all",
+        subGraphName,
+      });
+      if (share.promotedCount !== 0) {
+        emitMemoryGraphChanged?.({
+          contextGraphId: resolvedContextGraphId,
+          layers: ["wm", "swm"],
+          subGraphName,
+          operation: "assertion_promoted",
+          source: "api",
+          counts: { triples: share.promotedCount },
+        });
+        recordActivity(ctx, resolvedContextGraphId, "promoted", {
+          subGraphName,
+          tripleCount: share.promotedCount,
+        });
+      }
       return jsonResponse(res, 200, { swmShared: true, promotedCount: share.promotedCount });
     }
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
-      const opts = parsed.options && typeof parsed.options === "object" ? parsed.options : {};
-      const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
+      const opts = normalizeFinalizedPublishOptions(parsed.options);
+      const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
+        ...(subGraphName ? { subGraphName } : {}),
+        ...opts,
+      });
+      emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
       return jsonResponse(res, 200, {
         kaId: pub?.kaId,
         status: pub?.status,
@@ -179,6 +523,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       });
     }
   } catch (e: any) {
+    if (routeError(res, e)) return;
     return jsonResponse(res, 500, { error: e?.message ?? String(e) });
   }
 

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -155,16 +155,72 @@ function recordActivity(
   }
 }
 
-function normalizeFinalizedPublishOptions(raw: unknown): Record<string, unknown> {
+// Mirror the legacy `/api/shared-memory/publish` ceiling (`memory.ts`).
+const MAX_PUBLISH_EPOCHS = 0xffffffff;
+
+// Strict parser for the finalized-assertion publish options. Mirrors the
+// validation/coercion the legacy `/api/shared-memory/publish` path applies in
+// `memory.ts` so this surface never forwards raw JSON strings/invalid values
+// straight into `publishFromFinalizedAssertion()` (which would become 500s or
+// mis-typed publishes). `clearAfter` is the SDK spelling for the publisher's
+// `clearSharedMemoryAfter`. Returns `null` after writing a 400 on bad input;
+// returns `{}` when `raw` carries no recognised options (e.g. `alsoPublishVm:
+// true`). Only the recognised keys are forwarded — unknown fields are dropped.
+function resolveFinalizedPublishOptions(
+  ctx: RequestContext,
+  raw: unknown,
+): Record<string, unknown> | null {
+  const { res } = ctx;
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const { clearAfter, clearSharedMemoryAfter, ...rest } = raw as Record<string, unknown>;
+  const source = raw as Record<string, unknown>;
+  const { clearAfter, clearSharedMemoryAfter, publisherNodeIdentityIdOverride } = source;
+  const rawPublishEpochs = source.publishEpochs ?? source.epochs;
+  const publishEpochsField = source.publishEpochs !== undefined ? "publishEpochs" : "epochs";
+
+  let resolvedPublisherIdentityOverride: bigint | undefined;
+  if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
+    const v = String(publisherNodeIdentityIdOverride);
+    if (!/^\d+$/.test(v)) {
+      jsonResponse(res, 400, {
+        error: '"publisherNodeIdentityIdOverride" must be a non-negative integer (string or number)',
+      });
+      return null;
+    }
+    resolvedPublisherIdentityOverride = BigInt(v);
+  }
+
+  let resolvedPublishEpochs: number | undefined;
+  if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
+    const v = String(rawPublishEpochs).trim();
+    if (!/^[1-9]\d*$/.test(v)) {
+      jsonResponse(res, 400, {
+        error: `"${publishEpochsField}" must be a positive integer (string or number)`,
+      });
+      return null;
+    }
+    const n = Number(v);
+    if (!Number.isSafeInteger(n)) {
+      jsonResponse(res, 400, {
+        error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer`,
+      });
+      return null;
+    }
+    if (n > MAX_PUBLISH_EPOCHS) {
+      jsonResponse(res, 400, {
+        error: `"${publishEpochsField}" must be less than or equal to ${MAX_PUBLISH_EPOCHS}`,
+      });
+      return null;
+    }
+    resolvedPublishEpochs = n;
+  }
+
+  const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
   return {
-    ...rest,
-    ...(clearAfter !== undefined
-      ? { clearSharedMemoryAfter: clearAfter }
-      : clearSharedMemoryAfter !== undefined
-        ? { clearSharedMemoryAfter }
-        : {}),
+    ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
+    ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
+    ...(resolvedPublisherIdentityOverride !== undefined
+      ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+      : {}),
   };
 }
 
@@ -231,8 +287,29 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (quads !== undefined && (!Array.isArray(quads) || quads.length === 0)) {
       return jsonResponse(res, 400, { error: '"quads" must be a non-empty array when supplied' });
     }
+    // Validate the opt-in layer-transition combinations BEFORE create, so a
+    // deterministically-invalid request never leaves durable partial state.
+    // A tail needs something to finalize (quads), and publish reads from SWM
+    // only — so it must be preceded by a share.
+    const hasQuads = Array.isArray(quads) && quads.length > 0;
+    if ((alsoShareSwm || alsoPublishVm) && !hasQuads) {
+      return jsonResponse(res, 400, {
+        error:
+          '"alsoShareSwm"/"alsoPublishVm" require "quads" — there is nothing to finalize, share, or publish otherwise',
+      });
+    }
+    if (alsoPublishVm && !alsoShareSwm) {
+      return jsonResponse(res, 400, {
+        error:
+          '"alsoPublishVm" requires "alsoShareSwm" — publishFromFinalizedAssertion reads from Shared Memory, so the assertion must be shared first',
+      });
+    }
     const finalizeOptions = resolveFinalizeOptions(ctx, parsed);
     if (finalizeOptions === null) return;
+    // Coerce/validate publish controls up front too — bad option values 400
+    // before any assertion is created rather than after a durable seal.
+    const atomicPublishOptions = alsoPublishVm ? resolveFinalizedPublishOptions(ctx, alsoPublishVm) : {};
+    if (atomicPublishOptions === null) return;
     try {
       const assertionUri = await agent.assertion.create(
         resolvedContextGraphId,
@@ -320,16 +397,38 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
       if (alsoPublishVm) {
         try {
-          const opts = normalizeFinalizedPublishOptions(alsoPublishVm);
           const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
             ...(subGraphName ? { subGraphName } : {}),
-            ...opts,
+            ...atomicPublishOptions,
           });
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
-          result.status = "vm-confirmed";
-          emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
+          result.vmStatus = pub?.status;
+          if (pub?.contextGraphError) result.contextGraphError = pub.contextGraphError;
+          emitPublished(
+            ctx,
+            resolvedContextGraphId,
+            pub,
+            subGraphName,
+            clearSharedMemoryAfterForNamedPublish(atomicPublishOptions),
+          );
+          // `publishFromFinalizedAssertion` can return `tentative`/`failed` or a
+          // `contextGraphError` WITHOUT throwing. Only claim a confirmed VM
+          // publish when the publisher actually confirms; otherwise reflect the
+          // real status and record it as a partial failure so the response is a
+          // 207 over the (real, retryable) sealed+shared artifact, not a false 201.
+          if (pub?.status === "confirmed" && !pub?.contextGraphError) {
+            result.status = "vm-confirmed";
+          } else {
+            result.status = `vm-${typeof pub?.status === "string" ? pub.status : "unconfirmed"}`;
+            errors.push({
+              phase: "vm-publish",
+              error: pub?.contextGraphError
+                ? `contextGraphError: ${typeof pub.contextGraphError === "string" ? pub.contextGraphError : JSON.stringify(pub.contextGraphError)}`
+                : `publish not confirmed (status: ${pub?.status ?? "unknown"})`,
+            });
+          }
         } catch (e: any) {
           errors.push({ phase: "vm-publish", error: e?.message ?? String(e) });
         }
@@ -403,6 +502,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   }
 
   if (method !== "POST") return;
+
+  // Guard the supported (layer, verb) POST shapes BEFORE reading/validating the
+  // body, so an unknown shape (e.g. `/:name/foo/bar`) falls through to the
+  // daemon's 404 instead of returning a body-dependent 400/500. `pull-from` is
+  // a known shape (returns 501 below), so it stays in the supported set.
+  const isSupportedPostShape =
+    (layer === "wm" && (verb === "write" || verb === "finalize" || verb === "discard" || verb === "pull-from")) ||
+    (layer === "swm" && verb === "share") ||
+    (layer === "vm" && verb === "publish");
+  if (!isSupportedPostShape) return;
 
   const parsed = safeParseJson(await readBody(req), res);
   if (!parsed) return;
@@ -509,17 +618,22 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
-      const opts = normalizeFinalizedPublishOptions(parsed.options);
+      const opts = resolveFinalizedPublishOptions(ctx, parsed.options);
+      if (opts === null) return;
       const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
         ...(subGraphName ? { subGraphName } : {}),
         ...opts,
       });
       emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
-      return jsonResponse(res, 200, {
+      // Mirror the legacy publish route: a non-throwing `contextGraphError` is a
+      // partial success → 207, not 200.
+      const httpStatus = pub?.contextGraphError ? 207 : 200;
+      return jsonResponse(res, httpStatus, {
         kaId: pub?.kaId,
         status: pub?.status,
         ual: pub?.ual,
         txHash: pub?.onChainResult?.txHash,
+        ...(pub?.contextGraphError ? { contextGraphError: pub.contextGraphError } : {}),
       });
     }
   } catch (e: any) {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -127,6 +127,38 @@ function finalizedPublishOptionsInput(
   };
 }
 
+function validateFinalizedAssertionPublishRequest(
+  parsed: Record<string, unknown>,
+  res: RequestContext["res"],
+): boolean {
+  const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
+    ? parsed.options as Record<string, unknown>
+    : undefined;
+  const hasAuthorOverride =
+    parsed.authorAgentAddress != null ||
+    parsed.preSignedAuthorAttestation != null ||
+    nested?.authorAgentAddress != null ||
+    nested?.preSignedAuthorAttestation != null;
+  if (hasAuthorOverride) {
+    jsonResponse(res, 400, {
+      error:
+        '"authorAgentAddress" and "preSignedAuthorAttestation" cannot be combined with "assertionName" — the seal already encodes the author. Re-finalize the assertion if you need to change authorship.',
+    });
+    return false;
+  }
+
+  const selection = parsed.selection ?? nested?.selection;
+  if (selection !== undefined && selection !== "all") {
+    jsonResponse(res, 400, {
+      error:
+        '"selection" must be omitted or "all" when "assertionName" is supplied — the seal commits to the entire assertion content.',
+    });
+    return false;
+  }
+
+  return true;
+}
+
 function routeError(res: RequestContext["res"], err: unknown): boolean {
   const anyErr = err as any;
   if (anyErr?.name === "AssertionNotPersistedError" || anyErr?.code === "ASSERTION_NOT_PERSISTED") {
@@ -147,6 +179,11 @@ function routeError(res: RequestContext["res"], err: unknown): boolean {
     message.includes("Unsafe") ||
     message.includes("not registered on-chain") ||
     message.includes("not registered") ||
+    message.includes("not finalized") ||
+    message.includes("seal binds chainId") ||
+    message.includes("seal binds KAv10") ||
+    message.includes("expectedMerkleRoot mismatch") ||
+    message.includes("precomputedAttestation signer mismatch") ||
     message.includes("mutually exclusive") ||
     message.includes("not a registered local agent") ||
     message.includes("signer mismatch") ||
@@ -826,6 +863,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
+      if (!validateFinalizedAssertionPublishRequest(parsed, res)) return;
       const optionsInput = finalizedPublishOptionsInput(parsed, res);
       if (optionsInput === null) return;
       const opts = resolveFinalizedPublishOptions(ctx, optionsInput);

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -103,12 +103,20 @@ function publishResponsePayload(result: any): Record<string, unknown> {
   };
 }
 
-function finalizedPublishOptionsInput(parsed: Record<string, unknown>): unknown {
-  const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
-    ? parsed.options as Record<string, unknown>
-    : {};
+function finalizedPublishOptionsInput(
+  parsed: Record<string, unknown>,
+  res: RequestContext["res"],
+): unknown | null {
+  if (
+    parsed.options !== undefined &&
+    (parsed.options === null || typeof parsed.options !== "object" || Array.isArray(parsed.options))
+  ) {
+    jsonResponse(res, 400, { error: '"options" must be an object when supplied' });
+    return null;
+  }
+  const nested = parsed.options as Record<string, unknown> | undefined;
   return {
-    ...nested,
+    ...(nested ?? {}),
     ...(parsed.clearAfter !== undefined ? { clearAfter: parsed.clearAfter } : {}),
     ...(parsed.clearSharedMemoryAfter !== undefined ? { clearSharedMemoryAfter: parsed.clearSharedMemoryAfter } : {}),
     ...(parsed.publishEpochs !== undefined ? { publishEpochs: parsed.publishEpochs } : {}),
@@ -137,6 +145,7 @@ function routeError(res: RequestContext["res"], err: unknown): boolean {
     message.includes("not found") ||
     message.includes("Invalid") ||
     message.includes("Unsafe") ||
+    message.includes("not registered on-chain") ||
     message.includes("not registered") ||
     message.includes("mutually exclusive") ||
     message.includes("not a registered local agent") ||
@@ -817,7 +826,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
-      const opts = resolveFinalizedPublishOptions(ctx, finalizedPublishOptionsInput(parsed));
+      const optionsInput = finalizedPublishOptionsInput(parsed, res);
+      if (optionsInput === null) return;
+      const opts = resolveFinalizedPublishOptions(ctx, optionsInput);
       if (opts === null) return;
       // codex PR #971 F22: mirror the legacy operation-tracker dance from
       // `/api/shared-memory/publish` so the daemon's operation history

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -24,7 +24,12 @@
 // `(agent, number)` addressing is layered on by Option 1 later, on these same
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
-import { createOperationContext, validateAssertionName, type OperationContext } from "@origintrail-official/dkg-core";
+import {
+  contextGraphMetaUri,
+  createOperationContext,
+  validateAssertionName,
+  type OperationContext,
+} from "@origintrail-official/dkg-core";
 import { resolveChainConfig } from "../../config.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
 import { recordAssertionActivity } from "../activity-notification.js";
@@ -42,6 +47,62 @@ import {
 } from "../http-utils.js";
 
 const PREFIX = "/api/knowledge-assets";
+const DKG_NS = "http://dkg.io/ontology/";
+const PROV_NS = "http://www.w3.org/ns/prov#";
+
+function sparqlLiteral(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function stripSparqlValue(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value
+    .replace(/^<|>$/g, "")
+    .replace(/"\^\^<.*>$/, "")
+    .replace(/^"|"$/g, "");
+}
+
+function agentAddressFromDid(value: string | undefined): string | undefined {
+  const raw = stripSparqlValue(value);
+  if (!raw) return undefined;
+  const prefix = "did:dkg:agent:";
+  return raw.startsWith(prefix) ? raw.slice(prefix.length) : raw;
+}
+
+async function resolveAssertionOwnerAgentAddress(
+  agent: RequestContext["agent"],
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+): Promise<string | undefined> {
+  const store = (agent as unknown as { store?: { query?: (sparql: string) => Promise<any> } }).store;
+  if (!store?.query) return undefined;
+
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const assertionGraphPrefix = subGraphName
+    ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`
+    : `did:dkg:context-graph:${contextGraphId}/assertion/`;
+
+  try {
+    const result = await store.query(
+      `SELECT ?agent WHERE {
+        GRAPH <${metaGraph}> {
+          ?assertion <${DKG_NS}contextGraph> <did:dkg:context-graph:${contextGraphId}> ;
+                     <${DKG_NS}assertionName> ${sparqlLiteral(name)} ;
+                     <${PROV_NS}wasAttributedTo> ?agent .
+          OPTIONAL { ?assertion <${DKG_NS}assertionGraph> ?assertionGraph }
+          FILTER(!BOUND(?assertionGraph) || STRSTARTS(STR(?assertionGraph), ${sparqlLiteral(assertionGraphPrefix)}))
+        }
+      } LIMIT 1`,
+    );
+    if (result?.type !== "bindings" || !Array.isArray(result.bindings) || result.bindings.length === 0) {
+      return undefined;
+    }
+    return agentAddressFromDid(result.bindings[0]?.agent);
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Body-size cap by `(layer, verb)` (codex PR #971 F21). The control verbs
@@ -784,11 +845,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
     if (!validateOptionalSubGraphName(subGraphName, res)) return;
     try {
+      const resolvedAgentAddress = rawAgentAddress
+        ?? await resolveAssertionOwnerAgentAddress(agent, normalizedContextGraphId, name, subGraphName);
       const hist = await agent.assertion.history(
         normalizedContextGraphId,
         name,
-        rawAgentAddress || subGraphName
-          ? { ...(rawAgentAddress ? { agentAddress: rawAgentAddress } : {}), ...(subGraphName ? { subGraphName } : {}) }
+        resolvedAgentAddress || subGraphName
+          ? {
+              ...(resolvedAgentAddress ? { agentAddress: resolvedAgentAddress } : {}),
+              ...(subGraphName ? { subGraphName } : {}),
+            }
           : undefined,
       );
       if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${normalizedContextGraphId}"` });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -7,7 +7,6 @@
 //   POST /api/knowledge-assets                       create KA + open WM draft
 //                                                    (atomic: quads + also* flags)
 //   GET  /api/knowledge-assets/:name                 KA metadata / lifecycle state
-//   GET  /api/knowledge-assets/:name/{wm,swm,vm}     per-layer status
 //   POST /api/knowledge-assets/:name/wm/write        append quads to the draft
 //   POST /api/knowledge-assets/:name/wm/finalize     seal the draft (git commit)
 //   POST /api/knowledge-assets/:name/wm/discard      throw the draft away
@@ -25,7 +24,7 @@
 // `(agent, number)` addressing is layered on by Option 1 later, on these same
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
-import { createOperationContext, validateAssertionName } from "@origintrail-official/dkg-core";
+import { createOperationContext, validateAssertionName, type OperationContext } from "@origintrail-official/dkg-core";
 import { resolveChainConfig } from "../../config.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
 import { recordAssertionActivity } from "../activity-notification.js";
@@ -401,6 +400,7 @@ async function publishWithTracker(
     },
   });
   try {
+    await ensureRegisteredForNamedPublish(ctx, contextGraphId, opCtx);
     const result: any = await tracker.trackPhase(opCtx, "read-shared-memory", () =>
       agent.publishFromFinalizedAssertion(contextGraphId, name, {
         ...(options.subGraphName ? { subGraphName: options.subGraphName } : {}),
@@ -425,6 +425,27 @@ async function publishWithTracker(
   }
 }
 
+async function ensureRegisteredForNamedPublish(
+  ctx: RequestContext,
+  contextGraphId: string,
+  opCtx: OperationContext,
+): Promise<void> {
+  const { agent, tracker, requestAgentAddress } = ctx;
+  const existingOnChainId = await agent.getContextGraphOnChainId(contextGraphId);
+  if (existingOnChainId) return;
+
+  const storedOpts = await agent.getStoredContextGraphRegistrationOptions(contextGraphId);
+  await tracker.trackPhase(opCtx, "register-on-chain", () =>
+    agent.registerContextGraph(contextGraphId, {
+      ...(requestAgentAddress ? { callerAgentAddress: requestAgentAddress } : {}),
+      ...(storedOpts.publishPolicy !== undefined ? { publishPolicy: storedOpts.publishPolicy } : {}),
+      ...(storedOpts.publishAuthorityAccountId !== undefined
+        ? { publishAuthorityAccountId: storedOpts.publishAuthorityAccountId }
+        : {}),
+    }),
+  );
+}
+
 function emitPublished(
   ctx: RequestContext,
   contextGraphId: string,
@@ -432,12 +453,12 @@ function emitPublished(
   subGraphName?: string,
   clearSharedMemoryAfter = false,
 ): void {
+  if (result?.status !== "confirmed" || result?.contextGraphError) return;
   const publicTripleCount = Array.isArray(result?.publicQuads) ? result.publicQuads.length : 0;
   const rootCount = Array.isArray(result?.kaManifest) ? result.kaManifest.length : 0;
-  const publishedSwmCleaned = result?.status === "confirmed";
   ctx.emitMemoryGraphChanged?.({
     contextGraphId,
-    layers: publishedSwmCleaned ? ["swm", "vm"] : ["vm"],
+    layers: ["swm", "vm"],
     subGraphName,
     operation: "shared_memory_published",
     source: "api",
@@ -715,22 +736,6 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (routeError(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
     }
-  }
-
-  // GET /api/knowledge-assets/:name/{wm,swm,vm} — per-layer status [deferred]
-  //
-  // Deferred (returns 501) rather than echoing the same `assertion.history()`
-  // payload for every layer: the lifecycle descriptor exposes a single CURRENT
-  // `memoryLayer`, not per-layer presence, so /wm, /swm and /vm would return
-  // identical state after a promote/publish — a misleading route contract. A
-  // truthful per-layer view needs a descriptor/event → {present, status} mapping
-  // that does not exist yet; until it lands, use `GET /:name` for the full
-  // lifecycle state. (Tracked alongside the wm/pull-from follow-up, §10.5.3.)
-  if (method === "GET" && (layer === "wm" || layer === "swm" || layer === "vm") && !verb) {
-    return jsonResponse(res, 501, {
-      error: `Per-layer status (GET /:name/${layer}) is not implemented yet — the lifecycle descriptor has no per-layer view mapping. Use GET /api/knowledge-assets/${encodeURIComponent(name)} for full state (OT-RFC-43 §10.5 — follow-up).`,
-      layer,
-    });
   }
 
   if (method !== "POST") return;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -50,6 +50,16 @@ const PREFIX = "/api/knowledge-assets";
 const DKG_NS = "http://dkg.io/ontology/";
 const PROV_NS = "http://www.w3.org/ns/prov#";
 
+class AmbiguousKnowledgeAssetOwnerError extends Error {
+  constructor(contextGraphId: string, name: string) {
+    super(
+      `Multiple knowledge assets named "${name}" exist in context graph "${contextGraphId}"; ` +
+      `pass agentAddress to disambiguate`,
+    );
+    this.name = "AmbiguousKnowledgeAssetOwnerError";
+  }
+}
+
 function sparqlLiteral(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
@@ -85,7 +95,7 @@ async function resolveAssertionOwnerAgentAddress(
 
   try {
     const result = await store.query(
-      `SELECT ?agent WHERE {
+      `SELECT DISTINCT ?agent WHERE {
         GRAPH <${metaGraph}> {
           ?assertion <${DKG_NS}contextGraph> <did:dkg:context-graph:${contextGraphId}> ;
                      <${DKG_NS}assertionName> ${sparqlLiteral(name)} ;
@@ -93,13 +103,22 @@ async function resolveAssertionOwnerAgentAddress(
           OPTIONAL { ?assertion <${DKG_NS}assertionGraph> ?assertionGraph }
           FILTER(!BOUND(?assertionGraph) || STRSTARTS(STR(?assertionGraph), ${sparqlLiteral(assertionGraphPrefix)}))
         }
-      } LIMIT 1`,
+      } LIMIT 2`,
     );
     if (result?.type !== "bindings" || !Array.isArray(result.bindings) || result.bindings.length === 0) {
       return undefined;
     }
-    return agentAddressFromDid(result.bindings[0]?.agent);
-  } catch {
+    const owners: string[] = [
+      ...new Set<string>(
+        result.bindings
+          .map((row: Record<string, unknown>) => agentAddressFromDid(row.agent as string | undefined))
+          .filter((owner: string | undefined): owner is string => !!owner),
+      ),
+    ];
+    if (owners.length > 1) throw new AmbiguousKnowledgeAssetOwnerError(contextGraphId, name);
+    return owners[0];
+  } catch (err) {
+    if (err instanceof AmbiguousKnowledgeAssetOwnerError) throw err;
     return undefined;
   }
 }
@@ -860,6 +879,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${normalizedContextGraphId}"` });
       return jsonResponse(res, 200, hist);
     } catch (e: any) {
+      if (e instanceof AmbiguousKnowledgeAssetOwnerError) {
+        return jsonResponse(res, 400, { error: e.message });
+      }
       if (routeError(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
     }
@@ -970,12 +992,6 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           source: "api",
         });
         return jsonResponse(res, 200, { discarded: true });
-      }
-      if (verb === "pull-from") {
-        return jsonResponse(res, 501, {
-          error: "wm/pull-from is not implemented yet (OT-RFC-43 §10.5.3 — follow-up)",
-          layer,
-        });
       }
     }
 

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -188,6 +188,7 @@ function routeError(res: RequestContext["res"], err: unknown): boolean {
     message.includes("signer mismatch") ||
     message.includes("has no quads") ||
     message.includes("different merkleRoot") ||
+    message.includes("could not be auto-registered on-chain before publish") ||
     message.includes("reserved namespace") ||
     anyErr?.name === "ReservedNamespaceError"
   ) {
@@ -430,20 +431,28 @@ async function ensureRegisteredForNamedPublish(
   contextGraphId: string,
   opCtx: OperationContext,
 ): Promise<void> {
-  const { agent, tracker, requestAgentAddress } = ctx;
+  const { agent, tracker, requestToken } = ctx;
   const existingOnChainId = await agent.getContextGraphOnChainId(contextGraphId);
   if (existingOnChainId) return;
 
   const storedOpts = await agent.getStoredContextGraphRegistrationOptions(contextGraphId);
-  await tracker.trackPhase(opCtx, "register-on-chain", () =>
-    agent.registerContextGraph(contextGraphId, {
-      ...(requestAgentAddress ? { callerAgentAddress: requestAgentAddress } : {}),
-      ...(storedOpts.publishPolicy !== undefined ? { publishPolicy: storedOpts.publishPolicy } : {}),
-      ...(storedOpts.publishAuthorityAccountId !== undefined
-        ? { publishAuthorityAccountId: storedOpts.publishAuthorityAccountId }
-        : {}),
-    }),
-  );
+  const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
+  try {
+    await tracker.trackPhase(opCtx, "register-on-chain", () =>
+      agent.registerContextGraph(contextGraphId, {
+        ...(tokenAgentAddress ? { callerAgentAddress: tokenAgentAddress } : {}),
+        ...(storedOpts.publishPolicy !== undefined ? { publishPolicy: storedOpts.publishPolicy } : {}),
+        ...(storedOpts.publishAuthorityAccountId !== undefined
+          ? { publishAuthorityAccountId: storedOpts.publishAuthorityAccountId }
+          : {}),
+      }),
+    );
+  } catch (regErr: any) {
+    throw new Error(
+      `Context graph "${contextGraphId}" could not be auto-registered on-chain before publish: ` +
+      `${regErr?.message ?? String(regErr)}`,
+    );
+  }
 }
 
 function emitPublished(
@@ -643,7 +652,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           errors.push({ phase: "swm-share", error: e?.message ?? String(e) });
         }
       }
-      if (alsoPublishVm) {
+      if (alsoPublishVm && result.swmShared === true) {
         try {
           // codex PR #971 F22: the atomic-create publish tail records into
           // the same operation-tracker timeline as `/api/shared-memory/publish`

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -187,6 +187,7 @@ function routeError(res: RequestContext["res"], err: unknown): boolean {
     message.includes("not a registered local agent") ||
     message.includes("signer mismatch") ||
     message.includes("has no quads") ||
+    message.includes("has no pending shared-memory writes") ||
     message.includes("different merkleRoot") ||
     message.includes("could not be auto-registered on-chain before publish") ||
     message.includes("reserved namespace") ||
@@ -435,6 +436,16 @@ async function ensureRegisteredForNamedPublish(
   const existingOnChainId = await agent.getContextGraphOnChainId(contextGraphId);
   if (existingOnChainId) return;
 
+  if (
+    typeof agent.hasPendingSharedMemoryWrites === "function" &&
+    !agent.hasPendingSharedMemoryWrites(contextGraphId)
+  ) {
+    throw new Error(
+      `Context graph "${contextGraphId}" has no pending shared-memory writes — ` +
+      "nothing to publish to Verified Memory. Stage entities into SWM first, then retry publish.",
+    );
+  }
+
   const storedOpts = await agent.getStoredContextGraphRegistrationOptions(contextGraphId);
   const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
   try {
@@ -462,12 +473,12 @@ function emitPublished(
   subGraphName?: string,
   clearSharedMemoryAfter = false,
 ): void {
-  if (result?.status !== "confirmed" || result?.contextGraphError) return;
   const publicTripleCount = Array.isArray(result?.publicQuads) ? result.publicQuads.length : 0;
   const rootCount = Array.isArray(result?.kaManifest) ? result.kaManifest.length : 0;
+  const publishedSwmCleaned = result?.status === "confirmed";
   ctx.emitMemoryGraphChanged?.({
     contextGraphId,
-    layers: ["swm", "vm"],
+    layers: publishedSwmCleaned ? ["swm", "vm"] : ["vm"],
     subGraphName,
     operation: "shared_memory_published",
     source: "api",
@@ -551,6 +562,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         error:
           '"alsoPublishVm" requires "alsoShareSwm" — publishFromFinalizedAssertion reads from Shared Memory, so the assertion must be shared first',
       });
+    }
+    if (alsoPublishVmIsObject && !validateFinalizedAssertionPublishRequest(alsoPublishVm as Record<string, unknown>, res)) {
+      return;
     }
     const finalizeOptions = resolveFinalizeOptions(ctx, parsed);
     if (finalizeOptions === null) return;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -46,6 +46,55 @@ function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
 }
 
+function serializeSeal(seal: any): Record<string, unknown> {
+  return {
+    assertionUri: seal?.assertionUri,
+    merkleRoot: seal?.merkleRoot instanceof Uint8Array ? hex(seal.merkleRoot) : seal?.merkleRoot,
+    authorAddress: seal?.authorAddress,
+    schemeVersion: seal?.schemeVersion,
+    chainId: seal?.chainId != null ? String(seal.chainId) : undefined,
+    kav10Address: seal?.kav10Address,
+    eip712Digest: seal?.eip712Digest,
+  };
+}
+
+function publishResponsePayload(result: any): Record<string, unknown> {
+  const chain = result?.onChainResult;
+  const seal = serializeSeal(result?.seal);
+  return {
+    kaId: result?.kaId != null ? String(result.kaId) : undefined,
+    status: result?.status,
+    assertionUri: result?.assertionUri ?? seal.assertionUri,
+    authorAddress: seal.authorAddress,
+    merkleRoot: seal.merkleRoot,
+    ual: result?.ual,
+    kas: Array.isArray(result?.kaManifest)
+      ? result.kaManifest.map((ka: any) => ({
+        tokenId: ka?.tokenId != null ? String(ka.tokenId) : undefined,
+        rootEntity: ka?.rootEntity,
+      }))
+      : undefined,
+    ...(chain ? { txHash: chain.txHash, blockNumber: chain.blockNumber } : {}),
+    ...(result?.contextGraphError ? { contextGraphError: result.contextGraphError } : {}),
+  };
+}
+
+function finalizedPublishOptionsInput(parsed: Record<string, unknown>): unknown {
+  const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
+    ? parsed.options as Record<string, unknown>
+    : {};
+  return {
+    ...nested,
+    ...(parsed.clearAfter !== undefined ? { clearAfter: parsed.clearAfter } : {}),
+    ...(parsed.clearSharedMemoryAfter !== undefined ? { clearSharedMemoryAfter: parsed.clearSharedMemoryAfter } : {}),
+    ...(parsed.publishEpochs !== undefined ? { publishEpochs: parsed.publishEpochs } : {}),
+    ...(parsed.epochs !== undefined ? { epochs: parsed.epochs } : {}),
+    ...(parsed.publisherNodeIdentityIdOverride !== undefined
+      ? { publisherNodeIdentityIdOverride: parsed.publisherNodeIdentityIdOverride }
+      : {}),
+  };
+}
+
 function routeError(res: RequestContext["res"], err: unknown): boolean {
   const anyErr = err as any;
   if (anyErr?.name === "AssertionNotPersistedError" || anyErr?.code === "ASSERTION_NOT_PERSISTED") {
@@ -397,7 +446,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
             operation: "assertion_finalized",
             source: "api",
           });
-          result.merkleRoot = hex(seal.merkleRoot);
+          Object.assign(result, serializeSeal(seal));
           result.status = "wm-sealed";
         } catch (e: any) {
           const phase = result.written === quads.length ? "wm-finalize" : "wm-write";
@@ -608,7 +657,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           operation: "assertion_finalized",
           source: "api",
         });
-        return jsonResponse(res, 200, { merkleRoot: hex(seal.merkleRoot), eip712Digest: seal.eip712Digest });
+        return jsonResponse(res, 200, serializeSeal(seal));
       }
       if (verb === "discard") {
         await agent.assertion.discard(
@@ -663,7 +712,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
-      const opts = resolveFinalizedPublishOptions(ctx, parsed.options);
+      const opts = resolveFinalizedPublishOptions(ctx, finalizedPublishOptionsInput(parsed));
       if (opts === null) return;
       const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
         ...(subGraphName ? { subGraphName } : {}),
@@ -673,13 +722,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       // Mirror the atomic path: non-throwing tentative/failed/contextGraphError
       // results are partial successes, not confirmed publishes.
       const httpStatus = pub?.status === "confirmed" && !pub?.contextGraphError ? 200 : 207;
-      return jsonResponse(res, httpStatus, {
-        kaId: pub?.kaId,
-        status: pub?.status,
-        ual: pub?.ual,
-        txHash: pub?.onChainResult?.txHash,
-        ...(pub?.contextGraphError ? { contextGraphError: pub.contextGraphError } : {}),
-      });
+      return jsonResponse(res, httpStatus, publishResponsePayload(pub));
     }
   } catch (e: any) {
     if (routeError(res, e)) return;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -248,8 +248,14 @@ function emitPublished(
     status: typeof result?.status === "string" ? result.status : undefined,
     counts: { roots: rootCount, triples: publicTripleCount },
   });
+  // Attribute the activity to the actual seal author the publisher signed for
+  // (pre-signed / delegated / admin-as-agent flows), not the request token.
+  // Falls back to the request agent when the result carries no seal author.
+  const sealAuthorAddress =
+    typeof result?.seal?.authorAddress === "string" ? result.seal.authorAddress : undefined;
   recordActivity(ctx, contextGraphId, "published", {
     subGraphName,
+    actorAgentAddress: sealAuthorAddress,
     tripleCount: publicTripleCount,
     entityCount: rootCount,
   });
@@ -286,6 +292,21 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (!validateOptionalSubGraphName(subGraphName, res)) return;
     if (quads !== undefined && (!Array.isArray(quads) || quads.length === 0)) {
       return jsonResponse(res, 400, { error: '"quads" must be a non-empty array when supplied' });
+    }
+    // Type-check the opt-in flags before they are consumed by truthiness —
+    // otherwise `{"alsoShareSwm":"false"}` would leak into SWM and
+    // `{"alsoPublishVm":"x"}` would spend TRAC. `alsoPublishVm` also accepts an
+    // inline publish-options OBJECT (its supported control surface); a boolean
+    // is the "publish with defaults" form.
+    if (alsoShareSwm !== undefined && typeof alsoShareSwm !== "boolean") {
+      return jsonResponse(res, 400, { error: '"alsoShareSwm" must be a boolean' });
+    }
+    const alsoPublishVmIsObject =
+      typeof alsoPublishVm === "object" && alsoPublishVm !== null && !Array.isArray(alsoPublishVm);
+    if (alsoPublishVm !== undefined && typeof alsoPublishVm !== "boolean" && !alsoPublishVmIsObject) {
+      return jsonResponse(res, 400, {
+        error: '"alsoPublishVm" must be a boolean or an inline publish-options object',
+      });
     }
     // Validate the opt-in layer-transition combinations BEFORE create, so a
     // deterministically-invalid request never leaves durable partial state.
@@ -480,25 +501,20 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     }
   }
 
-  // GET /api/knowledge-assets/:name/{wm,swm,vm} — per-layer status
+  // GET /api/knowledge-assets/:name/{wm,swm,vm} — per-layer status [deferred]
+  //
+  // Deferred (returns 501) rather than echoing the same `assertion.history()`
+  // payload for every layer: the lifecycle descriptor exposes a single CURRENT
+  // `memoryLayer`, not per-layer presence, so /wm, /swm and /vm would return
+  // identical state after a promote/publish — a misleading route contract. A
+  // truthful per-layer view needs a descriptor/event → {present, status} mapping
+  // that does not exist yet; until it lands, use `GET /:name` for the full
+  // lifecycle state. (Tracked alongside the wm/pull-from follow-up, §10.5.3.)
   if (method === "GET" && (layer === "wm" || layer === "swm" || layer === "vm") && !verb) {
-    const cg = url.searchParams.get("contextGraphId");
-    if (!validateRequiredContextGraphId(cg, res)) return;
-    const normalizedContextGraphId = normalizeContextGraphIdOrUri(cg!);
-    const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
-    if (!validateOptionalSubGraphName(subGraphName, res)) return;
-    try {
-      const hist = await agent.assertion.history(
-        normalizedContextGraphId,
-        name,
-        subGraphName ? { subGraphName } : undefined,
-      );
-      if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}"` });
-      return jsonResponse(res, 200, { layer, ...hist });
-    } catch (e: any) {
-      if (routeError(res, e)) return;
-      return jsonResponse(res, 500, { error: e?.message ?? String(e) });
-    }
+    return jsonResponse(res, 501, {
+      error: `Per-layer status (GET /:name/${layer}) is not implemented yet — the lifecycle descriptor has no per-layer view mapping. Use GET /api/knowledge-assets/${encodeURIComponent(name)} for full state (OT-RFC-43 §10.5 — follow-up).`,
+      layer,
+    });
   }
 
   if (method !== "POST") return;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1,0 +1,186 @@
+// Route handlers for the GitHub-shaped Knowledge Asset HTTP surface.
+//
+// OT-RFC-43 §10.5 — one coherent resource model for a Knowledge Asset (KA):
+// the working tree is WM, SWM and VM are remote branches, assertions are
+// immutable commits, layer is EXPLICIT in every write path:
+//
+//   POST /api/knowledge-assets                       create KA + open WM draft
+//                                                    (atomic: quads + also* flags)
+//   GET  /api/knowledge-assets/:name                 KA metadata / lifecycle state
+//   GET  /api/knowledge-assets/:name/{wm,swm,vm}     per-layer status
+//   POST /api/knowledge-assets/:name/wm/write        append quads to the draft
+//   POST /api/knowledge-assets/:name/wm/finalize     seal the draft (git commit)
+//   POST /api/knowledge-assets/:name/wm/discard      throw the draft away
+//   POST /api/knowledge-assets/:name/wm/pull-from    seed draft from SWM/VM  [TODO]
+//   POST /api/knowledge-assets/:name/swm/share       advance the SWM pointer
+//   POST /api/knowledge-assets/:name/vm/publish      mint/update on chain
+//
+// These delegate to the SAME agent lifecycle methods the legacy
+// `/api/assertion/*` + `/api/shared-memory/*` routes use, so behavior is
+// identical; only the URL shape changes. This module is purely ADDITIVE — the
+// legacy routes are untouched (308 redirects from them land in a follow-up).
+//
+// Identifier note (OT-RFC-43 §10.5.7): for the v10.0 floor the KA is addressed
+// by its lifecycle NAME (the file handle) + `contextGraphId`. Minter-namespaced
+// `(agent, number)` addressing is layered on by Option 1 later, on these same
+// routes, as an additional accepted identifier form.
+import type { RequestContext } from "./context.js";
+import { jsonResponse, readBody, safeParseJson } from "../http-utils.js";
+
+const PREFIX = "/api/knowledge-assets";
+
+function hex(bytes: Uint8Array): string {
+  return "0x" + Buffer.from(bytes).toString("hex");
+}
+
+export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
+  const { req, res, agent, path, url } = ctx;
+  if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
+  const method = req.method ?? "GET";
+
+  // ── POST /api/knowledge-assets — create KA + open WM draft (atomic shortcut) ──
+  if (method === "POST" && path === PREFIX) {
+    const parsed = safeParseJson(await readBody(req), res);
+    if (!parsed) return;
+    const { contextGraphId, name, subGraphName, quads, authorAgentAddress, alsoShareSwm, alsoPublishVm } = parsed;
+    if (!contextGraphId || !name) {
+      return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
+    }
+    try {
+      const assertionUri = await agent.assertion.create(contextGraphId, name, { subGraphName });
+      const result: Record<string, unknown> = { name, assertionUri, status: "draft-open" };
+
+      // autoFinalize: when quads are supplied, write + seal in the same call
+      // (OT-RFC-43 §10.5.5). `also*` are opt-in layer transitions on top.
+      if (Array.isArray(quads) && quads.length > 0) {
+        await agent.assertion.write(contextGraphId, name, quads, { subGraphName });
+        result.written = quads.length;
+        const seal = await agent.assertion.finalize(contextGraphId, name, { subGraphName, authorAgentAddress });
+        result.merkleRoot = hex(seal.merkleRoot);
+        result.status = "wm-sealed";
+      }
+
+      const errors: Array<{ phase: string; error: string }> = [];
+      if (alsoShareSwm) {
+        try {
+          const share = await agent.assertion.promote(contextGraphId, name, { subGraphName });
+          result.swmShared = true;
+          result.promotedCount = share.promotedCount;
+          result.status = "swm-shared";
+        } catch (e: any) {
+          errors.push({ phase: "swm-share", error: e?.message ?? String(e) });
+        }
+      }
+      if (alsoPublishVm) {
+        try {
+          const opts = typeof alsoPublishVm === "object" && alsoPublishVm ? alsoPublishVm : {};
+          const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
+          result.kaId = pub?.kaId;
+          result.ual = pub?.ual;
+          result.txHash = pub?.onChainResult?.txHash;
+          result.status = "vm-confirmed";
+        } catch (e: any) {
+          errors.push({ phase: "vm-publish", error: e?.message ?? String(e) });
+        }
+      }
+
+      // 207 when a create+finalize succeeded but an opt-in tail failed; the
+      // sealed assertion is a real artifact the caller can retry against.
+      if (errors.length > 0) return jsonResponse(res, 207, { created: true, ...result, errors });
+      return jsonResponse(res, 201, result);
+    } catch (e: any) {
+      return jsonResponse(res, 500, { error: e?.message ?? String(e) });
+    }
+  }
+
+  // ── /api/knowledge-assets/:name[/{wm,swm,vm}[/verb]] ──
+  const segs = path.slice(`${PREFIX}/`.length).split("/").filter(Boolean).map(decodeURIComponent);
+  if (segs.length === 0) return;
+  const name = segs[0];
+  const layer = segs[1]; // wm | swm | vm | undefined
+  const verb = segs[2];
+
+  // GET /api/knowledge-assets/:name — KA metadata / lifecycle state
+  if (method === "GET" && segs.length === 1) {
+    const cg = url.searchParams.get("contextGraphId");
+    if (!cg) return jsonResponse(res, 400, { error: 'Missing "contextGraphId" query param' });
+    const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
+    const hist = await agent.assertion.history(cg, name, { subGraphName });
+    if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${cg}"` });
+    return jsonResponse(res, 200, hist);
+  }
+
+  // GET /api/knowledge-assets/:name/{wm,swm,vm} — per-layer status
+  if (method === "GET" && (layer === "wm" || layer === "swm" || layer === "vm") && !verb) {
+    const cg = url.searchParams.get("contextGraphId");
+    if (!cg) return jsonResponse(res, 400, { error: 'Missing "contextGraphId" query param' });
+    const subGraphName = url.searchParams.get("subGraphName") ?? undefined;
+    const hist = await agent.assertion.history(cg, name, { subGraphName });
+    if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}"` });
+    return jsonResponse(res, 200, { layer, ...hist });
+  }
+
+  if (method !== "POST") return;
+
+  const parsed = safeParseJson(await readBody(req), res);
+  if (!parsed) return;
+  const contextGraphId = parsed.contextGraphId;
+  const subGraphName = parsed.subGraphName;
+  if (!contextGraphId) return jsonResponse(res, 400, { error: 'Missing "contextGraphId"' });
+
+  try {
+    // ── WM verbs (the only writable layer) ──
+    if (layer === "wm") {
+      if (verb === "write") {
+        if (!Array.isArray(parsed.quads)) return jsonResponse(res, 400, { error: 'Missing "quads"' });
+        await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });
+        return jsonResponse(res, 200, { written: parsed.quads.length });
+      }
+      if (verb === "finalize") {
+        const seal = await agent.assertion.finalize(contextGraphId, name, {
+          subGraphName,
+          authorAgentAddress: parsed.authorAgentAddress,
+          preSignedAuthorAttestation: parsed.preSignedAuthorAttestation,
+          schemeVersion: parsed.schemeVersion,
+        });
+        return jsonResponse(res, 200, { merkleRoot: hex(seal.merkleRoot), eip712Digest: seal.eip712Digest });
+      }
+      if (verb === "discard") {
+        await agent.assertion.discard(contextGraphId, name, { subGraphName });
+        return jsonResponse(res, 200, { discarded: true });
+      }
+      if (verb === "pull-from") {
+        // Net-new primitive (the git-checkout equivalent): seed a fresh WM
+        // draft from the current SWM or VM state, with onConflict semantics
+        // for a dirty draft. Implemented in a focused follow-up — it needs the
+        // per-layer entity-scoped gather + conflict handling (OT-RFC-43 §10.5.3).
+        return jsonResponse(res, 501, {
+          error: "wm/pull-from is not implemented yet (OT-RFC-43 §10.5.3 — follow-up)",
+          layer: parsed.layer,
+        });
+      }
+    }
+
+    // ── SWM verb: share (WM → SWM; OT-RFC-43 §10.6 renames promote → share) ──
+    if (layer === "swm" && verb === "share") {
+      const share = await agent.assertion.promote(contextGraphId, name, { entities: parsed.entities, subGraphName });
+      return jsonResponse(res, 200, { swmShared: true, promotedCount: share.promotedCount });
+    }
+
+    // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
+    if (layer === "vm" && verb === "publish") {
+      const opts = parsed.options && typeof parsed.options === "object" ? parsed.options : {};
+      const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
+      return jsonResponse(res, 200, {
+        kaId: pub?.kaId,
+        status: pub?.status,
+        ual: pub?.ual,
+        txHash: pub?.onChainResult?.txHash,
+      });
+    }
+  } catch (e: any) {
+    return jsonResponse(res, 500, { error: e?.message ?? String(e) });
+  }
+
+  // Unmatched under the prefix — fall through to the daemon's 404.
+}

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -40,9 +40,15 @@ function createTracker(): RequestContext['tracker'] {
   } as unknown as RequestContext['tracker'];
 }
 
-function ctxFor(method: string, path: string, body: unknown, agent: Record<string, unknown>): RequestContext {
+function ctxFor(
+  method: string,
+  path: string,
+  body: unknown,
+  agent: Record<string, unknown>,
+  overrides: Partial<RequestContext> = {},
+): RequestContext {
   const url = new URL(`http://127.0.0.1${path}`);
-  return {
+  const ctx = {
     req: createRequest(method, path, method === 'GET' ? undefined : body),
     res: createResponse() as unknown as ServerResponse,
     agent: agent as RequestContext['agent'],
@@ -50,7 +56,7 @@ function ctxFor(method: string, path: string, body: unknown, agent: Record<strin
     publisherRuntime: null,
     config: {} as RequestContext['config'],
     startedAt: 0,
-    dashDb: {} as RequestContext['dashDb'],
+    dashDb: { insertNotification: vi.fn() } as unknown as RequestContext['dashDb'],
     opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
     network: null as RequestContext['network'],
     tracker: createTracker(),
@@ -68,11 +74,13 @@ function ctxFor(method: string, path: string, body: unknown, agent: Record<strin
     validTokens: new Set(),
     apiHost: '127.0.0.1',
     apiPortRef: { value: 0 },
+    routePlugins: [],
     url,
     path: url.pathname,
     requestToken: undefined,
     requestAgentAddress: '0x0000000000000000000000000000000000000001',
   } as RequestContext;
+  return { ...ctx, ...overrides } as RequestContext;
 }
 
 function body(ctx: RequestContext): Record<string, unknown> {
@@ -84,6 +92,16 @@ function status(ctx: RequestContext): number {
 
 function makeAssertionAgent(over: Record<string, any> = {}) {
   const { assertion: assertionOver, ...restOver } = over;
+  const knownContextGraphs = [
+    { id: 'cg', uri: 'did:dkg:context-graph:cg', isSystem: true, subscribed: true, synced: true },
+    {
+      id: 'canonical-cg',
+      uri: 'did:dkg:context-graph:canonical-cg',
+      isSystem: true,
+      subscribed: true,
+      synced: true,
+    },
+  ];
   const assertion = {
     create: vi.fn(async (_cg: string, name: string) => `urn:dkg:assertion:cg:agent:${name}`),
     write: vi.fn(async () => undefined),
@@ -100,7 +118,12 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
       status: 'confirmed',
       ual: 'did:dkg:hardhat:31337/0xabc/7',
       onChainResult: { txHash: '0xtx' },
+      publicQuads: [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }],
+      kaManifest: [{ assertion: 'urn:dkg:assertion:cg:agent:f' }],
     })),
+    listContextGraphs: vi.fn(async () => knownContextGraphs),
+    contextGraphExists: vi.fn(async (id: string) => knownContextGraphs.some((row) => row.id === id)),
+    resolveAgentByToken: vi.fn(),
     ...restOver,
   };
 }
@@ -112,7 +135,7 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(201);
     expect(body(ctx)).toMatchObject({ name: 'meeting-notes', status: 'draft-open' });
-    expect(agent.assertion.create).toHaveBeenCalledOnce();
+    expect(agent.assertion.create).toHaveBeenCalledWith('cg', 'meeting-notes', undefined);
     expect(agent.assertion.write).not.toHaveBeenCalled();
   });
 
@@ -123,8 +146,105 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(201);
     expect(body(ctx)).toMatchObject({ status: 'wm-sealed', written: 1, merkleRoot: '0xabcd' });
-    expect(agent.assertion.write).toHaveBeenCalledOnce();
-    expect(agent.assertion.finalize).toHaveBeenCalledOnce();
+    expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, undefined);
+    expect(agent.assertion.finalize).toHaveBeenCalledWith('cg', 'f', {});
+  });
+
+  it('POST /api/knowledge-assets resolves DID-form context graph ids before writing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'did:dkg:context-graph:canonical-cg', name: 'f' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.assertion.create).toHaveBeenCalledWith('canonical-cg', 'f', undefined);
+  });
+
+  it('atomic create passes pre-signed author attestation and scheme version to finalize', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const attestation = {
+      address: '0x1111111111111111111111111111111111111111',
+      signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+    };
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, preSignedAuthorAttestation: attestation, schemeVersion: 2 },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.assertion.finalize).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({
+        preSignedAuthorAttestation: {
+          address: attestation.address,
+          signature: { r: expect.any(Uint8Array), vs: expect.any(Uint8Array) },
+        },
+        schemeVersion: 2,
+      }),
+    );
+    expect(agent.assertion.finalize.mock.calls[0][2]).not.toHaveProperty('authorAgentAddress');
+  });
+
+  it('atomic create rejects mutually exclusive finalize author inputs', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      {
+        contextGraphId: 'cg',
+        name: 'f',
+        quads,
+        authorAgentAddress: '0x1111111111111111111111111111111111111111',
+        preSignedAuthorAttestation: {
+          address: '0x2222222222222222222222222222222222222222',
+          signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+        },
+      },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('mutually exclusive');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/knowledge-assets emits legacy side effects through publish', async () => {
+    const agent = makeAssertionAgent();
+    const emitMemoryGraphChanged = vi.fn();
+    const emitNotification = vi.fn();
+    const insertNotification = vi.fn();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+      {
+        emitMemoryGraphChanged,
+        emitNotification,
+        dashDb: { insertNotification } as unknown as RequestContext['dashDb'],
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(emitMemoryGraphChanged.mock.calls.map(([event]) => event.operation)).toEqual([
+      'assertion_created',
+      'assertion_written',
+      'assertion_finalized',
+      'assertion_promoted',
+      'shared_memory_published',
+    ]);
+    expect(emitMemoryGraphChanged.mock.calls.at(-1)?.[0]).toMatchObject({ clearSharedMemoryAfter: false });
+    expect(insertNotification).toHaveBeenCalledTimes(3);
+    expect(emitNotification).toHaveBeenCalledTimes(3);
   });
 
   it('atomic create with also* tails returns 207 when a tail fails', async () => {
@@ -149,7 +269,17 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ written: 1 });
-    expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
+    expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, undefined);
+  });
+
+  it('POST .../:name/wm/write reports malformed percent-encoding as a 400', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets/%E0%A4%A/wm/write', { contextGraphId: 'cg', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx)).toMatchObject({ error: 'Malformed percent-encoding in URL path' });
+    expect(agent.assertion.write).not.toHaveBeenCalled();
   });
 
   it('POST .../:name/wm/finalize seals the draft', async () => {
@@ -158,6 +288,23 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ merkleRoot: '0xabcd', eip712Digest: '0xdig' });
+  });
+
+  it('POST .../:name/wm/discard emits the WM discard side effect', async () => {
+    const agent = makeAssertionAgent();
+    const emitMemoryGraphChanged = vi.fn();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/discard',
+      { contextGraphId: 'cg' },
+      agent,
+      { emitMemoryGraphChanged },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ contextGraphId: 'cg', operation: 'assertion_discarded' }),
+    );
   });
 
   it('POST .../:name/swm/share advances the SWM pointer (promote→share)', async () => {
@@ -171,11 +318,24 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
 
   it('POST .../:name/vm/publish mints/updates on chain', async () => {
     const agent = makeAssertionAgent();
-    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    const emitMemoryGraphChanged = vi.fn();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: { clearAfter: true } },
+      agent,
+      { emitMemoryGraphChanged },
+    );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ status: 'confirmed', ual: 'did:dkg:hardhat:31337/0xabc/7', txHash: '0xtx' });
-    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { clearSharedMemoryAfter: true });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'shared_memory_published',
+        clearSharedMemoryAfter: true,
+      }),
+    );
   });
 
   it('GET /api/knowledge-assets/:name returns lifecycle state', async () => {
@@ -184,6 +344,22 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ state: 'created', memoryLayer: 'WorkingMemory' });
+  });
+
+  it('GET /api/knowledge-assets/:name normalizes DID-form context graph ids for history', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=did:dkg:context-graph:cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', undefined);
+  });
+
+  it('GET /api/knowledge-assets/:name validates history query params before dispatch', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg&subGraphName=_bad', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.assertion.history).not.toHaveBeenCalled();
   });
 
   it('POST .../:name/wm/pull-from is 501 (net-new, follow-up)', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -835,6 +835,17 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
 
+  it.each([
+    '/api/knowledge-assets/f//vm/publish',
+    '/api/knowledge-assets/f/vm/publish/',
+  ])('malformed path %s falls through to the daemon 404', async (path) => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', path, { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(ctx.res.writableEnded).toBe(false);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
   // ── 34ae7dd1f re-review ─────────────────────────────────────────────────────
 
   it('atomic create rejects a non-boolean alsoShareSwm (truthiness footgun)', async () => {
@@ -864,6 +875,30 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
       'POST',
       '/api/knowledge-assets',
       { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: { publishEpochs: '4' } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({ publishEpochs: 4 }),
+    );
+  });
+
+  it('atomic create accepts nested inline alsoPublishVm options and coerces them', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      {
+        contextGraphId: 'cg',
+        name: 'f',
+        quads,
+        alsoShareSwm: true,
+        alsoPublishVm: { options: { publishEpochs: '4' } },
+      },
       agent,
     );
     await handleKnowledgeAssetsRoutes(ctx);
@@ -1136,6 +1171,20 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx).error).toContain('cannot be combined with "assertionName"');
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
     expect((tracker as any).start).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish rejects legacy assertionName fields before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', assertionName: 'other-ka' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"assertionName" is not accepted');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
 
   it('vm/publish rejects nested author override fields before publishing', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -476,6 +476,22 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ state: 'created', memoryLayer: 'WorkingMemory' });
   });
 
+  it('GET /api/knowledge-assets/:name resolves peer-authored lifecycle owners before history', async () => {
+    const owner = '0x2222222222222222222222222222222222222222';
+    const store = {
+      query: vi.fn(async () => ({
+        type: 'bindings',
+        bindings: [{ agent: `did:dkg:agent:${owner}` }],
+      })),
+    };
+    const agent = makeAssertionAgent({ store });
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(store.query).toHaveBeenCalledWith(expect.stringContaining('assertionName'));
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', { agentAddress: owner });
+  });
+
   it('GET /api/knowledge-assets/:name normalizes DID-form context graph ids for history', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=did:dkg:context-graph:cg', undefined, agent);

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -262,6 +262,45 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect((b.errors as any[])[0]).toMatchObject({ phase: 'swm-share' });
   });
 
+  it('atomic create returns partial success if write fails after create', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        write: vi.fn(async () => { throw new Error('reserved namespace'); }),
+      },
+    });
+    const quads = [{ subject: 'urn:dkg:file:x', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({
+      created: true,
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
+      status: 'draft-open',
+    });
+    expect((body(ctx).errors as any[])[0]).toMatchObject({ phase: 'wm-write' });
+    expect(agent.assertion.create).toHaveBeenCalledOnce();
+    expect(agent.assertion.finalize).not.toHaveBeenCalled();
+  });
+
+  it('atomic create returns partial success if finalize fails after write', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        finalize: vi.fn(async () => { throw new Error('signer mismatch'); }),
+      },
+    });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({
+      created: true,
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
+      status: 'wm-written',
+      written: 1,
+    });
+    expect((body(ctx).errors as any[])[0]).toMatchObject({ phase: 'wm-finalize' });
+  });
+
   it('POST .../:name/wm/write appends quads', async () => {
     const agent = makeAssertionAgent();
     const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
@@ -352,6 +391,23 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', undefined);
+  });
+
+  it('GET /api/knowledge-assets/:name passes explicit agentAddress to history', async () => {
+    const agent = makeAssertionAgent();
+    const owner = '0x2222222222222222222222222222222222222222';
+    const ctx = ctxFor('GET', `/api/knowledge-assets/f?contextGraphId=cg&agentAddress=${owner}`, undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', { agentAddress: owner });
+  });
+
+  it('GET /api/knowledge-assets/:name rejects malformed agentAddress', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg&agentAddress=bad%20actor', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.assertion.history).not.toHaveBeenCalled();
   });
 
   it('GET /api/knowledge-assets/:name validates history query params before dispatch', async () => {
@@ -472,6 +528,37 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx).contextGraphError).toBe('context graph not subscribed');
   });
 
+  it('vm/publish surfaces a non-confirmed status as 207', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'tentative',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        publicQuads: [],
+        kaManifest: [],
+      })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({ status: 'tentative' });
+  });
+
+  it('vm/publish rejects mis-typed clearAfter before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: { clearAfter: 'false' } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"clearAfter" must be a boolean');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
   it('unknown POST (layer, verb) shapes fall through to the daemon 404 without reading the body', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/foo/bar', { contextGraphId: 'cg' }, agent);
@@ -550,6 +637,41 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
       .find((m: any) => m.kind === 'published');
     expect(publishedMeta).toBeTruthy();
     expect(String(publishedMeta.actorAgentDid).toLowerCase()).toContain(sealAuthor.toLowerCase());
+  });
+
+  it('attributes atomic created/promoted activities to the pre-signed author', async () => {
+    const attestedAuthor = '0x3333333333333333333333333333333333333333';
+    const agent = makeAssertionAgent();
+    const insertNotification = vi.fn(() => 1);
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      {
+        contextGraphId: 'cg',
+        name: 'f',
+        quads,
+        alsoShareSwm: true,
+        preSignedAuthorAttestation: {
+          address: attestedAuthor,
+          signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+        },
+      },
+      agent,
+      {
+        emitNotification: vi.fn(),
+        dashDb: { insertNotification } as unknown as RequestContext['dashDb'],
+        requestAgentAddress: '0x0000000000000000000000000000000000000001',
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    const activityMetas = insertNotification.mock.calls.map(([row]: [any]) => JSON.parse(row.meta));
+    for (const kind of ['created', 'promoted']) {
+      const meta = activityMetas.find((m: any) => m.kind === kind);
+      expect(meta).toBeTruthy();
+      expect(String(meta.actorAgentDid).toLowerCase()).toContain(attestedAuthor.toLowerCase());
+    }
   });
 
   it('per-layer GET /:name/{wm,swm,vm} is deferred (501) rather than echoing identical state', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -375,4 +375,109 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(ctx.res.writableEnded).toBe(false); // not handled here
   });
+
+  // ── Review follow-ups (88ab898 re-review) ──────────────────────────────────
+
+  it('atomic create rejects also* tails without quads (nothing to finalize)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', alsoShareSwm: true }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('require "quads"');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
+  it('atomic create rejects alsoPublishVm without alsoShareSwm (publish reads from SWM)', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads, alsoPublishVm: true }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('requires "alsoShareSwm"');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('atomic create reports the real VM status (207) when publish is not confirmed', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'tentative',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        publicQuads: [],
+        kaManifest: [],
+      })),
+    });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    const b = body(ctx);
+    expect(b.status).toBe('vm-tentative'); // NOT a false "vm-confirmed"
+    expect(b.vmStatus).toBe('tentative');
+    expect((b.errors as any[]).some((e) => e.phase === 'vm-publish')).toBe(true);
+  });
+
+  it('vm/publish coerces publishEpochs / publisherNodeIdentityIdOverride before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: { publishEpochs: '5', publisherNodeIdentityIdOverride: '9' } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', {
+      publishEpochs: 5, // number, not the JSON string "5"
+      publisherNodeIdentityIdOverride: 9n, // bigint
+    });
+  });
+
+  it('vm/publish rejects an invalid publishEpochs with a 400 (not a 500)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: { publishEpochs: 'abc' } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('publishEpochs');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish surfaces a non-throwing contextGraphError as 207', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        publicQuads: [],
+        kaManifest: [],
+        contextGraphError: 'context graph not subscribed',
+      })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx).contextGraphError).toBe('context graph not subscribed');
+  });
+
+  it('unknown POST (layer, verb) shapes fall through to the daemon 404 without reading the body', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/foo/bar', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(ctx.res.writableEnded).toBe(false); // not handled → daemon 404
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -137,6 +137,9 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
     })),
     listContextGraphs: vi.fn(async () => knownContextGraphs),
     contextGraphExists: vi.fn(async (id: string) => knownContextGraphs.some((row) => row.id === id)),
+    getContextGraphOnChainId: vi.fn(async () => '7'),
+    getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
+    registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
     resolveAgentByToken: vi.fn(),
     ...restOver,
   };
@@ -617,6 +620,80 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ status: 'tentative' });
   });
 
+  it('vm/publish does not emit published activity for partial-success results', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'tentative',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        publicQuads: [],
+        kaManifest: [],
+      })),
+    });
+    const emitMemoryGraphChanged = vi.fn();
+    const insertNotification = vi.fn(() => 1);
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      {
+        emitMemoryGraphChanged,
+        dashDb: { insertNotification } as unknown as RequestContext['dashDb'],
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
+    expect(insertNotification).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish auto-registers a local-only context graph before named publish', async () => {
+    const agent = makeAssertionAgent({
+      getContextGraphOnChainId: vi.fn(async () => null),
+      getStoredContextGraphRegistrationOptions: vi.fn(async () => ({
+        publishPolicy: 0,
+        publishAuthorityAccountId: 99n,
+      })),
+      registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
+    });
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      { tracker, requestAgentAddress: '0x0000000000000000000000000000000000000001' },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.registerContextGraph).toHaveBeenCalledWith('cg', {
+      callerAgentAddress: '0x0000000000000000000000000000000000000001',
+      publishPolicy: 0,
+      publishAuthorityAccountId: 99n,
+    });
+    expect((tracker as any).trackPhase.mock.calls.map((call: any[]) => call[1])).toContain('register-on-chain');
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
+  it('atomic alsoPublishVm auto-registers a local-only context graph before named publish', async () => {
+    const agent = makeAssertionAgent({
+      getContextGraphOnChainId: vi.fn(async () => null),
+      registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
+    });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.registerContextGraph).toHaveBeenCalledWith('cg', expect.any(Object));
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
   it('vm/publish rejects mis-typed clearAfter before publishing', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor(
@@ -750,12 +827,12 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     }
   });
 
-  it('per-layer GET /:name/{wm,swm,vm} is deferred (501) rather than echoing identical state', async () => {
+  it('per-layer GET /:name/{wm,swm,vm} is unclaimed until per-layer mapping exists', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('GET', '/api/knowledge-assets/f/swm?contextGraphId=cg', undefined, agent);
     await handleKnowledgeAssetsRoutes(ctx);
-    expect(status(ctx)).toBe(501);
-    expect(body(ctx)).toMatchObject({ layer: 'swm' });
+    expect(status(ctx)).toBe(0);
+    expect((ctx.res as any).writableEnded).toBe(false);
     expect(agent.assertion.history).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -408,7 +408,14 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
       blockNumber: 123,
       kas: [{ tokenId: '1', rootEntity: 'ex:A' }],
     });
-    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { clearSharedMemoryAfter: true });
+    // The third arg also carries an `operationCtx` from the F22 tracker
+    // helper; using `objectContaining` keeps the assertion pinned to the
+    // publish-control coercion without coupling it to the tracker dance.
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({ clearSharedMemoryAfter: true }),
+    );
     expect(emitMemoryGraphChanged).toHaveBeenCalledWith(
       expect.objectContaining({
         operation: 'shared_memory_published',
@@ -530,10 +537,14 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
-    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', {
-      publishEpochs: 5, // number, not the JSON string "5"
-      publisherNodeIdentityIdOverride: 9n, // bigint
-    });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({
+        publishEpochs: 5, // number, not the JSON string "5"
+        publisherNodeIdentityIdOverride: 9n, // bigint
+      }),
+    );
   });
 
   it('vm/publish accepts legacy top-level publish controls', async () => {
@@ -546,11 +557,15 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
-    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', {
-      clearSharedMemoryAfter: true,
-      publishEpochs: 6,
-      publisherNodeIdentityIdOverride: 10n,
-    });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({
+        clearSharedMemoryAfter: true,
+        publishEpochs: 6,
+        publisherNodeIdentityIdOverride: 10n,
+      }),
+    );
   });
 
   it('vm/publish rejects an invalid publishEpochs with a 400 (not a 500)', async () => {
@@ -658,7 +673,11 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(201);
-    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { publishEpochs: 4 });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith(
+      'cg',
+      'f',
+      expect.objectContaining({ publishEpochs: 4 }),
+    );
   });
 
   it('attributes the published activity row to the seal author, not the request token', async () => {
@@ -738,5 +757,178 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(status(ctx)).toBe(501);
     expect(body(ctx)).toMatchObject({ layer: 'swm' });
     expect(agent.assertion.history).not.toHaveBeenCalled();
+  });
+
+  // ── 5fd83a15 / f1a6e0f6 follow-up review (codex round 6) ────────────────────
+
+  it('POST with a known verb but trailing suffix segments falls through (F20: exact segment count)', async () => {
+    // Pre-fix `isSupportedPostShape` only checked (layer, verb) and accepted
+    // ANY segment count, so `/f/vm/publish/extra` matched (`vm`, `publish`)
+    // and ran the publish side effect. The fix pins each known POST shape
+    // to `segs.length === 3` (`<name>/<layer>/<verb>`).
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish/extra',
+      { contextGraphId: 'cg' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(ctx.res.writableEnded).toBe(false); // falls through to daemon 404
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('POST trailing suffix on other shapes also falls through (F20 coverage)', async () => {
+    // Same regression for `wm/write` (the only quad-bearing verb) and
+    // `swm/share` — every supported (layer, verb) MUST require an exact
+    // 3-segment path.
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+
+    const writeCtx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/write/extra',
+      { contextGraphId: 'cg', quads },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(writeCtx);
+    expect(writeCtx.res.writableEnded).toBe(false);
+    expect(agent.assertion.write).not.toHaveBeenCalled();
+
+    const shareCtx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/swm/share/extra',
+      { contextGraphId: 'cg' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(shareCtx);
+    expect(shareCtx.res.writableEnded).toBe(false);
+    expect(agent.assertion.promote).not.toHaveBeenCalled();
+  });
+
+  it('control verbs reject oversize bodies (F21: SMALL_BODY_BYTES cap)', async () => {
+    // `wm/finalize`, `wm/discard`, `swm/share`, `vm/publish` only carry
+    // scalar control fields — they MUST inherit the legacy
+    // `SMALL_BODY_BYTES` (256 KB) cap, not the 10 MB default. A 1 MB body
+    // here is well above the small cap; `readBody` throws
+    // `PayloadTooLargeError` which the daemon's outer error mapper
+    // (not tested here) surfaces as 413. We assert the route never
+    // reaches the storage layer.
+    const agent = makeAssertionAgent();
+    const oversize = 'x'.repeat(1024 * 1024); // 1 MB
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/finalize',
+      { contextGraphId: 'cg', filler: oversize },
+      agent,
+    );
+    let caught: unknown;
+    try {
+      await handleKnowledgeAssetsRoutes(ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe('PayloadTooLargeError');
+    expect((caught as Error).message).toContain(String(256 * 1024));
+    expect(agent.assertion.finalize).not.toHaveBeenCalled();
+  });
+
+  it('wm/write keeps the large body cap (F21: quad-bearing verbs)', async () => {
+    // `wm/write` is the only sub-route that carries quads, so it MUST
+    // retain the default `MAX_BODY_BYTES` cap — the same 1 MB body that
+    // tripped finalize above goes through here.
+    const agent = makeAssertionAgent();
+    const quads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
+    // ~50 KB per quad × 30 = ~1.5 MB of quad payload — comfortably above
+    // SMALL_BODY_BYTES (256 KB) and below MAX_BODY_BYTES (10 MB).
+    const big = 'y'.repeat(50 * 1024);
+    for (let i = 0; i < 30; i++) {
+      quads.push({ subject: 'ex:A', predicate: 'ex:p', object: `"${big}-${i}"`, graph: '' });
+    }
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/write',
+      { contextGraphId: 'cg', quads },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ written: 30 });
+    expect(agent.assertion.write).toHaveBeenCalledOnce();
+  });
+
+  it('vm/publish records the operation through the tracker (F22)', async () => {
+    const agent = makeAssertionAgent();
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    // tracker.start fired with the contextGraph + source=api details
+    expect((tracker as any).start).toHaveBeenCalledTimes(1);
+    expect((tracker as any).start.mock.calls[0][1]).toMatchObject({
+      contextGraphId: 'cg',
+      details: { source: 'api', assertionName: 'f' },
+    });
+    // The publish call was wrapped in `trackPhase('read-shared-memory', ...)`
+    expect((tracker as any).trackPhase).toHaveBeenCalledTimes(1);
+    expect((tracker as any).trackPhase.mock.calls[0][1]).toBe('read-shared-memory');
+    // Tx coordinates from the mock onChainResult landed on the operation row.
+    expect((tracker as any).setTxHash).toHaveBeenCalledWith(expect.anything(), '0xtx', undefined);
+    // Non-throwing publish ⇒ complete (not fail) — even when the HTTP
+    // status ends up being 207 for a partial-success the operation itself
+    // completed (mirrors the legacy memory.ts pattern).
+    expect((tracker as any).complete).toHaveBeenCalledTimes(1);
+    expect((tracker as any).fail).not.toHaveBeenCalled();
+    // operationCtx threads into the publish call so the publisher's own
+    // phase markers attach to the same operation row.
+    const [, , publishOpts] = (agent.publishFromFinalizedAssertion as any).mock.calls[0];
+    expect(publishOpts).toHaveProperty('operationCtx');
+  });
+
+  it('vm/publish records a tracker.fail when the publish throws (F22)', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => {
+        throw new Error('chain down');
+      }),
+    });
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    // Outer catch maps the throw to a 500 (no `routeError` match for
+    // "chain down"); the operation row is still flushed via tracker.fail.
+    expect(status(ctx)).toBe(500);
+    expect((tracker as any).fail).toHaveBeenCalledTimes(1);
+    expect((tracker as any).complete).not.toHaveBeenCalled();
+  });
+
+  it('atomic create publish tail also records through the tracker (F22)', async () => {
+    const agent = makeAssertionAgent();
+    const tracker = createTracker();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect((tracker as any).start).toHaveBeenCalledTimes(1);
+    expect((tracker as any).complete).toHaveBeenCalledTimes(1);
+    expect((tracker as any).fail).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -492,6 +492,24 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', { agentAddress: owner });
   });
 
+  it('GET /api/knowledge-assets/:name asks callers to disambiguate duplicate owners', async () => {
+    const store = {
+      query: vi.fn(async () => ({
+        type: 'bindings',
+        bindings: [
+          { agent: 'did:dkg:agent:0x2222222222222222222222222222222222222222' },
+          { agent: 'did:dkg:agent:0x3333333333333333333333333333333333333333' },
+        ],
+      })),
+    };
+    const agent = makeAssertionAgent({ store });
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toMatch(/pass agentAddress to disambiguate/);
+    expect(agent.assertion.history).not.toHaveBeenCalled();
+  });
+
   it('GET /api/knowledge-assets/:name normalizes DID-form context graph ids for history', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=did:dkg:context-graph:cg', undefined, agent);

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -504,6 +504,28 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
 
+  it('atomic create skips vm/publish when swm/share fails', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        promote: vi.fn(async () => {
+          throw new Error('CCL denied');
+        }),
+      },
+    });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect((body(ctx).errors as any[]).map((e) => e.phase)).toEqual(['swm-share']);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+    expect(agent.registerContextGraph).not.toHaveBeenCalled();
+  });
+
   it('atomic create reports the real VM status (207) when publish is not confirmed', async () => {
     const agent = makeAssertionAgent({
       publishFromFinalizedAssertion: vi.fn(async () => ({
@@ -668,12 +690,59 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(agent.registerContextGraph).toHaveBeenCalledWith('cg', {
-      callerAgentAddress: '0x0000000000000000000000000000000000000001',
       publishPolicy: 0,
       publishAuthorityAccountId: 99n,
     });
     expect((tracker as any).trackPhase.mock.calls.map((call: any[]) => call[1])).toContain('register-on-chain');
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
+  it('vm/publish forwards the token-scoped agent when auto-registering', async () => {
+    const tokenAgent = '0x2222222222222222222222222222222222222222';
+    const agent = makeAssertionAgent({
+      getContextGraphOnChainId: vi.fn(async () => null),
+      resolveAgentByToken: vi.fn(() => tokenAgent),
+      registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
+    });
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      {
+        requestToken: 'agent-token',
+        requestAgentAddress: '0x0000000000000000000000000000000000000001',
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.registerContextGraph).toHaveBeenCalledWith('cg', {
+      callerAgentAddress: tokenAgent,
+    });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
+  it('vm/publish maps auto-registration failures to a client error', async () => {
+    const agent = makeAssertionAgent({
+      getContextGraphOnChainId: vi.fn(async () => null),
+      registerContextGraph: vi.fn(async () => {
+        throw new Error('insufficient TRAC');
+      }),
+    });
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('could not be auto-registered on-chain before publish');
+    expect(body(ctx).error).toContain('insufficient TRAC');
+    expect((tracker as any).fail).toHaveBeenCalledTimes(1);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
 
   it('atomic alsoPublishVm auto-registers a local-only context graph before named publish', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -105,7 +105,15 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
   const assertion = {
     create: vi.fn(async (_cg: string, name: string) => `urn:dkg:assertion:cg:agent:${name}`),
     write: vi.fn(async () => undefined),
-    finalize: vi.fn(async () => ({ merkleRoot: new Uint8Array([0xab, 0xcd]), eip712Digest: '0xdig' })),
+    finalize: vi.fn(async (_cg: string, name: string) => ({
+      assertionUri: `urn:dkg:assertion:cg:agent:${name}`,
+      merkleRoot: new Uint8Array([0xab, 0xcd]),
+      authorAddress: '0x1111111111111111111111111111111111111111',
+      schemeVersion: 1,
+      chainId: 31337n,
+      kav10Address: '0x2222222222222222222222222222222222222222',
+      eip712Digest: '0xdig',
+    })),
     promote: vi.fn(async () => ({ promotedCount: 3 })),
     discard: vi.fn(async () => undefined),
     history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory' })),
@@ -116,10 +124,16 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
     publishFromFinalizedAssertion: vi.fn(async () => ({
       kaId: 7n,
       status: 'confirmed',
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
       ual: 'did:dkg:hardhat:31337/0xabc/7',
-      onChainResult: { txHash: '0xtx' },
+      onChainResult: { txHash: '0xtx', blockNumber: 123 },
       publicQuads: [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }],
-      kaManifest: [{ assertion: 'urn:dkg:assertion:cg:agent:f' }],
+      kaManifest: [{ tokenId: 1n, rootEntity: 'ex:A', assertion: 'urn:dkg:assertion:cg:agent:f' }],
+      seal: {
+        assertionUri: 'urn:dkg:assertion:cg:agent:f',
+        merkleRoot: new Uint8Array([0xab, 0xcd]),
+        authorAddress: '0x1111111111111111111111111111111111111111',
+      },
     })),
     listContextGraphs: vi.fn(async () => knownContextGraphs),
     contextGraphExists: vi.fn(async (id: string) => knownContextGraphs.some((row) => row.id === id)),
@@ -145,7 +159,17 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(201);
-    expect(body(ctx)).toMatchObject({ status: 'wm-sealed', written: 1, merkleRoot: '0xabcd' });
+    expect(body(ctx)).toMatchObject({
+      status: 'wm-sealed',
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
+      written: 1,
+      merkleRoot: '0xabcd',
+      authorAddress: '0x1111111111111111111111111111111111111111',
+      schemeVersion: 1,
+      chainId: '31337',
+      kav10Address: '0x2222222222222222222222222222222222222222',
+      eip712Digest: '0xdig',
+    });
     expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, undefined);
     expect(agent.assertion.finalize).toHaveBeenCalledWith('cg', 'f', {});
   });
@@ -326,7 +350,15 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/finalize', { contextGraphId: 'cg' }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
-    expect(body(ctx)).toMatchObject({ merkleRoot: '0xabcd', eip712Digest: '0xdig' });
+    expect(body(ctx)).toMatchObject({
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
+      merkleRoot: '0xabcd',
+      authorAddress: '0x1111111111111111111111111111111111111111',
+      schemeVersion: 1,
+      chainId: '31337',
+      kav10Address: '0x2222222222222222222222222222222222222222',
+      eip712Digest: '0xdig',
+    });
   });
 
   it('POST .../:name/wm/discard emits the WM discard side effect', async () => {
@@ -368,6 +400,14 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ status: 'confirmed', ual: 'did:dkg:hardhat:31337/0xabc/7', txHash: '0xtx' });
+    expect(body(ctx)).toMatchObject({
+      kaId: '7',
+      assertionUri: 'urn:dkg:assertion:cg:agent:f',
+      authorAddress: '0x1111111111111111111111111111111111111111',
+      merkleRoot: '0xabcd',
+      blockNumber: 123,
+      kas: [{ tokenId: '1', rootEntity: 'ex:A' }],
+    });
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { clearSharedMemoryAfter: true });
     expect(emitMemoryGraphChanged).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -493,6 +533,23 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', {
       publishEpochs: 5, // number, not the JSON string "5"
       publisherNodeIdentityIdOverride: 9n, // bigint
+    });
+  });
+
+  it('vm/publish accepts legacy top-level publish controls', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', clearAfter: true, publishEpochs: '6', publisherNodeIdentityIdOverride: '10' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', {
+      clearSharedMemoryAfter: true,
+      publishEpochs: 6,
+      publisherNodeIdentityIdOverride: 10n,
     });
   });
 

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -139,6 +139,7 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
     contextGraphExists: vi.fn(async (id: string) => knownContextGraphs.some((row) => row.id === id)),
     getContextGraphOnChainId: vi.fn(async () => '7'),
     getStoredContextGraphRegistrationOptions: vi.fn(async () => ({})),
+    hasPendingSharedMemoryWrites: vi.fn(() => true),
     registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
     resolveAgentByToken: vi.fn(),
     ...restOver,
@@ -526,6 +527,28 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.registerContextGraph).not.toHaveBeenCalled();
   });
 
+  it('atomic create validates inline alsoPublishVm before creating a draft', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      {
+        contextGraphId: 'cg',
+        name: 'f',
+        quads,
+        alsoShareSwm: true,
+        alsoPublishVm: { authorAgentAddress: '0x1111111111111111111111111111111111111111' },
+      },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('seal already encodes the author');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
   it('atomic create reports the real VM status (207) when publish is not confirmed', async () => {
     const agent = makeAssertionAgent({
       publishFromFinalizedAssertion: vi.fn(async () => ({
@@ -642,7 +665,7 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ status: 'tentative' });
   });
 
-  it('vm/publish does not emit published activity for partial-success results', async () => {
+  it('vm/publish emits legacy side effects for partial-success results', async () => {
     const agent = makeAssertionAgent({
       publishFromFinalizedAssertion: vi.fn(async () => ({
         kaId: 7n,
@@ -666,8 +689,12 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(207);
-    expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
-    expect(insertNotification).not.toHaveBeenCalled();
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'shared_memory_published',
+      layers: ['vm'],
+      status: 'tentative',
+    }));
+    expect(insertNotification).toHaveBeenCalled();
   });
 
   it('vm/publish auto-registers a local-only context graph before named publish', async () => {
@@ -743,6 +770,28 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx).error).toContain('insufficient TRAC');
     expect((tracker as any).fail).toHaveBeenCalledTimes(1);
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish refuses to auto-register when shared memory is empty', async () => {
+    const agent = makeAssertionAgent({
+      getContextGraphOnChainId: vi.fn(async () => null),
+      hasPendingSharedMemoryWrites: vi.fn(() => false),
+      registerContextGraph: vi.fn(async () => ({ contextGraphId: '7' })),
+    });
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg' },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('has no pending shared-memory writes');
+    expect(agent.registerContextGraph).not.toHaveBeenCalled();
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+    expect((tracker as any).fail).toHaveBeenCalledTimes(1);
   });
 
   it('atomic alsoPublishVm auto-registers a local-only context graph before named publish', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -480,4 +480,84 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.create).not.toHaveBeenCalled();
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
+
+  // ── 34ae7dd1f re-review ─────────────────────────────────────────────────────
+
+  it('atomic create rejects a non-boolean alsoShareSwm (truthiness footgun)', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: 'false' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"alsoShareSwm" must be a boolean');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
+  it('atomic create rejects an alsoPublishVm that is neither boolean nor an options object', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: 'yes' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"alsoPublishVm" must be a boolean or an inline publish-options object');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
+  it('atomic create accepts an inline alsoPublishVm options object and coerces it', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: { publishEpochs: '4' } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { publishEpochs: 4 });
+  });
+
+  it('attributes the published activity row to the seal author, not the request token', async () => {
+    const sealAuthor = '0xAAaAAaAAaAAAAAAAaaAAaAaAaaAAaAaaAaAAAAaa';
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        publicQuads: [],
+        kaManifest: [],
+        seal: { authorAddress: sealAuthor },
+      })),
+    });
+    const insertNotification = vi.fn(() => 1);
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true, alsoPublishVm: true },
+      agent,
+      {
+        emitNotification: vi.fn(),
+        dashDb: { insertNotification } as unknown as RequestContext['dashDb'],
+        requestAgentAddress: '0x0000000000000000000000000000000000000001',
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    const publishedMeta = insertNotification.mock.calls
+      .map(([row]: [any]) => JSON.parse(row.meta))
+      .find((m: any) => m.kind === 'published');
+    expect(publishedMeta).toBeTruthy();
+    expect(String(publishedMeta.actorAgentDid).toLowerCase()).toContain(sealAuthor.toLowerCase());
+  });
+
+  it('per-layer GET /:name/{wm,swm,vm} is deferred (501) rather than echoing identical state', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f/swm?contextGraphId=cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(501);
+    expect(body(ctx)).toMatchObject({ layer: 'swm' });
+    expect(agent.assertion.history).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -29,6 +29,12 @@ function createRequest(method: string, path: string, body?: unknown): RequestCon
   return request as RequestContext['req'];
 }
 
+function createRawRequest(method: string, path: string, rawBody: string): RequestContext['req'] {
+  const request = Readable.from([Buffer.from(rawBody)]);
+  Object.assign(request, { method, url: path, headers: { host: '127.0.0.1' } });
+  return request as RequestContext['req'];
+}
+
 function createTracker(): RequestContext['tracker'] {
   return {
     start: vi.fn(),
@@ -391,6 +397,40 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.promote).toHaveBeenCalledOnce();
   });
 
+  it('POST .../:name/swm/share attributes promoted activity to the finalized seal author', async () => {
+    const sealAuthor = '0x2222222222222222222222222222222222222222';
+    const agent = makeAssertionAgent({
+      assertion: {
+        history: vi.fn(async () => ({
+          state: 'finalized',
+          memoryLayer: 'SharedWorkingMemory',
+          assertionGraph: 'urn:dkg:assertion:cg:agent:f',
+          seal: { authorAddress: sealAuthor },
+          events: [],
+        })),
+      },
+    });
+    const insertNotification = vi.fn(() => 1);
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/swm/share',
+      { contextGraphId: 'cg' },
+      agent,
+      {
+        emitNotification: vi.fn(),
+        dashDb: { insertNotification } as unknown as RequestContext['dashDb'],
+        requestAgentAddress: '0x0000000000000000000000000000000000000001',
+      },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    const promotedMeta = insertNotification.mock.calls
+      .map(([row]: [any]) => JSON.parse(row.meta))
+      .find((m: any) => m.kind === 'promoted');
+    expect(promotedMeta).toBeTruthy();
+    expect(String(promotedMeta.actorAgentDid).toLowerCase()).toContain(sealAuthor.toLowerCase());
+  });
+
   it('POST .../:name/vm/publish mints/updates on chain', async () => {
     const agent = makeAssertionAgent();
     const emitMemoryGraphChanged = vi.fn();
@@ -474,6 +514,37 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'vm' }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(501);
+  });
+
+  it('POST .../:name/wm/pull-from returns 501 before parsing malformed JSON', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/pull-from',
+      undefined,
+      agent,
+      { req: createRawRequest('POST', '/api/knowledge-assets/f/wm/pull-from', '{') },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(501);
+    expect(agent.listContextGraphs).not.toHaveBeenCalled();
+  });
+
+  it('POST .../:name/wm/pull-from returns 501 before context graph validation', async () => {
+    const agent = makeAssertionAgent({
+      contextGraphExists: vi.fn(async () => false),
+      listContextGraphs: vi.fn(async () => []),
+    });
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/pull-from',
+      { contextGraphId: 'missing-cg', layer: 'vm' },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(501);
+    expect(agent.contextGraphExists).not.toHaveBeenCalled();
+    expect(agent.listContextGraphs).not.toHaveBeenCalled();
   });
 
   it('ignores non-/api/knowledge-assets paths', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -923,6 +923,80 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
   });
 
+  it('vm/publish rejects author override fields before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      {
+        contextGraphId: 'cg',
+        authorAgentAddress: '0x1111111111111111111111111111111111111111',
+      },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('cannot be combined with "assertionName"');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+    expect((tracker as any).start).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish rejects nested author override fields before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      {
+        contextGraphId: 'cg',
+        options: {
+          preSignedAuthorAttestation: {
+            address: '0x1111111111111111111111111111111111111111',
+            signature: { r: '0x' + '11'.repeat(32), vs: '0x' + '22'.repeat(32) },
+          },
+        },
+      },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('cannot be combined with "assertionName"');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish rejects selection overrides before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', selection: { rootEntities: ['ex:A'] } },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"selection" must be omitted or "all"');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'Assertion f is not finalized',
+    'seal binds chainId 1 but runtime chainId is 2',
+    'seal binds KAv10 0xabc but runtime KAv10 is 0xdef',
+    'expectedMerkleRoot mismatch',
+    'precomputedAttestation signer mismatch',
+  ])('vm/publish maps finalized assertion validation failure to 400: %s', async (message) => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => {
+        throw new Error(message);
+      }),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain(message);
+  });
+
   it('vm/publish maps not-registered-on-chain failures to 400', async () => {
     const agent = makeAssertionAgent({
       publishFromFinalizedAssertion: vi.fn(async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -892,6 +892,63 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(publishOpts).toHaveProperty('operationCtx');
   });
 
+  it('vm/publish rejects malformed options before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const tracker = createTracker();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: 'bad' },
+      agent,
+      { tracker },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"options" must be an object');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+    expect((tracker as any).start).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish rejects array options before publishing', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: [] },
+      agent,
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('"options" must be an object');
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('vm/publish maps not-registered-on-chain failures to 400', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => {
+        throw new Error('Context graph "cg" is not registered on-chain');
+      }),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('not registered on-chain');
+  });
+
+  it('wm/finalize maps not-registered-on-chain failures to 400', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        finalize: vi.fn(async () => {
+          throw new Error('Context graph "cg" is not registered on-chain');
+        }),
+      },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/finalize', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('not registered on-chain');
+  });
+
   it('vm/publish records a tracker.fail when the publish throws (F22)', async () => {
     const agent = makeAssertionAgent({
       publishFromFinalizedAssertion: vi.fn(async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    headers: undefined as Record<string, string> | undefined,
+    body: '',
+    writableEnded: false,
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body ?? '';
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+function createRequest(method: string, path: string, body?: unknown): RequestContext['req'] {
+  const request = Readable.from([Buffer.from(body === undefined ? '' : JSON.stringify(body))]);
+  Object.assign(request, { method, url: path, headers: { host: '127.0.0.1' } });
+  return request as RequestContext['req'];
+}
+
+function createTracker(): RequestContext['tracker'] {
+  return {
+    start: vi.fn(),
+    trackPhase: vi.fn((_c, _p, fn: () => Promise<unknown>) => fn()),
+    complete: vi.fn(),
+    fail: vi.fn(),
+    setCost: vi.fn(),
+    setTxHash: vi.fn(),
+  } as unknown as RequestContext['tracker'];
+}
+
+function ctxFor(method: string, path: string, body: unknown, agent: Record<string, unknown>): RequestContext {
+  const url = new URL(`http://127.0.0.1${path}`);
+  return {
+    req: createRequest(method, path, method === 'GET' ? undefined : body),
+    res: createResponse() as unknown as ServerResponse,
+    agent: agent as RequestContext['agent'],
+    publisherControl: {} as RequestContext['publisherControl'],
+    publisherRuntime: null,
+    config: {} as RequestContext['config'],
+    startedAt: 0,
+    dashDb: {} as RequestContext['dashDb'],
+    opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
+    network: null as RequestContext['network'],
+    tracker: createTracker(),
+    memoryManager: {} as RequestContext['memoryManager'],
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'test',
+    catchupTracker: {} as RequestContext['catchupTracker'],
+    extractionRegistry: {} as RequestContext['extractionRegistry'],
+    fileStore: {} as RequestContext['fileStore'],
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {} as RequestContext['vectorStore'],
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress: '0x0000000000000000000000000000000000000001',
+  } as RequestContext;
+}
+
+function body(ctx: RequestContext): Record<string, unknown> {
+  return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>;
+}
+function status(ctx: RequestContext): number {
+  return (ctx.res as unknown as { statusCode: number }).statusCode;
+}
+
+function makeAssertionAgent(over: Record<string, any> = {}) {
+  const { assertion: assertionOver, ...restOver } = over;
+  const assertion = {
+    create: vi.fn(async (_cg: string, name: string) => `urn:dkg:assertion:cg:agent:${name}`),
+    write: vi.fn(async () => undefined),
+    finalize: vi.fn(async () => ({ merkleRoot: new Uint8Array([0xab, 0xcd]), eip712Digest: '0xdig' })),
+    promote: vi.fn(async () => ({ promotedCount: 3 })),
+    discard: vi.fn(async () => undefined),
+    history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory' })),
+    ...(assertionOver ?? {}),
+  };
+  return {
+    assertion,
+    publishFromFinalizedAssertion: vi.fn(async () => ({
+      kaId: 7n,
+      status: 'confirmed',
+      ual: 'did:dkg:hardhat:31337/0xabc/7',
+      onChainResult: { txHash: '0xtx' },
+    })),
+    ...restOver,
+  };
+}
+
+describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => {
+  it('POST /api/knowledge-assets creates a KA + opens a WM draft', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'meeting-notes' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(body(ctx)).toMatchObject({ name: 'meeting-notes', status: 'draft-open' });
+    expect(agent.assertion.create).toHaveBeenCalledOnce();
+    expect(agent.assertion.write).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/knowledge-assets with quads auto-writes + auto-finalizes (sealed assertion v1)', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(body(ctx)).toMatchObject({ status: 'wm-sealed', written: 1, merkleRoot: '0xabcd' });
+    expect(agent.assertion.write).toHaveBeenCalledOnce();
+    expect(agent.assertion.finalize).toHaveBeenCalledOnce();
+  });
+
+  it('atomic create with also* tails returns 207 when a tail fails', async () => {
+    const agent = makeAssertionAgent({
+      assertion: { promote: vi.fn(async () => { throw new Error('CCL denied'); }) },
+    });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'f', quads, alsoShareSwm: true }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    const b = body(ctx);
+    expect(b.created).toBe(true);
+    expect(b.merkleRoot).toBe('0xabcd'); // the sealed assertion is a real artifact
+    expect(Array.isArray(b.errors)).toBe(true);
+    expect((b.errors as any[])[0]).toMatchObject({ phase: 'swm-share' });
+  });
+
+  it('POST .../:name/wm/write appends quads', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/write', { contextGraphId: 'cg', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ written: 1 });
+    expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
+  });
+
+  it('POST .../:name/wm/finalize seals the draft', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/finalize', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ merkleRoot: '0xabcd', eip712Digest: '0xdig' });
+  });
+
+  it('POST .../:name/swm/share advances the SWM pointer (promote→share)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/swm/share', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ swmShared: true, promotedCount: 3 });
+    expect(agent.assertion.promote).toHaveBeenCalledOnce();
+  });
+
+  it('POST .../:name/vm/publish mints/updates on chain', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ status: 'confirmed', ual: 'did:dkg:hardhat:31337/0xabc/7', txHash: '0xtx' });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
+  it('GET /api/knowledge-assets/:name returns lifecycle state', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ state: 'created', memoryLayer: 'WorkingMemory' });
+  });
+
+  it('POST .../:name/wm/pull-from is 501 (net-new, follow-up)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'vm' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(501);
+  });
+
+  it('ignores non-/api/knowledge-assets paths', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/assertion/create', { contextGraphId: 'cg', name: 'f' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(ctx.res.writableEnded).toBe(false); // not handled here
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
           'test/blazegraph-integration.test.ts',
           // #761 — context graph write-target validation (from main).
           'test/context-graph-write-path-validation.test.ts',
+          'test/knowledge-assets-route.test.ts',
           // Notifications-pane redesign (A3) — assertion_activity emitter
           // helper. Pure logic + a tmp SQLite DashboardDB, no hardhat.
           'test/activity-notification.test.ts',

--- a/packages/core/src/memory-model.ts
+++ b/packages/core/src/memory-model.ts
@@ -87,6 +87,11 @@ export interface AssertionDescriptor {
   state: AssertionState;
   memoryLayer: MemoryLayer | null;
   assertionGraph: string;
+  seal?: {
+    authorAddress: string;
+    schemeVersion?: number;
+    finalizedAtIso?: string;
+  };
   events: AssertionEvent[];
 }
 


### PR DESCRIPTION
## What & why

Introduces the clean, layer-explicit Knowledge Asset HTTP surface from OT-RFC-43 §10.5 — the integrator-facing centerpiece of the v10 publish-pipeline rework. A KA is modelled like a GitHub repo: the working tree is **WM**, **SWM**/**VM** are remote branches, assertions are immutable commits, and the **layer is explicit in every write path** so `wm/write` can't accidentally hit SWM and `swm/share` can't mint.

**Purely additive** — the legacy `/api/assertion/*` + `/api/shared-memory/*` routes are untouched (308 redirects from them are a follow-up), so nothing breaks.

## The surface

```
POST /api/knowledge-assets                    create KA + open WM draft
                                              (atomic: quads → auto write+finalize;
                                               alsoShareSwm / alsoPublishVm opt-in tails)
GET  /api/knowledge-assets/:name              KA lifecycle state
GET  /api/knowledge-assets/:name/{wm,swm,vm}  per-layer status
POST /api/knowledge-assets/:name/wm/write     append quads
POST /api/knowledge-assets/:name/wm/finalize  seal the draft (git commit)
POST /api/knowledge-assets/:name/wm/discard   throw the draft away
POST /api/knowledge-assets/:name/wm/pull-from  seed draft from SWM/VM   [501 — follow-up]
POST /api/knowledge-assets/:name/swm/share    advance SWM pointer (promote→share)
POST /api/knowledge-assets/:name/vm/publish   mint/update on chain
```

Every endpoint delegates to the **same** agent lifecycle methods the legacy routes already use (`agent.assertion.{create,write,finalize,promote,discard,history}`, `publishFromFinalizedAssertion`), so behavior is identical — only the URL shape changes.

- **Atomic create**: `quads` in the body → write + finalize in one call (`201` with a sealed assertion v1). `alsoShareSwm`/`alsoPublishVm` are opt-in layer transitions on top.
- **`207 Multi-Status`**: when create+finalize succeed but an opt-in `also*` tail fails, the sealed assertion is a real, retryable artifact — returned with an `errors[]` list, not rolled back.

## Identifier note (§10.5.7)

For the v10.0 floor a KA is addressed by its lifecycle **name** + `contextGraphId`. Minter-namespaced **`(agent, number)`** addressing layers onto these *same* routes when Option 1 lands — an additional accepted identifier, not a second route shape.

## Verification

cli closure builds clean; new route contract test **10/10** (create, atomic + auto-finalize, 207 partial-failure, write, finalize, share, publish, status read, `pull-from` 501, path-ignore).

## Follow-ups (deliberately out of this PR)

- **`wm/pull-from`** implementation (returns `501` now — net-new git-checkout-style primitive that seeds a WM draft from SWM/VM with `onConflict` semantics; §10.5.3).
- **308 redirects** from the legacy routes (one-version deprecation window).
- **Client-SDK migration** (`api-client`, `mcp-dkg`, adapters, `node-ui`).
- The **promote→share** verb rename in the data predicates/legacy route (this PR already uses `share` in the new URL surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)