### PR TITLE
fix: WM→SWM→VM publish flow — node-ui lifecycle + on-chain auto-register + VM marker flip

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2738,10 +2738,32 @@ export class PublishMethods extends DKGAgentBase {
     if (result.status === 'confirmed' || result.status === 'tentative') {
       try {
         await this._stampPointer(lifecycleUri, VM_CURRENT_ASSERTION_PRED, newMerkleHexBare, metaGraph);
+        // OT-RFC-44 Design B — the assertion now lives at Verifiable Memory, so
+        // make its lifecycle marker match the on-chain reality: flip
+        // dkg:memoryLayer -> "VM" and dkg:state -> "published". The VM record is
+        // thus equivalent to the WM/SWM ones, with the extra transaction metadata
+        // (dkg:vmCurrentAssertion + dkg:kaId + the on-chain UAL) layered on top.
+        // Promote stamps memoryLayer "SWM" on BOTH the lifecycle-URN and the
+        // data-graph-URI forms, so flip both — otherwise the published assertion
+        // lingers in the Shared-Memory layer (the dedicated published-metadata
+        // flip never fired: its trigger gate joins on dkg:rootEntity/dkg:agent
+        // predicates the lifecycle record does not carry).
+        const MEMORY_LAYER_PRED = 'http://dkg.io/ontology/memoryLayer';
+        const STATE_PRED = 'http://dkg.io/ontology/state';
+        for (const subj of [lifecycleUri, assertionUri]) {
+          await this.store.deleteByPattern({ subject: subj, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+          await this.store.insert([
+            { subject: subj, predicate: MEMORY_LAYER_PRED, object: `"${MemoryLayer.VerifiedMemory}"`, graph: metaGraph },
+          ]);
+        }
+        await this.store.deleteByPattern({ subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
+        await this.store.insert([
+          { subject: lifecycleUri, predicate: STATE_PRED, object: '"published"', graph: metaGraph },
+        ]);
       } catch (err) {
         this.log.warn(
           opts?.operationCtx ?? createOperationContext('publishFromSWM'),
-          `Failed to stamp vmCurrentAssertion for <${lifecycleUri}>: ` +
+          `Failed to stamp VM lifecycle marker for <${lifecycleUri}>: ` +
             (err instanceof Error ? err.message : String(err)),
         );
       }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -945,17 +945,28 @@ export async function listAssertions(
     const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
     const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
     const urnPrefix = `urn:dkg:assertion:${contextGraphId}:`;
-    const sparql = `SELECT ?g WHERE {
-      GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "SWM" }
+    // Exclude assertions already PUBLISHED to VM. Publish records a
+    // `dkg:vmCurrentAssertion` pointer but (a backend gap — the
+    // generateAssertionPublishedMetadata flip's SPARQL gate never matches the
+    // lifecycle record) does NOT flip `dkg:memoryLayer` off "SWM", so published
+    // assertions would otherwise linger in the Shared-Memory list. The pointer
+    // lives on the lifecycle-URN form; key the exclusion by (subGraph, name) so
+    // the data-graph-URI marker row for the same assertion is dropped too.
+    const sparql = `SELECT ?g ?vm WHERE {
+      GRAPH <${metaGraph}> {
+        ?g <http://dkg.io/ontology/memoryLayer> "SWM"
+        OPTIONAL { ?g <http://dkg.io/ontology/vmCurrentAssertion> ?vm }
+      }
       FILTER(!CONTAINS(STR(?g), "/meta/assertion/"))
     }`;
     const data = await executeQuery(sparql, contextGraphId);
     const bindings: any[] = data?.result?.bindings ?? [];
-    const seen = new Set<string>();
-    const result: AssertionInfo[] = [];
+    const published = new Set<string>();
+    const rows: Array<{ key: string; name: string; subGraph?: string; g: string }> = [];
     for (const b of bindings) {
       const g = typeof b.g === 'string' ? b.g : b.g?.value;
       if (!g) continue;
+      const vm = typeof b.vm === 'string' ? b.vm : b.vm?.value;
       let subGraph: string | undefined;
       let name: string | undefined;
       if (g.startsWith(cgPrefix)) {
@@ -983,9 +994,15 @@ export async function listAssertions(
       if (!name) continue;
       if (subGraph === 'meta') continue;
       const key = `${subGraph ?? ''} ${name}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      result.push({ name, graphUri: g, subGraph });
+      rows.push({ key, name, subGraph, g });
+      if (vm) published.add(key);
+    }
+    const seen = new Set<string>();
+    const result: AssertionInfo[] = [];
+    for (const r of rows) {
+      if (published.has(r.key) || seen.has(r.key)) continue;
+      seen.add(r.key);
+      result.push({ name: r.name, graphUri: r.g, subGraph: r.subGraph });
     }
     return result;
   }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -623,6 +623,30 @@ export const executeQuery = (
 ) =>
   postQueryDeduped({ sparql, contextGraphId, includeSharedMemory, graphSuffix, view, includeContextGraphPartitions });
 
+/**
+ * Map of assertion name → deterministic Option-1 UAL (`dkg:reservedUal`,
+ * `did:dkg:evm:<chainId>/<author>/<number>`). Stamped on the lifecycle URN at
+ * creation, so it's available for every assertion (WM/SWM/published) — the
+ * assertions list renders it next to the filename. Keyed by `dkg:assertionName`.
+ */
+export async function fetchAssertionUals(contextGraphId: string): Promise<Record<string, string>> {
+  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  const sparql = `SELECT ?name ?ual WHERE {
+    GRAPH <${metaGraph}> {
+      ?lc <http://dkg.io/ontology/assertionName> ?name ;
+          <http://dkg.io/ontology/reservedUal> ?ual .
+    }
+  }`;
+  const data = await executeQuery(sparql, contextGraphId);
+  const map: Record<string, string> = {};
+  for (const b of (data?.result?.bindings ?? [])) {
+    const name = typeof b.name === 'string' ? b.name : b.name?.value;
+    const ual = typeof b.ual === 'string' ? b.ual : b.ual?.value;
+    if (name && ual && !map[name]) map[name] = ual;
+  }
+  return map;
+}
+
 // --- Publish (assertion-lifecycle: RFC-001 §9.x sign-at-creation) ---
 //
 // Creates a fresh auto-named assertion, writes the supplied quads,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -908,28 +908,22 @@ export async function listAssertions(
   layer: 'wm' | 'swm' = 'wm',
 ): Promise<AssertionInfo[]> {
   if (layer === 'swm') {
-    const DKG = 'http://dkg.io/ontology/';
-    const swmMetaPrefix = `did:dkg:context-graph:${contextGraphId}`;
-    // Mirrors the pattern `useSwmAttributions.ts` uses to read
-    // `_shared_memory_meta` graphs — the explicit `GRAPH ?g { … }`
-    // plus `FILTER(STRSTARTS … STRENDS)` pair makes the query
-    // self-scoping: the query engine's `wrapWithGraph` early-returns
-    // when the SPARQL already contains `graph `, so the query runs
-    // raw over the store and the FILTER pins it to *this* CG's
-    // `_shared_memory_meta` partitions (root + each sub-graph) only.
-    // Codex tier-4m flagged this as "runs against the default WM
-    // view", which is incorrect for this shape of SPARQL; keeping
-    // the same shape as `useSwmAttributions` — which is already in
-    // production for the SWM agent-attribution badge — keeps both
-    // call sites consistent and provably working on the same path.
-    const sparql = `SELECT DISTINCT ?g ?source ?agent WHERE {
-      GRAPH ?g {
-        ?s a <${DKG}ShareTransition> ;
-           <${DKG}source> ?source ;
-           <${DKG}agent> ?agent .
-      }
-      FILTER(STRSTARTS(STR(?g), "${swmMetaPrefix}"))
-      FILTER(STRENDS(STR(?g), "/_shared_memory_meta"))
+    // SWM membership comes from the canonical `dkg:memoryLayer "SWM"` lifecycle
+    // marker in `<cg>/_meta` (flipped from "WM" by promote) — NOT from
+    // `dkg:ShareTransition` records in `_shared_memory_meta`. ShareTransitions
+    // are written by the ASYNC SWM share (key-setup/gossip) and therefore LAG
+    // the promote, so a publish fired right after promoting saw zero shared
+    // assertions ("nothing to publish") even though the content was already in
+    // SWM. The marker is synchronous and is the same source the WM listing uses.
+    // Parsing mirrors the WM branch: accept BOTH the lifecycle-URN and the
+    // data-graph-URI marker forms, dedupe by (subGraph, name), and exclude the
+    // reserved `meta` sub-graph.
+    const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+    const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+    const urnPrefix = `urn:dkg:assertion:${contextGraphId}:`;
+    const sparql = `SELECT ?g WHERE {
+      GRAPH <${metaGraph}> { ?g <http://dkg.io/ontology/memoryLayer> "SWM" }
+      FILTER(!CONTAINS(STR(?g), "/meta/assertion/"))
     }`;
     const data = await executeQuery(sparql, contextGraphId);
     const bindings: any[] = data?.result?.bindings ?? [];
@@ -937,38 +931,37 @@ export async function listAssertions(
     const result: AssertionInfo[] = [];
     for (const b of bindings) {
       const g = typeof b.g === 'string' ? b.g : b.g?.value;
-      const source = typeof b.source === 'string' ? b.source : b.source?.value;
-      const agentUri = typeof b.agent === 'string' ? b.agent : b.agent?.value;
-      if (!g || !source || !agentUri) continue;
-
-      // `dkg:source` literal is `assertion/<agent>/<name>`. The agent
-      // segment is a 0x EVM address (no slashes, no colons), but `<name>`
-      // is only slash/whitespace-free — it CAN contain `:` — so split on
-      // the first two `/` rather than a blind last-segment parse.
-      const m = source.match(/^assertion\/([^/]+)\/(.+)$/);
-      if (!m) continue;
-      const name = m[2];
-
-      // `dkg:agent` is `did:dkg:agent:<address>`; pull the address so we
-      // rebuild the exact lifecycle URN shape used on the authoring node.
-      const addrMatch = /^did:dkg:agent:(.+)$/.exec(agentUri);
-      const address = addrMatch ? addrMatch[1] : null;
-      if (!address) continue;
-
-      // Recover optional sub-graph segment from `?g`:
-      //   did:dkg:context-graph:<cg>/_shared_memory_meta          → none
-      //   did:dkg:context-graph:<cg>/<sg>/_shared_memory_meta     → <sg>
-      const tail = g.slice(swmMetaPrefix.length); // "/<sg?>/_shared_memory_meta"
-      const inner = tail.replace(/\/_shared_memory_meta$/, '').replace(/^\//, '');
-      const subGraphName = inner.length > 0 ? inner : undefined;
-
-      const lifecycle = subGraphName
-        ? `urn:dkg:assertion:${contextGraphId}:${subGraphName}:${address}:${name}`
-        : `urn:dkg:assertion:${contextGraphId}:${address}:${name}`;
-
-      if (seen.has(lifecycle)) continue;
-      seen.add(lifecycle);
-      result.push({ name, graphUri: lifecycle, subGraph: subGraphName });
+      if (!g) continue;
+      let subGraph: string | undefined;
+      let name: string | undefined;
+      if (g.startsWith(cgPrefix)) {
+        const segments = g.slice(cgPrefix.length).split('/');
+        if (segments.length === 3 && segments[0] === 'assertion') {
+          name = segments[2];
+        } else if (segments.length === 4 && segments[1] === 'assertion') {
+          subGraph = segments[0];
+          name = segments[3];
+        } else {
+          continue;
+        }
+      } else if (g.startsWith(urnPrefix)) {
+        const rest = g.slice(urnPrefix.length);
+        let m = /^(0x[0-9a-fA-F]{40}):(.+)$/.exec(rest);
+        if (m) {
+          name = m[2];
+        } else {
+          m = /^([^:]+):(0x[0-9a-fA-F]{40}):(.+)$/.exec(rest);
+          if (m) { subGraph = m[1]; name = m[3]; }
+        }
+      } else {
+        continue;
+      }
+      if (!name) continue;
+      if (subGraph === 'meta') continue;
+      const key = `${subGraph ?? ''} ${name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push({ name, graphUri: g, subGraph });
     }
     return result;
   }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1055,19 +1055,52 @@ export async function listAssertions(
   // would silently miss otherwise. The cgId itself is treated as
   // opaque (it may contain `/assertion/` as a literal substring,
   // per `validateContextGraphId`).
+  // The `dkg:memoryLayer "WM"` marker can sit on EITHER subject form:
+  //   • data-graph URI : did:dkg:context-graph:<cg>/[<sg>/]assertion/<agent>/<name>
+  //   • lifecycle URN  : urn:dkg:assertion:<cg>:[<sg>:]<agent>:<name>   (canonical,
+  //                      `assertionLifecycleUri`, written by every create path)
+  // Regular `create` writes BOTH; a FILE IMPORT writes ONLY the URN (the data-URI
+  // stamp is import-path-specific). The previous parser accepted only the data-URI
+  // form, so it silently dropped every file-imported WM assertion → the bulk-promote
+  // loop iterated zero times → "0 triples promoted" even though the content was
+  // fully promotable. Accept BOTH forms and dedupe by (subGraph, name).
   const result: AssertionInfo[] = [];
-  for (const b of bindings) {
+  const seen = new Set<string>();
+  const urnPrefix = `urn:dkg:assertion:${contextGraphId}:`;
+  // Data-URI rows first: the triple-count badge is keyed on the data graph in
+  // `countByGraph`, so preferring that form when both are present keeps the count.
+  const ordered = [...bindings].sort((a, b) => {
+    const ga = (typeof a.g === 'string' ? a.g : a.g?.value) ?? '';
+    const gb = (typeof b.g === 'string' ? b.g : b.g?.value) ?? '';
+    return (ga.startsWith(cgPrefix) ? 0 : 1) - (gb.startsWith(cgPrefix) ? 0 : 1);
+  });
+  for (const b of ordered) {
     const g = typeof b.g === 'string' ? b.g : b.g?.value;
-    if (!g || !g.startsWith(cgPrefix)) continue;
-    const segments = g.slice(cgPrefix.length).split('/');
+    if (!g) continue;
     let subGraph: string | undefined;
-    let name: string;
-    if (segments.length === 3 && segments[0] === 'assertion') {
-      subGraph = undefined;
-      name = segments[2];
-    } else if (segments.length === 4 && segments[1] === 'assertion') {
-      subGraph = segments[0];
-      name = segments[3];
+    let name: string | undefined;
+    if (g.startsWith(cgPrefix)) {
+      const segments = g.slice(cgPrefix.length).split('/');
+      if (segments.length === 3 && segments[0] === 'assertion') {
+        name = segments[2];
+      } else if (segments.length === 4 && segments[1] === 'assertion') {
+        subGraph = segments[0];
+        name = segments[3];
+      } else {
+        continue;
+      }
+    } else if (g.startsWith(urnPrefix)) {
+      // `<agent>` is a 0x EVM address (no colons); `<name>` MAY contain ':'.
+      // Peel the agent deterministically — whatever precedes it (if anything)
+      // is the sub-graph segment, the greedy remainder is the name.
+      const rest = g.slice(urnPrefix.length);
+      let m = /^(0x[0-9a-fA-F]{40}):(.+)$/.exec(rest);
+      if (m) {
+        name = m[2];
+      } else {
+        m = /^([^:]+):(0x[0-9a-fA-F]{40}):(.+)$/.exec(rest);
+        if (m) { subGraph = m[1]; name = m[3]; }
+      }
     } else {
       continue;
     }
@@ -1078,6 +1111,9 @@ export async function listAssertions(
     // assertions table or the bulk-promote flow. The SPARQL `metaFilter`
     // already drops these daemon-side; this guards the parser too.
     if (subGraph === 'meta') continue;
+    const key = `${subGraph ?? ''} ${name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
     const cnt = countByGraph.get(g);
     result.push({ name, graphUri: g, tripleCount: cnt, subGraph });
   }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -324,6 +324,39 @@ export async function createContextGraph(
   }
 }
 
+/**
+ * Register an EXISTING context graph on-chain. VM (Verifiable Memory) is the
+ * on-chain layer, so an off-chain CG must be registered before finalize / VM
+ * publish. Mirrors the daemon's `POST /api/context-graph/register`.
+ */
+export const registerContextGraph = (
+  id: string,
+  opts: { accessPolicy?: number; publishPolicy?: number } = {},
+) =>
+  post<{ registered: string; onChainId: string; hint?: string }>(
+    '/api/context-graph/register',
+    {
+      id,
+      ...(opts.accessPolicy !== undefined ? { accessPolicy: opts.accessPolicy } : {}),
+      ...(opts.publishPolicy !== undefined ? { publishPolicy: opts.publishPolicy } : {}),
+    },
+  );
+
+/**
+ * Ensure a context graph is registered on-chain before an operation that
+ * requires it (WM finalize / VM publish). Returns the on-chain id. No-op when
+ * already registered. The UI calls this transparently so users never hit
+ * "context graph is not registered on-chain" — VM is the on-chain layer, so
+ * publishing to it auto-registers the CG first.
+ */
+export async function ensureContextGraphOnChain(contextGraphId: string): Promise<string | undefined> {
+  const { contextGraphs } = await fetchContextGraphs();
+  const cg = (contextGraphs ?? []).find((c: any) => c?.id === contextGraphId);
+  if (cg?.onChainId) return String(cg.onChainId);
+  const res = await registerContextGraph(contextGraphId);
+  return res?.onChainId;
+}
+
 // --- Context Graph Participant Management ---
 export const addParticipant = (contextGraphId: string, agentAddress: string) =>
   post<{ ok: boolean }>(`/api/context-graph/${encodeURIComponent(contextGraphId)}/add-participant`, { agentAddress });

--- a/packages/node-ui/src/ui/views/project/components/entities.tsx
+++ b/packages/node-ui/src/ui/views/project/components/entities.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { useFetch } from '../../../hooks.js';
 import { encodeDocTabId, resolveDocRef } from '../../../lib/doc-tab-id.js';
 import { truncateMiddle } from '../../../lib/truncate.js';
-import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, publishSharedMemory, type AssertionInfo } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteResult, describePromoteError, ensureContextGraphOnChain, knowledgeAssetFinalize, knowledgeAssetPublish, fetchAssertionUals, type AssertionInfo } from '../../../api.js';
 import { useMemoryEntities, type TrustLevel, type MemoryEntity, type Triple } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { useAgentsContext } from '../../../hooks/useAgents.js';
@@ -13,7 +13,7 @@ import type { SwmAttributionsResult } from '../../../hooks/useSwmAttributions.js
 import { LAYER_CONFIG, SOURCE_CONTENT_TYPE, MARKDOWN_FORM, SOURCE_FILE, DKG_SIZE, entityAuthorUri, entityMeta, layerNoun, useLayerTriples, entityTimestamp, formatRelativeTime, type LayerContentTab } from '../helpers.js';
 import { EmptyState, StatStrip, toneForLayer } from '../../../components/ContextGraphPrimitives.js';
 import { LayerGraphPanel } from './graph.js';
-import { LayerWidgetStrip, fetchSwmPublishRoots } from './layer-widgets.js';
+import { LayerWidgetStrip } from './layer-widgets.js';
 
 // ─── Enhanced Entity list (sorted by triple count, with type pill) ──────
 
@@ -405,6 +405,13 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     [contextGraphId, layer],
     0
   );
+  // Deterministic Option-1 UAL per assertion (dkg:reservedUal), shown next to
+  // the filename. Refreshes alongside the list.
+  const { data: ualMap } = useFetch(
+    () => fetchAssertionUals(contextGraphId),
+    [contextGraphId, layer],
+    0
+  );
   const [busy, setBusy] = useState<string | null>(null);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -418,7 +425,19 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     setResult(null);
     setError(null);
     try {
+      // VM is the on-chain layer; finalize/publish need the CG registered, so
+      // auto-register transparently first.
+      await ensureContextGraphOnChain(contextGraphId);
       if (layer === 'wm') {
+        // Seal the draft before sharing — promote moves content out of WM and a
+        // later vm/publish requires a finalized assertion, so finalize must run
+        // here. Tolerate already-sealed / nothing-to-seal.
+        try {
+          await knowledgeAssetFinalize(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
+        } catch (e: any) {
+          const m = String(e?.message ?? '');
+          if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
+        }
         // PR #710 Fix A — sub-graph slug threads into the daemon's
         // `(cg, name, subGraph)` lookup so a row clicked from a
         // sub-graph partition resolves to that partition's
@@ -430,9 +449,11 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
         const outcome = describePromoteResult(assertion.name, res);
         setResult(outcome.message);
       } else {
-        const roots = await fetchSwmPublishRoots(contextGraphId);
-        await publishSharedMemory(contextGraphId, roots);
-        setResult('Published to Verifiable Memory');
+        // Publish THIS assertion as one Knowledge Asset (Design B, any entity
+        // count) via per-assertion vm/publish — NOT the legacy single-root
+        // shared-memory publish (which also wrongly published every SWM root).
+        await knowledgeAssetPublish(contextGraphId, assertion.name, assertion.subGraph ? { subGraphName: assertion.subGraph } : {});
+        setResult(`Published ${assertion.name} to Verifiable Memory`);
       }
       refresh();
       onComplete();
@@ -454,11 +475,18 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
     // "selected assertion …".
     let currentAssertion: string | null = null;
     try {
+      await ensureContextGraphOnChain(contextGraphId);
       if (layer === 'wm') {
         let total = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
+          try {
+            await knowledgeAssetFinalize(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
+          } catch (e: any) {
+            const m = String(e?.message ?? '');
+            if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
+          }
           // PR #710 — see comment on the single-row handler above.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
           total += res.promotedCount;
@@ -473,9 +501,24 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           setResult('No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.');
         }
       } else {
-        const roots = await fetchSwmPublishRoots(contextGraphId);
-        await publishSharedMemory(contextGraphId, roots);
-        setResult('Published all to Verifiable Memory');
+        // Publish each shared assertion as its own Knowledge Asset (Design B).
+        let published = 0;
+        let lastErr: string | null = null;
+        for (const a of assertions) {
+          currentAssertion = a.name;
+          try {
+            await knowledgeAssetPublish(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
+            published += 1;
+          } catch (e: any) {
+            lastErr = e?.message ?? 'publish failed';
+          }
+        }
+        if (published > 0) {
+          const tail = lastErr ? ' (some could not be published)' : '';
+          setResult(`Published ${published} knowledge asset${published !== 1 ? 's' : ''} to Verifiable Memory${tail}`);
+        } else {
+          throw new Error(lastErr ?? 'Publish failed');
+        }
       }
       refresh();
       onComplete();
@@ -542,6 +585,15 @@ export function AssertionsList({ contextGraphId, layer, onComplete, scrollKey }:
           <span className="v10-item-icon">▤</span>
           <div className="v10-item-info">
             <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
+            {ualMap?.[a.name] && (
+              <div
+                className="v10-item-ual"
+                style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text-tertiary)', opacity: 0.7, wordBreak: 'break-all', marginTop: 1 }}
+                title={ualMap[a.name]}
+              >
+                {ualMap[a.name]}
+              </div>
+            )}
             <div className="v10-item-meta-row">
               {a.tripleCount != null && <span className="v10-item-count">{a.tripleCount} triples</span>}
               {a.subGraph && (

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { listAssertions, promoteAssertion, describePromoteError, listSwmEntities, ensureContextGraphOnChain, knowledgeAssetFinalize, knowledgeAssetPublish } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteError, ensureContextGraphOnChain, knowledgeAssetFinalize, knowledgeAssetPublish } from '../../../api.js';
 import type { MemoryEntity } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { LAYER_CONFIG, entityMeta, layerNoun } from '../helpers.js';
@@ -99,24 +99,6 @@ export function LayerStatsWidget({ entities, entityCount, triples, layer }: {
   );
 }
 
-// Selection-based SWM publish is still single-root at the UI/daemon route.
-// Multi-root file lifecycles publish through finalized assertion/file paths
-// where the daemon can identify one lifecycle/assertion boundary.
-function collectPublishRoots(roots: string[]): string[] {
-  const uniqueRoots = [...new Set(roots.filter(Boolean))];
-  if (uniqueRoots.length < 1) {
-    throw new Error('Publish requires one root entity. Select a root and publish again.');
-  }
-  if (uniqueRoots.length > 1) {
-    throw new Error('Shared-memory publish currently requires exactly one root entity.');
-  }
-  return uniqueRoots;
-}
-
-export async function fetchSwmPublishRoots(contextGraphId: string): Promise<string[]> {
-  const roots = (await listSwmEntities(contextGraphId)).map((entity) => entity.uri);
-  return collectPublishRoots(roots);
-}
 
 export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }: {
   layer: 'wm' | 'swm';

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { listAssertions, promoteAssertion, describePromoteError, publishSharedMemory, listSwmEntities } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteError, listSwmEntities, ensureContextGraphOnChain, knowledgeAssetFinalize, knowledgeAssetPublish } from '../../../api.js';
 import type { MemoryEntity } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { LAYER_CONFIG, entityMeta, layerNoun } from '../helpers.js';
@@ -118,7 +118,7 @@ export async function fetchSwmPublishRoots(contextGraphId: string): Promise<stri
   return collectPublishRoots(roots);
 }
 
-export function LayerActionsWidget({ layer, count, contextGraphId, entities, onComplete }: {
+export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }: {
   layer: 'wm' | 'swm';
   count: number;
   contextGraphId: string;
@@ -140,11 +140,25 @@ export function LayerActionsWidget({ layer, count, contextGraphId, entities, onC
     let currentAssertion: string | null = null;
     try {
       if (isWm) {
+        // Verifiable Memory is the on-chain layer and `finalize` (the seal that
+        // a later VM publish requires) needs the CG registered on-chain. Promote
+        // moves content OUT of Working Memory, after which it can no longer be
+        // finalized — so we auto-register + finalize HERE, before sharing, so the
+        // shared assertions are publishable to VM later. (See OT-RFC-44 Design B.)
+        await ensureContextGraphOnChain(contextGraphId);
         const assertions = await listAssertions(contextGraphId, 'wm');
         let promoted = 0;
         let noopCount = 0;
         for (const a of assertions) {
           currentAssertion = a.name;
+          // Seal the draft first; tolerate already-sealed / nothing-to-seal so
+          // re-runs and empty drafts don't abort the batch (surface real errors).
+          try {
+            await knowledgeAssetFinalize(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
+          } catch (e: any) {
+            const m = String(e?.message ?? '');
+            if (!/already|finaliz|sealed|promoted|no quads|reserved/i.test(m)) throw e;
+          }
           // PR #710 — thread `subGraph` so sub-graph-scoped assertions
           // hit the correct daemon lookup key `(cg, name, subGraph)`.
           const res = await promoteAssertion(contextGraphId, a.name, 'all', a.subGraph);
@@ -161,9 +175,31 @@ export function LayerActionsWidget({ layer, count, contextGraphId, entities, onC
           setResult('No triples were promoted — every assertion was already in Shared Memory or its content is still being committed.');
         }
       } else {
-        const roots = collectPublishRoots(entities.map((entity) => entity.uri));
-        await publishSharedMemory(contextGraphId, roots);
-        setResult('Published to Verifiable Memory');
+        // SWM -> VM: publish each shared assertion as ONE Knowledge Asset
+        // (Design B, any entity count) via the per-assertion vm/publish path —
+        // NOT the legacy single-root shared-memory publish. Auto-register first
+        // since VM is the on-chain layer.
+        await ensureContextGraphOnChain(contextGraphId);
+        const assertions = await listAssertions(contextGraphId, 'swm');
+        let published = 0;
+        let lastErr: string | null = null;
+        for (const a of assertions) {
+          currentAssertion = a.name;
+          try {
+            await knowledgeAssetPublish(contextGraphId, a.name, a.subGraph ? { subGraphName: a.subGraph } : {});
+            published += 1;
+          } catch (e: any) {
+            lastErr = e?.message ?? 'publish failed';
+          }
+        }
+        if (published > 0) {
+          const tail = lastErr ? ' (some assertions could not be published)' : '';
+          setResult(`Published ${published} knowledge asset${published !== 1 ? 's' : ''} to Verifiable Memory${tail}`);
+        } else if (assertions.length === 0) {
+          setResult('Nothing to publish — promote assertions to Shared Memory first.');
+        } else {
+          throw new Error(lastErr ?? 'Publish failed');
+        }
       }
       onComplete?.();
     } catch (err: any) {
@@ -172,7 +208,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, entities, onC
     } finally {
       setBusy(false);
     }
-  }, [isWm, entities, contextGraphId, onComplete]);
+  }, [isWm, contextGraphId, onComplete]);
 
   if (count === 0) return null;
   const color = isWm ? '#f59e0b' : '#22c55e';

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -29,6 +29,7 @@ import {
   listSwmEntities,
   listAssertions,
   ensureContextGraphOnChain,
+  fetchAssertionUals,
   createSavedQuery,
   updateSavedQuery,
   deleteSavedQuery,
@@ -365,6 +366,16 @@ describe('UI API tests', () => {
       queryBindings = [{ g: { value: `urn:dkg:assertion:cg-1:${agent}:shared-doc.md` } }];
       const list = await listAssertions('cg-1', 'swm');
       expect(list.map(a => a.name)).toEqual(['shared-doc.md']);
+    });
+
+    it('fetchAssertionUals maps assertionName -> reservedUal (shown next to the filename)', async () => {
+      queryBindings = [
+        { name: { value: 'spec.md' }, ual: { value: 'did:dkg:evm:31337/0xabc/7' } },
+        { name: { value: 'demo.md' }, ual: { value: 'did:dkg:evm:31337/0xabc/8' } },
+      ];
+      const map = await fetchAssertionUals('cg-1');
+      expect(map['spec.md']).toBe('did:dkg:evm:31337/0xabc/7');
+      expect(map['demo.md']).toBe('did:dkg:evm:31337/0xabc/8');
     });
 
     it('ensureContextGraphOnChain auto-registers an off-chain CG before publishing', async () => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -368,6 +368,18 @@ describe('UI API tests', () => {
       expect(list.map(a => a.name)).toEqual(['shared-doc.md']);
     });
 
+    it('listAssertions(swm) excludes assertions already published to VM (dkg:vmCurrentAssertion)', async () => {
+      // Publish records a vmCurrentAssertion pointer but does NOT flip memoryLayer
+      // off "SWM" (backend gap), so the SWM list must drop published rows itself.
+      const agent = '0x' + '5'.repeat(40);
+      queryBindings = [
+        { g: { value: `urn:dkg:assertion:cg-1:${agent}:unpublished.md` } },
+        { g: { value: `urn:dkg:assertion:cg-1:${agent}:published.md` }, vm: { value: 'abc123deadbeef' } },
+      ];
+      const list = await listAssertions('cg-1', 'swm');
+      expect(list.map(a => a.name)).toEqual(['unpublished.md']);
+    });
+
     it('fetchAssertionUals maps assertionName -> reservedUal (shown next to the filename)', async () => {
       queryBindings = [
         { name: { value: 'spec.md' }, ual: { value: 'did:dkg:evm:31337/0xabc/7' } },

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -28,6 +28,7 @@ import {
   publishSharedMemory,
   listSwmEntities,
   listAssertions,
+  ensureContextGraphOnChain,
   createSavedQuery,
   updateSavedQuery,
   deleteSavedQuery,
@@ -354,6 +355,13 @@ describe('UI API tests', () => {
       expect(list).toEqual([
         { name: 'a:b.md', graphUri: `urn:dkg:assertion:cg-1:code:${agent}:a:b.md`, tripleCount: undefined, subGraph: 'code' },
       ]);
+    });
+
+    it('ensureContextGraphOnChain auto-registers an off-chain CG before publishing', async () => {
+      // mock /api/context-graph/list returns cg1 with no onChainId → the helper
+      // must POST /api/context-graph/register so VM publish (on-chain) can proceed.
+      await ensureContextGraphOnChain('cg1');
+      expect(requestLog.some(r => r.method === 'POST' && r.url.includes('/api/context-graph/register'))).toBe(true);
     });
 
     it('createSavedQuery sends POST', async () => {

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -357,6 +357,16 @@ describe('UI API tests', () => {
       ]);
     });
 
+    it('listAssertions(swm) reads the memoryLayer "SWM" marker (not async ShareTransition records)', async () => {
+      // The SWM listing must use the synchronous _meta memoryLayer marker, not
+      // _shared_memory_meta ShareTransition records which lag the promote and
+      // made "Publish to VM" report "nothing to publish" right after promoting.
+      const agent = '0x' + '4'.repeat(40);
+      queryBindings = [{ g: { value: `urn:dkg:assertion:cg-1:${agent}:shared-doc.md` } }];
+      const list = await listAssertions('cg-1', 'swm');
+      expect(list.map(a => a.name)).toEqual(['shared-doc.md']);
+    });
+
     it('ensureContextGraphOnChain auto-registers an off-chain CG before publishing', async () => {
       // mock /api/context-graph/list returns cg1 with no onChainId → the helper
       // must POST /api/context-graph/register so VM publish (on-chain) can proceed.

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -27,6 +27,7 @@ import {
   publishTriples,
   publishSharedMemory,
   listSwmEntities,
+  listAssertions,
   createSavedQuery,
   updateSavedQuery,
   deleteSavedQuery,
@@ -322,6 +323,36 @@ describe('UI API tests', () => {
       await expect(listSwmEntities('cg-1')).resolves.toEqual([
         { uri: 'https://example.org/doc/root', label: 'root', tripleCount: 5 },
         { uri: 'https://example.org/doc/child-only', label: 'child-only', tripleCount: 4 },
+      ]);
+    });
+
+    it('listAssertions(wm) recognizes the lifecycle-URN marker form (file imports)', async () => {
+      // File-imported assertions carry dkg:memoryLayer "WM" ONLY on the
+      // lifecycle URN (urn:dkg:assertion:<cg>:<agent>:<name>), not the
+      // data-graph URI. The parser must accept it — otherwise the bulk-promote
+      // loop sees an empty list and reports "0 triples promoted".
+      const agent = '0x' + '1'.repeat(40);
+      queryBindings = [{ g: { value: `urn:dkg:assertion:cg-1:${agent}:my-import.md` } }];
+      const list = await listAssertions('cg-1', 'wm');
+      expect(list.map(a => a.name)).toEqual(['my-import.md']);
+    });
+
+    it('listAssertions(wm) dedupes when BOTH the URN and data-URI markers exist', async () => {
+      const agent = '0x' + '2'.repeat(40);
+      queryBindings = [
+        { g: { value: `did:dkg:context-graph:cg-1/assertion/${agent}/doc` } },
+        { g: { value: `urn:dkg:assertion:cg-1:${agent}:doc` } },
+      ];
+      const list = await listAssertions('cg-1', 'wm');
+      expect(list.map(a => a.name)).toEqual(['doc']);
+    });
+
+    it('listAssertions(wm) parses sub-graph-scoped URN markers and names containing ":"', async () => {
+      const agent = '0x' + '3'.repeat(40);
+      queryBindings = [{ g: { value: `urn:dkg:assertion:cg-1:code:${agent}:a:b.md` } }];
+      const list = await listAssertions('cg-1', 'wm');
+      expect(list).toEqual([
+        { name: 'a:b.md', graphUri: `urn:dkg:assertion:cg-1:code:${agent}:a:b.md`, tripleCount: undefined, subGraph: 'code' },
       ]);
     });
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3944,11 +3944,18 @@ export class DKGPublisher implements Publisher {
     const DKG = 'http://dkg.io/ontology/';
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const result = await this.store.query(
-      `SELECT ?status ?count ?layer WHERE {
+      `SELECT ?status ?count ?layer ?urnLayer WHERE {
          GRAPH <${metaGraph}> {
            OPTIONAL { <${assertionGraph}> <${DKG}extractionStatus> ?status }
            OPTIONAL { <${assertionGraph}> <${DKG}structuralTripleCount> ?count }
            OPTIONAL { <${assertionGraph}> <${DKG}memoryLayer> ?layer }
+           # The memoryLayer marker is canonically on the lifecycle URN
+           # (assertionLifecycleUri), reachable via the dkg:assertionGraph
+           # back-link. File-imported assertions carry it ONLY there, not on
+           # the data-graph URI, so read it too — otherwise the "already
+           # promoted (SWM/VM) -> harmless no-op" check below cannot see their
+           # layer and a re-promote misfires AssertionNotPersistedError.
+           OPTIONAL { ?lc <${DKG}assertionGraph> <${assertionGraph}> ; <${DKG}memoryLayer> ?urnLayer }
          }
        } LIMIT 1`,
     );
@@ -3956,7 +3963,7 @@ export class DKGPublisher implements Publisher {
     const row = result.bindings[0];
     const statusRaw = row?.['status'];
     const countRaw = row?.['count'];
-    const layerRaw = row?.['layer'];
+    const layerRaw = row?.['layer'] ?? row?.['urnLayer'];
     // Codex review on #898 — the previous version raised
     // `AssertionNotPersistedError` whenever `extractionStatus="completed"`
     // + a positive `structuralTripleCount` were stamped, even after a


### PR DESCRIPTION
Makes the full Working Memory → Shared Working Memory → Verifiable Memory publish flow work end-to-end from the node-ui, and fixes the underlying lifecycle-marker logic. Stacked fixes (each builds on the prior):

1. **Promote enumeration** (`api.ts`): `listAssertions('wm')` accepted only the data-graph-URI `memoryLayer` marker form; file-imported assertions carry only the lifecycle-URN form, so they were silently dropped (promote no-op). Now accepts both + dedupes.

2. **Design-B publish + on-chain auto-register** (`api.ts`, `layer-widgets.tsx`, `entities.tsx`): the Publish buttons used the legacy single-root shared-memory publish ("requires exactly one root entity"). Replaced with per-assertion `vm/publish` (one KA per file, any entity count). VM is on-chain, so the flow `ensureContextGraphOnChain` auto-registers an off-chain CG, and Promote now finalizes before sharing (so shared assertions are publishable). Applied to **both** publish surfaces (layer widget + Assertions tab). Each row shows its deterministic Option-1 UAL.

3. **SWM listing reliability** (`api.ts`): `listAssertions('swm')` read async `ShareTransition` records that lag the promote ("nothing to publish" right after promoting). Switched to the synchronous `dkg:memoryLayer "SWM"` marker.

4. **VM marker flip — the proper root fix** (`packages/agent/src/dkg-agent-publish.ts`): a confirmed `vm/publish` recorded the `dkg:vmCurrentAssertion` pointer + `kaId` but did **not** flip `dkg:memoryLayer` off `"SWM"` / `dkg:state` off `"promoted"` — `generateAssertionPublishedMetadata` never fired because its trigger SPARQL gate (`dkg-publisher.ts:1523`) joins on `dkg:rootEntity`/`dkg:agent` predicates the lifecycle record never carries. So published assertions lingered in the Shared-Memory layer. Now publish flips `memoryLayer → "VM"` + `state → "published"` on **both** the lifecycle-URN and data-graph-URI forms, right where the VM pointer is stamped. **The VM lifecycle record is now equivalent to the WM/SWM records (a `memoryLayer` marker + `state`) with the on-chain transaction metadata (`vmCurrentAssertion` + `kaId` + UAL) layered on top.**

5. **SWM-list published backstop** (`api.ts`): `listAssertions('swm')` also excludes anything carrying a `vmCurrentAssertion` pointer — covers assertions published **before** fix #4 (whose marker stays `"SWM"`).

### Verification
- All reproduced + fixed on the devnet; fix #4 verified live (node1 reloaded): create → finalize → promote → `vm/publish` → assertion URN **and** data-URI both read `memoryLayer="VM"`, `state="published"`, + `vmCurrentAssertion`.
- node-ui `ui-api-pure` **42/42** (incl. new regression tests for each); typecheck clean; full build **20/20**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)