### PR TITLE
feat(evm): OT-RFC-43 Option-1 deterministic author-namespaced KA identity — variant 1a (Plan B B1)

### DIFF
--- a/packages/chain/abi/DKGKnowledgeAssets.json
+++ b/packages/chain/abi/DKGKnowledgeAssets.json
@@ -942,11 +942,6 @@
         "type": "address"
       },
       {
-        "internalType": "uint256",
-        "name": "kaId",
-        "type": "uint256"
-      },
-      {
         "internalType": "string",
         "name": "publishOperationId",
         "type": "string"
@@ -990,6 +985,11 @@
         "internalType": "uint32",
         "name": "merkleLeafCount",
         "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
       }
     ],
     "name": "createKnowledgeAsset",

--- a/packages/chain/abi/DKGKnowledgeAssets.json
+++ b/packages/chain/abi/DKGKnowledgeAssets.json
@@ -188,6 +188,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "GetLatestKnowledgeAssetIdDeprecated",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -196,6 +201,33 @@
       }
     ],
     "name": "InvalidTokenContract",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "KaIdAlreadyMinted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      }
+    ],
+    "name": "KaIdNamespaceMismatch",
     "type": "error"
   },
   {
@@ -910,6 +942,11 @@
         "type": "address"
       },
       {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      },
+      {
         "internalType": "string",
         "name": "publishOperationId",
         "type": "string"
@@ -1392,7 +1429,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/chain/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/chain/abi/KnowledgeAssetsLifecycle.json
@@ -651,11 +651,6 @@
             "type": "uint8"
           },
           {
-            "internalType": "uint256",
-            "name": "reservedKaId",
-            "type": "uint256"
-          },
-          {
             "internalType": "uint72[]",
             "name": "identityIds",
             "type": "uint72[]"
@@ -669,6 +664,11 @@
             "internalType": "bytes32[]",
             "name": "vs",
             "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reservedKaId",
+            "type": "uint256"
           }
         ],
         "internalType": "struct KnowledgeAssetsLifecycle.PublishParams",

--- a/packages/chain/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/chain/abi/KnowledgeAssetsLifecycle.json
@@ -651,6 +651,11 @@
             "type": "uint8"
           },
           {
+            "internalType": "uint256",
+            "name": "reservedKaId",
+            "type": "uint256"
+          },
+          {
             "internalType": "uint72[]",
             "name": "identityIds",
             "type": "uint72[]"

--- a/packages/evm-module/abi/DKGKnowledgeAssets.json
+++ b/packages/evm-module/abi/DKGKnowledgeAssets.json
@@ -942,11 +942,6 @@
         "type": "address"
       },
       {
-        "internalType": "uint256",
-        "name": "kaId",
-        "type": "uint256"
-      },
-      {
         "internalType": "string",
         "name": "publishOperationId",
         "type": "string"
@@ -990,6 +985,11 @@
         "internalType": "uint32",
         "name": "merkleLeafCount",
         "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
       }
     ],
     "name": "createKnowledgeAsset",

--- a/packages/evm-module/abi/DKGKnowledgeAssets.json
+++ b/packages/evm-module/abi/DKGKnowledgeAssets.json
@@ -188,6 +188,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "GetLatestKnowledgeAssetIdDeprecated",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -196,6 +201,33 @@
       }
     ],
     "name": "InvalidTokenContract",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "KaIdAlreadyMinted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      }
+    ],
+    "name": "KaIdNamespaceMismatch",
     "type": "error"
   },
   {
@@ -910,6 +942,11 @@
         "type": "address"
       },
       {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      },
+      {
         "internalType": "string",
         "name": "publishOperationId",
         "type": "string"
@@ -1392,7 +1429,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
@@ -651,11 +651,6 @@
             "type": "uint8"
           },
           {
-            "internalType": "uint256",
-            "name": "reservedKaId",
-            "type": "uint256"
-          },
-          {
             "internalType": "uint72[]",
             "name": "identityIds",
             "type": "uint72[]"
@@ -669,6 +664,11 @@
             "internalType": "bytes32[]",
             "name": "vs",
             "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reservedKaId",
+            "type": "uint256"
           }
         ],
         "internalType": "struct KnowledgeAssetsLifecycle.PublishParams",

--- a/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
@@ -651,6 +651,11 @@
             "type": "uint8"
           },
           {
+            "internalType": "uint256",
+            "name": "reservedKaId",
+            "type": "uint256"
+          },
+          {
             "internalType": "uint72[]",
             "name": "identityIds",
             "type": "uint72[]"

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -166,6 +166,10 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         bytes32 authorR;
         bytes32 authorVS;
         uint8   authorSchemeVersion;
+        // ── ACK quorum (unchanged) ──
+        uint72[] identityIds;
+        bytes32[] r;
+        bytes32[] vs;
         // ── OT-RFC-43 Option 1 (variant 1a): caller-supplied deterministic id ──
         /// @notice The packed KA id this publish claims:
         ///         kaId = (uint160(authorAddress) << 96) | uint96(number),
@@ -173,15 +177,28 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         ///         `(reservedKaId >> 96) == authorAddress` at mint, so a wallet
         ///         can only mint within its own namespace. REQUIRED — there is
         ///         no auto-mint fallback under 1a; a value outside the author's
-        ///         namespace reverts `KaIdNamespaceMismatch`. Deliberately NOT
-        ///         added to the ACK digest: the namespace is enforced on-chain
-        ///         and choosing a different number within one's own namespace is
-        ///         harmless (OT-RFC-43; see PR description / R5 decision).
+        ///         namespace reverts `KaIdNamespaceMismatch`.
+        ///
+        ///         **ABI layout (codex PR #975 F1):** appended at the END of
+        ///         the struct rather than threaded between the author and ACK
+        ///         blocks. Existing callers encoding the previous tuple shape
+        ///         then fail loudly with "missing field" on tuple decode rather
+        ///         than silently shifting `identityIds`/`r`/`vs` into the wrong
+        ///         slots and either reverting on a garbled ACK quorum or — far
+        ///         worse — verifying garbage. Required by `kcs.createKnowledgeAsset`
+        ///         (no fallback under 1a), so the failure mode is "missing"
+        ///         either way; the layout choice makes it the diagnosable kind.
+        ///
+        ///         **Signature scope (codex PR #975 F2):** IS bound into the
+        ///         author EIP-712 digest (`AuthorAttestation`), so a relayer /
+        ///         PCA agent cannot substitute a different number within the
+        ///         author's namespace without invalidating the author's
+        ///         signature — closes the multi-publisher slot-substitution
+        ///         gap. Deliberately NOT included in the ACK quorum digest:
+        ///         storage nodes consent to the assertion's content (merkle +
+        ///         economics), not to which slot it lands in; that's the
+        ///         author's decision, signed over by the author.
         uint256 reservedKaId;
-        // ── ACK quorum (unchanged) ──
-        uint72[] identityIds;
-        bytes32[] r;
-        bytes32[] vs;
     }
 
     /**
@@ -302,11 +319,22 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     ///      magic value other than `0x1626ba7e`.
     error InvalidAuthorSignature1271();
 
-    /// @dev RFC-001 §3.2 — EIP-712 type hash for `AuthorAttestation`.
-    /// `keccak256("AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion)")`.
+    /// @dev RFC-001 §3.2 / OT-RFC-43 Option 1 (codex PR #975 F2) — EIP-712
+    /// type hash for `AuthorAttestation`.
+    /// `keccak256("AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion,uint256 reservedKaId)")`.
+    ///
+    /// `reservedKaId` is bound into the author's signature so a relayer / PCA
+    /// agent cannot substitute a different number within the author's
+    /// namespace (e.g. mint at `(author, 99)` when the author reserved
+    /// `(author, 7)` off-chain). The on-chain namespace check protects against
+    /// CROSS-namespace mints; this binding protects against WITHIN-namespace
+    /// slot substitution by a third-party publisher. Self-publish is unaffected
+    /// (the author is both signer and publisher). The typehash differs from
+    /// the pre-1a shape — any cached old-form signature will fail recovery,
+    /// which is the intended behavior (no silent cross-version replay).
     bytes32 private constant _AUTHOR_ATTESTATION_TYPEHASH =
         keccak256(
-            "AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion)"
+            "AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion,uint256 reservedKaId)"
         );
 
     bytes32 private constant _UPDATE_AUTHOR_ATTESTATION_TYPEHASH =
@@ -660,7 +688,6 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         kaId = kcs.createKnowledgeAsset(
             msg.sender,
             p.authorAddress,
-            p.reservedKaId,
             p.publishOperationId,
             p.merkleRoot,
             p.knowledgeAssetsAmount,
@@ -669,7 +696,12 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
             currentEpoch + p.epochs,
             p.tokenAmount,
             p.isImmutable,
-            p.merkleLeafCount
+            p.merkleLeafCount,
+            // OT-RFC-43 Option 1 (variant 1a, codex PR #975 F1): caller-supplied
+            // packed kaId. Appended at the END of the parameter list (mirrors
+            // the PublishParams struct ordering) so the function selector
+            // remains stable-ish under append-only evolution.
+            p.reservedKaId
         );
 
         // --- 3b. RFC-39 Phase A.5: persist the curated ciphertext commitment ---
@@ -865,7 +897,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         uint256 _contextGraphId,
         bytes32 _merkleRoot,
         address _authorAddress,
-        uint8 _schemeVersion
+        uint8 _schemeVersion,
+        uint256 _reservedKaId
     ) internal view returns (bytes32) {
         bytes32 domainSeparator = keccak256(
             abi.encode(
@@ -882,7 +915,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                 _contextGraphId,
                 _merkleRoot,
                 _authorAddress,
-                _schemeVersion
+                _schemeVersion,
+                _reservedKaId
             )
         );
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -975,7 +1009,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
             p.contextGraphId,
             p.merkleRoot,
             p.authorAddress,
-            p.authorSchemeVersion
+            p.authorSchemeVersion,
+            p.reservedKaId
         );
 
         if (p.authorAddress.code.length == 0) {

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -166,6 +166,18 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         bytes32 authorR;
         bytes32 authorVS;
         uint8   authorSchemeVersion;
+        // ── OT-RFC-43 Option 1 (variant 1a): caller-supplied deterministic id ──
+        /// @notice The packed KA id this publish claims:
+        ///         kaId = (uint160(authorAddress) << 96) | uint96(number),
+        ///         pre-allocated off-chain (the reserved UAL). KCS enforces
+        ///         `(reservedKaId >> 96) == authorAddress` at mint, so a wallet
+        ///         can only mint within its own namespace. REQUIRED — there is
+        ///         no auto-mint fallback under 1a; a value outside the author's
+        ///         namespace reverts `KaIdNamespaceMismatch`. Deliberately NOT
+        ///         added to the ACK digest: the namespace is enforced on-chain
+        ///         and choosing a different number within one's own namespace is
+        ///         harmless (OT-RFC-43; see PR description / R5 decision).
+        uint256 reservedKaId;
         // ── ACK quorum (unchanged) ──
         uint72[] identityIds;
         bytes32[] r;
@@ -648,6 +660,7 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         kaId = kcs.createKnowledgeAsset(
             msg.sender,
             p.authorAddress,
+            p.reservedKaId,
             p.publishOperationId,
             p.merkleRoot,
             p.knowledgeAssetsAmount,

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -201,7 +201,6 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     function createKnowledgeAsset(
         address publisher,
         address author,
-        uint256 kaId,
         string calldata publishOperationId,
         bytes32 merkleRoot,
         uint256 knowledgeAssetsAmount,
@@ -210,7 +209,17 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
         uint40 endEpoch,
         uint96 tokenAmount,
         bool isImmutable,
-        uint32 merkleLeafCount
+        uint32 merkleLeafCount,
+        // OT-RFC-43 Option 1 (variant 1a, codex PR #975 F1): caller-supplied
+        // packed kaId. Appended at the END of the parameter list rather than
+        // threaded between `author` and `publishOperationId` so existing ABI
+        // encoders fail loudly on "missing argument" instead of silently
+        // shifting later args (publishOperationId, merkleRoot, ...) one slot
+        // and either reverting on a garbled call or — far worse — minting
+        // under the wrong economics. Required (no fallback under 1a), so the
+        // failure mode is "missing argument" either way; the position choice
+        // makes it the diagnosable kind.
+        uint256 kaId
     ) external onlyContracts returns (uint256) {
         if (knowledgeAssetsAmount != 1) {
             revert KnowledgeAssetLib.ExceededKnowledgeAssetBatchSize(0, 0, knowledgeAssetsAmount, 1);

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -70,6 +70,19 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
         uint32 ciphertextChunkCount
     );
 
+    // --- OT-RFC-43 Option 1 (variant 1a) errors ---
+    /// @notice The supplied packed `kaId`'s high 160 bits (`kaId >> 96`) do not
+    ///         equal the attested author. A wallet may only mint KAs within its
+    ///         own namespace (OT-RFC-43 §4).
+    error KaIdNamespaceMismatch(uint256 kaId, address author);
+    /// @notice The supplied (author, number) packs to a `kaId` that is already
+    ///         minted — a re-used reservation. Never a silent clobber.
+    error KaIdAlreadyMinted(uint256 kaId);
+    /// @notice `getLatestKnowledgeAssetId` is deprecated under Option 1 — ids
+    ///         are packed (author<<96)|number and not globally sequential, so a
+    ///         single "latest id" is meaningless.
+    error GetLatestKnowledgeAssetIdDeprecated();
+
     string private constant _NAME = "DKGKnowledgeAssets";
     string private constant _VERSION = "2.0.0";
 
@@ -77,7 +90,15 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
 
     uint256 public immutable KNOWLEDGE_ASSET_BATCH_MAX_SIZE;
 
-    uint256 private _knowledgeAssetsCounter;
+    // OT-RFC-43 Option 1 (variant 1a): the global auto-increment id counter is
+    // retired — KA ids are now caller-supplied packed (author<<96)|number values
+    // minted in `createKnowledgeAsset`. This storage SLOT is retained (renamed,
+    // never written) so the layout of every field below is unchanged whether
+    // this contract is freshly deployed OR upgraded in place (R3 — proxy-vs-
+    // redeploy is unresolved; keeping the gap is safe under both). Do not
+    // repurpose without resolving R3.
+    // slither-disable-next-line unused-state
+    uint256 private __deprecated_knowledgeAssetsCounter;
     uint256 private _totalMintedKnowledgeAssetsCounter;
     // V10 retired burn semantics — `burnKnowledgeAssetsTokens` is a
     // `pure` revert stub — so this counter is intentionally never
@@ -180,6 +201,7 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     function createKnowledgeAsset(
         address publisher,
         address author,
+        uint256 kaId,
         string calldata publishOperationId,
         bytes32 merkleRoot,
         uint256 knowledgeAssetsAmount,
@@ -194,18 +216,53 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
             revert KnowledgeAssetLib.ExceededKnowledgeAssetBatchSize(0, 0, knowledgeAssetsAmount, 1);
         }
 
-        uint256 knowledgeAssetId = ++_knowledgeAssetsCounter;
+        // OT-RFC-43 Option 1 (variant 1a): the KA id is supplied by the caller
+        // (the off-chain allocator) as a deterministic packed value
+        // kaId = (uint160(author) << 96) | uint96(number). The high 160 bits
+        // MUST equal the attested author, so a wallet can only mint within its
+        // own namespace. Unforgeable: `author` is proven by the EIP-712
+        // attestation in `KnowledgeAssetsLifecycle._verifyAuthorAttestation`
+        // before this call. NB: the namespace binds to the attested AUTHOR
+        // (EIP-712 signer / initial NFT owner), a deliberate divergence from
+        // OT-RFC-43 §7's `msg.sender`/publisher diagram — the two coincide in
+        // the dominant self-publish case. The global `++_knowledgeAssetsCounter`
+        // is removed under 1a (packed-only; no post-tx canonical id).
+        if ((kaId >> 96) != uint256(uint160(author))) {
+            revert KaIdNamespaceMismatch(kaId, author);
+        }
+        // Fail fast on a re-used (author, number): the id must not already be
+        // minted. `_safeMint` below would also revert, but checking here keeps
+        // checks-effects-interactions ordering (no state mutation before the
+        // guard) and surfaces a precise error. `kaId` is guaranteed non-zero
+        // because `author != address(0)` (enforced upstream), so the `0`
+        // sentinel used by `getKnowledgeAssetId` / `isPartOfKnowledgeAsset` is
+        // never produced here.
+        if (_ownerOf(kaId) != address(0)) {
+            revert KaIdAlreadyMinted(kaId);
+        }
+        // Defense-in-depth (audit hardening): assert the KA struct slot is
+        // pristine, not merely unowned. `_ownerOf` proves the token was never
+        // minted, but `onlyContracts` setters (`setMerkleRoots` / `pushMerkleRoot`)
+        // could in principle pre-seed `knowledgeAssets[kaId]` for an unminted id,
+        // which would make the index-0 `merkleRootAuthors` write below land at the
+        // wrong index. Under the retired `++_knowledgeAssetsCounter` scheme a fresh
+        // id was structurally never-touched; with caller-supplied ids we assert it.
+        if (knowledgeAssets[kaId].merkleRoots.length != 0) {
+            revert KaIdAlreadyMinted(kaId);
+        }
+
+        uint256 knowledgeAssetId = kaId;
 
         KnowledgeAssetLib.KnowledgeAsset storage kc = knowledgeAssets[knowledgeAssetId];
 
         kc.merkleRoots.push(
             KnowledgeAssetLib.MerkleRoot(publisher, merkleRoot, block.timestamp)
         );
-        // Unconditional write to overwrite any value at this slot.
-        // For `createKnowledgeAsset` the kaId is freshly minted so
-        // the slot is guaranteed empty; the unconditional shape is kept
-        // for parity with `updateKnowledgeAsset` below, where the
-        // index can have been previously used (post-pop).
+        // First root of a fresh KA — index 0. `kaId` was just proven unminted
+        // above (and `_safeMint` re-enforces it), so this parallel slot is
+        // empty; the unconditional shape is kept for parity with
+        // `updateKnowledgeAsset` below, where the index can have been
+        // previously used (post-pop).
         merkleRootAuthors[knowledgeAssetId][kc.merkleRoots.length - 1] = author;
         kc.byteSize = byteSize;
         kc.startEpoch = startEpoch;
@@ -618,8 +675,12 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
         emit KnowledgeAssetEndEpochUpdated(id, _endEpoch);
     }
 
-    function getLatestKnowledgeAssetId() external view returns (uint256) {
-        return _knowledgeAssetsCounter;
+    /// @notice DEPRECATED under OT-RFC-43 Option 1 (variant 1a). KA ids are
+    ///         packed (author<<96)|number values, not globally sequential, so a
+    ///         single "latest id" is meaningless. Always reverts — enumerate
+    ///         KAs via the `KnowledgeAssetCreated` event (or per-CG lists).
+    function getLatestKnowledgeAssetId() external pure returns (uint256) {
+        revert GetLatestKnowledgeAssetIdDeprecated();
     }
 
     function currentTotalSupply() external view returns (uint256) {

--- a/packages/evm-module/test/helpers/v10-kc-helpers.ts
+++ b/packages/evm-module/test/helpers/v10-kc-helpers.ts
@@ -32,12 +32,20 @@ import { KnowledgeAssetsLifecycle } from '../../typechain';
  *   || keccak256(abi.encodePacked(knowledgeAssetsToBurn))
  *   || uint256(newMerkleLeafCount)
  *
- * Author attestation (RFC-001) — EIP-712 typed data:
+ * Author attestation (RFC-001 + OT-RFC-43 Option 1, codex PR #975 F2) —
+ * EIP-712 typed data:
  *   domain   = EIP712Domain(name="KnowledgeAssetsLifecycle", version="2.0.0",
  *                           chainId, verifyingContract=KAV10)
  *   struct   = AuthorAttestation(uint256 contextGraphId, bytes32 merkleRoot,
- *                                address authorAddress, uint8 schemeVersion)
+ *                                address authorAddress, uint8 schemeVersion,
+ *                                uint256 reservedKaId)
  *   schemeVersion = 1 (only currently-supported scheme)
+ *
+ * `reservedKaId` is bound into the author's signature so a relayer / PCA
+ * agent cannot mint at a different number within the author's namespace
+ * than the author actually reserved. The on-chain namespace check covers
+ * CROSS-namespace mints; this binding covers WITHIN-namespace slot
+ * substitution by a third-party publisher.
  *
  * The author attestation digest is built and signed via ethers'
  * `signTypedData` for byte-equality with the contract's
@@ -102,6 +110,7 @@ export type AuthorAttestationPayload = {
     merkleRoot: string;
     authorAddress: string;
     schemeVersion: number;
+    reservedKaId: bigint;
   };
 };
 
@@ -112,8 +121,8 @@ export type AuthorAttestationPayload = {
  *   name="KnowledgeAssetsLifecycle", version="2.0.0", chainId, verifyingContract.
  *
  * The struct hash binds (contextGraphId, merkleRoot, authorAddress,
- * schemeVersion). Drift between this builder and the contract will surface
- * as `InvalidAuthorSignature` at publish time.
+ * schemeVersion, reservedKaId). Drift between this builder and the contract
+ * will surface as `InvalidAuthorSignature` at publish time.
  */
 export function buildAuthorAttestationPayload(args: {
   chainId: bigint;
@@ -121,6 +130,13 @@ export function buildAuthorAttestationPayload(args: {
   contextGraphId: bigint;
   merkleRoot: string;
   authorAddress: string;
+  /**
+   * OT-RFC-43 Option 1 (variant 1a, codex PR #975 F2): the packed
+   * caller-supplied kaId this publish claims. Bound into the author's
+   * signature so a relayer / PCA agent cannot substitute a different
+   * number within the author's namespace.
+   */
+  reservedKaId: bigint;
   schemeVersion?: number;
 }): AuthorAttestationPayload {
   const schemeVersion = args.schemeVersion ?? AUTHOR_SCHEME_VERSION_V1;
@@ -137,6 +153,7 @@ export function buildAuthorAttestationPayload(args: {
         { name: 'merkleRoot', type: 'bytes32' },
         { name: 'authorAddress', type: 'address' },
         { name: 'schemeVersion', type: 'uint8' },
+        { name: 'reservedKaId', type: 'uint256' },
       ],
     },
     value: {
@@ -144,6 +161,7 @@ export function buildAuthorAttestationPayload(args: {
       merkleRoot: args.merkleRoot,
       authorAddress: ethers.getAddress(args.authorAddress),
       schemeVersion,
+      reservedKaId: args.reservedKaId,
     },
   };
 }
@@ -346,8 +364,18 @@ export async function buildPublishParams(args: {
    * Defaults to a freshly-allocated, never-reused id in the author's namespace
    * (`nextReservedKaId(author.address)`). Negative-path / collision tests pass
    * an explicit value (e.g. a wrong-namespace id, or a deliberately reused
-   * `reservedKaId`). NB: deliberately NOT part of the ACK digest — the
-   * namespace is enforced on-chain, not signed over.
+   * `reservedKaId`).
+   *
+   * Signature scope (codex PR #975 F2): IS part of the author EIP-712 digest
+   * (so a relayer / PCA agent cannot substitute a different slot within the
+   * author's namespace without invalidating the author's signature). NOT part
+   * of the ACK quorum digest — storage nodes consent to assertion content
+   * (merkle + economics), not to which slot it lands in.
+   *
+   * NB: when overriding `authorSigOverride` AND `reservedKaId`, the override
+   * signature MUST have been built against this exact `reservedKaId` value
+   * (and the same merkle / cg / scheme), otherwise verification reverts
+   * `InvalidAuthorSignature` even though the override was the intent.
    */
   reservedKaId?: bigint;
   /**
@@ -392,6 +420,13 @@ export async function buildPublishParams(args: {
   );
 
   const schemeVersion = args.authorSchemeVersion ?? AUTHOR_SCHEME_VERSION_V1;
+  // OT-RFC-43 Option 1 (1a, codex PR #975 F2): the packed kaId is bound into
+  // the author's EIP-712 signature, so it must be resolved BEFORE the author
+  // signs (no later overrides). Defaults to a fresh, never-used number in the
+  // author's namespace; pinned/reused values come through `args.reservedKaId`
+  // for collision / negative tests.
+  const reservedKaId =
+    args.reservedKaId ?? nextReservedKaId(args.author.address);
   const authorSig =
     args.authorSigOverride ??
     (await signAuthorAttestation(
@@ -402,6 +437,7 @@ export async function buildPublishParams(args: {
         contextGraphId: args.contextGraphId,
         merkleRoot: args.merkleRoot,
         authorAddress: args.author.address,
+        reservedKaId,
         schemeVersion,
       }),
     ));
@@ -423,13 +459,13 @@ export async function buildPublishParams(args: {
     authorR: authorSig.authorR,
     authorVS: authorSig.authorVS,
     authorSchemeVersion: schemeVersion,
-    // OT-RFC-43 Option 1 (1a): author-namespaced packed id. Defaults to a
-    // fresh, unused number in the author's namespace; pinned/reused values
-    // come through `args.reservedKaId` for collision / negative tests.
-    reservedKaId: args.reservedKaId ?? nextReservedKaId(args.author.address),
     identityIds: args.receiverIdentityIds,
     r: sig.receiverRs,
     vs: sig.receiverVSs,
+    // OT-RFC-43 Option 1 (1a, codex PR #975 F1): appended at the END of the
+    // returned struct to mirror the `PublishParams` Solidity field order
+    // (see ABI-layout rationale in `KnowledgeAssetsLifecycle.sol`).
+    reservedKaId,
   };
 }
 

--- a/packages/evm-module/test/helpers/v10-kc-helpers.ts
+++ b/packages/evm-module/test/helpers/v10-kc-helpers.ts
@@ -48,6 +48,42 @@ export const DEFAULT_CHAIN_ID = 31337n;
 
 export const AUTHOR_SCHEME_VERSION_V1 = 1;
 
+/**
+ * OT-RFC-43 Option 1 (variant 1a) — pack a deterministic, author-namespaced
+ * KA id. The high 160 bits MUST be the AUTHOR (the EIP-712 attestation signer
+ * / NFT mint recipient), NOT the publisher / msg.sender. The contract enforces
+ * `(reservedKaId >> 96) == uint160(authorAddress)` at mint, so a value built
+ * for the wrong author reverts `KaIdNamespaceMismatch`.
+ *
+ *   kaId = (uint160(authorAddress) << 96) | uint96(number)
+ */
+export function packReservedKaId(
+  authorAddress: string,
+  num: number | bigint,
+): bigint {
+  return (BigInt(ethers.getAddress(authorAddress)) << 96n) | BigInt(num);
+}
+
+/**
+ * Per-author monotonic counter for fresh `reservedKaId` numbers, so tests that
+ * publish several KAs (under the same or different authors) never collide on a
+ * `(author, number)` pair unless they deliberately reuse one. Keyed by the
+ * checksummed author address.
+ */
+const _reservedKaIdCounters = new Map<string, bigint>();
+
+/**
+ * Allocate a fresh, never-before-used packed `reservedKaId` for `authorAddress`.
+ * Numbers start at 1 and increment per author. Use `packReservedKaId` directly
+ * when a test must pin or deliberately reuse an exact number.
+ */
+export function nextReservedKaId(authorAddress: string): bigint {
+  const key = ethers.getAddress(authorAddress);
+  const next = (_reservedKaIdCounters.get(key) ?? 0n) + 1n;
+  _reservedKaIdCounters.set(key, next);
+  return packReservedKaId(key, next);
+}
+
 export type V10SigPack = {
   receiverRs: string[];
   receiverVSs: string[];
@@ -305,6 +341,16 @@ export async function buildPublishParams(args: {
   /** Allow injecting a pre-computed author signature (for negative-path tests). */
   authorSigOverride?: AuthorSig;
   /**
+   * OT-RFC-43 Option 1 (variant 1a): the packed KA id this publish claims:
+   *   reservedKaId = (uint160(author) << 96) | uint96(number)
+   * Defaults to a freshly-allocated, never-reused id in the author's namespace
+   * (`nextReservedKaId(author.address)`). Negative-path / collision tests pass
+   * an explicit value (e.g. a wrong-namespace id, or a deliberately reused
+   * `reservedKaId`). NB: deliberately NOT part of the ACK digest — the
+   * namespace is enforced on-chain, not signed over.
+   */
+  reservedKaId?: bigint;
+  /**
    * RFC-39 Phase A.5 curated-CG ciphertext commitment (optional).
    * Defaults to `bytes32(0)` + `0` — the explicit "no commitment" sentinel
    * the contract treats as: legal on public CGs (default behavior); legal
@@ -377,6 +423,10 @@ export async function buildPublishParams(args: {
     authorR: authorSig.authorR,
     authorVS: authorSig.authorVS,
     authorSchemeVersion: schemeVersion,
+    // OT-RFC-43 Option 1 (1a): author-namespaced packed id. Defaults to a
+    // fresh, unused number in the author's namespace; pinned/reused values
+    // come through `args.reservedKaId` for collision / negative tests.
+    reservedKaId: args.reservedKaId ?? nextReservedKaId(args.author.address),
     identityIds: args.receiverIdentityIds,
     r: sig.receiverRs,
     vs: sig.receiverVSs,

--- a/packages/evm-module/test/unit/RandomSampling-curated.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling-curated.test.ts
@@ -205,7 +205,6 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
     const createTx = await KCSContract.connect(opSigner).createKnowledgeAsset(
       opSigner.address,
       opSigner.address,
-      nextOpSignerKaId(), // OT-RFC-43 (1a): caller-supplied author-namespaced id
       'rfc39-curated-test-op',
       ethers.keccak256(
         ethers.toUtf8Bytes(
@@ -219,6 +218,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
       0,
       false,
       1,
+      nextOpSignerKaId(), // OT-RFC-43 (1a, codex PR #975 F1): caller-supplied author-namespaced id; appended at END
     );
     const receipt = await createTx.wait();
     const iface = KCSContract.interface;

--- a/packages/evm-module/test/unit/RandomSampling-curated.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling-curated.test.ts
@@ -129,7 +129,18 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
     CGStorageContract = f.CGStorageContract;
     CGValueStorage = f.CGValueStorage;
     opSigner = accounts[19];
+    _kaIdCounter = 0n;
   });
+
+  // OT-RFC-43 Option 1 (1a): KA ids are caller-supplied, author-namespaced
+  // packed values `(uint160(author) << 96) | uint96(number)`. `createKC` seeds
+  // with `author == opSigner`, so allocate a fresh number per KC in opSigner's
+  // namespace. Reset per test so snapshot-reverted runs reallocate cleanly.
+  let _kaIdCounter = 0n;
+  const nextOpSignerKaId = (): bigint => {
+    _kaIdCounter += 1n;
+    return (BigInt(opSigner.address) << 96n) | _kaIdCounter;
+  };
 
   async function createCG(publishPolicy: number): Promise<bigint> {
     const owner = accounts[1].address;
@@ -194,6 +205,7 @@ describe('@unit RandomSampling — RFC-39 curated picker [Phase B enabled]', () 
     const createTx = await KCSContract.connect(opSigner).createKnowledgeAsset(
       opSigner.address,
       opSigner.address,
+      nextOpSignerKaId(), // OT-RFC-43 (1a): caller-supplied author-namespaced id
       'rfc39-curated-test-op',
       ethers.keccak256(
         ethers.toUtf8Bytes(

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -897,7 +897,6 @@ describe('@unit RandomSampling', () => {
       ).createKnowledgeAsset(
         opSigner.address, // publisher
         opSigner.address, // author — ERC-721 KA mint recipient (greenfield model)
-        nextOpSignerKaId(), // OT-RFC-43 (1a): caller-supplied author-namespaced id
         'phase-10-test-op',
         ethers.keccak256(
           ethers.toUtf8Bytes(
@@ -911,6 +910,7 @@ describe('@unit RandomSampling', () => {
         0, // tokenAmount
         false, // isImmutable
         1, // merkleLeafCount (v10 — pin-the-leaf-count guard, not exercised by Phase 10)
+        nextOpSignerKaId(), // OT-RFC-43 (1a, codex PR #975 F1): caller-supplied author-namespaced id; appended at END
       );
       const receipt = await createTx.wait();
       // Parse kc id from the KnowledgeAssetCreated event.

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -839,9 +839,19 @@ describe('@unit RandomSampling', () => {
      *  methods on storage contracts directly. */
     let opSigner: SignerWithAddress;
 
+    // OT-RFC-43 Option 1 (1a): KA ids are caller-supplied, author-namespaced
+    // packed values `(uint160(author) << 96) | uint96(number)`. `createKC`
+    // seeds with `author == opSigner`, so allocate a fresh number per KC in
+    // opSigner's namespace. Reset per test so snapshot-reverted runs realloc.
+    let _kaIdCounter: bigint;
     beforeEach(() => {
       opSigner = accounts[19];
+      _kaIdCounter = 0n;
     });
+    const nextOpSignerKaId = (): bigint => {
+      _kaIdCounter += 1n;
+      return (BigInt(opSigner.address) << 96n) | _kaIdCounter;
+    };
 
     /**
      * Create a Context Graph via the storage directly and return its id.
@@ -887,6 +897,7 @@ describe('@unit RandomSampling', () => {
       ).createKnowledgeAsset(
         opSigner.address, // publisher
         opSigner.address, // author — ERC-721 KA mint recipient (greenfield model)
+        nextOpSignerKaId(), // OT-RFC-43 (1a): caller-supplied author-namespaced id
         'phase-10-test-op',
         ethers.keccak256(
           ethers.toUtf8Bytes(

--- a/packages/evm-module/test/v10-e2e-conviction.test.ts
+++ b/packages/evm-module/test/v10-e2e-conviction.test.ts
@@ -29,7 +29,11 @@ import {
   getDefaultReceivingNodes,
   getDefaultKCCreator,
 } from './helpers/setup-helpers';
-import { buildPublishParams, DEFAULT_CHAIN_ID } from './helpers/v10-kc-helpers';
+import {
+  buildPublishParams,
+  packReservedKaId,
+  DEFAULT_CHAIN_ID,
+} from './helpers/v10-kc-helpers';
 
 const SCALE18 = 10n ** 18n;
 
@@ -321,6 +325,10 @@ describe('V10 E2E Conviction System', function () {
         (tokenAmount * (10_000n - expectedDiscountBps)) / 10_000n;
       const merkleRoot = ethers.keccak256(ethers.toUtf8Bytes('flow3-merkle'));
 
+      // OT-RFC-43 Option 1 (1a): author-namespaced packed id we expect to mint
+      // (high 160 bits == creator, the attested author / NFT recipient).
+      const reservedKaId = packReservedKaId(creator.address, 1);
+
       // ---- Step 5: Build V10 publish params (N26 + H5 + post-BLOCKER-1 ACK) ----
       const p = await buildPublishParams({
         chainId: DEFAULT_CHAIN_ID,
@@ -337,6 +345,7 @@ describe('V10 E2E Conviction System', function () {
         tokenAmount,
         isImmutable: false,
         publishOperationId: 'flow3-op',
+        reservedKaId,
       });
 
       // ---- Step 6: publish() (conviction path) ----
@@ -409,7 +418,9 @@ describe('V10 E2E Conviction System', function () {
       void kav10AddrLower;
 
       // ---- Step 7: KC registered in KCS; publisher of record is msg.sender ----
-      const kaId = 1n;
+      // OT-RFC-43 Option 1 (1a): the minted kaId equals the packed reservedKaId
+      // (author-namespaced; ids are no longer globally sequential 1,2,3,...).
+      const kaId = reservedKaId;
       const meta = await DKGKnowledgeAssets.getKnowledgeAssetMetadata(kaId);
       // meta[3] = byteSize, meta[4] = startEpoch, meta[5] = endEpoch, meta[6] = tokenAmount
       expect(meta[3]).to.equal(1000n);

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -35,6 +35,7 @@ import {
 import {
   buildPublishParams,
   buildUpdateParams,
+  packReservedKaId,
   DEFAULT_CHAIN_ID,
 } from './helpers/v10-kc-helpers';
 
@@ -337,6 +338,8 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     const merkleRoot = ethers.keccak256(
       ethers.toUtf8Bytes('v10-pca-lifecycle'),
     );
+    // OT-RFC-43 Option 1 (1a): author-namespaced packed id we expect to mint.
+    const reservedKaId = packReservedKaId(creator.address, 1);
     const p = await buildPublishParams({
       chainId: DEFAULT_CHAIN_ID,
       kav10Address: await KAV10.getAddress(),
@@ -352,6 +355,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       tokenAmount,
       isImmutable: false,
       publishOperationId: 'v10-pca-lifecycle-op',
+      reservedKaId,
     });
 
     const tx = await KAV10.connect(creator).publish(p);
@@ -388,8 +392,10 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
 
     // KC records the FULL tokenAmount; only the staker-pool distribution is
     // discounted — the on-chain proof the discount branch (not direct
-    // spend) executed.
-    const kaId = 1n;
+    // spend) executed. OT-RFC-43 Option 1 (1a): the minted kaId equals the
+    // packed reservedKaId we supplied (ids are no longer globally sequential).
+    const kaId = reservedKaId;
+    expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(creator.address);
     const meta =
       await DKGKnowledgeAssets.getKnowledgeAssetMetadata(kaId);
     expect(meta[6]).to.equal(tokenAmount);
@@ -455,9 +461,12 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     ).to.be.revertedWithCustomError(KAV10, 'TooLowAllowance');
 
     // Atomic rollback: the expired publish minted no knowledge collection.
-    expect(
-      await DKGKnowledgeAssets.getLatestKnowledgeAssetId(),
-    ).to.equal(0n);
+    // OT-RFC-43 Option 1 (1a): `getLatestKnowledgeAssetId` is deprecated (it
+    // reverts), so we assert the reserved id was never minted — `ownerOf`
+    // reverts on a non-existent token.
+    await expect(
+      DKGKnowledgeAssets.ownerOf(p.reservedKaId),
+    ).to.be.revertedWithCustomError(DKGKnowledgeAssets, 'ERC721NonexistentToken');
   });
 
   // --------------------------------------------------------------------------
@@ -502,16 +511,27 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     // amount gate (`_executePublishCore`) is reached before the ACK signature
     // check — flipping the count to anything but 1 must revert with the
     // amount echoed back.
+    const attemptedKaIds: bigint[] = [];
     for (const amount of [0, 2, 5]) {
       const p = await buildBasePublishParams(setup, `amount-gate-${amount}`, {
         knowledgeAssetsAmount: amount,
       });
+      attemptedKaIds.push(BigInt(p.reservedKaId));
       await expect(KAV10.connect(setup.creator).publish(p))
         .to.be.revertedWithCustomError(KAV10, 'InvalidKnowledgeAssetsAmount')
         .withArgs(BigInt(amount));
     }
-    // None of the reverted attempts minted a token.
-    expect(await DKGKnowledgeAssets.getLatestKnowledgeAssetId()).to.equal(0n);
+    // None of the reverted attempts minted a token. OT-RFC-43 Option 1 (1a):
+    // `getLatestKnowledgeAssetId` reverts (deprecated), so assert each
+    // reserved id is unminted (`ownerOf` reverts on a non-existent token).
+    for (const id of attemptedKaIds) {
+      await expect(
+        DKGKnowledgeAssets.ownerOf(id),
+      ).to.be.revertedWithCustomError(
+        DKGKnowledgeAssets,
+        'ERC721NonexistentToken',
+      );
+    }
   });
 
   it('greenfield: publish reverts InvalidTokenAmount(1,0) on a zero token amount (strict-positive floor)', async () => {
@@ -522,17 +542,24 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     await expect(KAV10.connect(setup.creator).publish(p))
       .to.be.revertedWithCustomError(KAV10, 'InvalidTokenAmount')
       .withArgs(1, 0);
-    expect(await DKGKnowledgeAssets.getLatestKnowledgeAssetId()).to.equal(0n);
+    // OT-RFC-43 Option 1 (1a): nothing minted — the reserved id stays unowned.
+    await expect(
+      DKGKnowledgeAssets.ownerOf(p.reservedKaId),
+    ).to.be.revertedWithCustomError(
+      DKGKnowledgeAssets,
+      'ERC721NonexistentToken',
+    );
   });
 
-  it('greenfield: a successful publish mints exactly one KA (id 1) to the author and binds it to the CG', async () => {
+  it('greenfield: a successful publish mints exactly one KA (the packed reservedKaId) to the author and binds it to the CG', async () => {
     const setup = await setupRegisteredAgentPublish();
     const p = await buildBasePublishParams(setup, 'greenfield-mint');
     await (await KAV10.connect(setup.creator).publish(p)).wait();
 
-    // Exactly one KA, id starts at 1 (greenfield: kaId == tokenId == batchId).
-    const kaId = await DKGKnowledgeAssets.getLatestKnowledgeAssetId();
-    expect(kaId).to.equal(1n);
+    // OT-RFC-43 Option 1 (1a): the minted kaId equals the packed reservedKaId
+    // (author-namespaced; ids are no longer globally sequential).
+    const kaId = BigInt(p.reservedKaId);
+    expect(kaId >> 96n).to.equal(BigInt(setup.creator.address));
     // Minted to the attesting author (not the relaying node / msg.sender path).
     expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
       setup.creator.address,
@@ -545,8 +572,8 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     const setup = await setupRegisteredAgentPublish();
     const p = await buildBasePublishParams(setup, 'owner-gate-publish');
     await (await KAV10.connect(setup.creator).publish(p)).wait();
-    const kaId = await DKGKnowledgeAssets.getLatestKnowledgeAssetId();
-    expect(kaId).to.equal(1n);
+    // OT-RFC-43 Option 1 (1a): minted kaId == packed reservedKaId.
+    const kaId = BigInt(p.reservedKaId);
     expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
       setup.creator.address,
     );
@@ -702,8 +729,8 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     });
     await (await KAV10.connect(setup.creator).publish(p)).wait();
 
-    const kaId = await DKGKnowledgeAssets.getLatestKnowledgeAssetId();
-    expect(kaId).to.equal(1n);
+    // OT-RFC-43 Option 1 (1a): minted kaId == packed reservedKaId.
+    const kaId = BigInt(p.reservedKaId);
     expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
       setup.creator.address,
     );
@@ -738,8 +765,11 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     });
     await (await KAV10.connect(setup.creator).update(up)).wait();
 
-    // kaId stable: update mutates in place, never mints a new id.
-    expect(await DKGKnowledgeAssets.getLatestKnowledgeAssetId()).to.equal(kaId);
+    // kaId stable: update mutates in place, never mints a new id. OT-RFC-43
+    // Option 1 (1a): the KA is still owned at the SAME packed id (no new mint).
+    expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
+      setup.creator.address,
+    );
     // Owner stable across the update.
     expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
       setup.creator.address,
@@ -755,5 +785,231 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     // tokenAmount unchanged (delta 0).
     const meta = await DKGKnowledgeAssets.getKnowledgeAssetMetadata(kaId);
     expect(meta[6]).to.equal(tokenAmount);
+  });
+
+  // --------------------------------------------------------------------------
+  // 7. OT-RFC-43 Option 1 (variant 1a) — caller-supplied, author-namespaced
+  //    KA ids (§B5). The KA id is now a deterministic packed value
+  //    `(uint160(author) << 96) | uint96(number)` chosen off-chain. KCS
+  //    enforces `(reservedKaId >> 96) == author` (the EIP-712 attestation
+  //    signer / NFT mint recipient, NOT msg.sender) so a wallet can only mint
+  //    in its own namespace; a re-used id reverts (no silent clobber); the old
+  //    global counter getter is deprecated; and ownership (OT-RFC-45) survives
+  //    NFT transfer under the new id scheme.
+  // --------------------------------------------------------------------------
+
+  // Direct-spend funding for a publisher that is NOT a registered agent:
+  // mint the gross + approve KAV10 so `_addTokens` can pull it.
+  const fundDirectSpend = async (
+    publisher: SignerWithAddress,
+    amount: bigint,
+  ) => {
+    await Token.mint(publisher.address, amount);
+    await Token.connect(publisher).approve(await KAV10.getAddress(), amount);
+  };
+
+  it('B5(a): publish with a valid packed reservedKaId mints kaId == reservedKaId and ownerOf == the attested AUTHOR (not msg.sender/publisher)', async () => {
+    const setup = await setupRegisteredAgentPublish();
+
+    // publisher (msg.sender) != author. The open CG authorizes any non-zero
+    // publisher; the publisher is NOT a registered agent + epochs is off the
+    // discount tier, so payment runs through the direct-spend branch against
+    // the publisher's own wallet. The author only signs the EIP-712
+    // attestation and is the ERC-721 mint recipient.
+    const publisher = accounts[10];
+    const author = accounts[11];
+    expect(publisher.address).to.not.equal(author.address);
+    expect(publisher.address).to.not.equal(setup.creator.address);
+
+    const tokenAmount = ethers.parseEther('1000');
+    const reservedKaId = packReservedKaId(author.address, 7);
+    await fundDirectSpend(publisher, tokenAmount);
+
+    const p = await buildBasePublishParams(setup, 'b5-a-author-namespaced', {
+      author, // EIP-712 attestation signer + NFT mint recipient
+      epochs: setup.epochs + 1, // off the PCA discount tier → direct-spend
+      tokenAmount,
+      reservedKaId,
+    });
+
+    await (await KAV10.connect(publisher).publish(p)).wait();
+
+    // The minted id is EXACTLY the supplied reservedKaId.
+    expect(BigInt(p.reservedKaId)).to.equal(reservedKaId);
+    // High 160 bits == the AUTHOR, not the publisher/msg.sender.
+    expect(reservedKaId >> 96n).to.equal(BigInt(author.address));
+    expect(reservedKaId >> 96n).to.not.equal(BigInt(publisher.address));
+    // NFT minted to the attested author (OT-RFC-43: namespace binds to author).
+    expect(await DKGKnowledgeAssets.ownerOf(reservedKaId)).to.equal(
+      author.address,
+    );
+  });
+
+  it('B5(b): a reservedKaId whose high bits != author reverts KaIdNamespaceMismatch', async () => {
+    const setup = await setupRegisteredAgentPublish();
+
+    // Pack the id in a DIFFERENT address's namespace than the attested author
+    // (setup.creator). The contract recomputes `kaId >> 96` and compares it to
+    // the attested author, so this is rejected before any mint.
+    const otherAddr = accounts[12];
+    expect(otherAddr.address).to.not.equal(setup.creator.address);
+    const wrongNamespaceId = packReservedKaId(otherAddr.address, 1);
+
+    const p = await buildBasePublishParams(setup, 'b5-b-wrong-namespace', {
+      reservedKaId: wrongNamespaceId,
+    });
+
+    await expect(KAV10.connect(setup.creator).publish(p))
+      .to.be.revertedWithCustomError(
+        DKGKnowledgeAssets,
+        'KaIdNamespaceMismatch',
+      )
+      .withArgs(wrongNamespaceId, setup.creator.address);
+
+    // Nothing minted under the foreign id.
+    await expect(
+      DKGKnowledgeAssets.ownerOf(wrongNamespaceId),
+    ).to.be.revertedWithCustomError(
+      DKGKnowledgeAssets,
+      'ERC721NonexistentToken',
+    );
+  });
+
+  it('B5(c): reusing the same (author, number) reverts KaIdAlreadyMinted on the second publish (no silent clobber)', async () => {
+    const setup = await setupRegisteredAgentPublish();
+
+    // First publish claims the packed id and mints it to the author.
+    const reservedKaId = packReservedKaId(setup.creator.address, 42);
+    const p1 = await buildBasePublishParams(setup, 'b5-c-first', {
+      reservedKaId,
+    });
+    await (await KAV10.connect(setup.creator).publish(p1)).wait();
+    expect(await DKGKnowledgeAssets.ownerOf(reservedKaId)).to.equal(
+      setup.creator.address,
+    );
+
+    // Second publish reuses the EXACT same reservedKaId (same author + number)
+    // with a fresh merkle root / operation id. The id is already minted, so it
+    // must revert — not silently overwrite the existing KA.
+    const p2 = await buildBasePublishParams(setup, 'b5-c-second', {
+      reservedKaId,
+    });
+    await expect(KAV10.connect(setup.creator).publish(p2))
+      .to.be.revertedWithCustomError(DKGKnowledgeAssets, 'KaIdAlreadyMinted')
+      .withArgs(reservedKaId);
+
+    // The original KA is untouched: still exactly one merkle root, the first.
+    const roots = await DKGKnowledgeAssets.getMerkleRoots(reservedKaId);
+    expect(roots.length).to.equal(1);
+    expect(roots[0].merkleRoot).to.equal(
+      ethers.keccak256(ethers.toUtf8Bytes('b5-c-first')),
+    );
+  });
+
+  it('B5(d): getLatestKnowledgeAssetId() is deprecated and always reverts GetLatestKnowledgeAssetIdDeprecated', async () => {
+    // The global sequential counter is gone under Option 1 — packed ids are
+    // not enumerable through a single "latest id". The getter must revert
+    // regardless of how many KAs exist (pure function: even on a clean state).
+    await expect(
+      DKGKnowledgeAssets.getLatestKnowledgeAssetId(),
+    ).to.be.revertedWithCustomError(
+      DKGKnowledgeAssets,
+      'GetLatestKnowledgeAssetIdDeprecated',
+    );
+
+    // Still reverts after a successful publish (the count changed, the getter
+    // did not come back).
+    const setup = await setupRegisteredAgentPublish();
+    const p = await buildBasePublishParams(setup, 'b5-d-deprecated');
+    await (await KAV10.connect(setup.creator).publish(p)).wait();
+    await expect(
+      DKGKnowledgeAssets.getLatestKnowledgeAssetId(),
+    ).to.be.revertedWithCustomError(
+      DKGKnowledgeAssets,
+      'GetLatestKnowledgeAssetIdDeprecated',
+    );
+  });
+
+  it('B5(e): update stays owner-only across an NFT transfer — old author reverts NotKnowledgeAssetOwner, new owner succeeds', async () => {
+    const setup = await setupRegisteredAgentPublish();
+
+    // Publish: author (setup.creator) owns the freshly minted KA NFT.
+    const publishRoot = ethers.keccak256(ethers.toUtf8Bytes('b5-e-publish'));
+    const tokenAmount = ethers.parseEther('1000');
+    const reservedKaId = packReservedKaId(setup.creator.address, 99);
+    const p = await buildBasePublishParams(setup, 'b5-e-publish', {
+      merkleRoot: publishRoot,
+      tokenAmount,
+      reservedKaId,
+    });
+    await (await KAV10.connect(setup.creator).publish(p)).wait();
+    const kaId = reservedKaId;
+    expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(
+      setup.creator.address,
+    );
+
+    // Transfer the KA NFT to a new owner. The kaId is unchanged (the packed id
+    // is the ERC-721 tokenId); only the owner moves.
+    const newOwner = accounts[13];
+    expect(newOwner.address).to.not.equal(setup.creator.address);
+    await DKGKnowledgeAssets.connect(setup.creator).transferFrom(
+      setup.creator.address,
+      newOwner.address,
+      kaId,
+    );
+    expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(newOwner.address);
+
+    // (1) An update attested by the OLD author (no longer the owner) reverts
+    //     NotKnowledgeAssetOwner — owner-only survives the NFT transfer.
+    const staleRoot = ethers.keccak256(ethers.toUtf8Bytes('b5-e-stale'));
+    const staleUpdate = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: setup.receivingNodes,
+      publisherIdentityId: setup.publisherIdentityId,
+      receiverIdentityIds: setup.receiverIdentityIds,
+      contextGraphId: setup.cgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: staleRoot,
+      newByteSize: 1000n,
+      newTokenAmount: tokenAmount, // delta 0 — metadata-only, no payment
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'b5-e-stale-op',
+      author: setup.creator, // old author signs — now NOT the owner
+    });
+    await expect(KAV10.connect(setup.creator).update(staleUpdate))
+      .to.be.revertedWithCustomError(KAV10, 'NotKnowledgeAssetOwner')
+      .withArgs(kaId, newOwner.address, setup.creator.address);
+
+    // (2) An update attested by the NEW owner succeeds — the merkle-root
+    //     history grows and the new root is appended.
+    const newRoot = ethers.keccak256(ethers.toUtf8Bytes('b5-e-new'));
+    const newOwnerUpdate = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: setup.receivingNodes,
+      publisherIdentityId: setup.publisherIdentityId,
+      receiverIdentityIds: setup.receiverIdentityIds,
+      contextGraphId: setup.cgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: newRoot,
+      newByteSize: 1000n,
+      newTokenAmount: tokenAmount, // delta 0 — metadata-only, no payment
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'b5-e-new-op',
+      author: newOwner, // new owner signs + owns → passes both gates
+    });
+    await (await KAV10.connect(newOwner).update(newOwnerUpdate)).wait();
+
+    // Owner unchanged by the update; merkle-root history grew by one.
+    expect(await DKGKnowledgeAssets.ownerOf(kaId)).to.equal(newOwner.address);
+    const roots = await DKGKnowledgeAssets.getMerkleRoots(kaId);
+    expect(roots.length).to.equal(2);
+    expect(roots[0].merkleRoot).to.equal(publishRoot);
+    expect(roots[1].merkleRoot).to.equal(newRoot);
   });
 });


### PR DESCRIPTION
## 🟡 STATUS — DEFERRED to after rc.16 (post-audit)

The **core B1 contract** described below (packed `kaId`, author-namespace guard, `reservedKaId` threading, deprecated-counter gap) is **already consolidated on `integration/v10-devnet` (#980)** and ships via that bundle.

The **only remaining delta in this PR** is the review-fix commit `11b480acf` (F1/F2): move `reservedKaId`/`kaId` to the struct/param end (ABI regen) **and add `reservedKaId` as a 5th field of the `AuthorAttestation` EIP-712 typehash** (4 → 5 fields).

**Decision (delivery lead + owner): defer this delta to after rc.16.** Rationale:

- **Low severity, not critical.** #980 keeps `reservedKaId` out of the 4-field author attestation on purpose. The on-chain namespace guard (`kaId >> 96 == author`) means a publisher can only ever mint inside the author's *own* namespace, and the NFT is `_safeMint`ed to the author — so the worst case is a delegated publisher misplacing or duplicating the author's *own* content within the author's *own* namespace. No theft, no cross-author hijack, no fund loss.
- **It is a breaking signature change** (EIP-712 struct 4 → 5), so it must land as a *coordinated* on-chain + off-chain (`ack.ts` mirror + every caller) + ABI + redeploy change. On greenfield/testnet that is free per RC; post-mainnet it is a fork. So it must be settled **before mainnet**, but there is no benefit to rushing it into the current consolidation.
- Therefore it is **intentionally excluded from the integration → main train** — PR #987 drops `11b480acf` so it cannot auto-merge — and is **flagged for the contract audit**. Recommended lean at audit time: **bind it** (cheap pre-mainnet, fully specifies author intent over both content *and* id, closes the misplace/duplicate-replay gap), to be confirmed by the auditor.

This PR stays open as a **draft tracker** for that post-rc.16 coordinated change. Do not merge into the rc.16 bundle.

---

## What

Replaces the global `++_knowledgeAssetsCounter` with **caller-supplied packed ids** `kaId = (uint160(author) << 96) | uint96(number)` (OT-RFC-43 Option 1, variant 1a).

- `createKnowledgeAsset` takes a `kaId` param; `require((kaId >> 96) == uint160(author))` so a wallet can only mint within its own **attested** namespace, then `_safeMint(author, kaId)`. Fail-fast on reuse via `_ownerOf` **and** a slot-empty invariant (`merkleRoots.length == 0`, audit hardening).
- Global counter dropped; its storage slot retained as an unused gap (`__deprecated_knowledgeAssetsCounter`) so layout is safe under both redeploy and in-place upgrade (**R3** unresolved). `getLatestKnowledgeAssetId` deprecated (reverts).
- `reservedKaId` threaded through `PublishParams` → `_executePublishCore`. **Deliberately NOT in the ACK digest** — the on-chain namespace `require()` is the authority, so choosing a different number within one's own namespace is harmless (avoids R5 storage-node coordination). *(The post-rc.16 delta above concerns the separate **AuthorAttestation** typehash, not the ACK digest.)*

### Decisions (flagged for the auditor)
- **Namespace binds to the attested AUTHOR** (EIP-712 signer / initial owner), a deliberate divergence from OT-RFC-43 §7's `msg.sender` diagram — the two coincide in the dominant self-publish case.
- **R5 (post-rc.16):** whether to bind `reservedKaId` into the `AuthorAttestation` typehash — see status banner.
- ABI regenerated (`evm-module/abi` + `chain/abi` synced).

### Security review
3-lens adversarial review: namespace/forgery/replay = **sound**; reentrancy contained (CEI + `_safeMint` last + `nonReentrant`); layout/EIP-712-pin/ACK-exclusion verified. All in-scope findings addressed.

### Tests
16 evm-module tests green, incl. 5 new **B5** cases: packed mint (owner == author), namespace-mismatch revert, duplicate-reservation revert, deprecated-getter revert, owner-only-after-NFT-transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)