### PR TITLE
feat(allocator): OT-RFC-43 Option-1 KA-number floor-correctness fixes (PR #976 F5–F9), re-authored onto #980

### DIFF
--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -34,8 +34,13 @@ const ADDRESS_HEX_CHARS = 40;
 export interface KaAllocation {
   /** Packed `(uint160(author) << 96) | uint96(number)`. Always non-zero. */
   kaId: bigint;
-  /** The per-author number just consumed (first allocation is 0). */
-  number: number;
+  /**
+   * The per-author number just consumed (first allocation is `0n`).
+   * `bigint` end-to-end (codex PR #976 F6) so the counter stays exact
+   * past `Number.MAX_SAFE_INTEGER`; the on-chain field is `uint96` and
+   * the store backs it with a SQLite signed INTEGER (`2^63 - 1` cap).
+   */
+  number: bigint;
 }
 
 export class KaNumberAllocator {
@@ -55,14 +60,29 @@ export class KaNumberAllocator {
   /**
    * Consume the next number for `authorAddress` and return it together
    * with the packed `kaId`. Throws if startup reconciliation has not
-   * been performed (`assertReconciled`) or if the address is not a valid
-   * 20-byte hex address.
+   * been performed (`assertReconciled`), if the address is not a valid
+   * 20-byte hex address, or if it is the zero address (codex PR #976
+   * F7 — `(0n << 96) | 0n === 0n`, which collides with the poller's
+   * "no kaId" sentinel and violates the `KaAllocation.kaId` non-zero
+   * contract).
+   *
+   * The address is canonicalized to the validated lowercase form
+   * (codex PR #976 F8) BEFORE being passed to the store, so any
+   * `KaNumberStore` implementation receives a single canonical key
+   * regardless of caller casing. Without this, `0xAbc…` vs `0xabc…`
+   * would fork the sequence in a store that forgot to lowercase its
+   * own key, producing duplicate low-96 counters under the same
+   * on-chain author.
    */
   allocate(authorAddress: string): KaAllocation {
     this.assertReconciled();
-    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
-    const number = this.store.allocate(authorAddress);
-    const kaId = (authorBits << NUMBER_BITS) | BigInt(number);
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    const authorBits = BigInt(canonical);
+    // `number` is a `bigint` straight off the store (codex PR #976 F6) —
+    // no `BigInt()` round-trip, no chance of a stray `Number()` cast at
+    // the call site silently truncating a counter past 2^53.
+    const number = this.store.allocate(canonical);
+    const kaId = (authorBits << NUMBER_BITS) | number;
     return { kaId, number };
   }
 
@@ -70,23 +90,31 @@ export class KaNumberAllocator {
    * Raise the stored floor for `authorAddress` from an observed on-chain
    * state. `observedNumber` is the highest number already minted under
    * that author; the next allocation must therefore be at least
-   * `observedNumber + 1`. Idempotent and monotonic (never lowers).
+   * `observedNumber + 1n`. Idempotent and monotonic (never lowers).
+   *
+   * `observedNumber` is a `bigint` (codex PR #976 F6) — the chain reads
+   * that compute it (`kaId & ((1n<<96n)-1n)`) already produce bigint;
+   * accepting `number` here would force a precision-losing cast at the
+   * caller. The address is canonicalized before being passed to the
+   * store (codex PR #976 F8) to keep the per-author key stable across
+   * casing variants.
    */
-  reconcile(authorAddress: string, observedNumber: number): void {
-    // Validate the address shape here too so reconciliation rejects junk
-    // before it can poison the floor.
-    KaNumberAllocator.authorToUint160(authorAddress);
-    this.store.reconcileFloor(authorAddress, observedNumber + 1);
+  reconcile(authorAddress: string, observedNumber: bigint): void {
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    this.store.reconcileFloor(canonical, observedNumber + 1n);
   }
 
   /**
    * The `kaId` the next `allocate(authorAddress)` would produce, without
-   * consuming it. Does NOT require reconciliation (read-only peek).
+   * consuming it. Does NOT require reconciliation (read-only peek). The
+   * address is canonicalized (codex PR #976 F8) so peek + allocate
+   * cannot disagree under mixed casing.
    */
   peekKaId(authorAddress: string): bigint {
-    const authorBits = KaNumberAllocator.authorToUint160(authorAddress);
-    const number = this.store.peekNext(authorAddress);
-    return (authorBits << NUMBER_BITS) | BigInt(number);
+    const canonical = KaNumberAllocator.canonicalizeAuthor(authorAddress);
+    const authorBits = BigInt(canonical);
+    const number = this.store.peekNext(canonical);
+    return (authorBits << NUMBER_BITS) | number;
   }
 
   /**
@@ -121,18 +149,44 @@ export class KaNumberAllocator {
    * 160-bit integer value. Uses `ethers.getAddress` to validate (it
    * throws on a malformed/checksum-invalid address); `BigInt(0x…)` then
    * yields the unsigned 160-bit value. NEVER uses `Number()`.
+   *
+   * Rejects the zero address (codex PR #976 F7) — see
+   * `canonicalizeAuthor()` for the rationale.
    */
   static authorToUint160(authorAddress: string): bigint {
-    // getAddress throws on anything that is not a valid 20-byte address
-    // (wrong length, non-hex, bad checksum casing). Re-wrap so the error
-    // is attributable to this module.
+    return BigInt(KaNumberAllocator.canonicalizeAuthor(authorAddress));
+  }
+
+  /**
+   * Validate `authorAddress` and return its canonical lowercase
+   * `0x`-prefixed 42-char form. This is the single normalization point
+   * the allocator uses before talking to the store, so any
+   * `KaNumberStore` implementation receives one canonical key per
+   * on-chain author regardless of caller casing (codex PR #976 F8).
+   *
+   * Rejects:
+   *   - Anything `ethers.getAddress()` rejects (wrong length, non-hex,
+   *     bad checksum casing).
+   *   - The zero address `0x0000…0000` (codex PR #976 F7). Allocating
+   *     under the zero address would yield `kaId = 0n`, which both
+   *     violates the `KaAllocation.kaId` non-zero contract and collides
+   *     with the poller's "no kaId" sentinel (see
+   *     `chain-event-poller.ts::handleKACreated`'s `if (kaId === 0n)
+   *     return`).
+   */
+  static canonicalizeAuthor(authorAddress: string): string {
     let checksummed: string;
     try {
       checksummed = ethers.getAddress(authorAddress);
     } catch {
       throw new Error(`KaNumberAllocator: invalid author address: ${authorAddress}`);
     }
-    return BigInt(checksummed);
+    if (checksummed === ethers.ZeroAddress) {
+      throw new Error(
+        'KaNumberAllocator: refusing to allocate under the zero address (kaId=0n collides with the poller "no kaId" sentinel and violates the KaAllocation non-zero contract)',
+      );
+    }
+    return checksummed.toLowerCase();
   }
 
   /**

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1821,7 +1821,8 @@ export class PublishMethods extends DKGAgentBase {
           }
         }
         if (chainMax >= 0n) {
-          this.kaNumberAllocator.reconcile(author, Number(chainMax));
+          // Pass the bigint straight through (PR #976 F6) — `Number()` would lose precision past 2^53.
+          this.kaNumberAllocator.reconcile(author, chainMax);
         }
         this.kaNumberAllocator.markReconciled();
         this.reconciledKaAuthors.add(key);

--- a/packages/agent/test/_helpers/ka-allocator.ts
+++ b/packages/agent/test/_helpers/ka-allocator.ts
@@ -21,23 +21,26 @@ import { KaNumberAllocator } from '../../src/allocator.js';
 
 /** In-memory `KaNumberStore` matching the `SqliteKaNumberStore` contract. */
 class InMemoryKaNumberStore implements KaNumberStore {
-  private readonly next = new Map<string, number>();
+  // bigint end-to-end (PR #976 F6) to mirror the durable SqliteKaNumberStore —
+  // the per-author number can exceed 2^53, so `number`/`Math.max` would lose
+  // precision and let the allocator re-issue an already-minted id.
+  private readonly next = new Map<string, bigint>();
 
-  allocate(authorAddress: string): number {
+  allocate(authorAddress: string): bigint {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, current + 1);
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current + 1n);
     return current;
   }
 
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, Math.max(current, nextNumberFloor));
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current > nextNumberFloor ? current : nextNumberFloor);
   }
 
-  peekNext(authorAddress: string): number {
-    return this.next.get(authorAddress.toLowerCase()) ?? 0;
+  peekNext(authorAddress: string): bigint {
+    return this.next.get(authorAddress.toLowerCase()) ?? 0n;
   }
 }
 

--- a/packages/agent/test/allocator.test.ts
+++ b/packages/agent/test/allocator.test.ts
@@ -26,25 +26,29 @@ import { KaNumberAllocator } from '../src/allocator.js';
  * keyed by lowercased author, `next_number` is the value to hand out next,
  * `allocate` returns the current value then increments, `reconcileFloor`
  * raises but never lowers.
+ *
+ * `bigint` end-to-end (codex PR #976 F6) so this fixture mirrors the
+ * SQLite store's `safeIntegers(true)` semantics and the counter stays
+ * exact past `Number.MAX_SAFE_INTEGER`.
  */
 class InMemoryKaNumberStore implements KaNumberStore {
-  private readonly next = new Map<string, number>();
+  private readonly next = new Map<string, bigint>();
 
-  allocate(authorAddress: string): number {
+  allocate(authorAddress: string): bigint {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, current + 1);
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current + 1n);
     return current;
   }
 
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
     const key = authorAddress.toLowerCase();
-    const current = this.next.get(key) ?? 0;
-    this.next.set(key, Math.max(current, nextNumberFloor));
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current > nextNumberFloor ? current : nextNumberFloor);
   }
 
-  peekNext(authorAddress: string): number {
-    return this.next.get(authorAddress.toLowerCase()) ?? 0;
+  peekNext(authorAddress: string): bigint {
+    return this.next.get(authorAddress.toLowerCase()) ?? 0n;
   }
 }
 
@@ -84,67 +88,93 @@ describe('KaNumberAllocator — cold-start refusal (RFC §4.5)', () => {
 });
 
 describe('KaNumberAllocator — monotonic per-author numbers', () => {
-  it('hands out 0,1,2,... for one author', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+  it('hands out 0n,1n,2n,... for one author', () => {
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2n);
   });
 
   it('keeps independent sequences per author', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_B).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
-    expect(alloc.allocate(AUTHOR_B).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
+    expect(alloc.allocate(AUTHOR_B).number).toBe(1n);
   });
 
   it('treats checksum-cased and lower-cased authors as the same sequence', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A.toLowerCase()).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A.toLowerCase()).number).toBe(1n);
   });
 
   it('never reclaims a number across allocator instances on a shared store', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
     // A fresh allocator over the SAME durable store must continue the
     // sequence, not restart it (durable, never-reclaimed contract).
     const alloc2 = new KaNumberAllocator(store);
     alloc2.markReconciled();
-    expect(alloc2.allocate(AUTHOR_A).number).toBe(2);
-    expect(alloc2.allocate(AUTHOR_A).number).toBe(3);
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(2n);
+    expect(alloc2.allocate(AUTHOR_A).number).toBe(3n);
+  });
+
+  // codex PR #976 F6 — the counter is bigint end-to-end. Crossing
+  // `Number.MAX_SAFE_INTEGER` MUST remain exact (no silent precision
+  // loss). Pre-fix this would have returned the same `number` twice
+  // (or skipped one) because every cast went through JS `number`.
+  it('stays exact past Number.MAX_SAFE_INTEGER (F6 precision invariant)', () => {
+    const past = BigInt(Number.MAX_SAFE_INTEGER); // 2^53 - 1
+    // Reconcile the floor so the next allocation lands at exactly `past`.
+    // `reconcile` adds 1, so observed = past - 1n => next = past.
+    alloc.reconcile(AUTHOR_A, past - 1n);
+    const a = alloc.allocate(AUTHOR_A);
+    const b = alloc.allocate(AUTHOR_A);
+    const c = alloc.allocate(AUTHOR_A);
+    expect(a.number).toBe(past);
+    expect(b.number).toBe(past + 1n);
+    expect(c.number).toBe(past + 2n);
+    // Critical: in JS `number`, `Number(past) + 2 === Number(past) + 3`
+    // (both round to the same 2^53 even). With `bigint`, the three
+    // allocations are distinct values — no kaId collision risk.
+    expect(a.number).not.toBe(b.number);
+    expect(b.number).not.toBe(c.number);
+    // And the kaId packing must reflect the distinct numbers too.
+    expect(a.kaId).not.toBe(b.kaId);
+    expect(b.kaId).not.toBe(c.kaId);
+    expect(typeof a.number).toBe('bigint');
   });
 });
 
 describe('KaNumberAllocator — reconcile (floor)', () => {
   it('advances the next number up to observed+1', () => {
     // Observed highest minted on-chain under AUTHOR_A is 41 => next is 42.
-    alloc.reconcile(AUTHOR_A, 41);
-    expect(store.peekNext(AUTHOR_A)).toBe(42);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(42);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(43);
+    alloc.reconcile(AUTHOR_A, 41n);
+    expect(store.peekNext(AUTHOR_A)).toBe(42n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(42n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(43n);
   });
 
   it('never lowers an already-higher next number', () => {
-    expect(alloc.allocate(AUTHOR_A).number).toBe(0);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(1);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(0n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(1n);
     // Local store is already at next=2. A stale floor of observed=0
     // (=> proposed next 1) must NOT pull the sequence backwards.
-    alloc.reconcile(AUTHOR_A, 0);
-    expect(store.peekNext(AUTHOR_A)).toBe(2);
-    expect(alloc.allocate(AUTHOR_A).number).toBe(2);
+    alloc.reconcile(AUTHOR_A, 0n);
+    expect(store.peekNext(AUTHOR_A)).toBe(2n);
+    expect(alloc.allocate(AUTHOR_A).number).toBe(2n);
   });
 
   it('reconcile is monotonic across repeated calls', () => {
-    alloc.reconcile(AUTHOR_A, 9); // next -> 10
-    alloc.reconcile(AUTHOR_A, 4); // stale, no-op
-    alloc.reconcile(AUTHOR_A, 19); // next -> 20
-    expect(store.peekNext(AUTHOR_A)).toBe(20);
+    alloc.reconcile(AUTHOR_A, 9n); // next -> 10
+    alloc.reconcile(AUTHOR_A, 4n); // stale, no-op
+    alloc.reconcile(AUTHOR_A, 19n); // next -> 20
+    expect(store.peekNext(AUTHOR_A)).toBe(20n);
   });
 });
 
 describe('KaNumberAllocator — kaId packing', () => {
   it('packs (uint160(author) << 96) | number and is non-zero', () => {
     const { kaId, number } = alloc.allocate(AUTHOR_A);
-    expect(number).toBe(0);
+    expect(number).toBe(0n);
     expect(typeof kaId).toBe('bigint');
     expect(kaId).not.toBe(0n);
     // Low 96 bits == number, high bits == author.
@@ -157,7 +187,7 @@ describe('KaNumberAllocator — kaId packing', () => {
     alloc.allocate(AUTHOR_B);
     alloc.allocate(AUTHOR_B);
     const { kaId, number } = alloc.allocate(AUTHOR_B);
-    expect(number).toBe(2);
+    expect(number).toBe(2n);
     const unpacked = KaNumberAllocator.unpack(kaId);
     expect(unpacked.number).toBe(2n);
     expect(unpacked.author).toBe(AUTHOR_B.toLowerCase());
@@ -189,5 +219,99 @@ describe('KaNumberAllocator — kaId packing', () => {
   it('rejects an invalid author address', () => {
     expect(() => alloc.allocate('not-an-address')).toThrow(/invalid author address/);
     expect(() => alloc.allocate('0x1234')).toThrow(/invalid author address/);
+  });
+});
+
+describe('KaNumberAllocator — zero address (codex PR #976 F7)', () => {
+  const ZERO = '0x0000000000000000000000000000000000000000';
+
+  it('refuses to allocate under the zero address', () => {
+    // Under the packed scheme `kaId = (uint160(author) << 96) | number`
+    // the first allocation for the zero address would produce
+    // `kaId = (0n << 96n) | 0n === 0n`. That:
+    //   (a) violates the documented `KaAllocation.kaId` non-zero contract;
+    //   (b) collides with the chain-event-poller's "no kaId" sentinel
+    //       (`handleKACreated`'s `if (kaId === 0n) return`), so the
+    //       reconciliation callback would silently drop the mint event.
+    // `ethers.getAddress(ZeroAddress)` accepts the zero address, so the
+    // allocator has to reject it explicitly.
+    expect(() => alloc.allocate(ZERO)).toThrow(/zero address/);
+  });
+
+  it('refuses to reconcile under the zero address', () => {
+    // Same rationale — never let a stray zero-address observation poison
+    // the floor map with a phantom-author key.
+    expect(() => alloc.reconcile(ZERO, 0n)).toThrow(/zero address/);
+  });
+
+  it('refuses to peek under the zero address', () => {
+    expect(() => alloc.peekKaId(ZERO)).toThrow(/zero address/);
+  });
+
+  it('accepts every non-zero address ethers.getAddress accepts', () => {
+    // Sanity: a barely-non-zero address still works (no over-rejection).
+    const oneLsb = '0x0000000000000000000000000000000000000001';
+    expect(alloc.allocate(oneLsb).number).toBe(0n);
+    expect(alloc.allocate(oneLsb).kaId).not.toBe(0n);
+  });
+});
+
+describe('KaNumberAllocator — canonical address (codex PR #976 F8)', () => {
+  it('passes a single canonical key to the store regardless of caller casing', () => {
+    // The allocator now canonicalizes (lowercase) before talking to the
+    // store, so a store implementation that forgot to lowercase its own
+    // key still gets one stable key per on-chain author. We pin this
+    // behaviour with a casing-aware fake store.
+    class CaseAwareStore implements KaNumberStore {
+      readonly seenKeys: string[] = [];
+      private readonly next = new Map<string, bigint>();
+      allocate(authorAddress: string): bigint {
+        // INTENTIONALLY does NOT lowercase — that's the bug F8 defends
+        // against. If the allocator forwards a checksummed string, the
+        // sequence forks per casing variant.
+        this.seenKeys.push(authorAddress);
+        const cur = this.next.get(authorAddress) ?? 0n;
+        this.next.set(authorAddress, cur + 1n);
+        return cur;
+      }
+      reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
+        this.seenKeys.push(authorAddress);
+        const cur = this.next.get(authorAddress) ?? 0n;
+        this.next.set(authorAddress, cur > nextNumberFloor ? cur : nextNumberFloor);
+      }
+      peekNext(authorAddress: string): bigint {
+        this.seenKeys.push(authorAddress);
+        return this.next.get(authorAddress) ?? 0n;
+      }
+    }
+    const store = new CaseAwareStore();
+    const a = new KaNumberAllocator(store);
+    a.markReconciled();
+
+    // Caller hands us THREE different casings of the same on-chain
+    // address. The allocator must collapse them to one key before the
+    // store ever sees them.
+    a.allocate(AUTHOR_A);                  // checksummed
+    a.allocate(AUTHOR_A.toLowerCase());
+    a.allocate(AUTHOR_A.toUpperCase().replace('0X', '0x')); // upper hex
+    a.peekKaId(AUTHOR_A);
+    a.reconcile(AUTHOR_A, 99n);
+
+    // Every store key must be the lowercased canonical form. Without
+    // the F8 fix the store would have seen the checksummed string at
+    // least once.
+    const lc = AUTHOR_A.toLowerCase();
+    for (const key of store.seenKeys) {
+      expect(key).toBe(lc);
+    }
+  });
+
+  it('peek + allocate cannot disagree under mixed casing', () => {
+    // Peek with one casing, allocate with another — the peeked kaId
+    // MUST equal the kaId the next allocate produces. Without F8 the
+    // two would index into different store keys and disagree.
+    const peeked = alloc.peekKaId(AUTHOR_A);
+    const { kaId } = alloc.allocate(AUTHOR_A.toLowerCase());
+    expect(peeked).toBe(kaId);
   });
 });

--- a/packages/core/src/messenger-types.ts
+++ b/packages/core/src/messenger-types.ts
@@ -271,32 +271,46 @@ export interface ProtocolOutboxStore {
  *
  * Allocation state is durable like `protocol_outbox`: it is NEVER
  * pruned. Reclaiming a number would risk minting a duplicate kaId.
+ *
+ * **Counter width (codex PR #976 F6):** every counter value crosses
+ * this interface as a `bigint`, not a JS `number`. The on-chain field
+ * is a `uint96` (max `2^96 - 1 ≈ 7.9e28`) and the design contemplates
+ * far-future high-throughput authors. Even though `1000 alloc/s × 1M
+ * years ≈ 2^55` keeps real load comfortably under `Number.MAX_SAFE_
+ * INTEGER (2^53 - 1)`, returning `number` would silently lose precision
+ * past that point — `allocate()`, `peekNext()`, and `observed + 1`
+ * would all start to skip or duplicate kaIds. Using `bigint` end-to-end
+ * is a defence-in-depth invariant: the interface cannot accidentally
+ * be wired through a `Number()` cast at a call site. SQLite's signed
+ * `INTEGER` (2^63 - 1) remains the hard ceiling for the implementation
+ * — orders of magnitude past any realistic load, and many orders past
+ * the `2^53` precision cliff that motivated this typing.
  */
 export interface KaNumberStore {
   /**
    * Atomically consume and return the next number for `authorAddress`.
-   * The first call for an author returns `0`; subsequent calls return
-   * `1, 2, 3, …` strictly monotonically. Implementations lowercase the
-   * address and perform the read-and-increment in a single atomic
+   * The first call for an author returns `0n`; subsequent calls return
+   * `1n, 2n, 3n, …` strictly monotonically. Implementations lowercase
+   * the address and perform the read-and-increment in a single atomic
    * statement (`INSERT … ON CONFLICT DO UPDATE … RETURNING`) so two
    * concurrent allocations never collide on the same number.
    */
-  allocate(authorAddress: string): number;
+  allocate(authorAddress: string): bigint;
 
   /**
    * Raise the stored next-number for `authorAddress` to *at least*
    * `nextNumberFloor`, never lowering it. Called at startup with
-   * `observedHighestMinted + 1` so a node that lost local state (or is
+   * `observedHighestMinted + 1n` so a node that lost local state (or is
    * cold) cannot re-issue a number the chain already used under that
    * author. Idempotent and monotonic: replaying an old floor is a
    * no-op.
    */
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void;
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void;
 
   /**
    * The number the *next* `allocate(authorAddress)` would return,
-   * without consuming it. Returns `0` when the author has never been
+   * without consuming it. Returns `0n` when the author has never been
    * seen. For diagnostics / reconciliation comparisons.
    */
-  peekNext(authorAddress: string): number;
+  peekNext(authorAddress: string): bigint;
 }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2586,6 +2586,19 @@ export class SqliteProtocolOutboxStore implements ProtocolOutboxStore {
  * other Sqlite*Store classes rely on — there is no `.transaction()`
  * in this module).
  *
+ * **Counter width (codex PR #976 F6):** every value crossing the
+ * `KaNumberStore` interface is a `bigint`. `better-sqlite3` returns
+ * INTEGER columns as JS `number` by default — which silently truncates
+ * once a counter passes `Number.MAX_SAFE_INTEGER (2^53 - 1)`. Each
+ * statement here opts into `.safeIntegers(true)`, returning `bigint`
+ * directly so `allocate()`, `peekNext()` and `observed + 1n` stay
+ * exact across the full SQLite signed INTEGER range (`2^63 - 1`). The
+ * RFC's worst-case load ("1000 alloc/s × 1M years ≈ 2^55") sits well
+ * past the `2^53` precision cliff and far under the `2^63` hard
+ * ceiling; if a single author ever does approach `2^63`, SQLite raises
+ * an INTEGER overflow on the next increment — a fail-loud surface
+ * that's strictly preferable to a silent kaId-collision risk.
+ *
  * Like `protocol_outbox`, this state is durable: it is NEVER added to
  * `prune()`. Reclaiming a number could re-mint a kaId already used
  * on-chain under that author.
@@ -2597,13 +2610,15 @@ export class SqliteKaNumberStore implements KaNumberStore {
     this.db = dashboard.db;
   }
 
-  allocate(authorAddress: string): number {
+  allocate(authorAddress: string): bigint {
     const author = authorAddress.toLowerCase();
     // Atomic read-and-increment. `next_number` is the value to hand
     // out; we increment it and RETURN the value just consumed
     // (`next_number - 1` after the update), so the first call for an
-    // author returns 0. On first insert `next_number` starts at 1, so
+    // author returns 0n. On first insert `next_number` starts at 1, so
     // `1 - 1 = 0` is returned there too — uniform either way.
+    // `safeIntegers(true)` opts INTO bigint returns so the counter is
+    // exact past `Number.MAX_SAFE_INTEGER` (codex PR #976 F6).
     const row = this.db
       .prepare(
         `INSERT INTO ka_numbers (author_address, next_number)
@@ -2611,14 +2626,16 @@ export class SqliteKaNumberStore implements KaNumberStore {
          ON CONFLICT(author_address) DO UPDATE SET next_number = next_number + 1
          RETURNING next_number - 1 AS number`,
       )
-      .get(author) as { number: number };
+      .safeIntegers(true)
+      .get(author) as { number: bigint };
     return row.number;
   }
 
-  reconcileFloor(authorAddress: string, nextNumberFloor: number): void {
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
     const author = authorAddress.toLowerCase();
     // Raise `next_number` to at least the floor, never lowering it.
     // `excluded.next_number` is the proposed floor from the VALUES row.
+    // `better-sqlite3` accepts bigint statement parameters natively.
     this.db
       .prepare(
         `INSERT INTO ka_numbers (author_address, next_number)
@@ -2629,12 +2646,13 @@ export class SqliteKaNumberStore implements KaNumberStore {
       .run(author, nextNumberFloor);
   }
 
-  peekNext(authorAddress: string): number {
+  peekNext(authorAddress: string): bigint {
     const author = authorAddress.toLowerCase();
     const row = this.db
       .prepare(`SELECT next_number FROM ka_numbers WHERE author_address = ?`)
-      .get(author) as { next_number: number } | undefined;
-    return row?.next_number ?? 0;
+      .safeIntegers(true)
+      .get(author) as { next_number: bigint } | undefined;
+    return row?.next_number ?? 0n;
   }
 }
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
+import { DashboardDB, SqliteKaNumberStore, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -949,6 +949,66 @@ describe('DashboardDB — V20 ka_numbers table migration (B2 KA-number allocator
       'SELECT next_number FROM ka_numbers WHERE author_address = ?',
     ).get('0xabc') as { next_number: number } | undefined;
     expect(row).toEqual({ next_number: 0 });
+  });
+});
+
+describe('SqliteKaNumberStore — bigint counter (codex PR #976 F6)', () => {
+  let db: DashboardDB;
+  let dir: string;
+  let store: SqliteKaNumberStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-ka-number-store-test-'));
+    db = new DashboardDB({ dataDir: dir });
+    store = new SqliteKaNumberStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const AUTHOR = '0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1';
+
+  it('allocate / peekNext return bigint, not number', () => {
+    const a = store.allocate(AUTHOR);
+    expect(typeof a).toBe('bigint');
+    expect(a).toBe(0n);
+
+    expect(typeof store.peekNext(AUTHOR)).toBe('bigint');
+    expect(store.peekNext(AUTHOR)).toBe(1n);
+
+    expect(store.allocate(AUTHOR)).toBe(1n);
+    expect(store.allocate(AUTHOR)).toBe(2n);
+  });
+
+  it('reconcileFloor accepts bigint and raises but never lowers', () => {
+    store.reconcileFloor(AUTHOR, 41n);
+    expect(store.peekNext(AUTHOR)).toBe(41n);
+    expect(store.allocate(AUTHOR)).toBe(41n);
+
+    // Stale floor must not pull the sequence backwards.
+    store.reconcileFloor(AUTHOR, 5n);
+    expect(store.peekNext(AUTHOR)).toBe(42n);
+  });
+
+  it('stays exact past Number.MAX_SAFE_INTEGER (no silent precision loss)', () => {
+    // This is the F6 invariant against the REAL sqlite path. Pre-fix
+    // the store returned JS `number`, so values past 2^53 would round
+    // to the nearest even — successive `allocate()` calls could either
+    // return the same value twice (kaId collision) or skip one.
+    const past = BigInt(Number.MAX_SAFE_INTEGER); // 2^53 - 1
+    store.reconcileFloor(AUTHOR, past);
+    const a = store.allocate(AUTHOR);
+    const b = store.allocate(AUTHOR);
+    const c = store.allocate(AUTHOR);
+    expect(a).toBe(past);
+    expect(b).toBe(past + 1n);
+    expect(c).toBe(past + 2n);
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    // peekNext is also exact.
+    expect(store.peekNext(AUTHOR)).toBe(past + 3n);
   });
 });
 

--- a/packages/publisher/src/chain-event-poller.ts
+++ b/packages/publisher/src/chain-event-poller.ts
@@ -254,13 +254,37 @@ export class ChainEventPoller {
     }
 
     // On first successful head fetch, seed cursor near the tip — but only
-    // when there are no pending publishes whose confirmations we might skip.
-    // Full-history context graph discovery is handled by discoverContextGraphsFromChain().
+    // when no subscriber depends on full chain history. The head-seed is
+    // a latency optimisation for the "watch for our own pending tx
+    // confirmation" use case: confirmations land at the tip, so scanning
+    // from `head - 500` is sufficient and avoids re-walking the chain on
+    // every cold start.
+    //
+    // Full-history context graph discovery is handled separately by
+    // `discoverContextGraphsFromChain()`.
+    //
+    // The OT-RFC-43 Option-1 allocator-reconciliation watcher
+    // (`onKnowledgeAssetCreated`) MUST observe every historical
+    // `KCCreated` event (codex PR #976 F9) — otherwise a fresh daemon
+    // would miss every author whose last mint was >500 blocks ago, the
+    // per-author floor would stay at 0, and a downstream
+    // `markReconciled()` would be unsound (the allocator would happily
+    // re-issue a number already minted on-chain). Treat this watcher
+    // exactly like `hasPending`: when wired AND there is no persisted
+    // cursor, refuse to seed near head and scan from block 0.
+    //
+    // Once a `cursorPersistence` round-trip lands (so `lastBlock > 0` on
+    // restart) the watcher resumes incrementally from that cursor like
+    // every other subscription — there is no extra cost beyond the
+    // first cold start.
     if (head != null && !this.headKnown) {
       this.headKnown = true;
-      if (this.lastBlock === 0 && !hasPending) {
+      const requiresFullHistory = hasPending || watchKACreated;
+      if (this.lastBlock === 0 && !requiresFullHistory) {
         this.lastBlock = Math.max(0, head - 500);
         this.log.info(ctx, `Seeded poller cursor near chain head: ${head} → scanning from ${this.lastBlock}`);
+      } else if (this.lastBlock === 0 && watchKACreated) {
+        this.log.info(ctx, `Allocator-reconciliation watcher wired and no persisted cursor → scanning from block 0 (codex PR #976 F9 backfill)`);
       }
     }
 
@@ -278,7 +302,19 @@ export class ChainEventPoller {
       eventTypes.push('ProfileUpdated');
     }
     if (watchKARegistered) eventTypes.push('KnowledgeAssetRegisteredToContextGraph');
-    if (this.onKnowledgeAssetCreated) eventTypes.push('KnowledgeAssetCreated');
+    // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5):
+    // The chain adapter's `listenForEvents()` decodes both the V10 greenfield
+    // `KnowledgeAssetCreated` event and the legacy V8/V9 batch-create event
+    // into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author, ... } }`
+    // surface (see packages/chain/src/evm-adapter-events.ts ~L119 and L193).
+    // A redundant `KnowledgeAssetCreated` subscription used to live here, but
+    // the adapter never yielded events with that type, so the dead branch
+    // below this loop never fired and allocator reconciliation never ran.
+    // Subscribe to `KCCreated` always (already implicit at the top of the
+    // list) and fan out to both `handleBatchCreated` AND `handleKACreated`
+    // inline below. When `onKnowledgeAssetCreated` is the ONLY subscriber
+    // wired (i.e. no PublishHandler pending state), still enter the poll
+    // loop — `watchKACreated` covers that case in the gating check above.
 
     const fromBlock = this.lastBlock + 1;
     const upperBound = head != null
@@ -298,6 +334,14 @@ export class ChainEventPoller {
       if (event.blockNumber > maxEventBlock) maxEventBlock = event.blockNumber;
       if (event.type === 'KCCreated') {
         await this.handleBatchCreated(event, ctx);
+        // OT-RFC-43 Option-1 allocator reconciliation (codex PR #976 F5).
+        // The adapter normalizes the greenfield `KnowledgeAssetCreated` event
+        // to `type: 'KCCreated'`, so there is no separate dispatch branch —
+        // we fan out off the same event here. `handleKACreated` is a no-op
+        // when `onKnowledgeAssetCreated` is not wired, when `kaId` is missing
+        // (legacy batch-create paths), or when `kaId` is zero (sentinel for
+        // `getKnowledgeAssetId`'s "not part of any KA" return — never minted).
+        await this.handleKACreated(event, ctx);
       } else if (event.type === 'NameClaimed' || event.type === 'ContextGraphCreated') {
         await this.handleContextGraphCreated(event, ctx);
       } else if (event.type === 'KnowledgeAssetUpdated') {
@@ -308,8 +352,6 @@ export class ChainEventPoller {
         await this.handleProfileEvent(event, ctx);
       } else if (event.type === 'KnowledgeAssetRegisteredToContextGraph') {
         await this.handleKARegistered(event, ctx);
-      } else if (event.type === 'KnowledgeAssetCreated') {
-        await this.handleKACreated(event, ctx);
       }
     }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -72,9 +72,11 @@ const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
  */
 export interface KaIdAllocator {
   /** Allocate the next packed kaId = (uint160(author)<<96)|number for `author`. */
-  allocate(author: string): { kaId: bigint; number: number };
-  /** Raise the per-author floor to `observedNumber + 1` (never lower) so the next allocate skips minted numbers. */
-  reconcile(author: string, observedNumber: number): void;
+  allocate(author: string): { kaId: bigint; number: bigint };
+  /** Raise the per-author floor to `observedNumber + 1` (never lower) so the next allocate skips minted numbers.
+   *  `observedNumber` is a `bigint` end-to-end (OT-RFC-43 Option-1, PR #976 F6) — the per-author number can
+   *  exceed 2^53, so `Number` would silently lose precision and let the allocator re-issue a minted id. */
+  reconcile(author: string, observedNumber: bigint): void;
   /** Satisfy the allocator's cold-start guard once reconciliation has run. */
   markReconciled(): void;
 }
@@ -4669,7 +4671,8 @@ export class DKGPublisher implements Publisher {
       }
       if (chainMax >= 0n) {
         // chainMax is the highest minted number; reconcile() raises the floor to chainMax + 1.
-        this.kaAllocator.reconcile(author, Number(chainMax));
+        // Pass the bigint straight through (PR #976 F6) — `Number()` would lose precision past 2^53.
+        this.kaAllocator.reconcile(author, chainMax);
       }
       this.kaAllocator.markReconciled();
       this.reconciledKaAuthors.add(key);

--- a/packages/publisher/test/_helpers/ka-allocator.ts
+++ b/packages/publisher/test/_helpers/ka-allocator.ts
@@ -25,8 +25,8 @@ const NUMBER_BITS = 96n;
 import { ethers } from 'ethers';
 
 export interface KaIdAllocator {
-  allocate(author: string): { kaId: bigint; number: number };
-  reconcile(author: string, observedNumber: number): void;
+  allocate(author: string): { kaId: bigint; number: bigint };
+  reconcile(author: string, observedNumber: bigint): void;
   markReconciled(): void;
 }
 
@@ -37,26 +37,28 @@ export interface KaIdAllocator {
  * `kaId = (uint160(author) << 96) | number` is computed entirely in bigint.
  */
 export class InMemoryKaIdAllocator implements KaIdAllocator {
-  private readonly next = new Map<string, number>();
+  private readonly next = new Map<string, bigint>();
   private reconciled = false;
 
-  allocate(author: string): { kaId: bigint; number: number } {
+  allocate(author: string): { kaId: bigint; number: bigint } {
     if (!this.reconciled) {
       throw new Error('InMemoryKaIdAllocator: allocate() before markReconciled()');
     }
     const key = author.toLowerCase();
-    const number = this.next.get(key) ?? 0;
-    this.next.set(key, number + 1);
+    const number = this.next.get(key) ?? 0n;
+    this.next.set(key, number + 1n);
     const authorBits = BigInt(ethers.getAddress(author));
-    const kaId = (authorBits << NUMBER_BITS) | BigInt(number);
+    const kaId = (authorBits << NUMBER_BITS) | number;
     return { kaId, number };
   }
 
-  reconcile(author: string, observedNumber: number): void {
+  reconcile(author: string, observedNumber: bigint): void {
     const key = author.toLowerCase();
-    const current = this.next.get(key) ?? 0;
+    const current = this.next.get(key) ?? 0n;
     // observedNumber is the highest already-minted number; the floor is +1.
-    this.next.set(key, Math.max(current, observedNumber + 1));
+    // bigint end-to-end (PR #976 F6) — no `Math.max` (mixes bigint/number).
+    const floor = observedNumber + 1n;
+    this.next.set(key, current > floor ? current : floor);
   }
 
   markReconciled(): void {

--- a/packages/publisher/test/chain-event-poller-ka-created.test.ts
+++ b/packages/publisher/test/chain-event-poller-ka-created.test.ts
@@ -1,0 +1,218 @@
+/**
+ * OT-RFC-43 Option-1 — ChainEventPoller surfaces `KnowledgeAssetCreated`
+ * (codex PR #976 F5 regression).
+ *
+ * The chain adapter's `listenForEvents()` decodes both the V10 greenfield
+ * `KnowledgeAssetCreated` Solidity event AND the legacy V8/V9 batch-create
+ * event into a SINGLE normalized `{ type: 'KCCreated', data: { kaId, author,
+ * txHash, txIndex, ... } }` surface (see `packages/chain/src/evm-adapter-
+ * events.ts` ~L119 and L193). A prior wiring iteration of the poller
+ * subscribed to a distinct `KnowledgeAssetCreated` event type and dispatched
+ * to `onKnowledgeAssetCreated` on a `event.type === 'KnowledgeAssetCreated'`
+ * branch — but the adapter never yielded events with that type, so the
+ * branch never fired and allocator reconciliation (`reconcileFloor`) never
+ * ran. Cold-start refusal in `KaNumberAllocator` therefore never lifted on
+ * a fresh daemon coming up against an existing chain.
+ *
+ * This test pins the corrected wiring: a `KCCreated` event (the only
+ * create-event type the adapter ever emits) carrying `kaId` / `author` /
+ * `txHash` / `txIndex` MUST dispatch to `onKnowledgeAssetCreated` with the
+ * unpacked `(author, number)` pair, in addition to whatever publish-handler
+ * fan-out the same event triggers.
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus } from '@origintrail-official/dkg-core';
+import type { ChainAdapter, EventFilter, ChainEvent } from '@origintrail-official/dkg-chain';
+import { ChainEventPoller } from '../src/chain-event-poller.js';
+import { PublishHandler } from '../src/publish-handler.js';
+
+function makeChain(head: number, events: ChainEvent[]): {
+  adapter: ChainAdapter;
+  filters: EventFilter[];
+} {
+  const filters: EventFilter[] = [];
+  const adapter = {
+    chainId: 'mock:0',
+    getBlockNumber: async () => head,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    listenForEvents: async function* (f: EventFilter): AsyncIterable<ChainEvent> {
+      filters.push(f);
+      for (const evt of events) {
+        if (f.eventTypes.includes(evt.type)) yield evt;
+      }
+    },
+  } as unknown as ChainAdapter;
+  return { adapter, filters };
+}
+
+describe('ChainEventPoller — KnowledgeAssetCreated (allocator reconciliation)', () => {
+  it('dispatches onKnowledgeAssetCreated off the adapter-normalized KCCreated event', async () => {
+    // Pack a representative author-namespaced kaId:
+    //   kaId = (uint160(author) << 96) | number
+    // The poller reverses this and passes the per-author `number` to the
+    // allocator's reconcileFloor.
+    const author = '0x' + 'a1'.repeat(20);                       // checksum-irrelevant
+    const number = 7n;
+    const packedKaId = (BigInt(author) << 96n) | number;
+
+    // The adapter ALWAYS yields create-events with `type: 'KCCreated'`,
+    // regardless of whether the underlying Solidity event was the V10
+    // greenfield `KnowledgeAssetCreated` or the legacy batch-create. This
+    // is the surface the poller must consume.
+    const event: ChainEvent = {
+      type: 'KCCreated',
+      blockNumber: 901,
+      data: {
+        kaId: packedKaId.toString(),
+        author,
+        // Fields the publish-handler fan-out consumes; the allocator
+        // reconciliation only needs kaId/author/txHash/txIndex.
+        merkleRoot: '0x' + '11'.repeat(32),
+        byteSize: '1024',
+        publisherAddress: author,
+        startKAId: packedKaId.toString(),
+        endKAId: packedKaId.toString(),
+        txHash: '0xdeadbeef',
+        txIndex: 2,
+      },
+    };
+
+    const { adapter, filters } = makeChain(1000, [event]);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const seen: Array<{
+      kaId: bigint;
+      author: string;
+      number: bigint;
+      txHash: string;
+      txIndex: number;
+      blockNumber: number;
+    }> = [];
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async (info) => {
+        seen.push({
+          kaId: info.kaId,
+          author: info.author,
+          number: info.number,
+          txHash: info.txHash,
+          txIndex: info.txIndex,
+          blockNumber: info.blockNumber,
+        });
+      },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    // (1) The poller subscribes to the real adapter surface (`KCCreated`),
+    //     not a phantom `KnowledgeAssetCreated` filter type that the adapter
+    //     does not emit. This is the wiring regression — the bot's F5.
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    for (const f of filters) {
+      expect(f.eventTypes).toContain('KCCreated');
+      expect(f.eventTypes).not.toContain('KnowledgeAssetCreated');
+    }
+
+    // (2) The callback receives the unpacked (author, number) plus tx
+    //     coordinates needed for the allocator's reconcileFloor + dedup.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].kaId).toBe(packedKaId);
+    expect(seen[0].author).toBe(author.toLowerCase());
+    expect(seen[0].number).toBe(number);
+    expect(seen[0].txHash).toBe('0xdeadbeef');
+    expect(seen[0].txIndex).toBe(2);
+    expect(seen[0].blockNumber).toBe(901);
+  });
+
+  it('enters the poll loop when onKnowledgeAssetCreated is the only subscriber wired', async () => {
+    // No pending publishes, no other callbacks — the only reason to scan is
+    // allocator reconciliation. The gating check must include `watchKACreated`.
+    const { adapter, filters } = makeChain(1000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async () => {
+        // intentionally empty — we only care that the poll fires
+      },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // KCCreated is always subscribed (it's the V10 publish-flow surface),
+    // independent of whether allocator reconciliation is also wired.
+    expect(filters[0].eventTypes).toContain('KCCreated');
+  });
+
+  // codex PR #976 F9: when `onKnowledgeAssetCreated` is wired and there
+  // is no persisted cursor, the poller MUST backfill from block 0.
+  // Without this, a fresh daemon would skip every `KCCreated` event
+  // older than ~500 blocks (the "seed near head" optimisation that
+  // applies to the pending-publish watcher) and the per-author floor
+  // for older authors would stay at 0. A subsequent `markReconciled()`
+  // would then be unsound — the allocator could re-issue a number
+  // already minted on-chain.
+  it('cold-starts from block 0 when onKnowledgeAssetCreated is wired (F9 backfill)', async () => {
+    // Chain head is 10_000 — well past the 500-block head-seed window.
+    // If the F9 backfill is missing, the poller would seed `lastBlock`
+    // at 9500 and the first filter would have fromBlock=9501, which
+    // would miss every historical `KCCreated` at e.g. block 1.
+    const { adapter, filters } = makeChain(10_000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onKnowledgeAssetCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // First poll scans from block 1 (fromBlock = lastBlock + 1, and
+    // lastBlock stays at 0 because the F9 backfill suppressed the
+    // head-seed). Pre-fix this would have been 9501.
+    expect(filters[0].fromBlock).toBe(1);
+    // toBlock is capped by MAX_RANGE (9000) not the chain head, but it
+    // MUST cover historical territory (block 1) not just the tip.
+    expect(filters[0].toBlock).toBeLessThanOrEqual(10_000);
+    expect(filters[0].toBlock).toBeGreaterThanOrEqual(1);
+  });
+
+  // Sanity inverse: with NO allocator watcher and no pending publishes,
+  // the head-seed optimisation still kicks in. We're not regressing
+  // the existing behaviour for the "watch context graphs only" path.
+  it('still seeds near head when onKnowledgeAssetCreated is NOT wired', async () => {
+    const { adapter, filters } = makeChain(10_000, []);
+    const handler = new PublishHandler(new OxigraphStore(), new TypedEventBus());
+
+    const poller = new ChainEventPoller({
+      chain: adapter,
+      publishHandler: handler,
+      intervalMs: 60_000,
+      onContextGraphCreated: async () => { /* sink */ },
+    });
+
+    await poller.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await poller.stop();
+
+    expect(filters.length).toBeGreaterThanOrEqual(1);
+    // head-seed: lastBlock = head - 500 = 9500, so fromBlock = 9501.
+    expect(filters[0].fromBlock).toBe(9_501);
+  });
+});


### PR DESCRIPTION
Re-authors the **allocator review-fix commits from PR #976** (`991a5a22b`, `45f665cb0`) onto `integration/v10-devnet`, **dropping the stacked #975 contract commit** (`11b480acf`).

## Why drop `11b480acf`
#976 is stacked on #975, so `11b480acf` (move `reservedKaId` to struct/param end + add it as a 5th `AuthorAttestation` EIP-712 typehash field) **auto-merges silently** — but it **reverses the deliberate R5 decision** on #980: `reservedKaId` is kept out of the 4-field `AuthorAttestation` typehash and mid-struct on purpose (intra-namespace number choice is harmless + enforced on-chain). Landing the 5-field typehash without a coordinated off-chain + ABI + redeploy change would break every publish with `InvalidAuthorSignature`. That's a separate, audit-gated decision (tracked under #975) and is **not** included here.

## What this lands (consensus-adjacent)
A missed historical `KCCreated` leaves the per-author allocator floor at 0 → the allocator re-issues an already-minted number → **UAL collision**. Fixes:

- **F5** — remove the dead `event.type === 'KnowledgeAssetCreated'` poller branch (the adapter only ever yields `'KCCreated'`, so the reconcile never fired — #980's own `lifecycle.ts` even flagged this as a "hardening follow-up") and fan reconcile out off the actually-yielded `KCCreated` event.
- **F6** — `number → bigint` end-to-end (core `KaNumberStore`, agent allocator, node-ui `SqliteKaNumberStore` + `.safeIntegers(true)`). The per-author number can exceed 2⁵³; `Number()` would silently lose precision and re-issue a minted id.
- **F7/F8** — allocator zero-address rejection + canonical-author key.
- **F9** — cold-start guard observes full `KCCreated` history when watching KA-created, so `markReconciled()` stays sound.
- New test `chain-event-poller-ka-created.test.ts`.

## Reconciliation onto #980 (not in the PR — #980-specific consumers)
- `dkg-publisher.ts`: `KaIdAllocator` interface → bigint; `reconcile(author, chainMax)` passes the bigint straight through (drops `Number()`).
- `dkg-agent-publish.ts`: same `Number(chainMax) → chainMax` drop.
- test mocks (`publisher` + `agent` `test/_helpers/ka-allocator.ts`): bigint, replacing `Math.max` (throws *cannot mix BigInt*) with a bigint comparison.

## Verification
- **publisher full suite: 1147 passed / 0 failed.**
- **agent full suite: 1214 passed.** The 2 remaining failures (`e2e-security`, `finalization-handler`) are confirmed **pre-existing on #980** (identical on the clean tip) and unrelated to this change.
- Targeted `allocator` (23) / `db` (78) / `chain-event-poller-ka-created` (4) all green.

## Landing
Targets `integration/v10-devnet` so it joins the bundle merging to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)