### PR TITLE
feat(sdk): wire knowledge-assets methods into node-ui, mcp-dkg, openclaw (OT-RFC-43 §10.5, A5)

### DIFF
--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -261,6 +261,12 @@ export interface KnowledgeAssetFinalizedPublishOptions {
   publisherNodeIdentityIdOverride?: bigint;
 }
 
+const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+  'clearAfter',
+  'publishEpochs',
+  'publisherNodeIdentityIdOverride',
+]);
+
 function assertExclusiveAuthorFields(args: {
   authorAgentAddress?: string;
   preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
@@ -288,8 +294,15 @@ function assertCreateFinalizeFieldsHaveQuads(args: {
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
+  allowedExtraKeys: readonly string[] = [],
 ): Record<string, unknown> | undefined {
   if (!options) return undefined;
+  const unsupportedKeys = Object.keys(options).filter(
+    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+  );
+  if (unsupportedKeys.length > 0) {
+    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
+  }
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
@@ -297,6 +310,19 @@ function finalizedPublishOptionsPayload(
     payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function createAlsoPublishVmPayload(value: unknown): boolean | Record<string, unknown> {
+  if (typeof value === 'boolean') return value;
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (Object.keys(value).length === 0) return {};
+    const payload = finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions);
+    if (payload) return payload;
+    throw new Error(
+      'alsoPublishVm options object must include at least one supported option; use true to publish with defaults',
+    );
+  }
+  throw new Error('alsoPublishVm must be a boolean or publish-options object');
 }
 
 export class DkgDaemonClient {
@@ -1189,9 +1215,9 @@ export class DkgDaemonClient {
       ...(opts ?? {}),
     };
     // Object form carries finalized-publish controls; translate to the daemon
-    // body shape (mirrors the cli ApiClient). `true` is left as-is.
-    if (opts?.alsoPublishVm && typeof opts.alsoPublishVm === 'object') {
-      payload.alsoPublishVm = finalizedPublishOptionsPayload(opts.alsoPublishVm) ?? {};
+    // body shape (mirrors the cli ApiClient). Booleans pass through.
+    if (opts?.alsoPublishVm !== undefined) {
+      payload.alsoPublishVm = createAlsoPublishVmPayload(opts.alsoPublishVm);
     }
     return this.post('/api/knowledge-assets', payload);
   }
@@ -1285,7 +1311,7 @@ export class DkgDaemonClient {
     name: string,
     opts?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<Record<string, unknown>> {
-    const publishOptions = finalizedPublishOptionsPayload(opts);
+    const publishOptions = finalizedPublishOptionsPayload(opts, ['subGraphName']);
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -270,6 +270,21 @@ function assertExclusiveAuthorFields(args: {
   }
 }
 
+function assertCreateFinalizeFieldsHaveQuads(args: {
+  quads?: unknown[];
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+  schemeVersion?: number;
+}): void {
+  const hasFinalizeOnlyField =
+    args.authorAgentAddress != null ||
+    args.preSignedAuthorAttestation != null ||
+    args.schemeVersion !== undefined;
+  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  }
+}
+
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
@@ -1167,6 +1182,7 @@ export class DkgDaemonClient {
     },
   ): Promise<Record<string, unknown>> {
     assertExclusiveAuthorFields(opts ?? {});
+    assertCreateFinalizeFieldsHaveQuads(opts ?? {});
     const payload: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       name,

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -261,6 +261,15 @@ export interface KnowledgeAssetFinalizedPublishOptions {
   publisherNodeIdentityIdOverride?: bigint;
 }
 
+function assertExclusiveAuthorFields(args: {
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+}): void {
+  if (args.authorAgentAddress != null && args.preSignedAuthorAttestation != null) {
+    throw new Error('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+  }
+}
+
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
@@ -1157,6 +1166,7 @@ export class DkgDaemonClient {
       alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
     },
   ): Promise<Record<string, unknown>> {
+    assertExclusiveAuthorFields(opts ?? {});
     const payload: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       name,
@@ -1208,6 +1218,7 @@ export class DkgDaemonClient {
       schemeVersion?: number;
     },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    assertExclusiveAuthorFields(opts ?? {});
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       ...(opts ?? {}),

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -1096,6 +1096,119 @@ export class DkgDaemonClient {
     }
     return res.json() as Promise<T>;
   }
+
+  // ── OT-RFC-43 §10.5 — GitHub-shaped Knowledge Asset client ──────────────
+  // Layer-explicit wrappers over the clean /api/knowledge-assets/... surface.
+  // One file = one Knowledge Asset (Design B / OT-RFC-44), carrying any number
+  // of member entities. WM → SWM → VM via the git-shaped verbs write →
+  // finalize → share → publish.
+
+  /** Create a KA + open its WM draft. Pass `quads` to atomically write+finalize. */
+  async createKnowledgeAsset(
+    contextGraphId: string,
+    name: string,
+    opts?: {
+      subGraphName?: string;
+      quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+      alsoShareSwm?: boolean;
+      alsoPublishVm?: boolean;
+    },
+  ): Promise<Record<string, unknown>> {
+    return this.post('/api/knowledge-assets', {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      name,
+      ...(opts ?? {}),
+    });
+  }
+
+  /** GET a KA's per-layer lifecycle state by name. */
+  async getKnowledgeAsset(
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string },
+  ): Promise<Record<string, unknown>> {
+    const qs = new URLSearchParams({
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+    }).toString();
+    return this.get(`/api/knowledge-assets/${encodeURIComponent(name)}?${qs}`);
+  }
+
+  /** Append quads to the KA's WM draft (git add/edit). */
+  async knowledgeAssetWrite(
+    contextGraphId: string,
+    name: string,
+    quads: Array<{ subject: string; predicate: string; object: string; graph: string }>,
+    opts?: { subGraphName?: string },
+  ): Promise<{ written: number }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/write`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      quads,
+      ...(opts ?? {}),
+    });
+  }
+
+  /** Seal the WM draft — computes the merkle root + signs the seal (git commit). */
+  async knowledgeAssetFinalize(
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string },
+  ): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts ?? {}),
+    });
+  }
+
+  /** Discard the open WM draft (git checkout -- .). */
+  async knowledgeAssetDiscard(
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string },
+  ): Promise<{ discarded: boolean }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/discard`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts ?? {}),
+    });
+  }
+
+  /** Seed a fresh WM draft from the file's current SWM/VM state (git checkout). */
+  async knowledgeAssetPullFrom(
+    contextGraphId: string,
+    name: string,
+    layer: 'swm' | 'vm',
+    opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
+  ): Promise<Record<string, unknown>> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/pull-from`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      layer,
+      ...(opts ?? {}),
+    });
+  }
+
+  /** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
+  async knowledgeAssetShare(
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string; entities?: string[] | 'all' },
+  ): Promise<{ swmShared: boolean; promotedCount: number }> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts ?? {}),
+    });
+  }
+
+  /** Publish to VM — mint or update on chain (git push origin main). */
+  async knowledgeAssetPublish(
+    contextGraphId: string,
+    name: string,
+    opts?: { subGraphName?: string },
+  ): Promise<Record<string, unknown>> {
+    return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
+      contextGraphId: normalizeContextGraphId(contextGraphId),
+      ...(opts ?? {}),
+    });
+  }
 }
 
 function stripTrailingSlashes(value: string): string {

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -235,6 +235,46 @@ function isChatTurnStoreNotFoundError(err: unknown): boolean {
   return lower.includes(CHAT_TURNS_ASSERTION_NAME);
 }
 
+/**
+ * Author attestation produced by an external signer. Mirrors the
+ * `packages/cli/src/api-client.ts` reference so the finalize/create KA flows
+ * can carry a pre-built EIP-712 attestation instead of signing on the daemon.
+ */
+export interface PreSignedAuthorAttestationPayload {
+  address: string;
+  signature: { r: string; vs: string };
+}
+
+/**
+ * VM-publish controls for the finalized-assertion publish path. Mirrors
+ * `KnowledgeAssetFinalizedPublishOptions` in `packages/cli/src/api-client.ts`
+ * verbatim so every first-party client exposes the same surface.
+ */
+export interface KnowledgeAssetFinalizedPublishOptions {
+  /**
+   * SDK-friendly spelling for the finalized publish cleanup flag. The
+   * knowledge-assets daemon route forwards `clearSharedMemoryAfter` to
+   * `publishFromFinalizedAssertion`, so the client translates before POST.
+   */
+  clearAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint;
+}
+
+/** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
+function finalizedPublishOptionsPayload(
+  options?: KnowledgeAssetFinalizedPublishOptions,
+): Record<string, unknown> | undefined {
+  if (!options) return undefined;
+  const payload: Record<string, unknown> = {};
+  if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
+  if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
+  if (options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
 export class DkgDaemonClient {
   readonly baseUrl: string;
   private readonly timeoutMs: number;
@@ -1110,15 +1150,24 @@ export class DkgDaemonClient {
     opts?: {
       subGraphName?: string;
       quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+      authorAgentAddress?: string;
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+      schemeVersion?: number;
       alsoShareSwm?: boolean;
-      alsoPublishVm?: boolean;
+      alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
     },
   ): Promise<Record<string, unknown>> {
-    return this.post('/api/knowledge-assets', {
+    const payload: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(contextGraphId),
       name,
       ...(opts ?? {}),
-    });
+    };
+    // Object form carries finalized-publish controls; translate to the daemon
+    // body shape (mirrors the cli ApiClient). `true` is left as-is.
+    if (opts?.alsoPublishVm && typeof opts.alsoPublishVm === 'object') {
+      payload.alsoPublishVm = finalizedPublishOptionsPayload(opts.alsoPublishVm) ?? {};
+    }
+    return this.post('/api/knowledge-assets', payload);
   }
 
   /** GET a KA's per-layer lifecycle state by name. */
@@ -1152,7 +1201,12 @@ export class DkgDaemonClient {
   async knowledgeAssetFinalize(
     contextGraphId: string,
     name: string,
-    opts?: { subGraphName?: string },
+    opts?: {
+      subGraphName?: string;
+      authorAgentAddress?: string;
+      preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+      schemeVersion?: number;
+    },
   ): Promise<{ merkleRoot: string; eip712Digest: string }> {
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
@@ -1202,11 +1256,13 @@ export class DkgDaemonClient {
   async knowledgeAssetPublish(
     contextGraphId: string,
     name: string,
-    opts?: { subGraphName?: string },
+    opts?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<Record<string, unknown>> {
+    const publishOptions = finalizedPublishOptionsPayload(opts);
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
       contextGraphId: normalizeContextGraphId(contextGraphId),
-      ...(opts ?? {}),
+      ...(opts?.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+      ...(publishOptions ? { options: publishOptions } : {}),
     });
   }
 }

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1155,6 +1155,13 @@ describe('DkgDaemonClient', () => {
       expect(body()).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
     });
 
+    it('knowledgeAssetPublish rejects unsupported option keys before HTTP serialization', async () => {
+      await expect(client.knowledgeAssetPublish('cg-1', 'f', {
+        publishEpoch: 3,
+      } as any)).rejects.toThrow('Unsupported finalized publish option(s): publishEpoch');
+      expect(fetchCalls).toHaveLength(0);
+    });
+
     it('knowledgeAssetFinalize forwards authorAgentAddress', async () => {
       ok({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
       await client.knowledgeAssetFinalize('cg-1', 'f', {
@@ -1217,6 +1224,26 @@ describe('DkgDaemonClient', () => {
         publishEpochs: 2,
         publisherNodeIdentityIdOverride: '7',
       });
+    });
+
+    it('createKnowledgeAsset treats empty alsoPublishVm options as default publish', async () => {
+      ok({ name: 'f' });
+      await client.createKnowledgeAsset('cg-1', 'f', { alsoPublishVm: {} });
+      expect(body().alsoPublishVm).toEqual({});
+    });
+
+    it('createKnowledgeAsset rejects unsupported alsoPublishVm options before HTTP serialization', async () => {
+      await expect(client.createKnowledgeAsset('cg-1', 'f', {
+        alsoPublishVm: { publishEpoch: 3 },
+      } as any)).rejects.toThrow('Unsupported finalized publish option(s): publishEpoch');
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset rejects array alsoPublishVm before HTTP serialization', async () => {
+      await expect(client.createKnowledgeAsset('cg-1', 'f', {
+        alsoPublishVm: [],
+      } as any)).rejects.toThrow('alsoPublishVm must be a boolean or publish-options object');
+      expect(fetchCalls).toHaveLength(0);
     });
   });
 });

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1200,6 +1200,13 @@ describe('DkgDaemonClient', () => {
       expect(fetchCalls).toHaveLength(0);
     });
 
+    it('createKnowledgeAsset rejects finalized publish fields without quads before HTTP serialization', async () => {
+      await expect(client.createKnowledgeAsset('cg-1', 'f', {
+        authorAgentAddress: '0xauthor',
+      })).rejects.toThrow('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+      expect(fetchCalls).toHaveLength(0);
+    });
+
     it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {
       ok({ name: 'f' });
       await client.createKnowledgeAsset('cg-1', 'f', {

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1155,20 +1155,49 @@ describe('DkgDaemonClient', () => {
       expect(body()).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
     });
 
-    it('knowledgeAssetFinalize forwards external-signer fields', async () => {
+    it('knowledgeAssetFinalize forwards authorAgentAddress', async () => {
       ok({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
       await client.knowledgeAssetFinalize('cg-1', 'f', {
         authorAgentAddress: '0xauthor',
-        preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
         schemeVersion: 1,
       });
       expect(url()).toBe('http://localhost:9200/api/knowledge-assets/f/wm/finalize');
       expect(body()).toMatchObject({
         contextGraphId: 'cg-1',
         authorAgentAddress: '0xauthor',
+        schemeVersion: 1,
+      });
+    });
+
+    it('knowledgeAssetFinalize forwards preSignedAuthorAttestation', async () => {
+      ok({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
+      const preSignedAuthorAttestation = { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } };
+      await client.knowledgeAssetFinalize('cg-1', 'f', {
         preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
         schemeVersion: 1,
       });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets/f/wm/finalize');
+      expect(body()).toMatchObject({
+        contextGraphId: 'cg-1',
+        preSignedAuthorAttestation,
+        schemeVersion: 1,
+      });
+    });
+
+    it('knowledgeAssetFinalize rejects mutually exclusive authorship fields before HTTP serialization', async () => {
+      await expect(client.knowledgeAssetFinalize('cg-1', 'f', {
+        authorAgentAddress: '0xauthor',
+        preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+      })).rejects.toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset rejects mutually exclusive authorship fields before HTTP serialization', async () => {
+      await expect(client.createKnowledgeAsset('cg-1', 'f', {
+        authorAgentAddress: '0xauthor',
+        preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+      })).rejects.toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+      expect(fetchCalls).toHaveLength(0);
     });
 
     it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1083,4 +1083,48 @@ describe('DkgDaemonClient', () => {
     const token = client.getAuthToken();
     expect(token === undefined || typeof token === 'string').toBe(true);
   });
+
+  // ── OT-RFC-43 §10.5 — GitHub-shaped Knowledge Asset client ──────────────
+  describe('knowledge-assets surface', () => {
+    const ok = (body: unknown = {}) =>
+      fetchResponses.push(new Response(JSON.stringify(body), { status: 200 }));
+    const url = (i = 0) => String(fetchCalls[i][0]);
+    const body = (i = 0) => JSON.parse(String(fetchCalls[i][1]!.body));
+
+    it('createKnowledgeAsset POSTs to /api/knowledge-assets with normalized cg + name', async () => {
+      ok({ name: 'f' });
+      await client.createKnowledgeAsset('cg-1', 'f', {
+        quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }],
+        alsoShareSwm: true,
+      });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets');
+      expect(fetchCalls[0][1]!.method).toBe('POST');
+      expect(body()).toMatchObject({ contextGraphId: 'cg-1', name: 'f', alsoShareSwm: true });
+    });
+
+    it('knowledgeAssetWrite URL-encodes the name and POSTs to .../wm/write', async () => {
+      ok({ written: 2 });
+      await client.knowledgeAssetWrite('cg-1', 'meeting notes', [
+        { subject: 's', predicate: 'p', object: 'o', graph: '' },
+      ]);
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets/meeting%20notes/wm/write');
+      expect(body().quads).toHaveLength(1);
+    });
+
+    it('knowledgeAssetPullFrom sends layer + onConflict to .../wm/pull-from', async () => {
+      ok({ seeded: 3 });
+      await client.knowledgeAssetPullFrom('cg-1', 'f', 'swm', { onConflict: 'replace' });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets/f/wm/pull-from');
+      expect(body()).toMatchObject({ layer: 'swm', onConflict: 'replace' });
+    });
+
+    it('share + publish target swm/share and vm/publish', async () => {
+      ok({ swmShared: true, promotedCount: 1 });
+      ok({ ual: 'did:dkg:x' });
+      await client.knowledgeAssetShare('cg-1', 'f');
+      await client.knowledgeAssetPublish('cg-1', 'f');
+      expect(url(0)).toBe('http://localhost:9200/api/knowledge-assets/f/swm/share');
+      expect(url(1)).toBe('http://localhost:9200/api/knowledge-assets/f/vm/publish');
+    });
+  });
 });

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1126,5 +1126,61 @@ describe('DkgDaemonClient', () => {
       expect(url(0)).toBe('http://localhost:9200/api/knowledge-assets/f/swm/share');
       expect(url(1)).toBe('http://localhost:9200/api/knowledge-assets/f/vm/publish');
     });
+
+    it('knowledgeAssetPublish nests finalized-publish controls under `options`', async () => {
+      ok({ ual: 'did:dkg:x' });
+      await client.knowledgeAssetPublish('cg-1', 'f', {
+        subGraphName: 'sg',
+        clearAfter: true,
+        publishEpochs: 3,
+        publisherNodeIdentityIdOverride: 42n,
+      });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets/f/vm/publish');
+      // `clearAfter` is the SDK spelling; the daemon expects `clearSharedMemoryAfter`.
+      // bigint overrides serialize as decimal strings (JSON has no bigint).
+      expect(body()).toMatchObject({
+        contextGraphId: 'cg-1',
+        subGraphName: 'sg',
+        options: {
+          clearSharedMemoryAfter: true,
+          publishEpochs: 3,
+          publisherNodeIdentityIdOverride: '42',
+        },
+      });
+    });
+
+    it('knowledgeAssetPublish omits `options` when no controls are passed', async () => {
+      ok({ ual: 'did:dkg:x' });
+      await client.knowledgeAssetPublish('cg-1', 'f', { subGraphName: 'sg' });
+      expect(body()).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+    });
+
+    it('knowledgeAssetFinalize forwards external-signer fields', async () => {
+      ok({ merkleRoot: '0xroot', eip712Digest: '0xdig' });
+      await client.knowledgeAssetFinalize('cg-1', 'f', {
+        authorAgentAddress: '0xauthor',
+        preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+        schemeVersion: 1,
+      });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets/f/wm/finalize');
+      expect(body()).toMatchObject({
+        contextGraphId: 'cg-1',
+        authorAgentAddress: '0xauthor',
+        preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+        schemeVersion: 1,
+      });
+    });
+
+    it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {
+      ok({ name: 'f' });
+      await client.createKnowledgeAsset('cg-1', 'f', {
+        alsoPublishVm: { clearAfter: true, publishEpochs: 2, publisherNodeIdentityIdOverride: 7n },
+      });
+      expect(body().alsoPublishVm).toEqual({
+        clearSharedMemoryAfter: true,
+        publishEpochs: 2,
+        publisherNodeIdentityIdOverride: '7',
+      });
+    });
   });
 });

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -37,6 +37,30 @@ function finalizedPublishOptionsPayload(
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
+function assertExclusiveAuthorFields(args: {
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+}): void {
+  if (args.authorAgentAddress != null && args.preSignedAuthorAttestation != null) {
+    throw new Error('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+  }
+}
+
+function assertCreateFinalizeFieldsHaveQuads(args: {
+  quads?: unknown[];
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+  schemeVersion?: number;
+}): void {
+  const hasFinalizeOnlyField =
+    args.authorAgentAddress != null ||
+    args.preSignedAuthorAttestation != null ||
+    args.schemeVersion !== undefined;
+  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  }
+}
+
 /**
  * Response shape for `/api/random-sampling/status`. Mirrors
  * `RandomSamplingStatus` from `@origintrail-official/dkg-agent` but
@@ -507,6 +531,8 @@ export class ApiClient {
       alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
     },
   ): Promise<Record<string, unknown>> {
+    assertExclusiveAuthorFields(options ?? {});
+    assertCreateFinalizeFieldsHaveQuads(options ?? {});
     const payload: Record<string, unknown> = { contextGraphId, name, ...(options ?? {}) };
     if (options?.alsoPublishVm && typeof options.alsoPublishVm === 'object') {
       payload.alsoPublishVm = finalizedPublishOptionsPayload(options.alsoPublishVm) ?? {};

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -24,10 +24,23 @@ export interface KnowledgeAssetFinalizedPublishOptions {
   publisherNodeIdentityIdOverride?: bigint;
 }
 
+const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+  'clearAfter',
+  'publishEpochs',
+  'publisherNodeIdentityIdOverride',
+]);
+
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
+  allowedExtraKeys: readonly string[] = [],
 ): Record<string, unknown> | undefined {
   if (!options) return undefined;
+  const unsupportedKeys = Object.keys(options).filter(
+    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+  );
+  if (unsupportedKeys.length > 0) {
+    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
+  }
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
@@ -35,6 +48,19 @@ function finalizedPublishOptionsPayload(
     payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+function createAlsoPublishVmPayload(value: unknown): boolean | Record<string, unknown> {
+  if (typeof value === 'boolean') return value;
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (Object.keys(value).length === 0) return {};
+    const payload = finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions);
+    if (payload) return payload;
+    throw new Error(
+      'alsoPublishVm options object must include at least one supported option; use true to publish with defaults',
+    );
+  }
+  throw new Error('alsoPublishVm must be a boolean or publish-options object');
 }
 
 function assertExclusiveAuthorFields(args: {
@@ -534,8 +560,8 @@ export class ApiClient {
     assertExclusiveAuthorFields(options ?? {});
     assertCreateFinalizeFieldsHaveQuads(options ?? {});
     const payload: Record<string, unknown> = { contextGraphId, name, ...(options ?? {}) };
-    if (options?.alsoPublishVm && typeof options.alsoPublishVm === 'object') {
-      payload.alsoPublishVm = finalizedPublishOptionsPayload(options.alsoPublishVm) ?? {};
+    if (options?.alsoPublishVm !== undefined) {
+      payload.alsoPublishVm = createAlsoPublishVmPayload(options.alsoPublishVm);
     }
     return this.post('/api/knowledge-assets', payload);
   }
@@ -600,7 +626,7 @@ export class ApiClient {
     name: string,
     options?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<Record<string, unknown>> {
-    const publishOptions = finalizedPublishOptionsPayload(options);
+    const publishOptions = finalizedPublishOptionsPayload(options, ['subGraphName']);
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
       contextGraphId,
       ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -29,6 +29,11 @@ import { jsonResponse, readBody, safeParseJson } from "../http-utils.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
 
 const PREFIX = "/api/knowledge-assets";
+const FINALIZE_ONLY_CREATE_FIELDS = [
+  "authorAgentAddress",
+  "preSignedAuthorAttestation",
+  "schemeVersion",
+] as const;
 
 function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
@@ -82,6 +87,10 @@ function resolveFinalizeOptions(
   };
 }
 
+function hasFinalizeOnlyCreateFields(raw: Record<string, unknown>): boolean {
+  return FINALIZE_ONLY_CREATE_FIELDS.some((field) => Object.prototype.hasOwnProperty.call(raw, field));
+}
+
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
   const { req, res, agent, path, url } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
@@ -106,6 +115,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
     }
     const shouldAutoFinalize = Array.isArray(quads) && quads.length > 0;
+    if (!shouldAutoFinalize && hasFinalizeOnlyCreateFields(parsed)) {
+      return jsonResponse(res, 400, {
+        error: '"authorAgentAddress", "preSignedAuthorAttestation", and "schemeVersion" require non-empty "quads"',
+      });
+    }
     const finalizeOptions = shouldAutoFinalize
       ? resolveFinalizeOptions({ subGraphName, authorAgentAddress, preSignedAuthorAttestation, schemeVersion }, res)
       : {};

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -42,7 +42,17 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   if (method === "POST" && path === PREFIX) {
     const parsed = safeParseJson(await readBody(req), res);
     if (!parsed) return;
-    const { contextGraphId, name, subGraphName, quads, authorAgentAddress, alsoShareSwm, alsoPublishVm } = parsed;
+    const {
+      contextGraphId,
+      name,
+      subGraphName,
+      quads,
+      authorAgentAddress,
+      preSignedAuthorAttestation,
+      schemeVersion,
+      alsoShareSwm,
+      alsoPublishVm,
+    } = parsed;
     if (!contextGraphId || !name) {
       return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
     }
@@ -55,7 +65,12 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (Array.isArray(quads) && quads.length > 0) {
         await agent.assertion.write(contextGraphId, name, quads, { subGraphName });
         result.written = quads.length;
-        const seal = await agent.assertion.finalize(contextGraphId, name, { subGraphName, authorAgentAddress });
+        const seal = await agent.assertion.finalize(contextGraphId, name, {
+          subGraphName,
+          authorAgentAddress,
+          preSignedAuthorAttestation,
+          schemeVersion,
+        });
         result.merkleRoot = hex(seal.merkleRoot);
         result.status = "wm-sealed";
       }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -26,11 +26,60 @@
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
 import { jsonResponse, readBody, safeParseJson } from "../http-utils.js";
+import { validatePreSignedAuthorAttestation } from "./memory.js";
 
 const PREFIX = "/api/knowledge-assets";
 
 function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
+}
+
+function resolveFinalizeOptions(
+  raw: Record<string, any>,
+  res: RequestContext["res"],
+): Record<string, unknown> | null {
+  const {
+    subGraphName,
+    authorAgentAddress,
+    preSignedAuthorAttestation,
+    schemeVersion,
+  } = raw;
+  if (authorAgentAddress != null && preSignedAuthorAttestation != null) {
+    jsonResponse(res, 400, {
+      error: '"authorAgentAddress" and "preSignedAuthorAttestation" are mutually exclusive',
+    });
+    return null;
+  }
+  if (
+    authorAgentAddress != null &&
+    (typeof authorAgentAddress !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(authorAgentAddress))
+  ) {
+    jsonResponse(res, 400, {
+      error: '"authorAgentAddress" must be a 0x-prefixed 20-byte EVM address',
+    });
+    return null;
+  }
+  let resolvedPreSignedAttestation:
+    | { address: string; signature: { r: Uint8Array; vs: Uint8Array } }
+    | undefined;
+  if (preSignedAuthorAttestation != null) {
+    const validated = validatePreSignedAuthorAttestation(preSignedAuthorAttestation, res);
+    if (validated === undefined) return null;
+    resolvedPreSignedAttestation = validated;
+  }
+  if (
+    schemeVersion != null &&
+    (typeof schemeVersion !== "number" || !Number.isInteger(schemeVersion) || schemeVersion < 1)
+  ) {
+    jsonResponse(res, 400, { error: '"schemeVersion" must be a positive integer when supplied' });
+    return null;
+  }
+  return {
+    ...(subGraphName ? { subGraphName } : {}),
+    ...(typeof authorAgentAddress === "string" ? { authorAgentAddress } : {}),
+    ...(resolvedPreSignedAttestation ? { preSignedAuthorAttestation: resolvedPreSignedAttestation } : {}),
+    ...(schemeVersion != null ? { schemeVersion } : {}),
+  };
 }
 
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
@@ -56,21 +105,21 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (!contextGraphId || !name) {
       return jsonResponse(res, 400, { error: 'Missing "contextGraphId" or "name"' });
     }
+    const shouldAutoFinalize = Array.isArray(quads) && quads.length > 0;
+    const finalizeOptions = shouldAutoFinalize
+      ? resolveFinalizeOptions({ subGraphName, authorAgentAddress, preSignedAuthorAttestation, schemeVersion }, res)
+      : {};
+    if (finalizeOptions === null) return;
     try {
       const assertionUri = await agent.assertion.create(contextGraphId, name, { subGraphName });
       const result: Record<string, unknown> = { name, assertionUri, status: "draft-open" };
 
       // autoFinalize: when quads are supplied, write + seal in the same call
       // (OT-RFC-43 §10.5.5). `also*` are opt-in layer transitions on top.
-      if (Array.isArray(quads) && quads.length > 0) {
+      if (shouldAutoFinalize) {
         await agent.assertion.write(contextGraphId, name, quads, { subGraphName });
         result.written = quads.length;
-        const seal = await agent.assertion.finalize(contextGraphId, name, {
-          subGraphName,
-          authorAgentAddress,
-          preSignedAuthorAttestation,
-          schemeVersion,
-        });
+        const seal = await agent.assertion.finalize(contextGraphId, name, finalizeOptions);
         result.merkleRoot = hex(seal.merkleRoot);
         result.status = "wm-sealed";
       }
@@ -152,12 +201,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         return jsonResponse(res, 200, { written: parsed.quads.length });
       }
       if (verb === "finalize") {
-        const seal = await agent.assertion.finalize(contextGraphId, name, {
-          subGraphName,
-          authorAgentAddress: parsed.authorAgentAddress,
-          preSignedAuthorAttestation: parsed.preSignedAuthorAttestation,
-          schemeVersion: parsed.schemeVersion,
-        });
+        const finalizeOptions = resolveFinalizeOptions(parsed, res);
+        if (finalizeOptions === null) return;
+        const seal = await agent.assertion.finalize(contextGraphId, name, finalizeOptions);
         return jsonResponse(res, 200, { merkleRoot: hex(seal.merkleRoot), eip712Digest: seal.eip712Digest });
       }
       if (verb === "discard") {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -571,6 +571,29 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(sent.alsoPublishVm).not.toHaveProperty('tokenAmount');
   });
 
+  it('createKnowledgeAsset treats empty alsoPublishVm options as default publish', async () => {
+    const calls = track({ name: 'f', status: 'vm-confirmed' });
+    await client.createKnowledgeAsset('cg', 'f', { alsoPublishVm: {} });
+    const sent = JSON.parse(calls[0].opts.body as string);
+    expect(sent.alsoPublishVm).toEqual({});
+  });
+
+  it('createKnowledgeAsset rejects unsupported alsoPublishVm options before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.createKnowledgeAsset('cg', 'f', {
+      alsoPublishVm: { publishEpoch: 3 },
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): publishEpoch');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('createKnowledgeAsset rejects array alsoPublishVm before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.createKnowledgeAsset('cg', 'f', {
+      alsoPublishVm: [],
+    } as any)).rejects.toThrow('alsoPublishVm must be a boolean or publish-options object');
+    expect(calls).toHaveLength(0);
+  });
+
   it('knowledgeAssetWrite POSTs to .../:name/wm/write (name URL-encoded)', async () => {
     const calls = track({ written: 1 });
     await client.knowledgeAssetWrite('cg', 'meeting notes', [{ subject: 's', predicate: 'p', object: 'o', graph: '' }]);
@@ -618,6 +641,14 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
         publisherNodeIdentityIdOverride: '123',
       },
     });
+  });
+
+  it('knowledgeAssetPublish rejects unsupported option keys before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.knowledgeAssetPublish('cg', 'f', {
+      publishEpoch: 3,
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): publishEpoch');
+    expect(calls).toHaveLength(0);
   });
 
   it('knowledgeAssetPullFrom sends layer + onConflict', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -117,6 +117,25 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.write).not.toHaveBeenCalled();
   });
 
+  it('POST /api/knowledge-assets rejects finalize-only fields without auto-finalize quads', async () => {
+    for (const payload of [
+      { authorAgentAddress: `0x${'11'.repeat(20)}` },
+      { quads: [], schemeVersion: 1 },
+    ]) {
+      const agent = makeAssertionAgent();
+      const ctx = ctxFor('POST', '/api/knowledge-assets', {
+        contextGraphId: 'cg',
+        name: 'f',
+        ...payload,
+      }, agent);
+      await handleKnowledgeAssetsRoutes(ctx);
+      expect(status(ctx)).toBe(400);
+      expect(body(ctx).error).toContain('require non-empty "quads"');
+      expect(agent.assertion.create).not.toHaveBeenCalled();
+      expect(agent.assertion.finalize).not.toHaveBeenCalled();
+    }
+  });
+
   it('POST /api/knowledge-assets with quads auto-writes + auto-finalizes (sealed assertion v1)', async () => {
     const agent = makeAssertionAgent();
     const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -128,29 +128,49 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.finalize).toHaveBeenCalledOnce();
   });
 
-  it('POST /api/knowledge-assets forwards atomic finalize external-signer fields', async () => {
+  it('POST /api/knowledge-assets validates and forwards atomic finalize external-signer fields', async () => {
     const agent = makeAssertionAgent();
     const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const address = `0x${'11'.repeat(20)}`;
     const preSignedAuthorAttestation = {
-      address: '0xauthor',
-      signature: { r: '0xr', vs: '0xvs' },
+      address,
+      signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
     };
     const ctx = ctxFor('POST', '/api/knowledge-assets', {
       contextGraphId: 'cg',
       name: 'f',
       quads,
-      authorAgentAddress: '0xauthor',
       preSignedAuthorAttestation,
       schemeVersion: 1,
     }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(201);
-    expect(agent.assertion.finalize).toHaveBeenCalledWith('cg', 'f', {
-      subGraphName: undefined,
-      authorAgentAddress: '0xauthor',
-      preSignedAuthorAttestation,
-      schemeVersion: 1,
-    });
+    const finalizeOpts = (agent.assertion.finalize as any).mock.calls[0][2];
+    expect(finalizeOpts.schemeVersion).toBe(1);
+    expect(finalizeOpts.authorAgentAddress).toBeUndefined();
+    expect(finalizeOpts.preSignedAuthorAttestation.address).toBe(address);
+    expect(finalizeOpts.preSignedAuthorAttestation.signature.r).toBeInstanceOf(Uint8Array);
+    expect(finalizeOpts.preSignedAuthorAttestation.signature.vs).toBeInstanceOf(Uint8Array);
+  });
+
+  it('POST /api/knowledge-assets rejects mutually exclusive atomic finalize authorship fields', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', {
+      contextGraphId: 'cg',
+      name: 'f',
+      quads,
+      authorAgentAddress: `0x${'11'.repeat(20)}`,
+      preSignedAuthorAttestation: {
+        address: `0x${'22'.repeat(20)}`,
+        signature: { r: `0x${'22'.repeat(32)}`, vs: `0x${'33'.repeat(32)}` },
+      },
+    }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('mutually exclusive');
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.assertion.finalize).not.toHaveBeenCalled();
   });
 
   it('atomic create with also* tails returns 207 when a tail fails', async () => {
@@ -184,6 +204,21 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ merkleRoot: '0xabcd', eip712Digest: '0xdig' });
+  });
+
+  it('POST .../:name/wm/finalize rejects malformed pre-signed attestations before finalize', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/finalize', {
+      contextGraphId: 'cg',
+      preSignedAuthorAttestation: {
+        address: `0x${'11'.repeat(20)}`,
+        signature: { r: '0xnot-32-bytes', vs: `0x${'33'.repeat(32)}` },
+      },
+    }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx).error).toContain('preSignedAuthorAttestation.signature.r');
+    expect(agent.assertion.finalize).not.toHaveBeenCalled();
   });
 
   it('POST .../:name/swm/share advances the SWM pointer (promote→share)', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -128,6 +128,31 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.finalize).toHaveBeenCalledOnce();
   });
 
+  it('POST /api/knowledge-assets forwards atomic finalize external-signer fields', async () => {
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const preSignedAuthorAttestation = {
+      address: '0xauthor',
+      signature: { r: '0xr', vs: '0xvs' },
+    };
+    const ctx = ctxFor('POST', '/api/knowledge-assets', {
+      contextGraphId: 'cg',
+      name: 'f',
+      quads,
+      authorAgentAddress: '0xauthor',
+      preSignedAuthorAttestation,
+      schemeVersion: 1,
+    }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(201);
+    expect(agent.assertion.finalize).toHaveBeenCalledWith('cg', 'f', {
+      subGraphName: undefined,
+      authorAgentAddress: '0xauthor',
+      preSignedAuthorAttestation,
+      schemeVersion: 1,
+    });
+  });
+
   it('atomic create with also* tails returns 207 when a tail fails', async () => {
     const agent = makeAssertionAgent({
       assertion: { promote: vi.fn(async () => { throw new Error('CCL denied'); }) },

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -108,6 +108,21 @@ function assertExclusiveAuthorFields(args: {
   }
 }
 
+function assertCreateFinalizeFieldsHaveQuads(args: {
+  quads?: unknown[];
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+  schemeVersion?: number;
+}): void {
+  const hasFinalizeOnlyField =
+    args.authorAgentAddress != null ||
+    args.preSignedAuthorAttestation != null ||
+    args.schemeVersion !== undefined;
+  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  }
+}
+
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
@@ -130,6 +145,7 @@ function createAlsoPublishVmPayload(
 ): boolean | Record<string, unknown> {
   if (typeof value === 'boolean') return value;
   if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (Object.keys(value).length === 0) return {};
     const payload = finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions);
     if (payload) return payload;
     throw new Error(
@@ -1111,6 +1127,7 @@ export class DkgClient {
     alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   }): Promise<Record<string, unknown>> {
     assertExclusiveAuthorFields(args);
+    assertCreateFinalizeFieldsHaveQuads(args);
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
       name: args.name,

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -125,6 +125,16 @@ function finalizedPublishOptionsPayload(
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
+function createAlsoPublishVmPayload(
+  value: unknown,
+): boolean | Record<string, unknown> {
+  if (typeof value === 'boolean') return value;
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions) ?? {};
+  }
+  throw new Error('alsoPublishVm must be a boolean or publish-options object');
+}
+
 /**
  * Per-peer diagnostic snapshot returned by `GET /api/peer-info`. Shape
  * mirrors the daemon-side `PeerDiagnostics` interface plus the legacy
@@ -1112,10 +1122,7 @@ export class DkgClient {
     if (args.alsoPublishVm !== undefined) {
       // Object form carries finalized-publish controls; translate to the daemon
       // body shape (mirrors the cli ApiClient). `true`/`false` pass through.
-      body.alsoPublishVm =
-        typeof args.alsoPublishVm === 'object'
-          ? (finalizedPublishOptionsPayload(args.alsoPublishVm) ?? {})
-          : args.alsoPublishVm;
+      body.alsoPublishVm = createAlsoPublishVmPayload(args.alsoPublishVm);
     }
     return this.request<Record<string, unknown>>('POST', '/api/knowledge-assets', body);
   }

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -130,7 +130,11 @@ function createAlsoPublishVmPayload(
 ): boolean | Record<string, unknown> {
   if (typeof value === 'boolean') return value;
   if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-    return finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions) ?? {};
+    const payload = finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions);
+    if (payload) return payload;
+    throw new Error(
+      'alsoPublishVm options object must include at least one supported option; use true to publish with defaults',
+    );
   }
   throw new Error('alsoPublishVm must be a boolean or publish-options object');
 }

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -94,6 +94,12 @@ export interface KnowledgeAssetFinalizedPublishOptions {
   publisherNodeIdentityIdOverride?: string;
 }
 
+const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+  'clearAfter',
+  'publishEpochs',
+  'publisherNodeIdentityIdOverride',
+]);
+
 function publisherNodeIdentityOverridePayload(value: unknown): string {
   if (typeof value === 'string' && /^\d+$/.test(value)) return value;
   throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
@@ -126,8 +132,15 @@ function assertCreateFinalizeFieldsHaveQuads(args: {
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
+  allowedExtraKeys: readonly string[] = [],
 ): Record<string, unknown> | undefined {
   if (!options) return undefined;
+  const unsupportedKeys = Object.keys(options).filter(
+    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+  );
+  if (unsupportedKeys.length > 0) {
+    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
+  }
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
@@ -1276,7 +1289,7 @@ export class DkgClient {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
-    const publishOptions = finalizedPublishOptionsPayload(args);
+    const publishOptions = finalizedPublishOptionsPayload(args, ['contextGraphId', 'name', 'subGraphName']);
     if (publishOptions) body.options = publishOptions;
     return this.request<Record<string, unknown>>(
       'POST',

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -80,8 +80,8 @@ export interface PreSignedAuthorAttestationPayload {
 /**
  * VM-publish controls for the finalized-assertion publish path. Mirrors
  * `KnowledgeAssetFinalizedPublishOptions` in `packages/cli/src/api-client.ts`.
- * `publisherNodeIdentityIdOverride` is widened to accept `string | number`
- * (JSON-RPC MCP callers cannot send a bigint) on top of the cli's `bigint`.
+ * MCP is JSON-facing, so large node identity ids must be passed as decimal
+ * strings rather than JavaScript numbers.
  */
 export interface KnowledgeAssetFinalizedPublishOptions {
   /**
@@ -91,7 +91,12 @@ export interface KnowledgeAssetFinalizedPublishOptions {
    */
   clearAfter?: boolean;
   publishEpochs?: number;
-  publisherNodeIdentityIdOverride?: bigint | string | number;
+  publisherNodeIdentityIdOverride?: string;
+}
+
+function publisherNodeIdentityOverridePayload(value: unknown): string {
+  if (typeof value === 'string') return value;
+  throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
 }
 
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
@@ -102,8 +107,11 @@ function finalizedPublishOptionsPayload(
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
-  if (options.publisherNodeIdentityIdOverride !== undefined) {
-    payload.publisherNodeIdentityIdOverride = String(options.publisherNodeIdentityIdOverride);
+  const publisherNodeIdentityIdOverride =
+    (options as Record<string, unknown>).publisherNodeIdentityIdOverride;
+  if (publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride =
+      publisherNodeIdentityOverridePayload(publisherNodeIdentityIdOverride);
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
 }

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1018,6 +1018,159 @@ export class DkgClient {
       throw err;
     }
   }
+
+  // ── OT-RFC-43 §10.5 — GitHub-shaped Knowledge Asset client ──────────────
+  // Layer-explicit wrappers over the clean /api/knowledge-assets/... surface.
+  // One file = one Knowledge Asset (Design B / OT-RFC-44), carrying any number
+  // of member entities. WM → SWM → VM via the git-shaped verbs write →
+  // finalize → share → publish. The legacy assertion/* + shared-memory/*
+  // methods above remain for back-compat during the v10 migration window.
+
+  /** Create a KA + open its WM draft. Pass `quads` to atomically write+finalize. */
+  async createKnowledgeAsset(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+    quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+    alsoShareSwm?: boolean;
+    alsoPublishVm?: boolean;
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+      name: args.name,
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.quads) body.quads = args.quads;
+    if (args.alsoShareSwm !== undefined) body.alsoShareSwm = args.alsoShareSwm;
+    if (args.alsoPublishVm !== undefined) body.alsoPublishVm = args.alsoPublishVm;
+    return this.request<Record<string, unknown>>('POST', '/api/knowledge-assets', body);
+  }
+
+  /** GET a KA's per-layer lifecycle state by name. */
+  async getKnowledgeAsset(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+  }): Promise<Record<string, unknown>> {
+    const qs = new URLSearchParams({
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+      ...(args.subGraphName ? { subGraphName: args.subGraphName } : {}),
+    }).toString();
+    return this.request<Record<string, unknown>>(
+      'GET',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}?${qs}`,
+    );
+  }
+
+  /** Append quads to the KA's WM draft (git add/edit). */
+  async knowledgeAssetWrite(args: {
+    contextGraphId: string;
+    name: string;
+    quads: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+    subGraphName?: string;
+  }): Promise<{ written: number }> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+      quads: args.quads,
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    return this.request<{ written: number }>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/write`,
+      body,
+    );
+  }
+
+  /** Seal the WM draft — computes the merkle root + signs the seal (git commit). */
+  async knowledgeAssetFinalize(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+  }): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    return this.request<{ merkleRoot: string; eip712Digest: string }>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/finalize`,
+      body,
+    );
+  }
+
+  /** Discard the open WM draft (git checkout -- .). */
+  async knowledgeAssetDiscard(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+  }): Promise<{ discarded: boolean }> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    return this.request<{ discarded: boolean }>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/discard`,
+      body,
+    );
+  }
+
+  /** Seed a fresh WM draft from the file's current SWM/VM state (git checkout). */
+  async knowledgeAssetPullFrom(args: {
+    contextGraphId: string;
+    name: string;
+    layer: 'swm' | 'vm';
+    subGraphName?: string;
+    onConflict?: 'reject' | 'replace';
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+      layer: args.layer,
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.onConflict) body.onConflict = args.onConflict;
+    return this.request<Record<string, unknown>>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/pull-from`,
+      body,
+    );
+  }
+
+  /** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
+  async knowledgeAssetShare(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+    entities?: string[] | 'all';
+  }): Promise<{ swmShared: boolean; promotedCount: number }> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.entities !== undefined) body.entities = args.entities;
+    return this.request<{ swmShared: boolean; promotedCount: number }>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/swm/share`,
+      body,
+    );
+  }
+
+  /** Publish to VM — mint or update on chain (git push origin main). */
+  async knowledgeAssetPublish(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+  }): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      contextGraphId: normalizeContextGraphId(args.contextGraphId),
+    };
+    if (args.subGraphName) body.subGraphName = args.subGraphName;
+    return this.request<Record<string, unknown>>(
+      'POST',
+      `/api/knowledge-assets/${encodeURIComponent(args.name)}/vm/publish`,
+      body,
+    );
+  }
 }
 
 /**

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -68,6 +68,47 @@ function toContextGraphUri(contextGraphIdOrUri: string): string {
 }
 
 /**
+ * Author attestation produced by an external signer. Mirrors the
+ * `packages/cli/src/api-client.ts` reference so finalize / create KA flows can
+ * carry a pre-built EIP-712 attestation instead of signing on the daemon.
+ */
+export interface PreSignedAuthorAttestationPayload {
+  address: string;
+  signature: { r: string; vs: string };
+}
+
+/**
+ * VM-publish controls for the finalized-assertion publish path. Mirrors
+ * `KnowledgeAssetFinalizedPublishOptions` in `packages/cli/src/api-client.ts`.
+ * `publisherNodeIdentityIdOverride` is widened to accept `string | number`
+ * (JSON-RPC MCP callers cannot send a bigint) on top of the cli's `bigint`.
+ */
+export interface KnowledgeAssetFinalizedPublishOptions {
+  /**
+   * SDK-friendly spelling for the finalized publish cleanup flag. The
+   * knowledge-assets daemon route forwards `clearSharedMemoryAfter` to
+   * `publishFromFinalizedAssertion`, so the client translates before POST.
+   */
+  clearAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint | string | number;
+}
+
+/** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
+function finalizedPublishOptionsPayload(
+  options?: KnowledgeAssetFinalizedPublishOptions,
+): Record<string, unknown> | undefined {
+  if (!options) return undefined;
+  const payload: Record<string, unknown> = {};
+  if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
+  if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
+  if (options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = String(options.publisherNodeIdentityIdOverride);
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+/**
  * Per-peer diagnostic snapshot returned by `GET /api/peer-info`. Shape
  * mirrors the daemon-side `PeerDiagnostics` interface plus the legacy
  * flat fields kept for back-compat with pre-diagnostic callers (the
@@ -1032,8 +1073,11 @@ export class DkgClient {
     name: string;
     subGraphName?: string;
     quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+    authorAgentAddress?: string;
+    preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+    schemeVersion?: number;
     alsoShareSwm?: boolean;
-    alsoPublishVm?: boolean;
+    alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   }): Promise<Record<string, unknown>> {
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
@@ -1041,8 +1085,20 @@ export class DkgClient {
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
     if (args.quads) body.quads = args.quads;
+    if (args.authorAgentAddress) body.authorAgentAddress = args.authorAgentAddress;
+    if (args.preSignedAuthorAttestation) {
+      body.preSignedAuthorAttestation = args.preSignedAuthorAttestation;
+    }
+    if (args.schemeVersion !== undefined) body.schemeVersion = args.schemeVersion;
     if (args.alsoShareSwm !== undefined) body.alsoShareSwm = args.alsoShareSwm;
-    if (args.alsoPublishVm !== undefined) body.alsoPublishVm = args.alsoPublishVm;
+    if (args.alsoPublishVm !== undefined) {
+      // Object form carries finalized-publish controls; translate to the daemon
+      // body shape (mirrors the cli ApiClient). `true`/`false` pass through.
+      body.alsoPublishVm =
+        typeof args.alsoPublishVm === 'object'
+          ? (finalizedPublishOptionsPayload(args.alsoPublishVm) ?? {})
+          : args.alsoPublishVm;
+    }
     return this.request<Record<string, unknown>>('POST', '/api/knowledge-assets', body);
   }
 
@@ -1086,11 +1142,19 @@ export class DkgClient {
     contextGraphId: string;
     name: string;
     subGraphName?: string;
+    authorAgentAddress?: string;
+    preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+    schemeVersion?: number;
   }): Promise<{ merkleRoot: string; eip712Digest: string }> {
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
+    if (args.authorAgentAddress) body.authorAgentAddress = args.authorAgentAddress;
+    if (args.preSignedAuthorAttestation) {
+      body.preSignedAuthorAttestation = args.preSignedAuthorAttestation;
+    }
+    if (args.schemeVersion !== undefined) body.schemeVersion = args.schemeVersion;
     return this.request<{ merkleRoot: string; eip712Digest: string }>(
       'POST',
       `/api/knowledge-assets/${encodeURIComponent(args.name)}/wm/finalize`,
@@ -1160,11 +1224,13 @@ export class DkgClient {
     contextGraphId: string;
     name: string;
     subGraphName?: string;
-  }): Promise<Record<string, unknown>> {
+  } & KnowledgeAssetFinalizedPublishOptions): Promise<Record<string, unknown>> {
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
+    const publishOptions = finalizedPublishOptionsPayload(args);
+    if (publishOptions) body.options = publishOptions;
     return this.request<Record<string, unknown>>(
       'POST',
       `/api/knowledge-assets/${encodeURIComponent(args.name)}/vm/publish`,

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -95,8 +95,17 @@ export interface KnowledgeAssetFinalizedPublishOptions {
 }
 
 function publisherNodeIdentityOverridePayload(value: unknown): string {
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return value;
   throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
+}
+
+function assertExclusiveAuthorFields(args: {
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+}): void {
+  if (args.authorAgentAddress != null && args.preSignedAuthorAttestation != null) {
+    throw new Error('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+  }
 }
 
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
@@ -1087,6 +1096,7 @@ export class DkgClient {
     alsoShareSwm?: boolean;
     alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   }): Promise<Record<string, unknown>> {
+    assertExclusiveAuthorFields(args);
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
       name: args.name,
@@ -1154,6 +1164,7 @@ export class DkgClient {
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
   }): Promise<{ merkleRoot: string; eip712Digest: string }> {
+    assertExclusiveAuthorFields(args);
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
     };

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -151,4 +151,19 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     } as any)).rejects.toThrow(/alsoPublishVm must be a boolean or publish-options object/);
     expect(calls).toHaveLength(0);
   });
+
+  it('createKnowledgeAsset rejects empty or unknown alsoPublishVm option objects', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      alsoPublishVm: {},
+    })).rejects.toThrow(/use true to publish with defaults/);
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      alsoPublishVm: { unknown: true },
+    } as any)).rejects.toThrow(/use true to publish with defaults/);
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -141,4 +141,14 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     await client.createKnowledgeAsset({ contextGraphId: 'cg-1', name: 'f', alsoPublishVm: true });
     expect(calls[0].body.alsoPublishVm).toBe(true);
   });
+
+  it('createKnowledgeAsset rejects null alsoPublishVm before HTTP serialization', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      alsoPublishVm: null,
+    } as any)).rejects.toThrow(/alsoPublishVm must be a boolean or publish-options object/);
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -152,18 +152,33 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(0);
   });
 
-  it('createKnowledgeAsset rejects empty or unknown alsoPublishVm option objects', async () => {
+  it('createKnowledgeAsset treats an empty alsoPublishVm options object as default publish', async () => {
     const { client, calls } = makeClient();
-    await expect(client.createKnowledgeAsset({
+    await client.createKnowledgeAsset({
       contextGraphId: 'cg-1',
       name: 'f',
       alsoPublishVm: {},
-    })).rejects.toThrow(/use true to publish with defaults/);
+    });
+    expect(calls[0].body.alsoPublishVm).toEqual({});
+  });
+
+  it('createKnowledgeAsset rejects unknown alsoPublishVm option objects', async () => {
+    const { client, calls } = makeClient();
     await expect(client.createKnowledgeAsset({
       contextGraphId: 'cg-1',
       name: 'f',
       alsoPublishVm: { unknown: true },
     } as any)).rejects.toThrow(/use true to publish with defaults/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('createKnowledgeAsset rejects finalize-only fields without quads before HTTP serialization', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      authorAgentAddress: '0xauthor',
+    })).rejects.toThrow(/require non-empty quads/);
     expect(calls).toHaveLength(0);
   });
 });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -78,6 +78,16 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(0);
   });
 
+  it('knowledgeAssetPublish rejects unknown finalized-publish option keys', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.knowledgeAssetPublish({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      publishEpoch: 3,
+    } as any)).rejects.toThrow(/Unsupported finalized publish option\(s\): publishEpoch/);
+    expect(calls).toHaveLength(0);
+  });
+
   it('knowledgeAssetFinalize forwards authorAgentAddress', async () => {
     const { client, calls } = makeClient();
     await client.knowledgeAssetFinalize({
@@ -168,7 +178,12 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
       contextGraphId: 'cg-1',
       name: 'f',
       alsoPublishVm: { unknown: true },
-    } as any)).rejects.toThrow(/use true to publish with defaults/);
+    } as any)).rejects.toThrow(/Unsupported finalized publish option\(s\): unknown/);
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      alsoPublishVm: { publishEpoch: 3 },
+    } as any)).rejects.toThrow(/Unsupported finalized publish option\(s\): publishEpoch/);
     expect(calls).toHaveLength(0);
   });
 

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -31,11 +31,11 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
       subGraphName: 'sg',
       clearAfter: true,
       publishEpochs: 3,
-      publisherNodeIdentityIdOverride: 42n,
+      publisherNodeIdentityIdOverride: '42',
     });
     expect(calls[0].url).toContain('/api/knowledge-assets/f/vm/publish');
     // `clearAfter` is the SDK spelling; the daemon expects `clearSharedMemoryAfter`.
-    // bigint overrides serialize to decimal strings (JSON has no bigint).
+    // JSON-facing callers send the uint64 override as a decimal string.
     expect(calls[0].body).toMatchObject({
       contextGraphId: 'cg-1',
       subGraphName: 'sg',
@@ -51,6 +51,16 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     const { client, calls } = makeClient();
     await client.knowledgeAssetPublish({ contextGraphId: 'cg-1', name: 'f', subGraphName: 'sg' });
     expect(calls[0].body).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+  });
+
+  it('knowledgeAssetPublish rejects numeric publisher identity overrides before HTTP serialization', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.knowledgeAssetPublish({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      publisherNodeIdentityIdOverride: Number.MAX_SAFE_INTEGER + 1,
+    } as any)).rejects.toThrow(/decimal string/);
+    expect(calls).toHaveLength(0);
   });
 
   it('knowledgeAssetFinalize forwards external-signer fields', async () => {

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { DkgClient } from '../src/client.js';
+import { makeConfig } from './harness.js';
+
+// ── OT-RFC-43 §10.5 — knowledge-assets client contract ──────────────────────
+// Pins the request body shapes for the VM-publish / finalize options the daemon
+// supports, mirroring the cli ApiClient reference. Regression for the review on
+// PR #978: these options were dropped, so external-signer / publish-control
+// flows were unreachable through the MCP KA surface.
+describe('DkgClient knowledge-assets — publish/finalize option serialization', () => {
+  const makeClient = () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const client = new DkgClient({
+      config: makeConfig(),
+      fetcher: (async (url, init) => {
+        calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch,
+    });
+    return { client, calls };
+  };
+
+  it('knowledgeAssetPublish nests finalized-publish controls under `options`', async () => {
+    const { client, calls } = makeClient();
+    await client.knowledgeAssetPublish({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      subGraphName: 'sg',
+      clearAfter: true,
+      publishEpochs: 3,
+      publisherNodeIdentityIdOverride: 42n,
+    });
+    expect(calls[0].url).toContain('/api/knowledge-assets/f/vm/publish');
+    // `clearAfter` is the SDK spelling; the daemon expects `clearSharedMemoryAfter`.
+    // bigint overrides serialize to decimal strings (JSON has no bigint).
+    expect(calls[0].body).toMatchObject({
+      contextGraphId: 'cg-1',
+      subGraphName: 'sg',
+      options: {
+        clearSharedMemoryAfter: true,
+        publishEpochs: 3,
+        publisherNodeIdentityIdOverride: '42',
+      },
+    });
+  });
+
+  it('knowledgeAssetPublish omits `options` when no controls are passed', async () => {
+    const { client, calls } = makeClient();
+    await client.knowledgeAssetPublish({ contextGraphId: 'cg-1', name: 'f', subGraphName: 'sg' });
+    expect(calls[0].body).toEqual({ contextGraphId: 'cg-1', subGraphName: 'sg' });
+  });
+
+  it('knowledgeAssetFinalize forwards external-signer fields', async () => {
+    const { client, calls } = makeClient();
+    await client.knowledgeAssetFinalize({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      authorAgentAddress: '0xauthor',
+      preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+      schemeVersion: 1,
+    });
+    expect(calls[0].url).toContain('/api/knowledge-assets/f/wm/finalize');
+    expect(calls[0].body).toMatchObject({
+      contextGraphId: 'cg-1',
+      authorAgentAddress: '0xauthor',
+      preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+      schemeVersion: 1,
+    });
+  });
+
+  it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {
+    const { client, calls } = makeClient();
+    await client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      alsoPublishVm: { clearAfter: true, publishEpochs: 2, publisherNodeIdentityIdOverride: '7' },
+    });
+    expect(calls[0].body.alsoPublishVm).toEqual({
+      clearSharedMemoryAfter: true,
+      publishEpochs: 2,
+      publisherNodeIdentityIdOverride: '7',
+    });
+  });
+
+  it('createKnowledgeAsset passes a boolean alsoPublishVm through unchanged', async () => {
+    const { client, calls } = makeClient();
+    await client.createKnowledgeAsset({ contextGraphId: 'cg-1', name: 'f', alsoPublishVm: true });
+    expect(calls[0].body.alsoPublishVm).toBe(true);
+  });
+});

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -63,22 +63,63 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(0);
   });
 
-  it('knowledgeAssetFinalize forwards external-signer fields', async () => {
+  it('knowledgeAssetPublish rejects malformed decimal-string publisher identity overrides', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.knowledgeAssetPublish({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      publisherNodeIdentityIdOverride: 'abc',
+    })).rejects.toThrow(/decimal string/);
+    await expect(client.knowledgeAssetPublish({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      publisherNodeIdentityIdOverride: '-1',
+    })).rejects.toThrow(/decimal string/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('knowledgeAssetFinalize forwards authorAgentAddress', async () => {
     const { client, calls } = makeClient();
     await client.knowledgeAssetFinalize({
       contextGraphId: 'cg-1',
       name: 'f',
       authorAgentAddress: '0xauthor',
-      preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
       schemeVersion: 1,
     });
     expect(calls[0].url).toContain('/api/knowledge-assets/f/wm/finalize');
     expect(calls[0].body).toMatchObject({
       contextGraphId: 'cg-1',
       authorAgentAddress: '0xauthor',
-      preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
       schemeVersion: 1,
     });
+  });
+
+  it('knowledgeAssetFinalize forwards preSignedAuthorAttestation', async () => {
+    const { client, calls } = makeClient();
+    const preSignedAuthorAttestation = { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } };
+    await client.knowledgeAssetFinalize({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      preSignedAuthorAttestation,
+      schemeVersion: 1,
+    });
+    expect(calls[0].url).toContain('/api/knowledge-assets/f/wm/finalize');
+    expect(calls[0].body).toMatchObject({
+      contextGraphId: 'cg-1',
+      preSignedAuthorAttestation,
+      schemeVersion: 1,
+    });
+  });
+
+  it('knowledgeAssetFinalize rejects mutually exclusive authorship fields before HTTP serialization', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.knowledgeAssetFinalize({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      authorAgentAddress: '0xauthor',
+      preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+    })).rejects.toThrow(/mutually exclusive/);
+    expect(calls).toHaveLength(0);
   });
 
   it('createKnowledgeAsset translates an alsoPublishVm options object', async () => {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,6 +1,14 @@
 const BASE = '';
+const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
+}
+
+function normalizeContextGraphId(contextGraphIdOrUri: string): string {
+  const trimmed = contextGraphIdOrUri.trim();
+  return trimmed.startsWith(CONTEXT_GRAPH_URI_PREFIX)
+    ? trimmed.slice(CONTEXT_GRAPH_URI_PREFIX.length)
+    : trimmed;
 }
 
 export function authHeaders(): Record<string, string> {
@@ -718,7 +726,12 @@ export const createKnowledgeAsset = (
     alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   } = {},
 ) => {
-  const body: Record<string, unknown> = { contextGraphId, name, ...opts };
+  const normalizedContextGraphId = normalizeContextGraphId(contextGraphId);
+  const body: Record<string, unknown> = {
+    contextGraphId: normalizedContextGraphId,
+    name,
+    ...opts,
+  };
   // Object form carries finalized-publish controls; translate to the daemon
   // body shape (mirrors the cli ApiClient). `true`/`false` pass through.
   if (opts.alsoPublishVm && typeof opts.alsoPublishVm === 'object') {
@@ -734,7 +747,7 @@ export const getKnowledgeAsset = (
   subGraphName?: string,
 ) => {
   const qs = new URLSearchParams({
-    contextGraphId,
+    contextGraphId: normalizeContextGraphId(contextGraphId),
     ...(subGraphName ? { subGraphName } : {}),
   }).toString();
   return get<Record<string, unknown>>(
@@ -751,7 +764,7 @@ export const knowledgeAssetWrite = (
 ) =>
   post<{ written: number }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/write`,
-    { contextGraphId, quads, ...opts },
+    { contextGraphId: normalizeContextGraphId(contextGraphId), quads, ...opts },
   );
 
 /** Seal the WM draft — computes the merkle root + signs the seal (git commit). */
@@ -767,7 +780,7 @@ export const knowledgeAssetFinalize = (
 ) =>
   post<{ merkleRoot: string; eip712Digest: string }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
-    { contextGraphId, ...opts },
+    { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
   );
 
 /** Discard the open WM draft (git checkout -- .). */
@@ -778,7 +791,7 @@ export const knowledgeAssetDiscard = (
 ) =>
   post<{ discarded: boolean }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/discard`,
-    { contextGraphId, ...opts },
+    { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
   );
 
 /** Seed a fresh WM draft from the file's current SWM/VM state (git checkout). */
@@ -790,7 +803,7 @@ export const knowledgeAssetPullFrom = (
 ) =>
   post<Record<string, unknown>>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/pull-from`,
-    { contextGraphId, layer, ...opts },
+    { contextGraphId: normalizeContextGraphId(contextGraphId), layer, ...opts },
   );
 
 /** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
@@ -801,7 +814,7 @@ export const knowledgeAssetShare = (
 ) =>
   post<{ swmShared: boolean; promotedCount: number }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`,
-    { contextGraphId, ...opts },
+    { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
   );
 
 /** Publish to VM — mint or update on chain (git push origin main). */
@@ -814,7 +827,7 @@ export const knowledgeAssetPublish = (
   return post<Record<string, unknown>>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
     {
-      contextGraphId,
+      contextGraphId: normalizeContextGraphId(contextGraphId),
       ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
       ...(publishOptions ? { options: publishOptions } : {}),
     },

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -710,6 +710,12 @@ export interface KnowledgeAssetFinalizedPublishOptions {
   publisherNodeIdentityIdOverride?: string;
 }
 
+const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+  'clearAfter',
+  'publishEpochs',
+  'publisherNodeIdentityIdOverride',
+]);
+
 const publisherNodeIdentityOverridePayload = (value: unknown): string => {
   if (typeof value === 'string' && /^\d+$/.test(value)) return value;
   throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
@@ -718,8 +724,15 @@ const publisherNodeIdentityOverridePayload = (value: unknown): string => {
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
 const finalizedPublishOptionsPayload = (
   options?: KnowledgeAssetFinalizedPublishOptions,
+  allowedExtraKeys: readonly string[] = [],
 ): Record<string, unknown> | undefined => {
   if (!options) return undefined;
+  const unsupportedKeys = Object.keys(options).filter(
+    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+  );
+  if (unsupportedKeys.length > 0) {
+    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
+  }
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
@@ -730,6 +743,19 @@ const finalizedPublishOptionsPayload = (
       publisherNodeIdentityOverridePayload(publisherNodeIdentityIdOverride);
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
+};
+
+const createAlsoPublishVmPayload = (value: unknown): boolean | Record<string, unknown> => {
+  if (typeof value === 'boolean') return value;
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (Object.keys(value).length === 0) return {};
+    const payload = finalizedPublishOptionsPayload(value as KnowledgeAssetFinalizedPublishOptions);
+    if (payload) return payload;
+    throw new Error(
+      'alsoPublishVm options object must include at least one supported option; use true to publish with defaults',
+    );
+  }
+  throw new Error('alsoPublishVm must be a boolean or publish-options object');
 };
 
 /**
@@ -760,8 +786,8 @@ export const createKnowledgeAsset = (
   };
   // Object form carries finalized-publish controls; translate to the daemon
   // body shape (mirrors the cli ApiClient). `true`/`false` pass through.
-  if (opts.alsoPublishVm && typeof opts.alsoPublishVm === 'object') {
-    body.alsoPublishVm = finalizedPublishOptionsPayload(opts.alsoPublishVm) ?? {};
+  if (opts.alsoPublishVm !== undefined) {
+    body.alsoPublishVm = createAlsoPublishVmPayload(opts.alsoPublishVm);
   }
   return post<Record<string, unknown>>('/api/knowledge-assets', body);
 };
@@ -851,7 +877,7 @@ export const knowledgeAssetPublish = (
   name: string,
   opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
 ) => {
-  const publishOptions = finalizedPublishOptionsPayload(opts);
+  const publishOptions = finalizedPublishOptionsPayload(opts, ['subGraphName']);
   return post<Record<string, unknown>>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
     {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -679,7 +679,7 @@ export interface KnowledgeAssetFinalizedPublishOptions {
 }
 
 const publisherNodeIdentityOverridePayload = (value: unknown): string => {
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return value;
   throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
 }
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -11,6 +11,30 @@ function normalizeContextGraphId(contextGraphIdOrUri: string): string {
     : trimmed;
 }
 
+function assertExclusiveAuthorFields(args: {
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+}): void {
+  if (args.authorAgentAddress != null && args.preSignedAuthorAttestation != null) {
+    throw new Error('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+  }
+}
+
+function assertCreateFinalizeFieldsHaveQuads(args: {
+  quads?: unknown[];
+  authorAgentAddress?: string;
+  preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+  schemeVersion?: number;
+}): void {
+  const hasFinalizeOnlyField =
+    args.authorAgentAddress != null ||
+    args.preSignedAuthorAttestation != null ||
+    args.schemeVersion !== undefined;
+  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  }
+}
+
 export function authHeaders(): Record<string, string> {
   if (typeof window === 'undefined') return {};
   const token = window.__DKG_TOKEN__;
@@ -726,6 +750,8 @@ export const createKnowledgeAsset = (
     alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   } = {},
 ) => {
+  assertExclusiveAuthorFields(opts);
+  assertCreateFinalizeFieldsHaveQuads(opts);
   const normalizedContextGraphId = normalizeContextGraphId(contextGraphId);
   const body: Record<string, unknown> = {
     contextGraphId: normalizedContextGraphId,
@@ -777,11 +803,13 @@ export const knowledgeAssetFinalize = (
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
   } = {},
-) =>
-  post<{ merkleRoot: string; eip712Digest: string }>(
+) => {
+  assertExclusiveAuthorFields(opts);
+  return post<{ merkleRoot: string; eip712Digest: string }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
     { contextGraphId: normalizeContextGraphId(contextGraphId), ...opts },
   );
+};
 
 /** Discard the open WM draft (git checkout -- .). */
 export const knowledgeAssetDiscard = (

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -664,8 +664,8 @@ export interface PreSignedAuthorAttestationPayload {
 /**
  * VM-publish controls for the finalized-assertion publish path. Mirrors
  * `KnowledgeAssetFinalizedPublishOptions` in `packages/cli/src/api-client.ts`.
- * `publisherNodeIdentityIdOverride` is widened to `string | number` (the browser
- * `JSON.stringify` cannot serialize a bigint) on top of the cli's `bigint`.
+ * Browser callers must pass large node identity ids as decimal strings rather
+ * than JavaScript numbers, which can lose uint64 precision before serialization.
  */
 export interface KnowledgeAssetFinalizedPublishOptions {
   /**
@@ -675,7 +675,12 @@ export interface KnowledgeAssetFinalizedPublishOptions {
    */
   clearAfter?: boolean;
   publishEpochs?: number;
-  publisherNodeIdentityIdOverride?: bigint | string | number;
+  publisherNodeIdentityIdOverride?: string;
+}
+
+const publisherNodeIdentityOverridePayload = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  throw new Error('publisherNodeIdentityIdOverride must be passed as a decimal string');
 }
 
 /** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
@@ -686,8 +691,11 @@ const finalizedPublishOptionsPayload = (
   const payload: Record<string, unknown> = {};
   if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
   if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
-  if (options.publisherNodeIdentityIdOverride !== undefined) {
-    payload.publisherNodeIdentityIdOverride = String(options.publisherNodeIdentityIdOverride);
+  const publisherNodeIdentityIdOverride =
+    (options as Record<string, unknown>).publisherNodeIdentityIdOverride;
+  if (publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride =
+      publisherNodeIdentityOverridePayload(publisherNodeIdentityIdOverride);
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
 };

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -652,6 +652,47 @@ export interface KnowledgeAssetQuad {
 }
 
 /**
+ * Author attestation produced by an external signer. Mirrors the
+ * `packages/cli/src/api-client.ts` reference so finalize / create KA flows can
+ * carry a pre-built EIP-712 attestation instead of signing on the daemon.
+ */
+export interface PreSignedAuthorAttestationPayload {
+  address: string;
+  signature: { r: string; vs: string };
+}
+
+/**
+ * VM-publish controls for the finalized-assertion publish path. Mirrors
+ * `KnowledgeAssetFinalizedPublishOptions` in `packages/cli/src/api-client.ts`.
+ * `publisherNodeIdentityIdOverride` is widened to `string | number` (the browser
+ * `JSON.stringify` cannot serialize a bigint) on top of the cli's `bigint`.
+ */
+export interface KnowledgeAssetFinalizedPublishOptions {
+  /**
+   * SDK-friendly spelling for the finalized publish cleanup flag. The
+   * knowledge-assets daemon route forwards `clearSharedMemoryAfter` to
+   * `publishFromFinalizedAssertion`, so the client translates before POST.
+   */
+  clearAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint | string | number;
+}
+
+/** Translate {@link KnowledgeAssetFinalizedPublishOptions} into the daemon body. */
+const finalizedPublishOptionsPayload = (
+  options?: KnowledgeAssetFinalizedPublishOptions,
+): Record<string, unknown> | undefined => {
+  if (!options) return undefined;
+  const payload: Record<string, unknown> = {};
+  if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
+  if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
+  if (options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = String(options.publisherNodeIdentityIdOverride);
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
+};
+
+/**
  * Create a KA and open its WM draft. Pass `quads` to atomically write+finalize
  * in one call; `alsoShareSwm` / `alsoPublishVm` to advance layers in the same
  * request (best-effort tails — partial failures are reported via HTTP 207).
@@ -662,10 +703,21 @@ export const createKnowledgeAsset = (
   opts: {
     subGraphName?: string;
     quads?: KnowledgeAssetQuad[];
+    authorAgentAddress?: string;
+    preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+    schemeVersion?: number;
     alsoShareSwm?: boolean;
-    alsoPublishVm?: boolean;
+    alsoPublishVm?: boolean | KnowledgeAssetFinalizedPublishOptions;
   } = {},
-) => post<Record<string, unknown>>('/api/knowledge-assets', { contextGraphId, name, ...opts });
+) => {
+  const body: Record<string, unknown> = { contextGraphId, name, ...opts };
+  // Object form carries finalized-publish controls; translate to the daemon
+  // body shape (mirrors the cli ApiClient). `true`/`false` pass through.
+  if (opts.alsoPublishVm && typeof opts.alsoPublishVm === 'object') {
+    body.alsoPublishVm = finalizedPublishOptionsPayload(opts.alsoPublishVm) ?? {};
+  }
+  return post<Record<string, unknown>>('/api/knowledge-assets', body);
+};
 
 /** GET a KA's per-layer lifecycle state by name. */
 export const getKnowledgeAsset = (
@@ -698,7 +750,12 @@ export const knowledgeAssetWrite = (
 export const knowledgeAssetFinalize = (
   contextGraphId: string,
   name: string,
-  opts: { subGraphName?: string } = {},
+  opts: {
+    subGraphName?: string;
+    authorAgentAddress?: string;
+    preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
+    schemeVersion?: number;
+  } = {},
 ) =>
   post<{ merkleRoot: string; eip712Digest: string }>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
@@ -743,12 +800,18 @@ export const knowledgeAssetShare = (
 export const knowledgeAssetPublish = (
   contextGraphId: string,
   name: string,
-  opts: { subGraphName?: string } = {},
-) =>
-  post<Record<string, unknown>>(
+  opts: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions = {},
+) => {
+  const publishOptions = finalizedPublishOptionsPayload(opts);
+  return post<Record<string, unknown>>(
     `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
-    { contextGraphId, ...opts },
+    {
+      contextGraphId,
+      ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+      ...(publishOptions ? { options: publishOptions } : {}),
+    },
   );
+};
 
 // --- Assertions (WM objects) ---
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -637,6 +637,119 @@ export const writeProfileQueryCatalog = (
     quads,
   });
 
+// --- Knowledge Assets (OT-RFC-43 §10.5 — GitHub-shaped KA surface) ---
+// Layer-explicit wrappers over the clean /api/knowledge-assets/... routes that
+// supersede the legacy assertion/* + shared-memory/* calls above during the v10
+// migration window. One file = one Knowledge Asset (Design B / OT-RFC-44): a KA
+// may carry any number of member entities. WM → SWM → VM maps to the git-shaped
+// verbs write → finalize → share → publish.
+
+export interface KnowledgeAssetQuad {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph: string;
+}
+
+/**
+ * Create a KA and open its WM draft. Pass `quads` to atomically write+finalize
+ * in one call; `alsoShareSwm` / `alsoPublishVm` to advance layers in the same
+ * request (best-effort tails — partial failures are reported via HTTP 207).
+ */
+export const createKnowledgeAsset = (
+  contextGraphId: string,
+  name: string,
+  opts: {
+    subGraphName?: string;
+    quads?: KnowledgeAssetQuad[];
+    alsoShareSwm?: boolean;
+    alsoPublishVm?: boolean;
+  } = {},
+) => post<Record<string, unknown>>('/api/knowledge-assets', { contextGraphId, name, ...opts });
+
+/** GET a KA's per-layer lifecycle state by name. */
+export const getKnowledgeAsset = (
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+) => {
+  const qs = new URLSearchParams({
+    contextGraphId,
+    ...(subGraphName ? { subGraphName } : {}),
+  }).toString();
+  return get<Record<string, unknown>>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}?${qs}`,
+  );
+};
+
+/** Append quads to the KA's WM draft (git add/edit). */
+export const knowledgeAssetWrite = (
+  contextGraphId: string,
+  name: string,
+  quads: KnowledgeAssetQuad[],
+  opts: { subGraphName?: string } = {},
+) =>
+  post<{ written: number }>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/wm/write`,
+    { contextGraphId, quads, ...opts },
+  );
+
+/** Seal the WM draft — computes the merkle root + signs the seal (git commit). */
+export const knowledgeAssetFinalize = (
+  contextGraphId: string,
+  name: string,
+  opts: { subGraphName?: string } = {},
+) =>
+  post<{ merkleRoot: string; eip712Digest: string }>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize`,
+    { contextGraphId, ...opts },
+  );
+
+/** Discard the open WM draft (git checkout -- .). */
+export const knowledgeAssetDiscard = (
+  contextGraphId: string,
+  name: string,
+  opts: { subGraphName?: string } = {},
+) =>
+  post<{ discarded: boolean }>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/wm/discard`,
+    { contextGraphId, ...opts },
+  );
+
+/** Seed a fresh WM draft from the file's current SWM/VM state (git checkout). */
+export const knowledgeAssetPullFrom = (
+  contextGraphId: string,
+  name: string,
+  layer: 'swm' | 'vm',
+  opts: { subGraphName?: string; onConflict?: 'reject' | 'replace' } = {},
+) =>
+  post<Record<string, unknown>>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/wm/pull-from`,
+    { contextGraphId, layer, ...opts },
+  );
+
+/** Advance the SWM pointer (WM → SWM; git push origin <branch>). */
+export const knowledgeAssetShare = (
+  contextGraphId: string,
+  name: string,
+  opts: { subGraphName?: string; entities?: string[] | 'all' } = {},
+) =>
+  post<{ swmShared: boolean; promotedCount: number }>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/swm/share`,
+    { contextGraphId, ...opts },
+  );
+
+/** Publish to VM — mint or update on chain (git push origin main). */
+export const knowledgeAssetPublish = (
+  contextGraphId: string,
+  name: string,
+  opts: { subGraphName?: string } = {},
+) =>
+  post<Record<string, unknown>>(
+    `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`,
+    { contextGraphId, ...opts },
+  );
+
 // --- Assertions (WM objects) ---
 
 export interface AssertionInfo {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -37,6 +37,7 @@ import {
   subscribeToContextGraph,
   shutdownNode,
   promoteAssertion,
+  knowledgeAssetPublish,
 } from '../src/ui/api.js';
 
 let server: Server;
@@ -295,6 +296,20 @@ describe('UI API tests', () => {
       expect(body.contextGraphId).toBe('cg-1');
       expect(body.selection).toEqual(['urn:root']);
       expect(body.clearAfter).toBe(false);
+    });
+
+    it('knowledgeAssetPublish rejects non-decimal publisher identity overrides before POSTing', async () => {
+      expect(() =>
+        knowledgeAssetPublish('cg-1', 'f', { publisherNodeIdentityIdOverride: 'abc' }),
+      ).toThrow('publisherNodeIdentityIdOverride must be passed as a decimal string');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('knowledgeAssetPublish rejects negative publisher identity overrides before POSTing', async () => {
+      expect(() =>
+        knowledgeAssetPublish('cg-1', 'f', { publisherNodeIdentityIdOverride: '-1' }),
+      ).toThrow('publisherNodeIdentityIdOverride must be passed as a decimal string');
+      expect(requestLog).toHaveLength(0);
     });
 
     it('listSwmEntities queries the shared-working-memory view', async () => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -314,6 +314,13 @@ describe('UI API tests', () => {
       expect(requestLog).toHaveLength(0);
     });
 
+    it('knowledgeAssetPublish rejects unsupported publish options before POSTing', async () => {
+      expect(() =>
+        knowledgeAssetPublish('cg-1', 'f', { publishEpoch: 3 } as any),
+      ).toThrow('Unsupported finalized publish option(s): publishEpoch');
+      expect(requestLog).toHaveLength(0);
+    });
+
     it('createKnowledgeAsset normalizes context graph URIs before POSTing', async () => {
       await createKnowledgeAsset('did:dkg:context-graph:cg-1', 'f');
       const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets'));
@@ -338,6 +345,27 @@ describe('UI API tests', () => {
           authorAgentAddress: '0xauthor',
         }),
       ).toThrow('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset treats empty alsoPublishVm options as default publish', async () => {
+      await createKnowledgeAsset('cg-1', 'f', { alsoPublishVm: {} });
+      const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets'));
+      const body = JSON.parse(call?.body ?? '{}');
+      expect(body.alsoPublishVm).toEqual({});
+    });
+
+    it('createKnowledgeAsset rejects unsupported alsoPublishVm options before POSTing', () => {
+      expect(() =>
+        createKnowledgeAsset('cg-1', 'f', { alsoPublishVm: { publishEpoch: 3 } as any }),
+      ).toThrow('Unsupported finalized publish option(s): publishEpoch');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset rejects array alsoPublishVm before POSTing', () => {
+      expect(() =>
+        createKnowledgeAsset('cg-1', 'f', { alsoPublishVm: [] as any }),
+      ).toThrow('alsoPublishVm must be a boolean or publish-options object');
       expect(requestLog).toHaveLength(0);
     });
 

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -39,6 +39,7 @@ import {
   promoteAssertion,
   createKnowledgeAsset,
   knowledgeAssetPublish,
+  knowledgeAssetFinalize,
 } from '../src/ui/api.js';
 
 let server: Server;
@@ -319,6 +320,35 @@ describe('UI API tests', () => {
       const body = JSON.parse(call?.body ?? '{}');
       expect(body.contextGraphId).toBe('cg-1');
       expect(body.name).toBe('f');
+    });
+
+    it('createKnowledgeAsset rejects mutually exclusive authorship fields before POSTing', () => {
+      expect(() =>
+        createKnowledgeAsset('cg-1', 'f', {
+          authorAgentAddress: '0xauthor',
+          preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+        }),
+      ).toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset rejects finalized publish fields without quads before POSTing', () => {
+      expect(() =>
+        createKnowledgeAsset('cg-1', 'f', {
+          authorAgentAddress: '0xauthor',
+        }),
+      ).toThrow('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+      expect(requestLog).toHaveLength(0);
+    });
+
+    it('knowledgeAssetFinalize rejects mutually exclusive authorship fields before POSTing', () => {
+      expect(() =>
+        knowledgeAssetFinalize('cg-1', 'f', {
+          authorAgentAddress: '0xauthor',
+          preSignedAuthorAttestation: { address: '0xauthor', signature: { r: '0xr', vs: '0xvs' } },
+        }),
+      ).toThrow('authorAgentAddress and preSignedAuthorAttestation are mutually exclusive');
+      expect(requestLog).toHaveLength(0);
     });
 
     it('listSwmEntities queries the shared-working-memory view', async () => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -37,6 +37,7 @@ import {
   subscribeToContextGraph,
   shutdownNode,
   promoteAssertion,
+  createKnowledgeAsset,
   knowledgeAssetPublish,
 } from '../src/ui/api.js';
 
@@ -310,6 +311,14 @@ describe('UI API tests', () => {
         knowledgeAssetPublish('cg-1', 'f', { publisherNodeIdentityIdOverride: '-1' }),
       ).toThrow('publisherNodeIdentityIdOverride must be passed as a decimal string');
       expect(requestLog).toHaveLength(0);
+    });
+
+    it('createKnowledgeAsset normalizes context graph URIs before POSTing', async () => {
+      await createKnowledgeAsset('did:dkg:context-graph:cg-1', 'f');
+      const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/knowledge-assets'));
+      const body = JSON.parse(call?.body ?? '{}');
+      expect(body.contextGraphId).toBe('cg-1');
+      expect(body.name).toBe('f');
     });
 
     it('listSwmEntities queries the shared-working-memory view', async () => {


### PR DESCRIPTION
Stacked on #973. Completes **Plan A5** — extends the GitHub-shaped `/api/knowledge-assets` surface (added to the cli `ApiClient` in #973) to the remaining first-party clients, so the clean KA API is actually reachable from the **UI**, the **MCP server**, and the **OpenCLAW adapter**.

### What
Mirror the cli reference verbatim (identical routes / bodies / layer verbs) in three clients:

| Client | File | Style |
|---|---|---|
| node-ui | `packages/node-ui/src/ui/api.ts` | positional-arg functional exports over `post()`/`get()` |
| mcp-dkg | `packages/mcp-dkg/src/client.ts` | args-object methods over `this.request()` (+ cg-id normalization) |
| adapter-openclaw | `packages/adapter-openclaw/src/dkg-client.ts` | positional methods over `this.post()`/`this.get()` + **fetch-mocked contract tests** |

Methods: `createKnowledgeAsset` / `getKnowledgeAsset` / `knowledgeAssetWrite` / `Finalize` / `Discard` / `PullFrom` (WM) / `Share` (SWM) / `Publish` (VM).

### Scope notes
- **adapter-hermes intentionally excluded** — it is a specialised hermes-channel adapter (connect/send/persist-turn), not a general KA-publishing client.
- Routes are identical to the cli surface (already contract-tested in `api-client.test.ts`); openclaw adds a focused route/method/body test (create, URL-encoded write, pull-from, share, publish). Validated end-to-end on the integration devnet.

### Test
- typecheck clean across node-ui, mcp-dkg, openclaw
- openclaw suite 70/70 (incl. 4 new KA contract tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)