### PR TITLE
feat: durable per-author KA-number allocator for OT-RFC-43 Option-1 (Plan B B2 core)

### DIFF
--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -34,8 +34,13 @@ const ADDRESS_HEX_CHARS = 40;
 export interface KaAllocation {
   /** Packed `(uint160(author) << 96) | uint96(number)`. Always non-zero. */
   kaId: bigint;
-  /** The per-author number just consumed (first allocation is 0). */
-  number: number;
+  /**
+   * The per-author number just consumed (first allocation is `0n`).
+   * `bigint` end-to-end (codex PR #976 F6) so the counter stays exact
+   * past `Number.MAX_SAFE_INTEGER`; the on-chain field is `uint96` and
+   * the store backs it with a SQLite signed INTEGER (`2^63 - 1` cap).
+   */
+  number: bigint;
 }
 
 export class KaNumberAllocator {
@@ -61,8 +66,11 @@ export class KaNumberAllocator {
   allocate(authorAddress: string): KaAllocation {
     this.assertReconciled();
     const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
+    // `number` is a `bigint` straight off the store (codex PR #976 F6) —
+    // no `BigInt()` round-trip, no chance of a stray `Number()` cast at
+    // the call site silently truncating a counter past 2^53.
     const number = this.store.allocate(authorAddress);
-    const kaId = (authorBits << NUMBER_BITS) | BigInt(number);
+    const kaId = (authorBits << NUMBER_BITS) | number;
     return { kaId, number };
   }
 
@@ -70,13 +78,18 @@ export class KaNumberAllocator {
    * Raise the stored floor for `authorAddress` from an observed on-chain
    * state. `observedNumber` is the highest number already minted under
    * that author; the next allocation must therefore be at least
-   * `observedNumber + 1`. Idempotent and monotonic (never lowers).
+   * `observedNumber + 1n`. Idempotent and monotonic (never lowers).
+   *
+   * `observedNumber` is a `bigint` (codex PR #976 F6) — the chain reads
+   * that compute it (`kaId & ((1n<<96n)-1n)`) already produce bigint;
+   * accepting `number` here would force a precision-losing cast at the
+   * caller.
    */
-  reconcile(authorAddress: string, observedNumber: number): void {
+  reconcile(authorAddress: string, observedNumber: bigint): void {
     // Validate the address shape here too so reconciliation rejects junk
     // before it can poison the floor.
     KaNumberAllocator.authorToUint160(authorAddress);
-    this.store.reconcileFloor(authorAddress, observedNumber + 1);
+    this.store.reconcileFloor(authorAddress, observedNumber + 1n);
   }
 
   /**
@@ -86,7 +99,7 @@ export class KaNumberAllocator {
   peekKaId(authorAddress: string): bigint {
     const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
     const number = this.store.peekNext(authorAddress);
-    return (authorBits << NUMBER_BITS) | BigInt(number);
+    return (authorBits << NUMBER_BITS) | number;
   }
 
   /**

--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -1,0 +1,150 @@
+import { ethers } from 'ethers';
+import type { KaNumberStore } from '@origintrail-official/dkg-core';
+
+/**
+ * OT-RFC-43 Option-1 deterministic KA identity — B2 author-number
+ * ALLOCATOR CORE (OFF-CHAIN only).
+ *
+ * Locked design decisions:
+ *   - The allocation namespace is the **attested author** address.
+ *   - A KA's full id is packed as
+ *       `kaId = (uint160(author) << 96) | uint96(number)`.
+ *   - The underlying `KaNumberStore` keys by author address and owns
+ *     the strictly-monotonic, never-reclaimed `number` half.
+ *
+ * This class is the thin domain wrapper around that store: it packs the
+ * 160-bit author into the high bits and the per-author number into the
+ * low 96 bits, all in `bigint` (NEVER `Number`, which would lose
+ * precision well below 2^96). It also carries the RFC §4.5 cold-start
+ * refusal guard: a node that has not run startup reconciliation against
+ * observed on-chain state MUST refuse to allocate, lest it re-issue a
+ * number the chain already minted under that author. The reconciliation
+ * *oracle* (the actual chain reads that compute the floor) is wired at
+ * the deferred T0 integration; here we only expose the flag + guard and
+ * the `reconcile()` floor-bump.
+ */
+
+/** Width of the `number` field in the packed kaId (low bits). */
+const NUMBER_BITS = 96n;
+/** Mask selecting the low `NUMBER_BITS` of a kaId. */
+const NUMBER_MASK = (1n << NUMBER_BITS) - 1n;
+/** Author hex length (20 bytes => 40 hex chars), for unpack padding. */
+const ADDRESS_HEX_CHARS = 40;
+
+export interface KaAllocation {
+  /** Packed `(uint160(author) << 96) | uint96(number)`. Always non-zero. */
+  kaId: bigint;
+  /** The per-author number just consumed (first allocation is 0). */
+  number: number;
+}
+
+export class KaNumberAllocator {
+  private readonly store: KaNumberStore;
+  /**
+   * RFC §4.5 cold-start refusal flag. Allocation is refused until a
+   * caller has run startup reconciliation and called `markReconciled()`.
+   * Starts `false` so a cold/just-restarted node cannot hand out a
+   * number before it has reconciled its floor against the chain.
+   */
+  private reconciled = false;
+
+  constructor(store: KaNumberStore) {
+    this.store = store;
+  }
+
+  /**
+   * Consume the next number for `authorAddress` and return it together
+   * with the packed `kaId`. Throws if startup reconciliation has not
+   * been performed (`assertReconciled`) or if the address is not a valid
+   * 20-byte hex address.
+   */
+  allocate(authorAddress: string): KaAllocation {
+    this.assertReconciled();
+    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
+    const number = this.store.allocate(authorAddress);
+    const kaId = (authorBits << NUMBER_BITS) | BigInt(number);
+    return { kaId, number };
+  }
+
+  /**
+   * Raise the stored floor for `authorAddress` from an observed on-chain
+   * state. `observedNumber` is the highest number already minted under
+   * that author; the next allocation must therefore be at least
+   * `observedNumber + 1`. Idempotent and monotonic (never lowers).
+   */
+  reconcile(authorAddress: string, observedNumber: number): void {
+    // Validate the address shape here too so reconciliation rejects junk
+    // before it can poison the floor.
+    KaNumberAllocator.authorToUint160(authorAddress);
+    this.store.reconcileFloor(authorAddress, observedNumber + 1);
+  }
+
+  /**
+   * The `kaId` the next `allocate(authorAddress)` would produce, without
+   * consuming it. Does NOT require reconciliation (read-only peek).
+   */
+  peekKaId(authorAddress: string): bigint {
+    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
+    const number = this.store.peekNext(authorAddress);
+    return (authorBits << NUMBER_BITS) | BigInt(number);
+  }
+
+  /**
+   * Mark this allocator as having completed startup reconciliation,
+   * unblocking `allocate()`. Called once the (deferred) reconciliation
+   * oracle has bumped every relevant author floor.
+   */
+  markReconciled(): void {
+    this.reconciled = true;
+  }
+
+  /** Whether `markReconciled()` has been called. */
+  isReconciled(): boolean {
+    return this.reconciled;
+  }
+
+  /**
+   * Throw unless startup reconciliation has run. The RFC §4.5 cold-start
+   * refusal: a node MUST NOT allocate before it has reconciled its floor
+   * against observed on-chain state.
+   */
+  assertReconciled(): void {
+    if (!this.reconciled) {
+      throw new Error(
+        'KaNumberAllocator: refusing to allocate before startup reconciliation (RFC §4.5 cold-start refusal); call markReconciled() after reconciling author floors',
+      );
+    }
+  }
+
+  /**
+   * Validate `authorAddress` is a 20-byte hex address and return its
+   * 160-bit integer value. Uses `ethers.getAddress` to validate (it
+   * throws on a malformed/checksum-invalid address); `BigInt(0x…)` then
+   * yields the unsigned 160-bit value. NEVER uses `Number()`.
+   */
+  static authorToUint160(authorAddress: string): bigint {
+    // getAddress throws on anything that is not a valid 20-byte address
+    // (wrong length, non-hex, bad checksum casing). Re-wrap so the error
+    // is attributable to this module.
+    let checksummed: string;
+    try {
+      checksummed = ethers.getAddress(authorAddress);
+    } catch {
+      throw new Error(`KaNumberAllocator: invalid author address: ${authorAddress}`);
+    }
+    return BigInt(checksummed);
+  }
+
+  /**
+   * Unpack a packed kaId back into its author + number components.
+   * `author` is a lowercase `0x`-prefixed 40-hex-char address; `number`
+   * is the low-96-bit value as a `bigint`. Mirrors the pack performed by
+   * `allocate`.
+   */
+  static unpack(kaId: bigint): { author: string; number: bigint } {
+    const authorBits = kaId >> NUMBER_BITS;
+    const author = '0x' + authorBits.toString(16).padStart(ADDRESS_HEX_CHARS, '0');
+    const number = kaId & NUMBER_MASK;
+    return { author, number };
+  }
+}

--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -60,16 +60,28 @@ export class KaNumberAllocator {
   /**
    * Consume the next number for `authorAddress` and return it together
    * with the packed `kaId`. Throws if startup reconciliation has not
-   * been performed (`assertReconciled`) or if the address is not a valid
-   * 20-byte hex address.
+   * been performed (`assertReconciled`), if the address is not a valid
+   * 20-byte hex address, or if it is the zero address (codex PR #976
+   * F7 — `(0n << 96) | 0n === 0n`, which collides with the poller's
+   * "no kaId" sentinel and violates the `KaAllocation.kaId` non-zero
+   * contract).
+   *
+   * The address is canonicalized to the validated lowercase form
+   * (codex PR #976 F8) BEFORE being passed to the store, so any
+   * `KaNumberStore` implementation receives a single canonical key
+   * regardless of caller casing. Without this, `0xAbc…` vs `0xabc…`
+   * would fork the sequence in a store that forgot to lowercase its
+   * own key, producing duplicate low-96 counters under the same
+   * on-chain author.
    */
   allocate(authorAddress: string): KaAllocation {
     this.assertReconciled();
-    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    const authorBits = BigInt(canonical);
     // `number` is a `bigint` straight off the store (codex PR #976 F6) —
     // no `BigInt()` round-trip, no chance of a stray `Number()` cast at
     // the call site silently truncating a counter past 2^53.
-    const number = this.store.allocate(authorAddress);
+    const number = this.store.allocate(canonical);
     const kaId = (authorBits << NUMBER_BITS) | number;
     return { kaId, number };
   }
@@ -83,22 +95,25 @@ export class KaNumberAllocator {
    * `observedNumber` is a `bigint` (codex PR #976 F6) — the chain reads
    * that compute it (`kaId & ((1n<<96n)-1n)`) already produce bigint;
    * accepting `number` here would force a precision-losing cast at the
-   * caller.
+   * caller. The address is canonicalized before being passed to the
+   * store (codex PR #976 F8) to keep the per-author key stable across
+   * casing variants.
    */
   reconcile(authorAddress: string, observedNumber: bigint): void {
-    // Validate the address shape here too so reconciliation rejects junk
-    // before it can poison the floor.
-    KaNumberAllocator.authorToUint160(authorAddress);
-    this.store.reconcileFloor(authorAddress, observedNumber + 1n);
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    this.store.reconcileFloor(canonical, observedNumber + 1n);
   }
 
   /**
    * The `kaId` the next `allocate(authorAddress)` would produce, without
-   * consuming it. Does NOT require reconciliation (read-only peek).
+   * consuming it. Does NOT require reconciliation (read-only peek). The
+   * address is canonicalized (codex PR #976 F8) so peek + allocate
+   * cannot disagree under mixed casing.
    */
   peekKaId(authorAddress: string): bigint {
-    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
-    const number = this.store.peekNext(authorAddress);
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    const authorBits = BigInt(canonical);
+    const number = this.store.peekNext(canonical);
     return (authorBits << NUMBER_BITS) | number;
   }
 
@@ -134,18 +149,44 @@ export class KaNumberAllocator {
    * 160-bit integer value. Uses `ethers.getAddress` to validate (it
    * throws on a malformed/checksum-invalid address); `BigInt(0x…)` then
    * yields the unsigned 160-bit value. NEVER uses `Number()`.
+   *
+   * Rejects the zero address (codex PR #976 F7) — see
+   * `canonicalizeAuthor()` for the rationale.
    */
   static authorToUint160(authorAddress: string): bigint {
-    // getAddress throws on anything that is not a valid 20-byte address
-    // (wrong length, non-hex, bad checksum casing). Re-wrap so the error
-    // is attributable to this module.
+    return BigInt(KaNumberAllocator.canonicalizeAuthor(authorAddress));
+  }
+
+  /**
+   * Validate `authorAddress` and return its canonical lowercase
+   * `0x`-prefixed 42-char form. This is the single normalization point
+   * the allocator uses before talking to the store, so any
+   * `KaNumberStore` implementation receives one canonical key per
+   * on-chain author regardless of caller casing (codex PR #976 F8).
+   *
+   * Rejects:
+   *   - Anything `ethers.getAddress()` rejects (wrong length, non-hex,
+   *     bad checksum casing).
+   *   - The zero address `0x0000…0000` (codex PR #976 F7). Allocating
+   *     under the zero address would yield `kaId = 0n`, which both
+   *     violates the `KaAllocation.kaId` non-zero contract and collides
+   *     with the poller's "no kaId" sentinel (see
+   *     `chain-event-poller.ts::handleKACreated`'s `if (kaId === 0n)
+   *     return`).
+   */
+  static canonicalizeAuthor(authorAddress: string): string {
     let checksummed: string;
     try {
       checksummed = ethers.getAddress(authorAddress);
     } catch {
       throw new Error(`KaNumberAllocator: invalid author address: ${authorAddress}`);
     }
-    return BigInt(checksummed);
+    if (checksummed === ethers.ZeroAddress) {
+      throw new Error(
+        'KaNumberAllocator: refusing to allocate under the zero address (kaId=0n collides with the poller "no kaId" sentinel and violates the KaAllocation non-zero contract)',
+      );
+    }
+    return checksummed.toLowerCase();
   }
 
   /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -155,3 +155,4 @@ export {
 export * from './source-worker.js';
 export * from './source-registry.js';
 export * from './generic-sql-source.js';
+export { KaNumberAllocator, type KaAllocation } from './allocator.js';

--- a/packages/agent/test/allocator.test.ts
+++ b/packages/agent/test/allocator.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { KaNumberStore } from '@origintrail-official/dkg-core';
+import { KaNumberAllocator } from '../src/allocator.js';
+
+/**
+ * OT-RFC-43 Option-1 deterministic KA identity — B2 allocator core.
+ *
+ * These pin the allocator invariants the RFC calls load-bearing:
+ *   - per-author numbers are strictly monotonic from 0 and never reclaimed,
+ *     including across allocator instances that share one durable store;
+ *   - `reconcileFloor` only ever raises the next-number, never lowers it;
+ *   - `kaId = (uint160(author) << 96) | uint96(number)` packs/unpacks
+ *     round-trip, is computed in bigint, and is always non-zero;
+ *   - a cold (un-reconciled) allocator refuses to allocate (RFC §4.5).
+ *
+ * `SqliteKaNumberStore` lives in `@origintrail-official/dkg-node-ui`, which
+ * the agent package does not depend on, so the store's SQL is exercised by
+ * a faithful in-memory `KaNumberStore` here (same atomic monotonic contract:
+ * `next_number` starts at the floor, `allocate` returns then increments).
+ * The DB-backed store gets its own test against the existing DashboardDB
+ * harness in node-ui (see open issue).
+ */
+
+/**
+ * In-memory `KaNumberStore` matching the `SqliteKaNumberStore` contract:
+ * keyed by lowercased author, `next_number` is the value to hand out next,
+ * `allocate` returns the current value then increments, `reconcileFloor`
+ * raises but never lowers.
+ */
+class InMemoryKaNumberStore implements KaNumberStore {
+  private readonly next = new Map<string, number>();
+
+  allocate(authorAddress: string): number {
+    const key = authorAddress.toLowerCase();
+    const current = this.next.get(key) ?? 0;
+    this.next.set(key, current + 1);
+    return current;
+  }
+
+  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+    const key = authorAddress.toLowerCase();
+    const current = this.next.get(key) ?? 0;
+    this.next.set(key, Math.max(current, nextNumberFloor));
+  }
+
+  peekNext(authorAddress: string): number {
+    return this.next.get(authorAddress.toLowerCase()) ?? 0;
+  }
+}
+
+// Two distinct, valid checksummed 20-byte addresses.
+const AUTHOR_A = '0x52908400098527886E0F7030069857D2E4169EE7';
+const AUTHOR_B = '0xde709f2102306220921060314715629080e2fb77';
+const NUMBER_MASK = (1n << 96n) - 1n;
+
+let store: InMemoryKaNumberStore;
+let alloc: KaNumberAllocator;
+
+beforeEach(() => {
+  store = new InMemoryKaNumberStore();
+  alloc = new KaNumberAllocator(store);
+  alloc.markReconciled();
+});
+
+describe('KaNumberAllocator — cold-start refusal (RFC §4.5)', () => {
+  it('refuses to allocate before reconciliation', () => {
+    const cold = new KaNumberAllocator(new InMemoryKaNumberStore());
+    expect(() => cold.allocate(AUTHOR_A)).toThrow(/cold-start refusal/);
+    expect(cold.isReconciled()).toBe(false);
+  });
+
+  it('allocates after markReconciled()', () => {
+    const warm = new KaNumberAllocator(new InMemoryKaNumberStore());
+    expect(warm.isReconciled()).toBe(false);
+    warm.markReconciled();
+    expect(warm.isReconciled()).toBe(true);
+    expect(() => warm.allocate(AUTHOR_A)).not.toThrow();
+  });
+
+  it('peekKaId does not require reconciliation', () => {
+    const cold = new KaNumberAllocator(new InMemoryKaNumberStore());
+    expect(() => cold.peekKaId(AUTHOR_A)).not.toThrow();
+  });
+});
+
+describe('KaNumberAllocator — monotonic per-author numbers', () => {
+  it('hands out 0,1,2,... for one author', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+  });
+
+  it('keeps independent sequences per author', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(1);
+  });
+
+  it('treats checksum-cased and lower-cased authors as the same sequence', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_A.toLowerCase()).number).toBe(1);
+  });
+
+  it('never reclaims a number across allocator instances on a shared store', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    // A fresh allocator over the SAME durable store must continue the
+    // sequence, not restart it (durable, never-reclaimed contract).
+    const alloc2 = new KaNumberAllocator(store);
+    alloc2.markReconciled();
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(2);
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(3);
+  });
+});
+
+describe('KaNumberAllocator — reconcile (floor)', () => {
+  it('advances the next number up to observed+1', () => {
+    // Observed highest minted on-chain under AUTHOR_A is 41 => next is 42.
+    alloc.reconcile(AUTHOR_A, 41);
+    expect(store.peekNext(AUTHOR_A)).toBe(42);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(42);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(43);
+  });
+
+  it('never lowers an already-higher next number', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    // Local store is already at next=2. A stale floor of observed=0
+    // (=> proposed next 1) must NOT pull the sequence backwards.
+    alloc.reconcile(AUTHOR_A, 0);
+    expect(store.peekNext(AUTHOR_A)).toBe(2);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+  });
+
+  it('reconcile is monotonic across repeated calls', () => {
+    alloc.reconcile(AUTHOR_A, 9); // next -> 10
+    alloc.reconcile(AUTHOR_A, 4); // stale, no-op
+    alloc.reconcile(AUTHOR_A, 19); // next -> 20
+    expect(store.peekNext(AUTHOR_A)).toBe(20);
+  });
+});
+
+describe('KaNumberAllocator — kaId packing', () => {
+  it('packs (uint160(author) << 96) | number and is non-zero', () => {
+    const { kaId, number } = alloc.allocate(AUTHOR_A);
+    expect(number).toBe(0);
+    expect(typeof kaId).toBe('bigint');
+    expect(kaId).not.toBe(0n);
+    // Low 96 bits == number, high bits == author.
+    expect(kaId & NUMBER_MASK).toBe(0n);
+    expect(kaId >> 96n).toBe(BigInt(AUTHOR_A));
+  });
+
+  it('round-trips through unpack for a non-zero number', () => {
+    // Consume a few so number is non-zero.
+    alloc.allocate(AUTHOR_B);
+    alloc.allocate(AUTHOR_B);
+    const { kaId, number } = alloc.allocate(AUTHOR_B);
+    expect(number).toBe(2);
+    const unpacked = KaNumberAllocator.unpack(kaId);
+    expect(unpacked.number).toBe(2n);
+    expect(unpacked.author).toBe(AUTHOR_B.toLowerCase());
+  });
+
+  it('unpack pads the author to 40 hex chars (leading-zero authors)', () => {
+    // An address with leading zero bytes must still round-trip to 40 chars.
+    const lowAuthor = '0x0000000000000000000000000000000000000abc';
+    const a = new KaNumberAllocator(new InMemoryKaNumberStore());
+    a.markReconciled();
+    const { kaId } = a.allocate(lowAuthor);
+    const unpacked = KaNumberAllocator.unpack(kaId);
+    expect(unpacked.author).toBe(lowAuthor);
+    expect(unpacked.author).toHaveLength(42); // '0x' + 40
+  });
+
+  it('peekKaId equals the kaId the next allocate would produce', () => {
+    const peeked = alloc.peekKaId(AUTHOR_A);
+    const { kaId } = alloc.allocate(AUTHOR_A);
+    expect(peeked).toBe(kaId);
+  });
+
+  it('every allocation yields a non-zero kaId', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(alloc.allocate(AUTHOR_A).kaId).not.toBe(0n);
+    }
+  });
+
+  it('rejects an invalid author address', () => {
+    expect(() => alloc.allocate('not-an-address')).toThrow(/invalid author address/);
+    expect(() => alloc.allocate('0x1234')).toThrow(/invalid author address/);
+  });
+});

--- a/packages/agent/test/allocator.test.ts
+++ b/packages/agent/test/allocator.test.ts
@@ -26,25 +26,29 @@ import { KaNumberAllocator } from '../src/allocator.js';
  * keyed by lowercased author, `next_number` is the value to hand out next,
  * `allocate` returns the current value then increments, `reconcileFloor`
  * raises but never lowers.
+ *
+ * `bigint` end-to-end (codex PR #976 F6) so this fixture mirrors the
+ * SQLite store's `safeIntegers(true)` semantics and the counter stays
+ * exact past `Number.MAX_SAFE_INTEGER`.
  */
 class InMemoryKaNumberStore implements KaNumberStore {
-  private readonly next = new Map<string, number>();
+  private readonly next = new Map<string, bigint>();
 
-  allocate(authorAddress: string): number {
+  allocate(authorAddress: string): bigint {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, current + 1);
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current + 1n);
     return current;
   }
 
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, Math.max(current, nextNumberFloor));
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current > nextNumberFloor ? current : nextNumberFloor);
   }
 
-  peekNext(authorAddress: string): number {
-    return this.next.get(authorAddress.toLowerCase()) ?? 0;
+  peekNext(authorAddress: string): bigint {
+    return this.next.get(authorAddress.toLowerCase()) ?? 0n;
   }
 }
 
@@ -84,67 +88,93 @@ describe('KaNumberAllocator — cold-start refusal (RFC §4.5)', () => {
 });
 
 describe('KaNumberAllocator — monotonic per-author numbers', () => {
-  it('hands out 0,1,2,... for one author', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+  it('hands out 0n,1n,2n,... for one author', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2n);
   });
 
   it('keeps independent sequences per author', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_B).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
-    expect(alloc.allocate(AUTHOR_B).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(1n);
   });
 
   it('treats checksum-cased and lower-cased authors as the same sequence', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A.toLowerCase()).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A.toLowerCase()).number).toBe(1n);
   });
 
   it('never reclaims a number across allocator instances on a shared store', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
     // A fresh allocator over the SAME durable store must continue the
     // sequence, not restart it (durable, never-reclaimed contract).
     const alloc2 = new KaNumberAllocator(store);
     alloc2.markReconciled();
-    expect(alloc2.allocate(AUTHOR_A).number).toBe(2);
-    expect(alloc2.allocate(AUTHOR_A).number).toBe(3);
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(2n);
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(3n);
+  });
+
+  // codex PR #976 F6 — the counter is bigint end-to-end. Crossing
+  // `Number.MAX_SAFE_INTEGER` MUST remain exact (no silent precision
+  // loss). Pre-fix this would have returned the same `number` twice
+  // (or skipped one) because every cast went through JS `number`.
+  it('stays exact past Number.MAX_SAFE_INTEGER (F6 precision invariant)', () => {
+    const past = BigInt(Number.MAX_SAFE_INTEGER); // 2^53 - 1
+    // Reconcile the floor so the next allocation lands at exactly `past`.
+    // `reconcile` adds 1, so observed = past - 1n => next = past.
+    alloc.reconcile(AUTHOR_A, past - 1n);
+    const a = alloc.allocate(AUTHOR_A);
+    const b = alloc.allocate(AUTHOR_A);
+    const c = alloc.allocate(AUTHOR_A);
+    expect(a.number).toBe(past);
+    expect(b.number).toBe(past + 1n);
+    expect(c.number).toBe(past + 2n);
+    // Critical: in JS `number`, `Number(past) + 2 === Number(past) + 3`
+    // (both round to the same 2^53 even). With `bigint`, the three
+    // allocations are distinct values — no kaId collision risk.
+    expect(a.number).not.toBe(b.number);
+    expect(b.number).not.toBe(c.number);
+    // And the kaId packing must reflect the distinct numbers too.
+    expect(a.kaId).not.toBe(b.kaId);
+    expect(b.kaId).not.toBe(c.kaId);
+    expect(typeof a.number).toBe('bigint');
   });
 });
 
 describe('KaNumberAllocator — reconcile (floor)', () => {
   it('advances the next number up to observed+1', () => {
     // Observed highest minted on-chain under AUTHOR_A is 41 => next is 42.
-    alloc.reconcile(AUTHOR_A, 41);
-    expect(store.peekNext(AUTHOR_A)).toBe(42);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(42);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(43);
+    alloc.reconcile(AUTHOR_A, 41n);
+    expect(store.peekNext(AUTHOR_A)).toBe(42n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(42n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(43n);
   });
 
   it('never lowers an already-higher next number', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
     // Local store is already at next=2. A stale floor of observed=0
     // (=> proposed next 1) must NOT pull the sequence backwards.
-    alloc.reconcile(AUTHOR_A, 0);
-    expect(store.peekNext(AUTHOR_A)).toBe(2);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+    alloc.reconcile(AUTHOR_A, 0n);
+    expect(store.peekNext(AUTHOR_A)).toBe(2n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2n);
   });
 
   it('reconcile is monotonic across repeated calls', () => {
-    alloc.reconcile(AUTHOR_A, 9); // next -> 10
-    alloc.reconcile(AUTHOR_A, 4); // stale, no-op
-    alloc.reconcile(AUTHOR_A, 19); // next -> 20
-    expect(store.peekNext(AUTHOR_A)).toBe(20);
+    alloc.reconcile(AUTHOR_A, 9n); // next -> 10
+    alloc.reconcile(AUTHOR_A, 4n); // stale, no-op
+    alloc.reconcile(AUTHOR_A, 19n); // next -> 20
+    expect(store.peekNext(AUTHOR_A)).toBe(20n);
   });
 });
 
 describe('KaNumberAllocator — kaId packing', () => {
   it('packs (uint160(author) << 96) | number and is non-zero', () => {
     const { kaId, number } = alloc.allocate(AUTHOR_A);
-    expect(number).toBe(0);
+    expect(number).toBe(0n);
     expect(typeof kaId).toBe('bigint');
     expect(kaId).not.toBe(0n);
     // Low 96 bits == number, high bits == author.
@@ -157,7 +187,7 @@ describe('KaNumberAllocator — kaId packing', () => {
     alloc.allocate(AUTHOR_B);
     alloc.allocate(AUTHOR_B);
     const { kaId, number } = alloc.allocate(AUTHOR_B);
-    expect(number).toBe(2);
+    expect(number).toBe(2n);
     const unpacked = KaNumberAllocator.unpack(kaId);
     expect(unpacked.number).toBe(2n);
     expect(unpacked.author).toBe(AUTHOR_B.toLowerCase());

--- a/packages/agent/test/allocator.test.ts
+++ b/packages/agent/test/allocator.test.ts
@@ -221,3 +221,97 @@ describe('KaNumberAllocator — kaId packing', () => {
     expect(() => alloc.allocate('0x1234')).toThrow(/invalid author address/);
   });
 });
+
+describe('KaNumberAllocator — zero address (codex PR #976 F7)', () => {
+  const ZERO = '0x0000000000000000000000000000000000000000';
+
+  it('refuses to allocate under the zero address', () => {
+    // Under the packed scheme `kaId = (uint160(author) << 96) | number`
+    // the first allocation for the zero address would produce
+    // `kaId = (0n << 96n) | 0n === 0n`. That:
+    //   (a) violates the documented `KaAllocation.kaId` non-zero contract;
+    //   (b) collides with the chain-event-poller's "no kaId" sentinel
+    //       (`handleKACreated`'s `if (kaId === 0n) return`), so the
+    //       reconciliation callback would silently drop the mint event.
+    // `ethers.getAddress(ZeroAddress)` accepts the zero address, so the
+    // allocator has to reject it explicitly.
+    expect(() => alloc.allocate(ZERO)).toThrow(/zero address/);
+  });
+
+  it('refuses to reconcile under the zero address', () => {
+    // Same rationale — never let a stray zero-address observation poison
+    // the floor map with a phantom-author key.
+    expect(() => alloc.reconcile(ZERO, 0n)).toThrow(/zero address/);
+  });
+
+  it('refuses to peek under the zero address', () => {
+    expect(() => alloc.peekKaId(ZERO)).toThrow(/zero address/);
+  });
+
+  it('accepts every non-zero address ethers.getAddress accepts', () => {
+    // Sanity: a barely-non-zero address still works (no over-rejection).
+    const oneLsb = '0x0000000000000000000000000000000000000001';
+    expect(alloc.allocate(oneLsb).number).toBe(0n);
+    expect(alloc.allocate(oneLsb).kaId).not.toBe(0n);
+  });
+});
+
+describe('KaNumberAllocator — canonical address (codex PR #976 F8)', () => {
+  it('passes a single canonical key to the store regardless of caller casing', () => {
+    // The allocator now canonicalizes (lowercase) before talking to the
+    // store, so a store implementation that forgot to lowercase its own
+    // key still gets one stable key per on-chain author. We pin this
+    // behaviour with a casing-aware fake store.
+    class CaseAwareStore implements KaNumberStore {
+      readonly seenKeys: string[] = [];
+      private readonly next = new Map<string, bigint>();
+      allocate(authorAddress: string): bigint {
+        // INTENTIONALLY does NOT lowercase — that's the bug F8 defends
+        // against. If the allocator forwards a checksummed string, the
+        // sequence forks per casing variant.
+        this.seenKeys.push(authorAddress);
+        const cur = this.next.get(authorAddress) ?? 0n;
+        this.next.set(authorAddress, cur + 1n);
+        return cur;
+      }
+      reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
+        this.seenKeys.push(authorAddress);
+        const cur = this.next.get(authorAddress) ?? 0n;
+        this.next.set(authorAddress, cur > nextNumberFloor ? cur : nextNumberFloor);
+      }
+      peekNext(authorAddress: string): bigint {
+        this.seenKeys.push(authorAddress);
+        return this.next.get(authorAddress) ?? 0n;
+      }
+    }
+    const store = new CaseAwareStore();
+    const a = new KaNumberAllocator(store);
+    a.markReconciled();
+
+    // Caller hands us THREE different casings of the same on-chain
+    // address. The allocator must collapse them to one key before the
+    // store ever sees them.
+    a.allocate(AUTHOR_A);                  // checksummed
+    a.allocate(AUTHOR_A.toLowerCase());
+    a.allocate(AUTHOR_A.toUpperCase().replace('0X', '0x')); // upper hex
+    a.peekKaId(AUTHOR_A);
+    a.reconcile(AUTHOR_A, 99n);
+
+    // Every store key must be the lowercased canonical form. Without
+    // the F8 fix the store would have seen the checksummed string at
+    // least once.
+    const lc = AUTHOR_A.toLowerCase();
+    for (const key of store.seenKeys) {
+      expect(key).toBe(lc);
+    }
+  });
+
+  it('peek + allocate cannot disagree under mixed casing', () => {
+    // Peek with one casing, allocate with another — the peeked kaId
+    // MUST equal the kaId the next allocate produces. Without F8 the
+    // two would index into different store keys and disagree.
+    const peeked = alloc.peekKaId(AUTHOR_A);
+    const { kaId } = alloc.allocate(AUTHOR_A.toLowerCase());
+    expect(peeked).toBe(kaId);
+  });
+});

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -59,7 +59,7 @@ import {
   MockChainAdapter,
   type ApprovalPolicy,
 } from '@origintrail-official/dkg-chain';
-import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
+import { DKGAgent, loadOpWallets, KaNumberAllocator } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
@@ -73,6 +73,7 @@ import {
   LlmClient,
   SqliteMessageIdempotencyStore,
   SqliteProtocolOutboxStore,
+  SqliteKaNumberStore,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
 import {
@@ -1168,6 +1169,22 @@ export async function runDaemonInner(
       return DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS[idx];
     },
   });
+
+  // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
+  // Durable per-author KA-number sequence backing the off-chain
+  // `KaNumberAllocator`. Constructed here (alongside the other durable
+  // substrate stores) so the V20 `ka_numbers` table is opened and its
+  // sequence is co-located with the rest of the node's persistent state.
+  //
+  // TODO(T0 integration, deferred — overlaps Plan A): the actual
+  // publish-time `kaNumberAllocator.allocate(author)` call site is NOT
+  // wired here, nor is the startup reconciliation oracle that bumps each
+  // author floor + calls `markReconciled()`. Until that lands the
+  // allocator will (correctly) refuse to allocate per RFC §4.5
+  // cold-start refusal. This block only constructs the off-chain core.
+  const kaNumberStore = new SqliteKaNumberStore(dashDb);
+  const kaNumberAllocator = new KaNumberAllocator(kaNumberStore);
+  void kaNumberAllocator; // wired at the deferred T0 integration
 
   const agent = await DKGAgent.create({
     name: config.name,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,6 +126,7 @@ export {
   type IdempotencyCheckResult,
   type ProtocolOutboxStore,
   type ProtocolOutboxEntry,
+  type KaNumberStore,
   RESPONSE_CACHE_BYTES,
   RESPONSE_GONE_MARKER,
 } from './messenger-types.js';

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -249,3 +249,54 @@ export interface ProtocolOutboxStore {
    */
   getEntry(peer: string, protocol: string, messageId: string): ProtocolOutboxEntry | undefined;
 }
+
+/**
+ * Durable per-author KA-number allocator (OT-RFC-43 Option-1
+ * deterministic KA identity, B2 allocator core).
+ *
+ * The locked design decision: the allocation namespace is the
+ * *attested author* address, and a KA's full id is packed as
+ * `kaId = (uint160(author) << 96) | uint96(number)`. This store owns
+ * only the `number` half — a strictly-monotonic, never-reclaimed
+ * sequence *per author address* — so a daemon crash mid-publish never
+ * re-hands a number that may already have been minted on-chain under
+ * that author.
+ *
+ * The store keys by author address (lowercased by the implementation),
+ * not by node/operator identity: two nodes attesting the same author
+ * draw from the same logical sequence, which is why startup
+ * reconciliation against observed on-chain state (`reconcileFloor`) is
+ * required before a cold node may allocate (RFC §4.5 cold-start
+ * refusal — enforced by the wrapping `KaNumberAllocator`, not here).
+ *
+ * Allocation state is durable like `protocol_outbox`: it is NEVER
+ * pruned. Reclaiming a number would risk minting a duplicate kaId.
+ */
+export interface KaNumberStore {
+  /**
+   * Atomically consume and return the next number for `authorAddress`.
+   * The first call for an author returns `0`; subsequent calls return
+   * `1, 2, 3, …` strictly monotonically. Implementations lowercase the
+   * address and perform the read-and-increment in a single atomic
+   * statement (`INSERT … ON CONFLICT DO UPDATE … RETURNING`) so two
+   * concurrent allocations never collide on the same number.
+   */
+  allocate(authorAddress: string): number;
+
+  /**
+   * Raise the stored next-number for `authorAddress` to *at least*
+   * `nextNumberFloor`, never lowering it. Called at startup with
+   * `observedHighestMinted + 1` so a node that lost local state (or is
+   * cold) cannot re-issue a number the chain already used under that
+   * author. Idempotent and monotonic: replaying an old floor is a
+   * no-op.
+   */
+  reconcileFloor(authorAddress: string, nextNumberFloor: number): void;
+
+  /**
+   * The number the *next* `allocate(authorAddress)` would return,
+   * without consuming it. Returns `0` when the author has never been
+   * seen. For diagnostics / reconciliation comparisons.
+   */
+  peekNext(authorAddress: string): number;
+}

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -271,32 +271,46 @@ export interface ProtocolOutboxStore {
  *
  * Allocation state is durable like `protocol_outbox`: it is NEVER
  * pruned. Reclaiming a number would risk minting a duplicate kaId.
+ *
+ * **Counter width (codex PR #976 F6):** every counter value crosses
+ * this interface as a `bigint`, not a JS `number`. The on-chain field
+ * is a `uint96` (max `2^96 - 1 ≈ 7.9e28`) and the design contemplates
+ * far-future high-throughput authors. Even though `1000 alloc/s × 1M
+ * years ≈ 2^55` keeps real load comfortably under `Number.MAX_SAFE_
+ * INTEGER (2^53 - 1)`, returning `number` would silently lose precision
+ * past that point — `allocate()`, `peekNext()`, and `observed + 1`
+ * would all start to skip or duplicate kaIds. Using `bigint` end-to-end
+ * is a defence-in-depth invariant: the interface cannot accidentally
+ * be wired through a `Number()` cast at a call site. SQLite's signed
+ * `INTEGER` (2^63 - 1) remains the hard ceiling for the implementation
+ * — orders of magnitude past any realistic load, and many orders past
+ * the `2^53` precision cliff that motivated this typing.
  */
 export interface KaNumberStore {
   /**
    * Atomically consume and return the next number for `authorAddress`.
-   * The first call for an author returns `0`; subsequent calls return
-   * `1, 2, 3, …` strictly monotonically. Implementations lowercase the
-   * address and perform the read-and-increment in a single atomic
+   * The first call for an author returns `0n`; subsequent calls return
+   * `1n, 2n, 3n, …` strictly monotonically. Implementations lowercase
+   * the address and perform the read-and-increment in a single atomic
    * statement (`INSERT … ON CONFLICT DO UPDATE … RETURNING`) so two
    * concurrent allocations never collide on the same number.
    */
-  allocate(authorAddress: string): number;
+  allocate(authorAddress: string): bigint;
 
   /**
    * Raise the stored next-number for `authorAddress` to *at least*
    * `nextNumberFloor`, never lowering it. Called at startup with
-   * `observedHighestMinted + 1` so a node that lost local state (or is
+   * `observedHighestMinted + 1n` so a node that lost local state (or is
    * cold) cannot re-issue a number the chain already used under that
    * author. Idempotent and monotonic: replaying an old floor is a
    * no-op.
    */
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void;
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void;
 
   /**
    * The number the *next* `allocate(authorAddress)` would return,
-   * without consuming it. Returns `0` when the author has never been
+   * without consuming it. Returns `0n` when the author has never been
    * seen. For diagnostics / reconciliation comparisons.
    */
-  peekNext(authorAddress: string): number;
+  peekNext(authorAddress: string): bigint;
 }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2586,6 +2586,19 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
  * other Sqlite*Store classes rely on — there is no `.transaction()`
  * in this module).
  *
+ * **Counter width (codex PR #976 F6):** every value crossing the
+ * `KaNumberStore` interface is a `bigint`. `better-sqlite3` returns
+ * INTEGER columns as JS `number` by default — which silently truncates
+ * once a counter passes `Number.MAX_SAFE_INTEGER (2^53 - 1)`. Each
+ * statement here opts into `.safeIntegers(true)`, returning `bigint`
+ * directly so `allocate()`, `peekNext()` and `observed + 1n` stay
+ * exact across the full SQLite signed INTEGER range (`2^63 - 1`). The
+ * RFC's worst-case load ("1000 alloc/s × 1M years ≈ 2^55") sits well
+ * past the `2^53` precision cliff and far under the `2^63` hard
+ * ceiling; if a single author ever does approach `2^63`, SQLite raises
+ * an INTEGER overflow on the next increment — a fail-loud surface
+ * that's strictly preferable to a silent kaId-collision risk.
+ *
  * Like `protocol_outbox`, this state is durable: it is NEVER added to
  * `prune()`. Reclaiming a number could re-mint a kaId already used
  * on-chain under that author.
@@ -2597,13 +2610,15 @@ export class SqliteKaNumberStore implements KaNumberStore {
     this.db = dashboard.db;
   }
 
-  allocate(authorAddress: string): number {
+  allocate(authorAddress: string): bigint {
     const author = authorAddress.toLowerCase();
     // Atomic read-and-increment. `next_number` is the value to hand
     // out; we increment it and RETURN the value just consumed
     // (`next_number - 1` after the update), so the first call for an
-    // author returns 0. On first insert `next_number` starts at 1, so
+    // author returns 0n. On first insert `next_number` starts at 1, so
     // `1 - 1 = 0` is returned there too — uniform either way.
+    // `safeIntegers(true)` opts INTO bigint returns so the counter is
+    // exact past `Number.MAX_SAFE_INTEGER` (codex PR #976 F6).
     const row = this.db
       .prepare(
         `INSERT INTO ka_numbers (author_address, next_number)
@@ -2611,14 +2626,16 @@ export class SqliteKaNumberStore implements KaNumberStore {
          ON CONFLICT(author_address) DO UPDATE SET next_number = next_number + 1
          RETURNING next_number - 1 AS number`,
       )
-      .get(author) as { number: number };
+      .safeIntegers(true)
+      .get(author) as { number: bigint };
     return row.number;
   }
 
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
     const author = authorAddress.toLowerCase();
     // Raise `next_number` to at least the floor, never lowering it.
     // `excluded.next_number` is the proposed floor from the VALUES row.
+    // `better-sqlite3` accepts bigint statement parameters natively.
     this.db
       .prepare(
         `INSERT INTO ka_numbers (author_address, next_number)
@@ -2629,12 +2646,13 @@ export class SqliteKaNumberStore implements KaNumberStore {
       .run(author, nextNumberFloor);
   }
 
-  peekNext(authorAddress: string): number {
+  peekNext(authorAddress: string): bigint {
     const author = authorAddress.toLowerCase();
     const row = this.db
       .prepare(`SELECT next_number FROM ka_numbers WHERE author_address = ?`)
-      .get(author) as { next_number: number } | undefined;
-    return row?.next_number ?? 0;
+      .safeIntegers(true)
+      .get(author) as { next_number: bigint } | undefined;
+    return row?.next_number ?? 0n;
   }
 }
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -3,13 +3,14 @@ import { join } from 'node:path';
 import {
   RESPONSE_CACHE_BYTES,
   type IdempotencyCheckResult,
+  type KaNumberStore,
   type MessageDirection,
   type MessageIdempotencyStore,
   type ProtocolOutboxEntry,
   type ProtocolOutboxStore,
 } from '@origintrail-official/dkg-core';
 
-const SCHEMA_VERSION = 19;
+const SCHEMA_VERSION = 20;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -722,6 +723,32 @@ export class DashboardDB {
       if (!cols.has('core_hosted')) {
         this.db.exec(`ALTER TABLE context_graph_subscriptions ADD COLUMN core_hosted INTEGER;`);
       }
+    }
+
+    if (version < 20) {
+      // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
+      // Per-author durable KA-number sequence. The allocation namespace is
+      // the *attested author* address (locked design decision); a KA's full
+      // id is packed off-chain as `(uint160(author) << 96) | uint96(number)`.
+      // This table owns only the `number` half: one strictly-monotonic,
+      // never-reclaimed counter per author address.
+      //   - `author_address` is stored lowercase (the `SqliteKaNumberStore`
+      //     lowercases before every read/write) so checksum-cased and
+      //     lower-cased inputs map to the same sequence.
+      //   - `next_number` is the NEXT number to hand out for that author;
+      //     `allocate()` returns `next_number` then increments, so the first
+      //     call for an author returns 0.
+      // INTEGER (SQLite's signed 64-bit) is sufficient: at 1000 allocations/s
+      // for a million years a single author consumes ~2^55 numbers, far under
+      // the 2^63 INTEGER max and under the uint96 on-chain field. Like
+      // `protocol_outbox`, this state is durable and is NEVER pruned —
+      // reclaiming a number could mint a duplicate kaId.
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS ka_numbers (
+          author_address TEXT PRIMARY KEY,
+          next_number INTEGER NOT NULL
+        );
+      `);
     }
 
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
@@ -2543,6 +2570,71 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
       nextAttemptAt: row.next_attempt_at,
       lastError: row.last_error ?? '',
     };
+  }
+}
+
+/**
+ * SQLite-backed `KaNumberStore` against the V20 `ka_numbers` table.
+ * Per-author durable KA-number allocator for OT-RFC-43 Option-1
+ * deterministic KA identity (B2 allocator core, OFF-CHAIN only).
+ *
+ * Keyed by the attested author address (stored lowercase). Every
+ * method is a single prepared statement; the read-and-increment in
+ * `allocate` is atomic via `INSERT … ON CONFLICT DO UPDATE …
+ * RETURNING`, so concurrent allocations under the same author never
+ * collide on a number (the same atomic-single-statement contract the
+ * other Sqlite*Store classes rely on — there is no `.transaction()`
+ * in this module).
+ *
+ * Like `protocol_outbox`, this state is durable: it is NEVER added to
+ * `prune()`. Reclaiming a number could re-mint a kaId already used
+ * on-chain under that author.
+ */
+export class SqliteKaNumberStore implements KaNumberStore {
+  private readonly db: Database.Database;
+
+  constructor(dashboard: DashboardDB) {
+    this.db = dashboard.db;
+  }
+
+  allocate(authorAddress: string): number {
+    const author = authorAddress.toLowerCase();
+    // Atomic read-and-increment. `next_number` is the value to hand
+    // out; we increment it and RETURN the value just consumed
+    // (`next_number - 1` after the update), so the first call for an
+    // author returns 0. On first insert `next_number` starts at 1, so
+    // `1 - 1 = 0` is returned there too — uniform either way.
+    const row = this.db
+      .prepare(
+        `INSERT INTO ka_numbers (author_address, next_number)
+         VALUES (?, 1)
+         ON CONFLICT(author_address) DO UPDATE SET next_number = next_number + 1
+         RETURNING next_number - 1 AS number`,
+      )
+      .get(author) as { number: number };
+    return row.number;
+  }
+
+  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+    const author = authorAddress.toLowerCase();
+    // Raise `next_number` to at least the floor, never lowering it.
+    // `excluded.next_number` is the proposed floor from the VALUES row.
+    this.db
+      .prepare(
+        `INSERT INTO ka_numbers (author_address, next_number)
+         VALUES (?, ?)
+         ON CONFLICT(author_address) DO UPDATE SET
+           next_number = MAX(next_number, excluded.next_number)`,
+      )
+      .run(author, nextNumberFloor);
+  }
+
+  peekNext(authorAddress: string): number {
+    const author = authorAddress.toLowerCase();
+    const row = this.db
+      .prepare(`SELECT next_number FROM ka_numbers WHERE author_address = ?`)
+      .get(author) as { next_number: number } | undefined;
+    return row?.next_number ?? 0;
   }
 }
 

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -3,6 +3,7 @@ export {
   SqliteMessageIdempotencyStore,
   SqliteProtocolOutboxStore,
   type SqliteProtocolOutboxStoreOptions,
+  SqliteKaNumberStore,
   // Notifications-pane redesign (V16): activity-digest primitives shared
   // with the daemon's `assertion_activity` emitters + scoped read path.
   ACTIVITY_DIGEST_WINDOW_MS,

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteKaNumberStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -949,6 +949,66 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
       'SELECT next_number FROM ka_numbers WHERE author_address = ?',
     ).get('0xabc') as { next_number: number } | undefined;
     expect(row).toEqual({ next_number: 0 });
+  });
+});
+
+describe('SqliteKaNumberStore — bigint counter (codex PR #976 F6)', () => {
+  let db: DashboardDB;
+  let dir: string;
+  let store: SqliteKaNumberStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-ka-number-store-test-'));
+    db = new DashboardDB({ dataDir: dir });
+    store = new SqliteKaNumberStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const AUTHOR = '0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1';
+
+  it('allocate / peekNext return bigint, not number', () => {
+    const a = store.allocate(AUTHOR);
+    expect(typeof a).toBe('bigint');
+    expect(a).toBe(0n);
+
+    expect(typeof store.peekNext(AUTHOR)).toBe('bigint');
+    expect(store.peekNext(AUTHOR)).toBe(1n);
+
+    expect(store.allocate(AUTHOR)).toBe(1n);
+    expect(store.allocate(AUTHOR)).toBe(2n);
+  });
+
+  it('reconcileFloor accepts bigint and raises but never lowers', () => {
+    store.reconcileFloor(AUTHOR, 41n);
+    expect(store.peekNext(AUTHOR)).toBe(41n);
+    expect(store.allocate(AUTHOR)).toBe(41n);
+
+    // Stale floor must not pull the sequence backwards.
+    store.reconcileFloor(AUTHOR, 5n);
+    expect(store.peekNext(AUTHOR)).toBe(42n);
+  });
+
+  it('stays exact past Number.MAX_SAFE_INTEGER (no silent precision loss)', () => {
+    // This is the F6 invariant against the REAL sqlite path. Pre-fix
+    // the store returned JS `number`, so values past 2^53 would round
+    // to the nearest even — successive `allocate()` calls could either
+    // return the same value twice (kaId collision) or skip one.
+    const past = BigInt(Number.MAX_SAFE_INTEGER); // 2^53 - 1
+    store.reconcileFloor(AUTHOR, past);
+    const a = store.allocate(AUTHOR);
+    const b = store.allocate(AUTHOR);
+    const c = store.allocate(AUTHOR);
+    expect(a).toBe(past);
+    expect(b).toBe(past + 1n);
+    expect(c).toBe(past + 2n);
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    // peekNext is also exact.
+    expect(store.peekNext(AUTHOR)).toBe(past + 3n);
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -86,7 +86,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const cols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -142,7 +142,7 @@ describe('DashboardDB — metric snapshots', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const newSnapshotCols = (db.db.prepare('PRAGMA table_info(metric_snapshots)').all() as { name: string }[])
       .map(c => c.name);
@@ -545,7 +545,7 @@ describe('DashboardDB — V15 migration: drop FTS5 logs index', () => {
 
     const upgraded = new DashboardDB({ dataDir: upgradeDir });
     try {
-      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(19);
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(20);
 
       const ftsTables = upgraded.db.prepare(
         `SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'logs_fts%'`,
@@ -761,7 +761,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -782,7 +782,7 @@ describe('DashboardDB — V17 subscription columns migration (Phase B)', () => {
       .map((c) => c.name);
     expect(cols).toContain('on_chain_hash');
     expect(cols).toContain('last_reconciled_ordinal');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
   });
 });
 
@@ -866,7 +866,7 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const cols = (db.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -877,6 +877,78 @@ describe('DashboardDB — V19 core_hosted column migration (Phase D)', () => {
       on_chain_id: '0xabc',
       core_hosted: null,
     }]);
+  });
+});
+
+describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator)', () => {
+  let db: DashboardDB;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-db-v20-test-'));
+    db = new DashboardDB({ dataDir: dir });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fresh install lands at V20 and already carries the ka_numbers table', () => {
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
+
+    const table = db.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
+    ).get() as { name: string } | undefined;
+    expect(table).toEqual({ name: 'ka_numbers' });
+
+    // The B2 allocator packs `(uint160(author) << 96) | uint96(number)`;
+    // this table owns the per-author `number` half. Lock the column shape
+    // the SqliteKaNumberStore depends on: author_address PRIMARY KEY +
+    // a NOT NULL next_number counter.
+    const cols = db.db.prepare('PRAGMA table_info(ka_numbers)').all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      pk: number;
+    }>;
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect([...byName.keys()].sort()).toEqual(['author_address', 'next_number']);
+    expect(byName.get('author_address')).toMatchObject({ type: 'TEXT', pk: 1 });
+    expect(byName.get('next_number')).toMatchObject({ type: 'INTEGER', notnull: 1 });
+  });
+
+  it('creates ka_numbers when upgrading a pre-V20 (V19) DB', () => {
+    // Stepwise upgrade: build a fresh DB, drop ka_numbers + reset
+    // user_version to 19 to simulate a node that last booted before the
+    // B2 allocator's V20 bump, then reopen via DashboardDB and verify the
+    // `version < 20` block adds the table and advances user_version to 20.
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec('DROP TABLE IF EXISTS ka_numbers;');
+    raw.pragma('user_version = 19');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
+
+    const table = db.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='ka_numbers'",
+    ).get() as { name: string } | undefined;
+    expect(table).toEqual({ name: 'ka_numbers' });
+
+    // The upgraded table accepts the allocator's row shape.
+    expect(() =>
+      db.db.prepare(
+        'INSERT INTO ka_numbers (author_address, next_number) VALUES (?, ?)',
+      ).run('0xabc', 0),
+    ).not.toThrow();
+    const row = db.db.prepare(
+      'SELECT next_number FROM ka_numbers WHERE author_address = ?',
+    ).get('0xabc') as { next_number: number } | undefined;
+    expect(row).toEqual({ next_number: 0 });
   });
 });
 
@@ -1234,7 +1306,7 @@ describe('DashboardDB — V11→V13 chat schema migration chain', () => {
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const cols = (db.db.prepare('PRAGMA table_info(chat_messages)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1300,7 +1372,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     raw.close();
 
     db = new DashboardDB({ dataDir: dir });
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
 
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
@@ -1329,7 +1401,7 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     const cols = (db.db.prepare('PRAGMA table_info(notifications)').all() as Array<{ name: string }>)
       .map((c) => c.name);
     expect(cols).toContain('context_graph_id');
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
   });
 
   it('insertNotification writes context_graph_id to the column; omitted → NULL', () => {
@@ -1551,7 +1623,7 @@ describe('DashboardDB — replication telemetry (Phase F)', () => {
     raw.pragma('user_version = 17');
     raw.close();
     const upgraded = new DashboardDB({ dataDir: dir });
-    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(19);
+    expect(upgraded.db.pragma('user_version', { simple: true })).toBe(20);
     // insert works → table exists
     upgraded.insertReplicationEvent({ ts: now, context_graph_id: 'cg', action: 'promote' });
     expect(upgraded.getReplicationSummary(60_000).promotes).toBe(1);

--- a/packages/node-ui/test/messenger-stores.test.ts
+++ b/packages/node-ui/test/messenger-stores.test.ts
@@ -45,8 +45,9 @@ describe('V12 migration', () => {
     // `message_idempotency` table. Both bumps are tested at the
     // DB layer in `db.test.ts`; this assertion just pins that
     // the substrate store fixtures are created against the
-    // current SCHEMA_VERSION.
-    expect(db.db.pragma('user_version', { simple: true })).toBe(19);
+    // current SCHEMA_VERSION (now 20 after the B2 KA-number
+    // allocator added the `ka_numbers` table at migration V20).
+    expect(db.db.pragma('user_version', { simple: true })).toBe(20);
   });
 });
 

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -254,13 +254,37 @@ export class ChainEventPoller {
     }
 
     // On first successful head fetch, seed cursor near the tip — but only
-    // when there are no pending publishes whose confirmations we might skip.
-    // Full-history context graph discovery is handled by discoverContextGraphsFromChain().
+    // when no subscriber depends on full chain history. The head-seed is
+    // a latency optimisation for the "watch for our own pending tx
+    // confirmation" use case: confirmations land at the tip, so scanning
+    // from `head - 500` is sufficient and avoids re-walking the chain on
+    // every cold start.
+    //
+    // Full-history context graph discovery is handled separately by
+    // `discoverContextGraphsFromChain()`.
+    //
+    // The OT-RFC-43 Option-1 allocator-reconciliation watcher
+    // (`onKnowledgeAssetCreated`) MUST observe every historical
+    // `KCCreated` event (codex PR #976 F9) — otherwise a fresh daemon
+    // would miss every author whose last mint was >500 blocks ago, the
+    // per-author floor would stay at 0, and a downstream
+    // `markReconciled()` would be unsound (the allocator would happily
+    // re-issue a number already minted on-chain). Treat this watcher
+    // exactly like `hasPending`: when wired AND there is no persisted
+    // cursor, refuse to seed near head and scan from block 0.
+    //
+    // Once a `cursorPersistence` round-trip lands (so `lastBlock > 0` on
+    // restart) the watcher resumes incrementally from that cursor like
+    // every other subscription — there is no extra cost beyond the
+    // first cold start.
     if (head != null && !this.headKnown) {
       this.headKnown = true;
-      if (this.lastBlock === 0 && !hasPending) {
+      const requiresFullHistory = hasPending || watchKACreated;
+      if (this.lastBlock === 0 && !requiresFullHistory) {
         this.lastBlock = Math.max(0, head - 500);
         this.log.info(ctx, `Seeded poller cursor near chain head: ${head} → scanning from ${this.lastBlock}`);
+      } else if (this.lastBlock === 0 && watchKACreated) {
+        this.log.info(ctx, `Allocator-reconciliation watcher wired and no persisted cursor → scanning from block 0 (codex PR #976 F9 backfill)`);
       }
     }
 

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -278,7 +278,19 @@ export class ChainEventPoller {
       eventTypes.push('ProfileUpdated');
     }
     if (watchKARegistered) eventTypes.push('KnowledgeAssetRegisteredToContextGraph');
-    if (this.onKnowledgeAssetCreated) eventTypes.push('KnowledgeAssetCreated');
+    // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5):
+    // The chain adapter's `listenForEvents()` decodes both the V10 greenfield
+    // `KnowledgeAssetCreated` event and the legacy V8/V9 batch-create event
+    // into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author, ... } }`
+    // surface (see packages/chain/src/evm-adapter-events.ts ~L119 and L193).
+    // A redundant `KnowledgeAssetCreated` subscription used to live here, but
+    // the adapter never yielded events with that type, so the dead branch
+    // below this loop never fired and allocator reconciliation never ran.
+    // Subscribe to `KCCreated` always (already implicit at the top of the
+    // list) and fan out to both `handleBatchCreated` AND `handleKACreated`
+    // inline below. When `onKnowledgeAssetCreated` is the ONLY subscriber
+    // wired (i.e. no PublishHandler pending state), still enter the poll
+    // loop — `watchKACreated` covers that case in the gating check above.
 
     const fromBlock = this.lastBlock + 1;
     const upperBound = head != null
@@ -298,6 +310,14 @@ export class ChainEventPoller {
       if (event.blockNumber > maxEventBlock) maxEventBlock = event.blockNumber;
       if (event.type === 'KCCreated') {
         await this.handleBatchCreated(event, ctx);
+        // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5).
+        // The adapter normalizes the greenfield `KnowledgeAssetCreated` event
+        // to `type: 'KCCreated'`, so there is no separate dispatch branch —
+        // we fan out off the same event here. `handleKACreated` is a no-op
+        // when `onKnowledgeAssetCreated` is not wired, when `kaId` is missing
+        // (legacy batch-create paths), or when `kaId` is zero (sentinel for
+        // `getKnowledgeAssetId`'s "not part of any KA" return — never minted).
+        await this.handleKACreated(event, ctx);
       } else if (event.type === 'NameClaimed' || event.type === 'ContextGraphCreated') {
         await this.handleContextGraphCreated(event, ctx);
       } else if (event.type === 'KnowledgeAssetUpdated') {
@@ -308,8 +328,6 @@ export class ChainEventPoller {
         await this.handleProfileEvent(event, ctx);
       } else if (event.type === 'KnowledgeAssetRegisteredToContextGraph') {
         await this.handleKARegistered(event, ctx);
-      } else if (event.type === 'KnowledgeAssetCreated') {
-        await this.handleKACreated(event, ctx);
       }
     }
 

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -57,6 +57,15 @@ export type OnKARegisteredToContextGraph = (info: {
   blockNumber: number;
 }) => Promise<void>;
 
+/**
+ * Callback for `KnowledgeAssetCreated` events — OT-RFC-43 Option-1 allocator
+ * reconciliation. The storage contract emits `KnowledgeAssetCreated(kaId,
+ * author, …)` (see `packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol`).
+ * `number` is the per-author ordinal extracted from the low 96 bits of `kaId`
+ * using full-precision bigint math.
+ */
+export type OnKnowledgeAssetCreated = (e: { kaId: bigint; author: string; number: bigint; txHash: string; txIndex: number; blockNumber: number }) => void | Promise<void>;
+
 /** Persistence interface for saving/loading the last processed block. */
 export interface CursorPersistence {
   load(): Promise<number | undefined>;
@@ -78,6 +87,8 @@ export interface ChainEventPollerConfig {
   onProfileEvent?: OnProfileEvent;
   /** Called when a KnowledgeAssetRegisteredToContextGraph event is detected (Phase B). */
   onKARegisteredToContextGraph?: OnKARegisteredToContextGraph;
+  /** Called when a KnowledgeAssetCreated event is detected (OT-RFC-43 Option-1 allocator reconciliation). */
+  onKnowledgeAssetCreated?: OnKnowledgeAssetCreated;
   /** Persistent cursor for surviving restarts. */
   cursorPersistence?: CursorPersistence;
 }
@@ -108,6 +119,7 @@ export class ChainEventPoller {
   private readonly onAllowListUpdated?: OnAllowListUpdated;
   private readonly onProfileEvent?: OnProfileEvent;
   private readonly onKARegisteredToContextGraph?: OnKARegisteredToContextGraph;
+  private readonly onKnowledgeAssetCreated?: OnKnowledgeAssetCreated;
   private readonly cursorPersistence?: CursorPersistence;
   private readonly log = new Logger('ChainEventPoller');
   private lastBlock = 0;
@@ -138,6 +150,7 @@ export class ChainEventPoller {
     this.onAllowListUpdated = config.onAllowListUpdated;
     this.onProfileEvent = config.onProfileEvent;
     this.onKARegisteredToContextGraph = config.onKARegisteredToContextGraph;
+    this.onKnowledgeAssetCreated = config.onKnowledgeAssetCreated;
     this.cursorPersistence = config.cursorPersistence;
   }
 
@@ -228,7 +241,8 @@ export class ChainEventPoller {
     const watchAllowList = !!this.onAllowListUpdated;
     const watchProfiles = !!this.onProfileEvent;
     const watchKARegistered = !!this.onKARegisteredToContextGraph;
-    if (!hasPending && !watchContextGraphs && !watchUpdates && !watchAllowList && !watchProfiles && !watchKARegistered) return;
+    const watchKACreated = !!this.onKnowledgeAssetCreated;
+    if (!hasPending && !watchContextGraphs && !watchUpdates && !watchAllowList && !watchProfiles && !watchKARegistered && !watchKACreated) return;
 
     const ctx = createOperationContext('publish');
 
@@ -264,6 +278,7 @@ export class ChainEventPoller {
       eventTypes.push('ProfileUpdated');
     }
     if (watchKARegistered) eventTypes.push('KnowledgeAssetRegisteredToContextGraph');
+    if (this.onKnowledgeAssetCreated) eventTypes.push('KnowledgeAssetCreated');
 
     const fromBlock = this.lastBlock + 1;
     const upperBound = head != null
@@ -293,6 +308,8 @@ export class ChainEventPoller {
         await this.handleProfileEvent(event, ctx);
       } else if (event.type === 'KnowledgeAssetRegisteredToContextGraph') {
         await this.handleKARegistered(event, ctx);
+      } else if (event.type === 'KnowledgeAssetCreated') {
+        await this.handleKACreated(event, ctx);
       }
     }
 
@@ -460,6 +477,40 @@ export class ChainEventPoller {
       });
     } catch (err) {
       this.log.warn(ctx, `onKARegisteredToContextGraph callback failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private async handleKACreated(event: ChainEvent, ctx: OperationContext): Promise<void> {
+    if (!this.onKnowledgeAssetCreated) return;
+    const { data } = event;
+    const kaId = BigInt((data['kaId'] as string) ?? '0');
+    if (kaId === 0n) return;
+    const author = String(data['author'] ?? '').toLowerCase();
+    const txHash = String(data['txHash'] ?? '');
+    const rawTxIndex = data['txIndex'];
+    const txIndex = typeof rawTxIndex === 'number' && Number.isFinite(rawTxIndex) && rawTxIndex >= 0
+      ? rawTxIndex
+      : 0;
+    // OT-RFC-43 Option-1 — the per-author ordinal lives in the low 96 bits of
+    // the kaId. Use full-precision bigint math; never coerce through Number()
+    // (the value can exceed Number.MAX_SAFE_INTEGER and silently lose digits).
+    const number = kaId & ((1n << 96n) - 1n);
+
+    this.log.info(ctx,
+      `Chain event: KnowledgeAssetCreated block=${event.blockNumber} kaId=${kaId} author=${author.slice(0, 10)}… number=${number}`,
+    );
+
+    try {
+      await this.onKnowledgeAssetCreated({
+        kaId,
+        author,
+        number,
+        txHash,
+        txIndex,
+        blockNumber: event.blockNumber,
+      });
+    } catch (err) {
+      this.log.warn(ctx, `onKnowledgeAssetCreated callback failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 }

--- a/packages/publisher/test/chain-event-poller-ka-created.test.ts
+++ b/packages/publisher/test/chain-event-poller-ka-created.test.ts
@@ -154,4 +154,65 @@ describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)'
     // independent of whether allocator reconciliation is also wired.
     expect(filters[0].eventTypes).toContain('KCCreated');
   });
+
+  // codex PR #976 F9: when `onKnowledgeAssetCreated` is wired and there
+  // is no persisted cursor, the poller MUST backfill from block 0.
+  // Without this, a fresh daemon would skip every `KCCreated` event
+  // older than ~500 blocks (the "seed near head" optimisation that
+  // applies to the pending-publish watcher) and the per-author floor
+  // for older authors would stay at 0. A subsequent `markReconciled()`
+  // would then be unsound — the allocator could re-issue a number
+  // already minted on-chain.
+  it('cold-starts from block 0 when onKnowledgeAssetCreated is wired (F9 backfill)', async () => {
+    // Chain head is 10_000 — well past the 500-block head-seed window.
+    // If the F9 backfill is missing, the poller would seed `lastBlock`
+    // at 9500 and the first filter would have fromBlock=9501, which
+    // would miss every historical `KCCreated` at e.g. block 1.
+    const { adapter, filters } = makeChain(10_000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // First poll scans from block 1 (fromBlock = lastBlock + 1, and
+    // lastBlock stays at 0 because the F9 backfill suppressed the
+    // head-seed). Pre-fix this would have been 9501.
+    expect(filters[0].fromBlock).toBe(1);
+    // toBlock is capped by MAX_RANGE (9000) not the chain head, but it
+    // MUST cover historical territory (block 1) not just the tip.
+    expect(filters[0].toBlock).toBeLessThanOrEqual(10_000);
+    expect(filters[0].toBlock).toBeGreaterThanOrEqual(1);
+  });
+
+  // Sanity inverse: with NO allocator watcher and no pending publishes,
+  // the head-seed optimisation still kicks in. We're not regressing
+  // the existing behaviour for the "watch context graphs only" path.
+  it('still seeds near head when onKnowledgeAssetCreated is NOT wired', async () => {
+    const { adapter, filters } = makeChain(10_000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // head-seed: lastBlock = head - 500 = 9500, so fromBlock = 9501.
+    expect(filters[0].fromBlock).toBe(9_501);
+  });
 });

--- a/packages/publisher/test/chain-event-poller-ka-created.test.ts
+++ b/packages/publisher/test/chain-event-poller-ka-created.test.ts
@@ -1,0 +1,157 @@
+/**
+ * OT-RFC-43 Option-1 — ChainEventPoller surfaces `KnowledgeAssetCreated`
+ * (codex PR #976 F5 regression).
+ *
+ * The chain adapter's `listenForEvents()` decodes both the V10 greenfield
+ * `KnowledgeAssetCreated` Solidity event AND the legacy V8/V9 batch-create
+ * event into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author,
+ * txHash, txIndex, ... } }` surface (see `packages/chain/src/evm-adapter-
+ * events.ts` ~L119 and L193). A prior wiring iteration of the poller
+ * subscribed to a distinct `KnowledgeAssetCreated` event type and dispatched
+ * to `onKnowledgeAssetCreated` on a `event.type === 'KnowledgeAssetCreated'`
+ * branch — but the adapter never yielded events with that type, so the
+ * branch never fired and allocator reconciliation (`reconcileFloor`) never
+ * ran. Cold-start refusal in `KaNumberAllocator` therefore never lifted on
+ * a fresh daemon coming up against an existing chain.
+ *
+ * This test pins the corrected wiring: a `KCCreated` event (the only
+ * create-event type the adapter ever emits) carrying `kaId` / `author` /
+ * `txHash` / `txIndex` MUST dispatch to `onKnowledgeAssetCreated` with the
+ * unpacked `(author, number)` pair, in addition to whatever publish-handler
+ * fan-out the same event triggers.
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus } from '@origintrail-official/dkg-core';
+import type { ChainAdapter, EventFilter, ChainEvent } from '@origintrail-official/dkg-chain';
+import { ChainEventPoller } from '../src/chain-event-poller.js';
+import { PublishHandler } from '../src/publish-handler.js';
+
+function makeChain(head: number, events: ChainEvent[]): {
+  adapter: ChainAdapter;
+  filters: EventFilter[];
+} {
+  const filters: EventFilter[] = [];
+  const adapter = {
+    chainId: 'mock:0',
+    getBlockNumber: async () => head,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+      filters.push(f);
+      for (const evt of events) {
+        if (f.eventTypes.includes(evt.type)) yield evt;
+      }
+    },
+  } as unknown as ChainAdapter;
+  return { adapter, filters };
+}
+
+describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)', () => {
+  it('dispatches onKnowledgeAssetCreated off the adapter-normalized KCCreated event', async () => {
+    // Pack a representative author-namespaced kaId:
+    //   kaId = (uint160(author) << 96) | number
+    // The poller reverses this and passes the per-author `number` to the
+    // allocator's reconcileFloor.
+    const author = '0x' + 'a1'.repeat(20);                       // checksum-irrelevant
+    const number = 7n;
+    const packedKaId = (BigInt(author) << 96n) | number;
+
+    // The adapter ALWAYS yields create-events with `type: 'KCCreated'`,
+    // regardless of whether the underlying Solidity event was the V10
+    // greenfield `KnowledgeAssetCreated` or the legacy batch-create. This
+    // is the surface the poller must consume.
+    const event: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 901,
+      data: {
+        kaId: packedKaId.toString(),
+        author,
+        // Fields the publish-handler fan-out consumes; the allocator
+        // reconciliation only needs kaId/author/txHash/txIndex.
+        merkleRoot: '0x' + '11'.repeat(32),
+        byteSize: '1024',
+        publisherAddress: author,
+        startKAId: packedKaId.toString(),
+        endKAId: packedKaId.toString(),
+        txHash: '0xdeadbeef',
+        txIndex: 2,
+      },
+    };
+
+    const { adapter, filters } = makeChain(1000, [event]);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const seen: Array<{
+      kaId: bigint;
+      author: string;
+      number: bigint;
+      txHash: string;
+      txIndex: number;
+      blockNumber: number;
+    }> = [];
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async (info) => {
+        seen.push({
+          kaId: info.kaId,
+          author: info.author,
+          number: info.number,
+          txHash: info.txHash,
+          txIndex: info.txIndex,
+          blockNumber: info.blockNumber,
+        });
+      },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    // (1) The poller subscribes to the real adapter surface (`KCCreated`),
+    //     not a phantom `KnowledgeAssetCreated` filter type that the adapter
+    //     does not emit. This is the wiring regression — the bot's F5.
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    for (const f of filters) {
+      expect(f.eventTypes).toContain('KCCreated');
+      expect(f.eventTypes).not.toContain('KnowledgeAssetCreated');
+    }
+
+    // (2) The callback receives the unpacked (author, number) plus tx
+    //     coordinates needed for the allocator's reconcileFloor + dedup.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].kaId).toBe(packedKaId);
+    expect(seen[0].author).toBe(author.toLowerCase());
+    expect(seen[0].number).toBe(number);
+    expect(seen[0].txHash).toBe('0xdeadbeef');
+    expect(seen[0].txIndex).toBe(2);
+    expect(seen[0].blockNumber).toBe(901);
+  });
+
+  it('enters the poll loop when onKnowledgeAssetCreated is the only subscriber wired', async () => {
+    // No pending publishes, no other callbacks — the only reason to scan is
+    // allocator reconciliation. The gating check must include `watchKACreated`.
+    const { adapter, filters } = makeChain(1000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async () => {
+        // intentionally empty — we only care that the poll fires
+      },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // KCCreated is always subscribed (it's the V10 publish-flow surface),
+    // independent of whether allocator reconciliation is also wired.
+    expect(filters[0].eventTypes).toContain('KCCreated');
+  });
+});


### PR DESCRIPTION
## What

The off-chain allocator that mints deterministic packed `kaId`s for OT-RFC-43 Option 1.

- **`KaNumberStore`** interface (core) + **`SqliteKaNumberStore`** on the shared `dashDb` (node-ui). Schema **v19 → v20** adds `ka_numbers(author_address PK, next_number)`. `allocate()` is a single atomic `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`; `reconcileFloor()` raises the floor (never lowers). Durable allocation state — not pruned.
- **`KaNumberAllocator`** (agent): `allocate(author) → { kaId, number }` packing `kaId = (uint160(author) << 96) | number` entirely in **bigint** (no `Number()`), a reconciled-before-allocate cold-start guard (RFC-43 §4.5), and a static `unpack()`.
- **`chain-event-poller`**: a `KnowledgeAssetCreated` listener decoding `number = kaId & ((1<<96)-1)` for startup reconciliation.
- Constructs the store + allocator in the daemon lifecycle.

The publish-time `allocate()` call site (T0 stamping) is the deferred **Bucket-2** integration; this PR is the durable core + wiring.

### Tests
16 allocator unit tests (monotonic, no-reclaim, reconcile floor, packing round-trip, cold-start refusal); node-ui schema-v20 migration tests; **node-ui 96 green**. Full turbo build green.

Stacks on #975 (Option-1 contract) — independent of it in code, stacked for the Bucket-1 set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)