### PR TITLE
fix(ci): green PR #980's 4 remaining checks (allocator wiring + minSig=3 devnet sizing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,16 +532,19 @@ jobs:
         run: pnpm --filter @origintrail-official/dkg-node-ui test
 
   # node-ui Playwright e2e — REAL NODE, NO MOCKS. The suite boots a live
-  # 2-node devnet (Hardhat + two DKG daemons) via Playwright's `webServer`
+  # 4-node devnet (Hardhat + four DKG daemons) via Playwright's `webServer`
   # (see `e2e/bootstrap-devnet.ts`, chained `bootstrap && pnpm dev:ui`),
   # drives the real UI against node 1's live `/api`, and tears the devnet
   # down in `e2e/global-teardown.ts` when the run finishes. There is no
   # route-mock lane anymore: every test exercises real daemon round-trips.
   #
-  # Why 2 nodes: VM publishing needs ACK quorum from a connected CORE peer.
-  # A single-node devnet fails every publish with `QuorumUnmetError`, so the
-  # WM→SWM→VM pipeline (and the data-driven UI views that depend on it) can't
-  # be exercised. Two core nodes is the minimum (see playwright.config.ts).
+  # Why 4 nodes: VM publishing needs StorageACK quorum, and scripts/devnet.sh
+  # pins `minimumRequiredSignatures = 3` (the real mainnet 3-of-N quorum — DO
+  # NOT lower it). A publisher collects ACKs from its PEERS only, so it needs
+  # minSig OTHER reachable core nodes = 4 total. With fewer, every publish aborts
+  # `QuorumUnmetError: need 3 ACKs but only N core peers connected`, so the
+  # WM→SWM→VM pipeline (and the data-driven UI views that depend on it) can't be
+  # exercised. Four core nodes is the minimum (see playwright.config.ts).
   #
   # Channel is pinned to bundled chromium in playwright.config.ts under CI
   # (see `ciChromium`) since we only `playwright install chromium`.

--- a/packages/agent/test/e2e-security.test.ts
+++ b/packages/agent/test/e2e-security.test.ts
@@ -46,6 +46,10 @@ function messengerFor(router: import('@origintrail-official/dkg-core').ProtocolR
 }
 import { wrapPublisherForTest } from '../../publisher/test/_helpers/seal.js';
 import { hardhatACKProvider } from '../../publisher/test/_helpers/acks.js';
+// OT-RFC-43 Option-1: the real EVM adapter requires a packed reservedKaId per
+// mint; a directly-constructed DKGPublisher only supplies one when a
+// kaAllocator is wired (DKGPublisher only auto-allocates when configured).
+import { makeTestKaAllocator } from '../../publisher/test/_helpers/ka-allocator.js';
 import { ethers } from 'ethers';
 
 const agents: DKGAgent[] = [];
@@ -285,6 +289,7 @@ describe('Access protocol denial', () => {
     const keypairA = await generateEd25519Keypair();
 
     const publisherA = await wrapPub(new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
       store: storeA,
       chain: chainA,
       eventBus: busA,
@@ -420,6 +425,7 @@ describe('Access protocol round-trip', () => {
     const ENTITY = 'did:dkg:test:AccessEntity';
 
     const publisherA = await wrapPub(new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
       store: storeA,
       chain: chainA,
       eventBus: busA,

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -80,6 +80,11 @@ describe('FinalizationHandler', () => {
       nquads: new TextEncoder().encode('<urn:s> <urn:p> <urn:o> .'),
       contextGraphId: CONTEXT_GRAPH,
       kas: [{ tokenId: 1, rootEntity: 'urn:s', privateTripleCount: 0, privateMerkleRoot: new Uint8Array(0) }],
+      // OT-RFC-43 Option-1: startKAId/endKAId are now required id fields on the
+      // wire (encoded via idToProtoString); omitting them throws inside the
+      // encoder before the message ever reaches the handler under test.
+      startKAId: 1,
+      endKAId: 1,
       txHash: '',
       blockNumber: 0,
     });

--- a/packages/node-ui/e2e/bootstrap-devnet.ts
+++ b/packages/node-ui/e2e/bootstrap-devnet.ts
@@ -36,8 +36,11 @@ const API_PORT_FILE = resolve(NODE_DIR, 'api.port');
 const DAEMON_LOG_FILE = resolve(NODE_DIR, 'daemon.log');
 const MARKER_FILE = resolve(DEVNET_DIR, '.playwright-managed');
 
+// 4-node minSig=3 devnet (see playwright.config.ts NUM_NODES): one extra daemon
+// boot + a wider libp2p mesh to settle vs the old 3-node default, so give the
+// mesh-wait headroom (240s) under the generous 600s CI webServer timeout.
 const BOOTSTRAP_TIMEOUT_MS = parseInt(
-  process.env.PLAYWRIGHT_DEVNET_TIMEOUT_MS || '180000',
+  process.env.PLAYWRIGHT_DEVNET_TIMEOUT_MS || '240000',
   10,
 );
 

--- a/packages/node-ui/e2e/helpers/devnet.ts
+++ b/packages/node-ui/e2e/helpers/devnet.ts
@@ -139,8 +139,12 @@ const IS_CI = !!process.env.CI;
 // node-availability gate can tell "node down" (a real failure) apart from "node
 // is outside the booted topology" (genuinely not applicable — e.g. node2 on a
 // `PLAYWRIGHT_DEVNET_NUM_NODES=1` run). Read from env rather than importing
-// real-node.ts to keep this low-level helper dependency-light.
-const CONFIGURED_NUM_NODES = Number(process.env.PLAYWRIGHT_DEVNET_NUM_NODES) || 3;
+// real-node.ts to keep this low-level helper dependency-light. The fallback MUST
+// match the NUM_NODES default in playwright.config.ts (4): the runner process
+// does not always have PLAYWRIGHT_DEVNET_NUM_NODES exported (the webServer
+// command sets it only for the bootstrap/Vite subprocess), so a stale `3` here
+// would mark node4 as "outside topology" even though the webServer booted 4.
+const CONFIGURED_NUM_NODES = Number(process.env.PLAYWRIGHT_DEVNET_NUM_NODES) || 4;
 
 type SkippableTest = { skip: (condition: boolean, description: string) => void };
 

--- a/packages/node-ui/e2e/helpers/real-node.ts
+++ b/packages/node-ui/e2e/helpers/real-node.ts
@@ -36,7 +36,10 @@ export const SEEDED_CGS = [PRIMARY_CG, SECONDARY_CG] as const;
  * `NUM_CORE_NODES` nodes boot as `core`; the rest are `edge`.
  */
 export const UI_NODE = Number(process.env.DEVNET_NODE || process.env.UI_NODE_ID) || 1;
-export const NUM_NODES = Number(process.env.PLAYWRIGHT_DEVNET_NUM_NODES) || 3;
+// Default 4 — matches playwright.config.ts. scripts/devnet.sh pins minSig=3, so
+// a VM publish needs minSig OTHER core peers = 4 nodes total; node1 (relay hub)
+// then settles at EXPECTED_MIN_PEERS = N-1 = 3.
+export const NUM_NODES = Number(process.env.PLAYWRIGHT_DEVNET_NUM_NODES) || 4;
 export const NUM_CORE_NODES = Number(process.env.NUM_CORE_NODES) || 4;
 /** node1 is the relay hub every other node dials. */
 export const IS_RELAY_HUB = UI_NODE === 1;

--- a/packages/node-ui/playwright.config.ts
+++ b/packages/node-ui/playwright.config.ts
@@ -31,6 +31,19 @@ const DEVNET_NODE = process.env.DEVNET_NODE || process.env.UI_NODE_ID || '1';
 // VM publish can collect its 3 ACKs. Override with PLAYWRIGHT_DEVNET_NUM_NODES.
 const NUM_NODES = process.env.PLAYWRIGHT_DEVNET_NUM_NODES || '4';
 
+// Mesh-settle budget for the chained `bootstrap-devnet.ts` (it reads this via
+// PLAYWRIGHT_DEVNET_TIMEOUT_MS). Declared here so `webServer.timeout` below can
+// be DERIVED from the same value: otherwise a cold 4-node boot can run right up
+// to the bootstrap's budget and get killed by a smaller webServer.timeout before
+// that headroom is ever usable. Override with PLAYWRIGHT_DEVNET_TIMEOUT_MS.
+const DEVNET_BOOTSTRAP_TIMEOUT_MS = Number(process.env.PLAYWRIGHT_DEVNET_TIMEOUT_MS) || 240_000;
+// Vite still has to start and bind :5173 AFTER the bootstrap returns, so the
+// webServer command (bootstrap && pnpm dev:ui) needs the bootstrap budget plus a
+// margin for Vite. CI keeps its generous contract-compile headroom.
+const WEB_SERVER_TIMEOUT_MS = CI
+  ? Math.max(600_000, DEVNET_BOOTSTRAP_TIMEOUT_MS + 120_000)
+  : DEVNET_BOOTSTRAP_TIMEOUT_MS + 120_000;
+
 export default defineConfig({
   testDir: './e2e/specs',
   // Every spec drives the SAME shared real node. Read-only specs parallelise
@@ -101,7 +114,7 @@ export default defineConfig({
     // bootstrap reuses an already-running devnet (fast path for local
     // iteration) and only spawns one when none is reachable.
     command:
-      `cross-env PLAYWRIGHT_DEVNET_NUM_NODES=${NUM_NODES} pnpm exec tsx e2e/bootstrap-devnet.ts && ` +
+      `cross-env PLAYWRIGHT_DEVNET_NUM_NODES=${NUM_NODES} PLAYWRIGHT_DEVNET_TIMEOUT_MS=${DEVNET_BOOTSTRAP_TIMEOUT_MS} pnpm exec tsx e2e/bootstrap-devnet.ts && ` +
       `cross-env DEVNET_NODE=${DEVNET_NODE} pnpm dev:ui`,
     cwd: __dirname,
     port: PORT,
@@ -112,12 +125,15 @@ export default defineConfig({
     // the command guarantees the devnet is pinned; the bootstrap itself reuses an
     // already-running devnet cheaply, so a fresh Vite restart is the only cost.
     reuseExistingServer: false,
-    // Cold boot = Hardhat (+ Solidity compile when artifacts aren't cached) + 2
+    // Cold boot = Hardhat (+ Solidity compile when artifacts aren't cached) + 4
     // nodes + on-chain identity/stake/ask + CG registration + cross-node
     // propagation, THEN Vite. Locally (artifacts cached, devnet often reused)
     // that's ~40–90s; a cold CI runner adds the ~2-min contract compile. The CI
     // job pre-compiles contracts in a dedicated step to keep this fast, but we
     // budget generously so a cache miss never trips the webServer timeout.
-    timeout: CI ? 600_000 : 180_000,
+    // Derived from DEVNET_BOOTSTRAP_TIMEOUT_MS so the chained bootstrap can never
+    // out-wait the webServer (a cold 4-node boot used to hit the bootstrap's 240s
+    // budget but get killed by a 180s webServer.timeout).
+    timeout: WEB_SERVER_TIMEOUT_MS,
   },
 });

--- a/packages/node-ui/playwright.config.ts
+++ b/packages/node-ui/playwright.config.ts
@@ -21,11 +21,15 @@ const DEVNET_NODE = process.env.DEVNET_NODE || process.env.UI_NODE_ID || '1';
 //   - node1 is the relay HUB and every other node dials it (scripts/devnet.sh
 //     sets node{2..N}.relay = node1's multiaddr), so node1 — the node the UI
 //     reads `connectedPeers` from — reports exactly N-1 connected peers.
-// We boot THREE nodes so node1 shows 2 peers (a real multi-peer topology, not
-// the degenerate 1-peer case), and the VM-publish quorum has 3 core members
-// instead of the bare 2-node minimum. `peer-connectivity.spec.ts` asserts the
-// resulting ">1 peer" invariant. Override with PLAYWRIGHT_DEVNET_NUM_NODES.
-const NUM_NODES = process.env.PLAYWRIGHT_DEVNET_NUM_NODES || '3';
+// scripts/devnet.sh pins `minimumRequiredSignatures = 3` (the real mainnet
+// 3-of-N StorageACK quorum — DO NOT lower it). A publisher collects ACKs from
+// its PEERS only (it does not self-sign quorum), so a VM publish needs minSig
+// OTHER reachable core nodes — i.e. >= minSig + 1 = 4 nodes total. With only 3
+// the publish aborts `QuorumUnmetError: need 3 ACKs but only 2 core peers
+// connected`. We therefore boot FOUR nodes: node1 sees 3 peers (still a real
+// multi-peer topology, satisfies `peer-connectivity.spec.ts` ">1 peer"), and a
+// VM publish can collect its 3 ACKs. Override with PLAYWRIGHT_DEVNET_NUM_NODES.
+const NUM_NODES = process.env.PLAYWRIGHT_DEVNET_NUM_NODES || '4';
 
 export default defineConfig({
   testDir: './e2e/specs',

--- a/packages/publisher/test/publisher-evm-e2e.test.ts
+++ b/packages/publisher/test/publisher-evm-e2e.test.ts
@@ -21,6 +21,9 @@ import {
 } from '../../chain/test/hardhat-harness.js';
 import { wrapPublisherForTest } from './_helpers/seal.js';
 import { makeHardhatReceiverACKProvider } from './_helpers/acks.js';
+// OT-RFC-43 Option-1: the real EVM adapter requires a packed reservedKaId per
+// mint, which DKGPublisher only allocates when a kaAllocator is configured.
+import { makeTestKaAllocator } from './_helpers/ka-allocator.js';
 
 const HARDHAT_PORT = 8548;
 let CONTEXT_GRAPH: string;
@@ -69,6 +72,7 @@ describe('Publisher EVM E2E: DKGPublisher with real contracts', () => {
     const kav10Address = await adapter.getKnowledgeAssetsLifecycleAddress();
     publisher = wrapPublisherForTest(
       new DKGPublisher({
+        kaAllocator: makeTestKaAllocator(),
         store,
         chain: adapter,
         eventBus: bus,


### PR DESCRIPTION
Targets the 4 red checks on `integration/v10-devnet` (#980). All four trace to the OT-RFC-43 Option-1 chain change (packed `reservedKaId` + pinned `minSig=3`), **not** product regressions. Same class of test-harness fix as #982.

| Check | Failing test | Cause | Fix |
|---|---|---|---|
| `agent [3/10]` | e2e-security `denies access when KA exists but has no private triples` | direct `DKGPublisher` (via `wrapPub`) had no `kaAllocator` → real EVM adapter throws `reservedKaId is required` | wire `makeTestKaAllocator()` into both direct-publisher ctors |
| `EVM integration: publisher` | publisher-evm-e2e `V10 CREATE … 3-of-N ACK quorum` (+ siblings) | same missing `kaAllocator` | wire it into the ctor — **verified 10/10** via `vitest.evm-integration.ts` |
| `agent [5/10]` | finalization-handler `silently skips non-finalization protobuf messages (wrong wire type)` | the test's own `encodePublishRequest` omitted the now-required Option-1 `startKAId`/`endKAId`, so `idToProtoString(undefined)` threw before the handler ran | add the fields (encoder stays fail-loud) |
| `node-ui e2e (Playwright)` | every VM publish → `QuorumUnmetError("need 3 ACKs but only 2 core peers")` | `scripts/devnet.sh` pins `minimumRequiredSignatures = 3` (real mainnet quorum, must not be lowered) → needs `≥ minSig + 1 = 4` core nodes; Playwright booted 3 | boot **4** nodes (`playwright.config.ts` + `real-node.ts`), widen bootstrap mesh-wait to 240s, refresh stale 2-node comments |

### Verification
- `e2e-security` "denies access…" → **pass** (hardhat)
- `finalization-handler` "wrong wire type" → **pass**
- `publisher-evm-e2e.test.ts` (full file via EVM-integration config) → **10/10 pass**
- node-ui Playwright (4-node devnet) validated as part of the minSig=3 devnet bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)