### PR TITLE
cli SDK: GitHub-shaped knowledge-assets methods on ApiClient (OT-RFC-43 §10.5)

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -459,6 +459,84 @@ export class ApiClient {
    * went through the legacy `/api/shared-memory/write` (now removed)
    * use this method instead.
    */
+  // ── OT-RFC-43 §10.5 — GitHub-shaped Knowledge Asset SDK ──────────────────
+  // Layer-explicit wrappers over /api/knowledge-assets/... (the new clean
+  // surface). The legacy assertion/* + shared-memory/* methods below remain
+  // for back-compat during the migration window.
+
+  /** Create a KA + open a WM draft (atomic: pass `quads` to auto write+finalize). */
+  async createKnowledgeAsset(
+    contextGraphId: string,
+    name: string,
+    options?: {
+      subGraphName?: string;
+      quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+      authorAgentAddress?: string;
+      alsoShareSwm?: boolean;
+      alsoPublishVm?: boolean | { epochs?: number; tokenAmount?: string };
+    },
+  ): Promise<Record<string, unknown>> {
+    return this.post('/api/knowledge-assets', { contextGraphId, name, ...(options ?? {}) });
+  }
+
+  /** GET a KA's lifecycle state by name. */
+  async getKnowledgeAsset(contextGraphId: string, name: string, subGraphName?: string): Promise<Record<string, unknown>> {
+    const qs = new URLSearchParams({ contextGraphId, ...(subGraphName ? { subGraphName } : {}) }).toString();
+    return this.get(`/api/knowledge-assets/${encodeURIComponent(name)}?${qs}`);
+  }
+
+  /** Append quads to the KA's WM draft. */
+  async knowledgeAssetWrite(
+    contextGraphId: string,
+    name: string,
+    quads: Array<{ subject: string; predicate: string; object: string; graph: string }>,
+    options?: { subGraphName?: string },
+  ): Promise<{ written: number }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/write`, { contextGraphId, quads, ...(options ?? {}) });
+  }
+
+  /** Seal the WM draft (git commit). */
+  async knowledgeAssetFinalize(
+    contextGraphId: string,
+    name: string,
+    options?: { subGraphName?: string; authorAgentAddress?: string },
+  ): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...(options ?? {}) });
+  }
+
+  /** Discard the WM draft. */
+  async knowledgeAssetDiscard(contextGraphId: string, name: string, options?: { subGraphName?: string }): Promise<{ discarded: boolean }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/discard`, { contextGraphId, ...(options ?? {}) });
+  }
+
+  /** Seed a fresh WM draft from the file's SWM/VM state (git checkout). */
+  async knowledgeAssetPullFrom(
+    contextGraphId: string,
+    name: string,
+    layer: 'swm' | 'vm',
+    options?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
+  ): Promise<Record<string, unknown>> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/pull-from`, { contextGraphId, layer, ...(options ?? {}) });
+  }
+
+  /** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
+  async knowledgeAssetShare(
+    contextGraphId: string,
+    name: string,
+    options?: { subGraphName?: string; entities?: string[] | 'all' },
+  ): Promise<{ swmShared: boolean; promotedCount: number }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`, { contextGraphId, ...(options ?? {}) });
+  }
+
+  /** Publish to VM (mint or update on chain; git push origin main). */
+  async knowledgeAssetPublish(
+    contextGraphId: string,
+    name: string,
+    options?: { subGraphName?: string; options?: Record<string, unknown> },
+  ): Promise<Record<string, unknown>> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, { contextGraphId, ...(options ?? {}) });
+  }
+
   async createAssertion(
     contextGraphId: string,
     name: string,

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -8,6 +8,35 @@ export type QueryResult =
   | { type: 'boolean'; value: boolean }
   | { type?: undefined; [key: string]: unknown };
 
+export interface PreSignedAuthorAttestationPayload {
+  address: string;
+  signature: { r: string; vs: string };
+}
+
+export interface KnowledgeAssetFinalizedPublishOptions {
+  /**
+   * SDK-friendly spelling for the finalized publish cleanup flag. The
+   * knowledge-assets daemon route forwards `clearSharedMemoryAfter` to
+   * `publishFromFinalizedAssertion`, so the client translates before POST.
+   */
+  clearAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint;
+}
+
+function finalizedPublishOptionsPayload(
+  options?: KnowledgeAssetFinalizedPublishOptions,
+): Record<string, unknown> | undefined {
+  if (!options) return undefined;
+  const payload: Record<string, unknown> = {};
+  if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
+  if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
+  if (options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
 /**
  * Response shape for `/api/random-sampling/status`. Mirrors
  * `RandomSamplingStatus` from `@origintrail-official/dkg-agent` but
@@ -472,11 +501,17 @@ export class ApiClient {
       subGraphName?: string;
       quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
       authorAgentAddress?: string;
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+      schemeVersion?: number;
       alsoShareSwm?: boolean;
-      alsoPublishVm?: boolean | { epochs?: number; tokenAmount?: string };
+      alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
     },
   ): Promise<Record<string, unknown>> {
-    return this.post('/api/knowledge-assets', { contextGraphId, name, ...(options ?? {}) });
+    const payload: Record<string, unknown> = { contextGraphId, name, ...(options ?? {}) };
+    if (options?.alsoPublishVm && typeof options.alsoPublishVm === 'object') {
+      payload.alsoPublishVm = finalizedPublishOptionsPayload(options.alsoPublishVm) ?? {};
+    }
+    return this.post('/api/knowledge-assets', payload);
   }
 
   /** GET a KA's lifecycle state by name. */
@@ -499,7 +534,12 @@ export class ApiClient {
   async knowledgeAssetFinalize(
     contextGraphId: string,
     name: string,
-    options?: { subGraphName?: string; authorAgentAddress?: string },
+    options?: {
+      subGraphName?: string;
+      authorAgentAddress?: string;
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+      schemeVersion?: number;
+    },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, { contextGraphId, ...(options ?? {}) });
   }
@@ -532,9 +572,14 @@ export class ApiClient {
   async knowledgeAssetPublish(
     contextGraphId: string,
     name: string,
-    options?: { subGraphName?: string; options?: Record<string, unknown> },
+    options?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<Record<string, unknown>> {
-    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, { contextGraphId, ...(options ?? {}) });
+    const publishOptions = finalizedPublishOptionsPayload(options);
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
+      contextGraphId,
+      ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
+      ...(publishOptions ? { options: publishOptions } : {}),
+    });
   }
 
   async createAssertion(
@@ -546,10 +591,7 @@ export class ApiClient {
       finalize?: boolean;
       promote?: boolean;
       authorAgentAddress?: string;
-      preSignedAuthorAttestation?: {
-        address: string;
-        signature: { r: string; vs: string };
-      };
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;
     },
   ): Promise<{
@@ -615,10 +657,7 @@ export class ApiClient {
     options?: {
       subGraphName?: string;
       authorAgentAddress?: string;
-      preSignedAuthorAttestation?: {
-        address: string;
-        signature: { r: string; vs: string };
-      };
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;
     },
   ): Promise<{
@@ -704,10 +743,7 @@ export class ApiClient {
     options?: {
       subGraphName?: string;
       authorAgentAddress?: string;
-      preSignedAuthorAttestation?: {
-        address: string;
-        signature: { r: string; vs: string };
-      };
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;
       clearAfter?: boolean;
       publishEpochs?: number;

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -539,11 +539,61 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(sent.quads).toHaveLength(1);
   });
 
+  it('createKnowledgeAsset normalizes finalized publish and author seal options', async () => {
+    const calls = track({ name: 'f', status: 'vm-confirmed' });
+    const preSignedAuthorAttestation = {
+      address: '0x1111111111111111111111111111111111111111',
+      signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+    };
+    await client.createKnowledgeAsset('cg', 'f', {
+      quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }],
+      preSignedAuthorAttestation,
+      schemeVersion: 2,
+      alsoPublishVm: {
+        clearAfter: false,
+        publishEpochs: 9,
+        publisherNodeIdentityIdOverride: 7n,
+      },
+    });
+    const sent = JSON.parse(calls[0].opts.body as string);
+    expect(sent).toMatchObject({
+      contextGraphId: 'cg',
+      name: 'f',
+      preSignedAuthorAttestation,
+      schemeVersion: 2,
+      alsoPublishVm: {
+        clearSharedMemoryAfter: false,
+        publishEpochs: 9,
+        publisherNodeIdentityIdOverride: '7',
+      },
+    });
+    expect(sent.alsoPublishVm).not.toHaveProperty('epochs');
+    expect(sent.alsoPublishVm).not.toHaveProperty('tokenAmount');
+  });
+
   it('knowledgeAssetWrite POSTs to .../:name/wm/write (name URL-encoded)', async () => {
     const calls = track({ written: 1 });
     await client.knowledgeAssetWrite('cg', 'meeting notes', [{ subject: 's', predicate: 'p', object: 'o', graph: '' }]);
     expect(calls[0].url).toBe(`${base}/api/knowledge-assets/meeting%20notes/wm/write`);
     expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({ contextGraphId: 'cg' });
+  });
+
+  it('knowledgeAssetFinalize sends pre-signed author attestation and scheme version', async () => {
+    const calls = track({ merkleRoot: '0xabc', eip712Digest: '0xdig' });
+    const preSignedAuthorAttestation = {
+      address: '0x1111111111111111111111111111111111111111',
+      signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+    };
+    await client.knowledgeAssetFinalize('cg', 'f', {
+      preSignedAuthorAttestation,
+      schemeVersion: 2,
+    });
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/wm/finalize`);
+    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({
+      contextGraphId: 'cg',
+      preSignedAuthorAttestation,
+      schemeVersion: 2,
+    });
   });
 
   it('knowledgeAssetShare → swm/share, knowledgeAssetPublish → vm/publish', async () => {
@@ -552,8 +602,22 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/swm/share`);
 
     calls = track({ kaId: '7', status: 'confirmed' });
-    await client.knowledgeAssetPublish('cg', 'f');
+    await client.knowledgeAssetPublish('cg', 'f', {
+      subGraphName: 'notes',
+      clearAfter: true,
+      publishEpochs: 12,
+      publisherNodeIdentityIdOverride: 123n,
+    });
     expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/vm/publish`);
+    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({
+      contextGraphId: 'cg',
+      subGraphName: 'notes',
+      options: {
+        clearSharedMemoryAfter: true,
+        publishEpochs: 12,
+        publisherNodeIdentityIdOverride: '123',
+      },
+    });
   });
 
   it('knowledgeAssetPullFrom sends layer + onConflict', async () => {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -515,3 +515,57 @@ describe('ApiClient', () => {
     });
   });
 });
+
+describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ApiClient;
+  const base = `http://127.0.0.1:${PORT}`;
+  beforeEach(() => { client = new ApiClient(PORT, 'test-token'); });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  function track(body: unknown = { ok: true }) {
+    const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body });
+    globalThis.fetch = fetch;
+    return calls;
+  }
+
+  it('createKnowledgeAsset POSTs to /api/knowledge-assets', async () => {
+    const calls = track({ name: 'f', status: 'wm-sealed' });
+    await client.createKnowledgeAsset('cg', 'f', { quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }], alsoShareSwm: true });
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets`);
+    expect(calls[0].opts.method).toBe('POST');
+    const sent = JSON.parse(calls[0].opts.body as string);
+    expect(sent).toMatchObject({ contextGraphId: 'cg', name: 'f', alsoShareSwm: true });
+    expect(sent.quads).toHaveLength(1);
+  });
+
+  it('knowledgeAssetWrite POSTs to .../:name/wm/write (name URL-encoded)', async () => {
+    const calls = track({ written: 1 });
+    await client.knowledgeAssetWrite('cg', 'meeting notes', [{ subject: 's', predicate: 'p', object: 'o', graph: '' }]);
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/meeting%20notes/wm/write`);
+    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({ contextGraphId: 'cg' });
+  });
+
+  it('knowledgeAssetShare → swm/share, knowledgeAssetPublish → vm/publish', async () => {
+    let calls = track({ swmShared: true, promotedCount: 2 });
+    await client.knowledgeAssetShare('cg', 'f');
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/swm/share`);
+
+    calls = track({ kaId: '7', status: 'confirmed' });
+    await client.knowledgeAssetPublish('cg', 'f');
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/vm/publish`);
+  });
+
+  it('knowledgeAssetPullFrom sends layer + onConflict', async () => {
+    const calls = track({ wmDraft: 'open' });
+    await client.knowledgeAssetPullFrom('cg', 'f', 'vm', { onConflict: 'replace' });
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/wm/pull-from`);
+    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({ contextGraphId: 'cg', layer: 'vm', onConflict: 'replace' });
+  });
+
+  it('getKnowledgeAsset GETs .../:name?contextGraphId=', async () => {
+    const calls = track({ state: 'created' });
+    await client.getKnowledgeAsset('cg', 'f');
+    expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f?contextGraphId=cg`);
+  });
+});


### PR DESCRIPTION
## What

Additive client SDK for the new `/api/knowledge-assets` surface (#971 + #972). The canonical cli `ApiClient` gains layer-explicit methods so callers can drive the clean API; the legacy `assertion/*` + `shared-memory/*` methods are **untouched** for back-compat during the migration window.

```ts
createKnowledgeAsset(cg, name, { quads?, authorAgentAddress?, alsoShareSwm?, alsoPublishVm? })
getKnowledgeAsset(cg, name)                         // GET  /api/knowledge-assets/:name
knowledgeAssetWrite / Finalize / Discard / PullFrom // .../wm/*
knowledgeAssetShare                                 // .../swm/share
knowledgeAssetPublish                               // .../vm/publish
```

## Verification

cli builds clean; **5 fetch-mocked SDK tests** assert URL + method + body: atomic create (quads + `alsoShareSwm`), URL-encoded name on write, `share`→`swm/share`, `publish`→`vm/publish`, `pull-from` layer + `onConflict`, GET with `contextGraphId` query.

## Follow-ups

Migrate the remaining clients (`mcp-dkg`, `adapter-openclaw`/`-hermes`, `node-ui`) to these methods, and add **308 redirects** from the legacy routes — both separate PRs.

**Stacked on #972.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)