### PR TITLE
test: fix PR 980 CI — Option-1 256-bit/reservedKaId test-harness adjustments (no prod change)

### DIFF
--- a/packages/agent/test/e2e-publish-protocol.test.ts
+++ b/packages/agent/test/e2e-publish-protocol.test.ts
@@ -236,9 +236,9 @@ describe('E2E: Design B — multi-entity file publishes as one KA, ACKed cross-n
   });
 
   it('bootstraps 3 agents and a context graph', async () => {
-    nodeA = await DKGAgent.create({ name: 'DBMultiA', listenPort: 0, skills: [], chainAdapter: chainA, nodeRole: 'core' });
-    nodeB = await DKGAgent.create({ name: 'DBMultiB', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP), nodeRole: 'core' });
-    nodeC = await DKGAgent.create({ name: 'DBMultiC', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP), nodeRole: 'core' });
+    nodeA = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiA', listenPort: 0, skills: [], chainAdapter: chainA, nodeRole: 'core' });
+    nodeB = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiB', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP), nodeRole: 'core' });
+    nodeC = await DKGAgent.create({ kaNumberAllocator: makeTestKaNumberAllocator(), name: 'DBMultiC', listenPort: 0, skills: [], chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP), nodeRole: 'core' });
 
     await nodeA.start();
     await nodeB.start();

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -137,7 +137,12 @@ const PINNED_DIGESTS: Record<string, string> = {
   // Greenfield rename (rc.12): logic + storage pair replaces the legacy names.
   KnowledgeAssetsLifecycle:     '45957310345c8cc8dd027ccf006bd0730e47510d72f8d14857de251788b10a52',
 
-  DKGKnowledgeAssets:           'c7c402825334252247d64a3ff4c13a4b757885bb8a1585974b5c01e14d5ac0f8',
+  // Re-pinned for OT-RFC-43 Option-1 (variant 1a, PR #975): deterministic
+  // author-namespaced KA identity. `createKnowledgeAsset` now takes an explicit
+  // caller-supplied `uint256 kaId` (the packed author-namespaced id), and two
+  // guard errors were added — `KaIdAlreadyMinted(uint256)` and
+  // `KaIdNamespaceMismatch(uint256,address)` — plus a deprecated accessor.
+  DKGKnowledgeAssets:           'da5e46f24dd410b30c90bad66060b9da240aa4b0426c24a1550b0e1b6168b5ea',
   // V8 `KnowledgeCollection` ABI was moved to `abi/archive/` in
   // `archive-non-v10-contracts`; the pin entry is intentionally dropped.
   // Updated for SPEC_CG_MEMORY_MODEL: per-CG hosting committees and

--- a/packages/core/test/proto-finalization-edge.test.ts
+++ b/packages/core/test/proto-finalization-edge.test.ts
@@ -39,8 +39,11 @@ describe('encodeFinalizationMessage uint64 bounds', () => {
   });
 
   it('throws RangeError when any uint64 field overflows', () => {
+    // batchId is now the 256-bit-safe decimal-string KA-id wire (OT-RFC-43 §9),
+    // so it can never uint64-overflow. blockNumber is still a genuine uint64
+    // field guarded by bigIntToProtoSafe — keep the overflow coverage there.
     expect(() =>
-      encodeFinalizationMessage(minimalFinalization({ batchId: MAX_UINT64 + 1n }) as any),
+      encodeFinalizationMessage(minimalFinalization({ blockNumber: MAX_UINT64 + 1n }) as any),
     ).toThrow(RangeError);
     expect(() =>
       encodeFinalizationMessage(minimalFinalization({ timestampMs: -1n }) as any),

--- a/packages/core/test/proto.test.ts
+++ b/packages/core/test/proto.test.ts
@@ -32,6 +32,10 @@ describe('Protobuf: PublishRequest round-trip', () => {
         },
       ],
       publisherIdentity: new Uint8Array(32),
+      // OT-RFC-43 §9: startKAId/endKAId are now required decimal-string id
+      // fields; encodePublishRequest stringifies them unconditionally.
+      startKAId: 1,
+      endKAId: 1,
     };
     const encoded = encodePublishRequest(original);
     expect(encoded).toBeInstanceOf(Uint8Array);

--- a/packages/core/test/v10-protocol-coverage.test.ts
+++ b/packages/core/test/v10-protocol-coverage.test.ts
@@ -147,9 +147,11 @@ describe('VerifyProposal proto — full-field round-trip [C-7]', () => {
     const vmId = typeof decoded.verifiedMemoryId === 'number'
       ? decoded.verifiedMemoryId
       : (decoded.verifiedMemoryId.high * 2 ** 32) + decoded.verifiedMemoryId.low;
-    const bId = typeof decoded.batchId === 'number'
-      ? decoded.batchId
-      : (decoded.batchId.high * 2 ** 32) + decoded.batchId.low;
+    // batchId is a KA id: the wire type is now the 256-bit-safe decimal
+    // string (OT-RFC-43 §9), not a uint64/Long. Assert the new contract and
+    // that the value still round-trips. (verifiedMemoryId stays uint64/Long.)
+    expect(typeof decoded.batchId).toBe('string');
+    const bId = Number(decoded.batchId);
     expect(vmId).toBe(7);
     expect(bId).toBe(42);
   });

--- a/packages/publisher/test/e2e.test.ts
+++ b/packages/publisher/test/e2e.test.ts
@@ -156,15 +156,18 @@ describe('End-to-end: Publish → Replicate → Query', () => {
       nquads: new TextEncoder().encode(nquads),
       contextGraphId: CONTEXT_GRAPH,
       kas: publishResult.kaManifest.map((m) => ({
-        tokenId: Number(m.tokenId),
+        // OT-RFC-43 Option-1: kaIds are packed ~256-bit values — never narrow
+        // through Number() (lossy float → idToProtoString emits exponential →
+        // receiver BigInt() throws). Pass the bigint id straight through.
+        tokenId: m.tokenId,
         rootEntity: m.rootEntity,
         privateMerkleRoot: m.privateMerkleRoot ?? new Uint8Array(0),
         privateTripleCount: m.privateTripleCount ?? 0,
       })),
       publisherIdentity: keypairA.publicKey,
       publisherAddress: onChain.publisherAddress,
-      startKAId: Number(onChain.startKAId),
-      endKAId: Number(onChain.endKAId),
+      startKAId: onChain.startKAId,
+      endKAId: onChain.endKAId,
       chainId: chainA.chainId,
       publisherSignatureR: new Uint8Array(0),
       publisherSignatureVs: new Uint8Array(0),


### PR DESCRIPTION
Fixes all **7 red CI checks** on #980. **All are test-harness adjustments from the Option-1 256-bit-id / `reservedKaId` migration — no production code change.** Verified green against the live #980 tip.

### Diagnosis (adversarially verified)
The `UnauthorizedAccess("Only Contracts in Hub")` line in the agent logs is a **benign, deliberately-caught red herring** — DKGPublisher calls the Hub-only `ContextGraphs.verify()` from an EOA, catches the expected revert, and logs `Explicit verify not needed (V10 auto-registered)`. The Hub wiring is correct; the real failures are five test gaps.

### Fixes
| Area | Fix |
|---|---|
| **agent e2e** (3 shards) | The 3 Design-B `DKGAgent.create` calls (`e2e-publish-protocol.test.ts`) omitted `kaNumberAllocator` (every other block has it). Without it, `ensureReservedKaId` → `undefined` → the EVM adapter fail-louds `reservedKaId is required`. Added the allocator. |
| **publisher e2e** | `e2e.test.ts` narrowed packed ~256-bit kaIds through `Number()` → lossy float → `idToProtoString` emits exponential → receiver `BigInt('…e+76')` throws. Pass the bigint id straight through. |
| **core proto** (3) | `batchId`/`startKAId`/`endKAId` are now 256-bit-safe decimal strings, not `uint64`. Retarget the uint64-overflow assertion to `blockNumber` (still uint64), supply now-required `startKAId/endKAId`, assert decimal-string `batchId`. No coverage lost. |
| **chain ABI** | Re-pin `DKGKnowledgeAssets` digest — the Option-1 contract legitimately added a `uint256 kaId` param + `KaIdAlreadyMinted`/`KaIdNamespaceMismatch` guards (#975); the pin guard correctly fired. |

### Verification (on this branch, off the live #980)
- core **1035 ✓** · chain abi **20 ✓** · agent canary (THE CANARY) **17 ✓** · publisher e2e **8 ✓** · full build **20/20**

### For maintainers — landing on `main`
This is a **#980-targeted handoff** so the active integration agent can merge without collision. For the fixes to also reach `main` when the stacked PRs merge:
- **core-proto** + **publisher-e2e** (256-bit wire) belong on **#979** `feat/v10-option1-supply-chain`.
- **chain-abi** re-pin belongs on **#975** `feat/v10-option1-contract` (recompute the digest against that branch's ABI — it may differ from this one due to stack decoupling).
- The **agent Design-B allocator** fix is **integration-only** — the Design-B canary block (Plan A #968) and `reservedKaId` (Plan B) only coexist here, so it has no single underlying PR home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)