### PR TITLE
Implement wm/pull-from — seed a WM draft from SWM/VM (OT-RFC-43 §10.5.3)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1520,6 +1520,15 @@ export class DKGAgent extends DKGAgentBase {
       async query(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<import('@origintrail-official/dkg-storage').Quad[]> {
         return agent.publisher.assertionQuery(contextGraphId, name, agentAddress, opts?.subGraphName);
       },
+      /** OT-RFC-43 §10.5.3 — seed a fresh WM draft from this file's SWM/VM state. */
+      async pullFrom(
+        contextGraphId: string,
+        name: string,
+        sourceLayer: 'swm' | 'vm',
+        opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
+      ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
+        return agent.publisher.assertionPullFrom(contextGraphId, name, agentAddress, sourceLayer, opts);
+      },
       async promote(contextGraphId: string, name: string, opts?: { entities?: string[] | 'all'; subGraphName?: string }): Promise<{ promotedCount: number }> {
         // Resolve the gossip signer up-front (mirrors `share()` /
         // `conditionalShare()` patterns) so the publisher can wrap the

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -481,6 +481,14 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         const onConflict = parsed.onConflict === "replace" ? "replace" : "reject";
         try {
           const result = await agent.assertion.pullFrom(resolvedContextGraphId, name, sourceLayer, { subGraphName, onConflict });
+          emitMemoryGraphChanged?.({
+            contextGraphId: resolvedContextGraphId,
+            layers: ["wm"],
+            subGraphName,
+            operation: "assertion_pull_from",
+            source: "api",
+            counts: { triples: result.seeded, roots: result.entities },
+          });
           return jsonResponse(res, 200, { wmDraft: "open", seededFrom: { layer: sourceLayer }, ...result });
         } catch (e: any) {
           if (e?.code === "WM_DRAFT_CONFLICT") {
@@ -488,6 +496,12 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           }
           if (e?.code === "PULL_FROM_EMPTY_SOURCE") {
             return jsonResponse(res, 409, { code: "PULL_FROM_EMPTY_SOURCE", error: e.message });
+          }
+          if (e?.code === "PULL_FROM_UNFINALIZED_ASSERTION") {
+            return jsonResponse(res, 409, { code: "PULL_FROM_UNFINALIZED_ASSERTION", error: e.message });
+          }
+          if (e?.code === "PULL_FROM_INVALID_SEAL") {
+            return jsonResponse(res, 409, { code: "PULL_FROM_INVALID_SEAL", error: e.message });
           }
           throw e; // -> outer catch -> 500
         }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -172,6 +172,18 @@ function clearSharedMemoryAfterForNamedPublish(opts: Record<string, unknown>): b
   return typeof opts.clearSharedMemoryAfter === "boolean" ? opts.clearSharedMemoryAfter : false;
 }
 
+function isConfirmedPublish(result: any): boolean {
+  return result?.status === "confirmed" && !result?.contextGraphError;
+}
+
+function publishIncompleteReason(result: any): string {
+  if (typeof result?.contextGraphError === "string" && result.contextGraphError.length > 0) {
+    return result.contextGraphError;
+  }
+  const status = typeof result?.status === "string" ? result.status : "unknown";
+  return `VM publish did not confirm (status: ${status})`;
+}
+
 function emitPublished(
   ctx: RequestContext,
   contextGraphId: string,
@@ -328,8 +340,15 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
-          result.status = "vm-confirmed";
-          emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
+          result.status = isConfirmedPublish(pub) ? "vm-confirmed" : "vm-tentative";
+          if (typeof pub?.contextGraphError === "string") {
+            result.contextGraphError = pub.contextGraphError;
+          }
+          if (isConfirmedPublish(pub)) {
+            emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
+          } else {
+            errors.push({ phase: "vm-publish", error: publishIncompleteReason(pub) });
+          }
         } catch (e: any) {
           errors.push({ phase: "vm-publish", error: e?.message ?? String(e) });
         }
@@ -539,12 +558,15 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         ...(subGraphName ? { subGraphName } : {}),
         ...opts,
       });
-      emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
-      return jsonResponse(res, 200, {
+      if (isConfirmedPublish(pub)) {
+        emitPublished(ctx, resolvedContextGraphId, pub, subGraphName, clearSharedMemoryAfterForNamedPublish(opts));
+      }
+      return jsonResponse(res, isConfirmedPublish(pub) ? 200 : 207, {
         kaId: pub?.kaId,
         status: pub?.status,
         ual: pub?.ual,
         txHash: pub?.onChainResult?.txHash,
+        ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
       });
     }
   } catch (e: any) {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -151,13 +151,21 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
       if (verb === "pull-from") {
         // Net-new primitive (the git-checkout equivalent): seed a fresh WM
-        // draft from the current SWM or VM state, with onConflict semantics
-        // for a dirty draft. Implemented in a focused follow-up — it needs the
-        // per-layer entity-scoped gather + conflict handling (OT-RFC-43 §10.5.3).
-        return jsonResponse(res, 501, {
-          error: "wm/pull-from is not implemented yet (OT-RFC-43 §10.5.3 — follow-up)",
-          layer: parsed.layer,
-        });
+        // draft from the current SWM or VM state (OT-RFC-43 §10.5.3).
+        const sourceLayer = parsed.layer;
+        if (sourceLayer !== "swm" && sourceLayer !== "vm") {
+          return jsonResponse(res, 400, { error: 'pull-from requires "layer": "swm" | "vm"' });
+        }
+        const onConflict = parsed.onConflict === "replace" ? "replace" : "reject";
+        try {
+          const result = await agent.assertion.pullFrom(contextGraphId, name, sourceLayer, { subGraphName, onConflict });
+          return jsonResponse(res, 200, { wmDraft: "open", seededFrom: { layer: sourceLayer }, ...result });
+        } catch (e: any) {
+          if (e?.code === "WM_DRAFT_CONFLICT") {
+            return jsonResponse(res, 409, { code: "WM_DRAFT_CONFLICT", error: e.message });
+          }
+          throw e; // -> outer catch -> 500
+        }
       }
     }
 

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -365,11 +365,26 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
 
   it('POST .../:name/wm/pull-from seeds a draft from the given layer', async () => {
     const agent = makeAssertionAgent();
-    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'vm' }, agent);
+    const emitMemoryGraphChanged = vi.fn();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/wm/pull-from',
+      { contextGraphId: 'cg', layer: 'vm' },
+      agent,
+      { emitMemoryGraphChanged },
+    );
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ wmDraft: 'open', seededFrom: { layer: 'vm' }, seeded: 5 });
     expect(agent.assertion.pullFrom).toHaveBeenCalledWith('cg', 'f', 'vm', { subGraphName: undefined, onConflict: 'reject' });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'cg',
+      layers: ['wm'],
+      subGraphName: undefined,
+      operation: 'assertion_pull_from',
+      source: 'api',
+      counts: { triples: 5, roots: 2 },
+    });
   });
 
   it('POST .../:name/wm/pull-from resolves DID-form context graph ids before dispatch', async () => {
@@ -421,6 +436,34 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(409);
     expect(body(ctx)).toMatchObject({ code: 'PULL_FROM_EMPTY_SOURCE' });
+  });
+
+  it('POST .../:name/wm/pull-from maps an unfinalized assertion to 409', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        pullFrom: vi.fn(async () => {
+          throw Object.assign(new Error('not finalized yet'), { code: 'PULL_FROM_UNFINALIZED_ASSERTION' });
+        }),
+      },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'swm' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(409);
+    expect(body(ctx)).toMatchObject({ code: 'PULL_FROM_UNFINALIZED_ASSERTION' });
+  });
+
+  it('POST .../:name/wm/pull-from maps a broken assertion seal to 409', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        pullFrom: vi.fn(async () => {
+          throw Object.assign(new Error('invalid seal'), { code: 'PULL_FROM_INVALID_SEAL' });
+        }),
+      },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'swm' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(409);
+    expect(body(ctx)).toMatchObject({ code: 'PULL_FROM_INVALID_SEAL' });
   });
 
   it('ignores non-/api/knowledge-assets paths', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -248,6 +248,37 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(emitNotification).toHaveBeenCalledTimes(3);
   });
 
+  it('POST /api/knowledge-assets returns 207 without published side effects for a tentative VM tail', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'tentative',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        publicQuads: [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }],
+        kaManifest: [{ assertion: 'urn:dkg:assertion:cg:agent:f' }],
+      })),
+    });
+    const emitMemoryGraphChanged = vi.fn();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets',
+      { contextGraphId: 'cg', name: 'f', quads, alsoPublishVm: true },
+      agent,
+      { emitMemoryGraphChanged },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({ created: true, status: 'vm-tentative' });
+    expect((body(ctx).errors as any[])[0]).toMatchObject({
+      phase: 'vm-publish',
+      error: 'VM publish did not confirm (status: tentative)',
+    });
+    expect(emitMemoryGraphChanged.mock.calls.map(([event]) => event.operation)).not.toContain(
+      'shared_memory_published',
+    );
+  });
+
   it('atomic create with also* tails returns 207 when a tail fails', async () => {
     const agent = makeAssertionAgent({
       assertion: { promote: vi.fn(async () => { throw new Error('CCL denied'); }) },
@@ -337,6 +368,38 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
         clearSharedMemoryAfter: true,
       }),
     );
+  });
+
+  it('POST .../:name/vm/publish returns 207 without published side effects when context graph publish fails', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        contextGraphError: 'Context graph publish failed',
+        publicQuads: [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }],
+        kaManifest: [{ assertion: 'urn:dkg:assertion:cg:agent:f' }],
+      })),
+    });
+    const emitMemoryGraphChanged = vi.fn();
+    const ctx = ctxFor(
+      'POST',
+      '/api/knowledge-assets/f/vm/publish',
+      { contextGraphId: 'cg', options: { clearAfter: true } },
+      agent,
+      { emitMemoryGraphChanged },
+    );
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({
+      status: 'confirmed',
+      contextGraphError: 'Context graph publish failed',
+      ual: 'did:dkg:hardhat:31337/0xabc/7',
+      txHash: '0xtx',
+    });
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledWith('cg', 'f', { clearSharedMemoryAfter: true });
+    expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
   });
 
   it('GET /api/knowledge-assets/:name returns lifecycle state', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -91,6 +91,7 @@ function makeAssertionAgent(over: Record<string, any> = {}) {
     promote: vi.fn(async () => ({ promotedCount: 3 })),
     discard: vi.fn(async () => undefined),
     history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory' })),
+    pullFrom: vi.fn(async () => ({ seeded: 5, fromLayer: 'vm', entities: 2 })),
     ...(assertionOver ?? {}),
   };
   return {
@@ -186,11 +187,32 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ state: 'created', memoryLayer: 'WorkingMemory' });
   });
 
-  it('POST .../:name/wm/pull-from is 501 (net-new, follow-up)', async () => {
+  it('POST .../:name/wm/pull-from seeds a draft from the given layer', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'vm' }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
-    expect(status(ctx)).toBe(501);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ wmDraft: 'open', seededFrom: { layer: 'vm' }, seeded: 5 });
+    expect(agent.assertion.pullFrom).toHaveBeenCalledWith('cg', 'f', 'vm', { subGraphName: undefined, onConflict: 'reject' });
+  });
+
+  it('POST .../:name/wm/pull-from requires a valid layer', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+  });
+
+  it('POST .../:name/wm/pull-from maps a dirty-draft conflict to 409', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        pullFrom: vi.fn(async () => { throw Object.assign(new Error('draft exists'), { code: 'WM_DRAFT_CONFLICT' }); }),
+      },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/pull-from', { contextGraphId: 'cg', layer: 'swm' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(409);
+    expect(body(ctx)).toMatchObject({ code: 'WM_DRAFT_CONFLICT' });
   });
 
   it('ignores non-/api/knowledge-assets paths', async () => {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -46,6 +46,7 @@ import {
   ReservedNamespaceError,
   AssertionNotPersistedError,
   MultiRootPublishNotAtomicError,
+  PullFromPreconditionError,
   type CASCondition,
 } from './errors.js';
 
@@ -59,6 +60,7 @@ export {
   ReservedNamespaceError,
   AssertionNotPersistedError,
   MultiRootPublishNotAtomicError,
+  PullFromPreconditionError,
   type CASCondition,
 };
 
@@ -3953,6 +3955,48 @@ export class DKGPublisher implements Publisher {
     return graphUri;
   }
 
+  private async reopenAssertionDraftForPullFrom(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName: string | undefined,
+    hasDraft: boolean,
+  ): Promise<void> {
+    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
+    const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const DKG = 'http://dkg.io/ontology/';
+
+    if (hasDraft) {
+      await this.store.dropGraph(graphUri);
+    }
+    await this.store.createGraph(graphUri);
+
+    // Pull-from reopens the editable WM draft, but it is not a fresh file
+    // creation. Preserve the lifecycle event history and only reset mutable
+    // state plus assertion-URI metadata whose seal/hash rows describe the
+    // previous finalized draft.
+    await this.store.deleteByPattern({ subject: graphUri, graph: metaGraph });
+    await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: `${DKG}state` });
+    await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: `${DKG}memoryLayer` });
+
+    await this.store.insert(generateAssertionCreatedMetadata({
+      contextGraphId,
+      agentAddress,
+      assertionName: name,
+      subGraphName,
+      timestamp: new Date(),
+    }));
+
+    await this.store.insert([{
+      subject: graphUri,
+      predicate: `${DKG}memoryLayer`,
+      object: '"WM"',
+      graph: metaGraph,
+    }]);
+  }
+
   async assertionWrite(
     contextGraphId: string,
     name: string,
@@ -4030,9 +4074,19 @@ export class DKGPublisher implements Publisher {
     const sealRes = await this.store.query(
       `CONSTRUCT { <${wmGraph}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${wmGraph}> ?p ?o } }`,
     );
-    const seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
+    let seal: ReturnType<typeof parseAssertionSealQuads>;
+    try {
+      seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      throw new PullFromPreconditionError(
+        'PULL_FROM_INVALID_SEAL',
+        `Invalid assertion seal for "${name}" in context graph "${contextGraphId}": ${reason}`,
+      );
+    }
     if (!seal) {
-      throw new Error(
+      throw new PullFromPreconditionError(
+        'PULL_FROM_UNFINALIZED_ASSERTION',
         `No sealed entity list for "${name}" in context graph "${contextGraphId}" — pull-from `
         + `requires a finalized assertion (its seal records the member entities).`,
       );
@@ -4064,11 +4118,9 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    // Open a fresh WM draft (clears stale lifecycle/seal) and seed it.
-    if (hasDraft) {
-      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout after source validation
-    }
-    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
+    // Open a fresh WM draft after source validation, preserving lifecycle
+    // history while clearing stale assertion-URI seal/hash metadata.
+    await this.reopenAssertionDraftForPullFrom(contextGraphId, name, agentAddress, subGraphName, hasDraft);
     await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
     return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
   }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4050,13 +4050,15 @@ export class DKGPublisher implements Publisher {
     sourceLayer: 'swm' | 'vm',
     opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
   ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
-    DKGPublisher.validateOptionalSubGraph(opts?.subGraphName);
     const subGraphName = opts?.subGraphName;
+    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     const wmGraph = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const sourceGraph = sourceLayer === 'swm'
       ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
-      : this.graphManager.dataGraphUri(contextGraphId);
+      : subGraphName
+        ? this.graphManager.subGraphUri(contextGraphId, subGraphName)
+        : this.graphManager.dataGraphUri(contextGraphId);
 
     // onConflict: refuse to clobber a dirty WM draft unless told to replace it.
     const draftProbe = await this.store.query(`ASK { GRAPH <${wmGraph}> { ?s ?p ?o } }`);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, parseAssertionSealQuads } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, parseAssertionSealQuads, MemoryLayer } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -3981,20 +3981,26 @@ export class DKGPublisher implements Publisher {
     await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: `${DKG}state` });
     await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: `${DKG}memoryLayer` });
 
-    await this.store.insert(generateAssertionCreatedMetadata({
-      contextGraphId,
-      agentAddress,
-      assertionName: name,
-      subGraphName,
-      timestamp: new Date(),
-    }));
-
-    await this.store.insert([{
-      subject: graphUri,
-      predicate: `${DKG}memoryLayer`,
-      object: '"WM"',
-      graph: metaGraph,
-    }]);
+    await this.store.insert([
+      {
+        subject: lifecycleSubject,
+        predicate: `${DKG}state`,
+        object: '"created"',
+        graph: metaGraph,
+      },
+      {
+        subject: lifecycleSubject,
+        predicate: `${DKG}memoryLayer`,
+        object: `"${MemoryLayer.WorkingMemory}"`,
+        graph: metaGraph,
+      },
+      {
+        subject: graphUri,
+        predicate: `${DKG}memoryLayer`,
+        object: `"${MemoryLayer.WorkingMemory}"`,
+        graph: metaGraph,
+      },
+    ]);
   }
 
   async assertionWrite(

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, parseAssertionSealQuads } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -4010,7 +4010,6 @@ export class DKGPublisher implements Publisher {
     const subGraphName = opts?.subGraphName;
     const wmGraph = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
     const sourceGraph = sourceLayer === 'swm'
       ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
       : this.graphManager.dataGraphUri(contextGraphId);
@@ -4026,25 +4025,19 @@ export class DKGPublisher implements Publisher {
           { code: 'WM_DRAFT_CONFLICT' },
         );
       }
-      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout
     }
 
-    // Resolve the file's member entities from the seal (dual-read the predicate
-    // rename: dkg:assertionRootEntity OR dkg:assertionEntity, OT-RFC-43 §10.1).
-    const entityRes = await this.store.query(
-      `SELECT DISTINCT ?e WHERE { GRAPH <${metaGraph}> {
-         <${lifecycleSubject}> (<http://dkg.io/ontology/assertionRootEntity>|<http://dkg.io/ontology/assertionEntity>) ?e .
-       } }`,
+    const sealRes = await this.store.query(
+      `CONSTRUCT { <${wmGraph}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${wmGraph}> ?p ?o } }`,
     );
-    const entities = entityRes.type === 'bindings'
-      ? [...new Set(entityRes.bindings.map((b) => b['e']).filter(Boolean) as string[])]
-      : [];
-    if (entities.length === 0) {
+    const seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
+    if (!seal) {
       throw new Error(
         `No sealed entity list for "${name}" in context graph "${contextGraphId}" — pull-from `
         + `requires a finalized assertion (its seal records the member entities).`,
       );
     }
+    const entities = seal.rootEntities;
 
     // Gather the source-layer quads scoped to the entity set + skolem children
     // (same filter the publish gather / RS prover use), minus trust/ownership
@@ -4060,12 +4053,23 @@ export class DKGPublisher implements Publisher {
     const gathered = gather.type === 'quads'
       ? gather.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
       : [];
+    if (gathered.length === 0) {
+      throw Object.assign(
+        new Error(
+          `No ${sourceLayer.toUpperCase()} quads found for "${name}" in context graph "${contextGraphId}" `
+          + `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `
+          + 'WM draft was not modified.',
+        ),
+        { code: 'PULL_FROM_EMPTY_SOURCE' },
+      );
+    }
 
     // Open a fresh WM draft (clears stale lifecycle/seal) and seed it.
-    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
-    if (gathered.length > 0) {
-      await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
+    if (hasDraft) {
+      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout after source validation
     }
+    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
+    await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
     return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
   }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3985,6 +3985,90 @@ export class DKGPublisher implements Publisher {
     return result.type === 'quads' ? result.quads : [];
   }
 
+  /**
+   * OT-RFC-43 §10.5.3 — `wm/pull-from`: seed a fresh WM draft from this file's
+   * current SWM or VM state (the `git checkout origin/<branch>` equivalent).
+   *
+   * WM is the only writable surface; to edit content that already lives in SWM
+   * or VM you pull it into a new WM draft, edit, then re-share / re-publish.
+   * The file's entity set is read from the assertion seal (on the lifecycle
+   * URN); the source layer's quads for those entities (+ their skolemized
+   * children) are gathered and written into a fresh WM draft.
+   *
+   * `onConflict` applies only when the WM draft already holds content:
+   *   - 'reject' (default): throw `WM_DRAFT_CONFLICT` — the caller decides.
+   *   - 'replace': discard the open draft, then seed fresh (git force-checkout).
+   */
+  async assertionPullFrom(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    sourceLayer: 'swm' | 'vm',
+    opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
+  ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
+    DKGPublisher.validateOptionalSubGraph(opts?.subGraphName);
+    const subGraphName = opts?.subGraphName;
+    const wmGraph = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
+    const sourceGraph = sourceLayer === 'swm'
+      ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
+      : this.graphManager.dataGraphUri(contextGraphId);
+
+    // onConflict: refuse to clobber a dirty WM draft unless told to replace it.
+    const draftProbe = await this.store.query(`ASK { GRAPH <${wmGraph}> { ?s ?p ?o } }`);
+    const hasDraft = draftProbe.type === 'boolean' && draftProbe.value === true;
+    if (hasDraft) {
+      const onConflict = opts?.onConflict ?? 'reject';
+      if (onConflict === 'reject') {
+        throw Object.assign(
+          new Error(`A WM draft already exists for "${name}" in context graph "${contextGraphId}"; pass onConflict:"replace" to overwrite it.`),
+          { code: 'WM_DRAFT_CONFLICT' },
+        );
+      }
+      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout
+    }
+
+    // Resolve the file's member entities from the seal (dual-read the predicate
+    // rename: dkg:assertionRootEntity OR dkg:assertionEntity, OT-RFC-43 §10.1).
+    const entityRes = await this.store.query(
+      `SELECT DISTINCT ?e WHERE { GRAPH <${metaGraph}> {
+         <${lifecycleSubject}> (<http://dkg.io/ontology/assertionRootEntity>|<http://dkg.io/ontology/assertionEntity>) ?e .
+       } }`,
+    );
+    const entities = entityRes.type === 'bindings'
+      ? [...new Set(entityRes.bindings.map((b) => b['e']).filter(Boolean) as string[])]
+      : [];
+    if (entities.length === 0) {
+      throw new Error(
+        `No sealed entity list for "${name}" in context graph "${contextGraphId}" — pull-from `
+        + `requires a finalized assertion (its seal records the member entities).`,
+      );
+    }
+
+    // Gather the source-layer quads scoped to the entity set + skolem children
+    // (same filter the publish gather / RS prover use), minus trust/ownership
+    // bookkeeping that never belongs in a working draft.
+    const values = entities.map((e) => `<${e}>`).join(' ');
+    const gather = await this.store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${sourceGraph}> {
+         VALUES ?root { ${values} }
+         ?s ?p ?o .
+         FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+       } }`,
+    );
+    const gathered = gather.type === 'quads'
+      ? gather.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
+      : [];
+
+    // Open a fresh WM draft (clears stale lifecycle/seal) and seed it.
+    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
+    if (gathered.length > 0) {
+      await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
+    }
+    return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
+  }
+
   async assertionPromote(
     contextGraphId: string,
     name: string,

--- a/packages/publisher/src/errors.ts
+++ b/packages/publisher/src/errors.ts
@@ -116,3 +116,16 @@ export class MultiRootPublishNotAtomicError extends Error {
     this.rootEntities = [...rootEntities];
   }
 }
+
+export type PullFromPreconditionCode =
+  | 'PULL_FROM_UNFINALIZED_ASSERTION'
+  | 'PULL_FROM_INVALID_SEAL';
+
+export class PullFromPreconditionError extends Error {
+  readonly code: PullFromPreconditionCode;
+  constructor(code: PullFromPreconditionCode, message: string) {
+    super(message);
+    this.name = 'PullFromPreconditionError';
+    this.code = code;
+  }
+}

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -204,6 +204,7 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     for (const eventUri of beforeEvents) {
       expect(afterEvents).toContain(eventUri);
     }
+    expect(afterEvents).toHaveLength(beforeEvents.length);
 
     const staleAssertionMeta = await store.query(
       `ASK { GRAPH <${meta}> {

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -6,6 +6,7 @@ import {
   contextGraphMetaUri,
   contextGraphAssertionUri,
   assertionLifecycleUri,
+  contextGraphSubGraphUri,
   buildAssertionSealQuads,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -18,6 +19,7 @@ import { DKGPublisher } from '../src/index.js';
 const CG = 'pull-from-test';
 const AGENT = '0x00000000000000000000000000000000000000a1';
 const NAME = 'meeting-notes';
+const SG = 'code';
 const SWM_GRAPH = `did:dkg:context-graph:${CG}/_shared_memory`;
 const SCHEMA = 'http://schema.org/name';
 const DKG = 'http://dkg.io/ontology/';
@@ -44,9 +46,21 @@ function q(subject: string, predicate: string, object: string, graph: string): Q
   return { subject, predicate, object, graph };
 }
 
+async function registerSubGraph(store: OxigraphStore): Promise<void> {
+  const meta = contextGraphMetaUri(CG);
+  const subGraphUri = contextGraphSubGraphUri(CG, SG);
+  await store.createGraph(meta);
+  await store.createGraph(subGraphUri);
+  await store.insert([
+    q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', `${DKG}SubGraph`, meta),
+    q(subGraphUri, `${SCHEMA}`, `"${SG}"`, meta),
+    q(subGraphUri, `${DKG}createdBy`, 'did:dkg:agent:test-agent', meta),
+  ]);
+}
+
 /** Seal: record the finalized file's member entities on the assertion URI in _meta. */
-function sealEntities(entities: string[]): Quad[] {
-  const assertionUri = contextGraphAssertionUri(CG, AGENT, NAME);
+function sealEntities(entities: string[], subGraphName?: string): Quad[] {
+  const assertionUri = contextGraphAssertionUri(CG, AGENT, NAME, subGraphName);
   const meta = contextGraphMetaUri(CG);
   return buildAssertionSealQuads({
     assertionUri,
@@ -63,8 +77,8 @@ function sealEntities(entities: string[]): Quad[] {
   });
 }
 
-async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
-  const wm = contextGraphAssertionUri(CG, AGENT, NAME);
+async function wmQuads(store: OxigraphStore, subGraphName?: string): Promise<Quad[]> {
+  const wm = contextGraphAssertionUri(CG, AGENT, NAME, subGraphName);
   const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${wm}> { ?s ?p ?o } }`);
   return r.type === 'quads' ? r.quads : [];
 }
@@ -135,6 +149,36 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     const subjects = new Set(draft.map((d) => d.subject));
     expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
     expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
+  });
+
+  it('seeds a sub-graph WM draft from the VM sub-graph, not the root data graph', async () => {
+    const { publisher, store } = await makePublisher();
+    const rootVmGraph = `did:dkg:context-graph:${CG}`;
+    const subGraphVmGraph = contextGraphSubGraphUri(CG, SG);
+    await registerSubGraph(store);
+    await store.insert([
+      q(ENTITY_1, SCHEMA, '"Alice from root VM"', rootVmGraph),
+      q(ENTITY_1, SCHEMA, '"Alice from sub-graph VM"', subGraphVmGraph),
+      ...sealEntities([ENTITY_1], SG),
+    ]);
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'vm', { subGraphName: SG });
+    expect(result.fromLayer).toBe('vm');
+    expect(result.entities).toBe(1);
+
+    const draft = await wmQuads(store, SG);
+    expect(draft.some((quad) => quad.subject === ENTITY_1 && quad.object === '"Alice from sub-graph VM"')).toBe(true);
+    expect(draft.some((quad) => quad.object === '"Alice from root VM"')).toBe(false);
+  });
+
+  it('rejects an unregistered sub-graph before seal/source preconditions', async () => {
+    const { publisher } = await makePublisher();
+
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { subGraphName: SG }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/Sub-graph "code" has not been registered/);
+    expect((err as any).code).not.toBe('PULL_FROM_UNFINALIZED_ASSERTION');
+    expect((err as any).code).not.toBe('PULL_FROM_EMPTY_SOURCE');
   });
 
   it('reopens a draft without erasing lifecycle history or stale assertion metadata', async () => {

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -5,6 +5,7 @@ import {
   generateEd25519Keypair,
   contextGraphMetaUri,
   contextGraphAssertionUri,
+  assertionLifecycleUri,
   buildAssertionSealQuads,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -68,6 +69,18 @@ async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
   return r.type === 'quads' ? r.quads : [];
 }
 
+async function lifecycleEventUris(store: OxigraphStore): Promise<string[]> {
+  const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+  const meta = contextGraphMetaUri(CG);
+  const r = await store.query(
+    `SELECT DISTINCT ?event WHERE { GRAPH <${meta}> {
+       ?event ?p ?o .
+       FILTER(STRSTARTS(STR(?event), "${lifecycle}/event/"))
+     } }`,
+  );
+  return r.type === 'bindings' ? r.bindings.map((row) => row['event']).filter(Boolean) : [];
+}
+
 describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
   it('seeds a WM draft from SWM, scoped to the file\'s sealed entities (+ skolem children)', async () => {
     const { publisher, store } = await makePublisher();
@@ -124,6 +137,56 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
   });
 
+  it('reopens a draft without erasing lifecycle history or stale assertion metadata', async () => {
+    const { publisher, store } = await makePublisher();
+    const assertionUri = contextGraphAssertionUri(CG, AGENT, NAME);
+    const lifecycleUri = assertionLifecycleUri(CG, AGENT, NAME);
+    const meta = contextGraphMetaUri(CG);
+
+    await publisher.assertionCreate(CG, NAME, AGENT);
+    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"Alice"' }]);
+    await publisher.assertionPromote(CG, NAME, AGENT);
+    await store.insert([
+      ...sealEntities([ENTITY_1]),
+      q(assertionUri, `${DKG}sourceFileHash`, '"old-source-hash"', meta),
+    ]);
+
+    const beforeEvents = await lifecycleEventUris(store);
+    expect(beforeEvents.length).toBeGreaterThanOrEqual(2);
+
+    await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+
+    const afterEvents = await lifecycleEventUris(store);
+    for (const eventUri of beforeEvents) {
+      expect(afterEvents).toContain(eventUri);
+    }
+
+    const staleAssertionMeta = await store.query(
+      `ASK { GRAPH <${meta}> {
+         <${assertionUri}> <${DKG}sourceFileHash>|<${DKG}assertionMerkleRoot> ?o
+       } }`,
+    );
+    expect(staleAssertionMeta.type).toBe('boolean');
+    if (staleAssertionMeta.type === 'boolean') {
+      expect(staleAssertionMeta.value).toBe(false);
+    }
+
+    const currentLifecycleState = await store.query(
+      `SELECT ?state ?layer WHERE { GRAPH <${meta}> {
+         <${lifecycleUri}> <${DKG}state> ?state ;
+           <${DKG}memoryLayer> ?layer .
+       } } LIMIT 1`,
+    );
+    expect(currentLifecycleState.type).toBe('bindings');
+    if (currentLifecycleState.type === 'bindings') {
+      expect(currentLifecycleState.bindings[0]['state']).toBe('"created"');
+      expect(currentLifecycleState.bindings[0]['layer']).toBe('"WM"');
+    }
+
+    const draft = await wmQuads(store);
+    expect(draft.some((quad) => quad.subject === ENTITY_1 && quad.object === '"Alice"')).toBe(true);
+  });
+
   it('onConflict:"replace" does not clobber a dirty draft when the source layer is empty', async () => {
     const { publisher, store } = await makePublisher();
     await store.insert(sealEntities([ENTITY_1]));
@@ -152,6 +215,7 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
 
     const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
     expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('PULL_FROM_INVALID_SEAL');
     expect((err as Error).message).toMatch(/invalid assertionRootEntity IRI/i);
     expect(await wmQuads(store)).toHaveLength(0);
   });
@@ -161,6 +225,7 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH)]); // no seal entities
     const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
     expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('PULL_FROM_UNFINALIZED_ASSERTION');
     expect((err as Error).message).toMatch(/no sealed entity list/i);
   });
 });

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -3,9 +3,9 @@ import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   TypedEventBus,
   generateEd25519Keypair,
-  assertionLifecycleUri,
   contextGraphMetaUri,
   contextGraphAssertionUri,
+  buildAssertionSealQuads,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { DKGPublisher } from '../src/index.js';
@@ -25,6 +25,8 @@ const ENTITY_1 = 'urn:e:alice';
 const ENTITY_2 = 'urn:e:bob';
 const SKOLEM_1 = `${ENTITY_1}/.well-known/genid/n1`;
 const OTHER_FILE_ENTITY = 'urn:e:carol-other-file';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const KAV10 = '0x2222222222222222222222222222222222222222';
 
 async function makePublisher() {
   const store = new OxigraphStore();
@@ -41,11 +43,23 @@ function q(subject: string, predicate: string, object: string, graph: string): Q
   return { subject, predicate, object, graph };
 }
 
-/** Seal: record the file's member entities on the lifecycle URN in _meta. */
+/** Seal: record the finalized file's member entities on the assertion URI in _meta. */
 function sealEntities(entities: string[]): Quad[] {
-  const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+  const assertionUri = contextGraphAssertionUri(CG, AGENT, NAME);
   const meta = contextGraphMetaUri(CG);
-  return entities.map((e) => q(lifecycle, `${DKG}assertionRootEntity`, `<${e}>`, meta));
+  return buildAssertionSealQuads({
+    assertionUri,
+    metaGraph: meta,
+    merkleRoot: new Uint8Array(32).fill(0x11),
+    authorAddress: AUTHOR,
+    authorAttestationR: new Uint8Array(32).fill(0x22),
+    authorAttestationVS: new Uint8Array(32).fill(0x33),
+    authorSchemeVersion: 1,
+    chainId: 31337n,
+    kav10Address: KAV10,
+    finalizedAtIso: '2026-06-03T00:00:00.000Z',
+    rootEntities: entities,
+  });
 }
 
 async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
@@ -108,6 +122,38 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     const subjects = new Set(draft.map((d) => d.subject));
     expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
     expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
+  });
+
+  it('onConflict:"replace" does not clobber a dirty draft when the source layer is empty', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert(sealEntities([ENTITY_1]));
+    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_2, predicate: SCHEMA, object: '"local edit"' }]);
+
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('PULL_FROM_EMPTY_SOURCE');
+
+    const draft = await wmQuads(store);
+    expect(draft).toHaveLength(1);
+    expect(draft[0]).toMatchObject({ subject: ENTITY_2, predicate: SCHEMA, object: '"local edit"' });
+  });
+
+  it('rejects unsafe root entities from a corrupted seal before building the source query', async () => {
+    const { publisher, store } = await makePublisher();
+    const corruptedSeal = sealEntities([ENTITY_1]).map((quad) =>
+      quad.predicate === `${DKG}assertionRootEntity`
+        ? { ...quad, object: '"urn:e:bad root"' }
+        : quad,
+    );
+    await store.insert([
+      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
+      ...corruptedSeal,
+    ]);
+
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/invalid assertionRootEntity IRI/i);
+    expect(await wmQuads(store)).toHaveLength(0);
   });
 
   it('throws when the file has no sealed entity list (never finalized)', async () => {

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  TypedEventBus,
+  generateEd25519Keypair,
+  assertionLifecycleUri,
+  contextGraphMetaUri,
+  contextGraphAssertionUri,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGPublisher } from '../src/index.js';
+
+// OT-RFC-43 §10.5.3 — `wm/pull-from` seeds a fresh WM draft from the file's
+// current SWM/VM state. These are store-backed (real OxigraphStore) so the
+// entity-scoped gather + onConflict behavior is exercised end to end.
+
+const CG = 'pull-from-test';
+const AGENT = '0x00000000000000000000000000000000000000a1';
+const NAME = 'meeting-notes';
+const SWM_GRAPH = `did:dkg:context-graph:${CG}/_shared_memory`;
+const SCHEMA = 'http://schema.org/name';
+const DKG = 'http://dkg.io/ontology/';
+
+const ENTITY_1 = 'urn:e:alice';
+const ENTITY_2 = 'urn:e:bob';
+const SKOLEM_1 = `${ENTITY_1}/.well-known/genid/n1`;
+const OTHER_FILE_ENTITY = 'urn:e:carol-other-file';
+
+async function makePublisher() {
+  const store = new OxigraphStore();
+  const publisher = new DKGPublisher({
+    store,
+    chain: new NoChainAdapter(),
+    eventBus: new TypedEventBus(),
+    keypair: await generateEd25519Keypair(),
+  });
+  return { publisher, store };
+}
+
+function q(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
+}
+
+/** Seal: record the file's member entities on the lifecycle URN in _meta. */
+function sealEntities(entities: string[]): Quad[] {
+  const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
+  const meta = contextGraphMetaUri(CG);
+  return entities.map((e) => q(lifecycle, `${DKG}assertionRootEntity`, `<${e}>`, meta));
+}
+
+async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
+  const wm = contextGraphAssertionUri(CG, AGENT, NAME);
+  const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${wm}> { ?s ?p ?o } }`);
+  return r.type === 'quads' ? r.quads : [];
+}
+
+describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
+  it('seeds a WM draft from SWM, scoped to the file\'s sealed entities (+ skolem children)', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert([
+      // this file's entities in SWM
+      q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH),
+      q(SKOLEM_1, SCHEMA, '"Alice detail"', SWM_GRAPH),
+      q(ENTITY_2, SCHEMA, '"Bob"', SWM_GRAPH),
+      // trust/ownership bookkeeping that must NOT land in the draft
+      q(ENTITY_1, `${DKG}workspaceOwner`, '"peer-a"', SWM_GRAPH),
+      // a DIFFERENT file's entity co-resident in the same SWM graph
+      q(OTHER_FILE_ENTITY, SCHEMA, '"Carol"', SWM_GRAPH),
+      ...sealEntities([ENTITY_1, ENTITY_2]),
+    ]);
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm');
+    expect(result.fromLayer).toBe('swm');
+    expect(result.entities).toBe(2);
+
+    const draft = await wmQuads(store);
+    const subjects = new Set(draft.map((d) => d.subject));
+    // the file's entities + skolem child are present...
+    expect(subjects.has(ENTITY_1)).toBe(true);
+    expect(subjects.has(SKOLEM_1)).toBe(true);
+    expect(subjects.has(ENTITY_2)).toBe(true);
+    // ...the co-resident other-file entity is NOT pulled in...
+    expect(subjects.has(OTHER_FILE_ENTITY)).toBe(false);
+    // ...and the workspaceOwner bookkeeping is filtered out.
+    expect(draft.some((d) => d.predicate === `${DKG}workspaceOwner`)).toBe(false);
+  });
+
+  it('rejects with WM_DRAFT_CONFLICT when a draft already exists (default onConflict)', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH), ...sealEntities([ENTITY_1])]);
+    // open + dirty a WM draft
+    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"local edit"' }]);
+
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('WM_DRAFT_CONFLICT');
+  });
+
+  it('onConflict:"replace" overwrites a dirty draft with the source layer', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert([q(ENTITY_2, SCHEMA, '"Bob from SWM"', SWM_GRAPH), ...sealEntities([ENTITY_2])]);
+    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"stale local"' }]);
+
+    const result = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' });
+    expect(result.fromLayer).toBe('swm');
+
+    const draft = await wmQuads(store);
+    const subjects = new Set(draft.map((d) => d.subject));
+    expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
+    expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
+  });
+
+  it('throws when the file has no sealed entity list (never finalized)', async () => {
+    const { publisher, store } = await makePublisher();
+    await store.insert([q(ENTITY_1, SCHEMA, '"Alice"', SWM_GRAPH)]); // no seal entities
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/no sealed entity list/i);
+  });
+});

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'test/verify-proposal-handler.test.ts',
       'test/views-min-trust-extra.test.ts',
       'test/async-promote-queue.test.ts',
+      'test/assertion-pull-from.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## What

The net-new **`wm/pull-from`** primitive for the GitHub-shaped KA API (#971), where it currently returns `501`. It's the `git checkout origin/<branch>` equivalent: WM is the only writable surface, so to edit content already in **SWM** or **VM** you pull it into a fresh WM draft, edit, then re-share / re-publish.

## How

- **`DKGPublisher.assertionPullFrom(cg, name, agent, 'swm'|'vm', opts)`** — reads the file's member entities from the assertion **seal** (lifecycle URN, dual-reading `dkg:assertionRootEntity | dkg:assertionEntity`), gathers the source layer's quads scoped to those entities + their skolemized children (the **same** `?s = <entity> || STRSTARTS(?s, "<entity>/.well-known/genid/")` filter the publish gather and the RS prover use), drops trust/ownership bookkeeping, and seeds a fresh WM draft.
- **`onConflict`** guards a dirty draft: `reject` (default → throws `WM_DRAFT_CONFLICT`) or `replace` (force-checkout).
- **`agent.assertion.pullFrom`** facade; the cli route `POST /api/knowledge-assets/:name/wm/pull-from` calls it (`400` bad layer, `409` conflict).

## Verification

- **Store-backed publisher test (4)** — entity-scoped gather pulls the file's entities + skolem child but **not** a co-resident other-file entity, and filters `workspaceOwner`; reject vs replace conflict; throws when unfinalized.
- **Route test now 12/12** — pull-from success / bad-layer 400 / `WM_DRAFT_CONFLICT` → 409.
- cli closure builds clean.

## Note / follow-up

pull-from reads the entity set from the **last finalize's seal**; re-pulling a draft *before* finalizing it isn't supported (finalize or discard first) — a durable source-layer entity list would lift that constraint if it matters.

**Stacked on #971.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)