### PR TITLE
feat(#968 salvage): Design-B multi-entity resolveKA read + aggregate <ual> KnowledgeAsset node

### DIFF
--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -177,6 +177,41 @@ export function generateKCMetadata(
     }
   }
 
+  // OT-RFC-44 Design B: the bare <ual> IS the Knowledge Asset (one file = one
+  // KA, any entity count), but #980 only typed it dkg:KnowledgeCollection — the
+  // bare UAL was never typed dkg:KnowledgeAsset. Emit an aggregate KA node on
+  // the bare UAL (type + summed counts + every member tokenId + every member
+  // entity) so consumers can resolve the KA directly from <ual> (PR #968
+  // salvage; uses ka.tokenId, no metadataTokenId). The per-row <ual>/N rows
+  // below are retained for not-yet-migrated per-root consumers.
+  // NB: deliberately NO `<ual> partOf <ual>` self-edge — that would make the
+  // bare node match `?x partOf <ual>` member-enumeration (incl. resolveKA) and
+  // double-count members; the aggregate node is purely self-describing.
+  if (kaEntries.length > 0) {
+    const aggPublicTripleCount = kaEntries.reduce((sum, ka) => sum + ka.publicTripleCount, 0);
+    const aggPrivateTripleCount = kaEntries.reduce((sum, ka) => sum + ka.privateTripleCount, 0);
+    const memberTokenIds = [...new Set(kaEntries.map((ka) => ka.tokenId.toString()))];
+    const memberRoots = [...new Set(kaEntries.map((ka) => ka.rootEntity))];
+    quads.push(
+      mq(meta.ual, `${RDF}type`, `${DKG}KnowledgeAsset`, metaGraph),
+      mq(meta.ual, `${DKG}publicTripleCount`, intLit(aggPublicTripleCount), metaGraph),
+    );
+    for (const tokenId of memberTokenIds) {
+      quads.push(mq(meta.ual, `${DKG}tokenId`, intLit(BigInt(tokenId)), metaGraph));
+    }
+    for (const root of memberRoots) {
+      // dual-write dkg:rootEntity + dkg:entity, matching the per-row rows (§10.1).
+      quads.push(...entityMemberQuads(meta.ual, root, metaGraph));
+    }
+    if (aggPrivateTripleCount > 0) {
+      quads.push(mq(meta.ual, `${DKG}privateTripleCount`, intLit(aggPrivateTripleCount), metaGraph));
+      const privateRoots = kaEntries.filter((ka) => ka.privateMerkleRoot);
+      if (privateRoots.length === 1 && privateRoots[0].privateMerkleRoot) {
+        quads.push(mq(meta.ual, `${DKG}privateMerkleRoot`, lit(toHex(privateRoots[0].privateMerkleRoot)), metaGraph));
+      }
+    }
+  }
+
   // KA metadata. OT-RFC-44 keeps one on-chain KA per file/lifecycle, but the
   // current update and private-access paths still resolve per-root label rows
   // at <ual>/1, <ual>/2, ... . Keep this compatibility shape until those

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -127,49 +127,55 @@ describe('generateKCMetadata', () => {
     const kas = [makeKA({ tokenId: 1n }), makeKA({ tokenId: 2n, rootEntity: 'did:dkg:entity:bob' })];
     const quads = generateKCMetadata(makeMeta({ kaCount: 2 }), kas);
     const kaSubjects = new Set(quads.filter(q => q.predicate === RDF_TYPE && q.object === `${DKG}KnowledgeAsset`).map(q => q.subject));
-    expect(kaSubjects.size).toBe(2);
+    // PR #968: the bare UAL (aggregate node) is now typed too, alongside the 2 per-root rows.
+    expect(kaSubjects).toEqual(new Set([UAL, `${UAL}/1`, `${UAL}/2`]));
   });
 
-  it('Design B compatibility: one on-chain KA keeps per-root metadata rows', () => {
-    // One file = one on-chain KA, however many entities. Until update/private
-    // access aggregate multi-root KA metadata directly, label metadata remains
-    // one row per root at <UAL>/1, <UAL>/2, ... .
+  it('Design B: per-root rows + aggregate <ual> KnowledgeAsset node (PR #968)', () => {
+    // One file = one on-chain KA, however many entities. The bare <UAL> is now
+    // typed as the aggregate KnowledgeAsset (summed counts + every member
+    // tokenId/entity); per-root label rows at <UAL>/1, <UAL>/2, ... are
+    // retained for not-yet-migrated update/private-access consumers.
     const kas = [
       makeKA({ tokenId: 1n, rootEntity: 'did:dkg:entity:alice', publicTripleCount: 5 }),
       makeKA({ tokenId: 2n, rootEntity: 'did:dkg:entity:bob', publicTripleCount: 3 }),
       makeKA({ tokenId: 3n, rootEntity: 'did:dkg:entity:carol', publicTripleCount: 2 }),
     ];
     const quads = generateKCMetadata(makeMeta({ kaCount: 1 }), kas);
+
+    // dkg:KnowledgeAsset now types the bare UAL AND each per-root row.
     const kaSubjects = new Set(
       quads.filter(q => q.predicate === RDF_TYPE && q.object === `${DKG}KnowledgeAsset`).map(q => q.subject),
     );
-    expect(kaSubjects).toEqual(new Set([`${UAL}/1`, `${UAL}/2`, `${UAL}/3`]));
+    expect(kaSubjects).toEqual(new Set([UAL, `${UAL}/1`, `${UAL}/2`, `${UAL}/3`]));
 
-    expect(quads.find(q => q.subject === `${UAL}/1` && q.predicate === `${DKG}rootEntity`)?.object)
-      .toBe('did:dkg:entity:alice');
-    expect(quads.find(q => q.subject === `${UAL}/2` && q.predicate === `${DKG}rootEntity`)?.object)
-      .toBe('did:dkg:entity:bob');
-    expect(quads.find(q => q.subject === `${UAL}/3` && q.predicate === `${DKG}rootEntity`)?.object)
-      .toBe('did:dkg:entity:carol');
+    // Per-root rows unchanged (legacy dkg:rootEntity + §10.1 dual-written dkg:entity).
+    expect(quads.find(q => q.subject === `${UAL}/1` && q.predicate === `${DKG}rootEntity`)?.object).toBe('did:dkg:entity:alice');
+    expect(quads.find(q => q.subject === `${UAL}/2` && q.predicate === `${DKG}rootEntity`)?.object).toBe('did:dkg:entity:bob');
+    expect(quads.find(q => q.subject === `${UAL}/3` && q.predicate === `${DKG}rootEntity`)?.object).toBe('did:dkg:entity:carol');
+    expect(quads.find(q => q.subject === `${UAL}/1` && q.predicate === `${DKG}entity`)?.object).toBe('did:dkg:entity:alice');
+    expect(quads.find(q => q.subject === `${UAL}/3` && q.predicate === `${DKG}entity`)?.object).toBe('did:dkg:entity:carol');
 
+    // Aggregate node on the bare UAL: summed public count (5+3+2=10) first, then per-root rows.
     const publicCounts = quads
       .filter(q => q.predicate === `${DKG}publicTripleCount`)
       .map(q => [q.subject, q.object]);
     expect(publicCounts).toEqual([
+      [UAL, '"10"^^<http://www.w3.org/2001/XMLSchema#integer>'],
       [`${UAL}/1`, '"5"^^<http://www.w3.org/2001/XMLSchema#integer>'],
       [`${UAL}/2`, '"3"^^<http://www.w3.org/2001/XMLSchema#integer>'],
       [`${UAL}/3`, '"2"^^<http://www.w3.org/2001/XMLSchema#integer>'],
     ]);
+    const intLit = (n: string) => `"${n}"^^<http://www.w3.org/2001/XMLSchema#integer>`;
+    expect(new Set(quads.filter(q => q.subject === UAL && q.predicate === `${DKG}tokenId`).map(q => q.object)))
+      .toEqual(new Set([intLit('1'), intLit('2'), intLit('3')]));
+    expect(new Set(quads.filter(q => q.subject === UAL && q.predicate === `${DKG}rootEntity`).map(q => q.object)))
+      .toEqual(new Set(['did:dkg:entity:alice', 'did:dkg:entity:bob', 'did:dkg:entity:carol']));
+    expect(new Set(quads.filter(q => q.subject === UAL && q.predicate === `${DKG}entity`).map(q => q.object)))
+      .toEqual(new Set(['did:dkg:entity:alice', 'did:dkg:entity:bob', 'did:dkg:entity:carol']));
 
-    // OT-RFC-43 §10.1 dual-write: each per-root label ALSO carries the new
-    // dkg:entity predicate alongside the legacy dkg:rootEntity (readers still
-    // resolve via the legacy name until the reader migration lands).
-    expect(quads.find(q => q.subject === `${UAL}/1` && q.predicate === `${DKG}entity`)?.object)
-      .toBe('did:dkg:entity:alice');
-    expect(quads.find(q => q.subject === `${UAL}/2` && q.predicate === `${DKG}entity`)?.object)
-      .toBe('did:dkg:entity:bob');
-    expect(quads.find(q => q.subject === `${UAL}/3` && q.predicate === `${DKG}entity`)?.object)
-      .toBe('did:dkg:entity:carol');
+    // Deliberately NO `<UAL> partOf <UAL>` self-edge (would pollute `?x partOf <UAL>` member enumeration, incl. resolveKA).
+    expect(quads.find(q => q.subject === UAL && q.predicate === `${DKG}partOf` && q.object === UAL)).toBeUndefined();
   });
 
   it('GH #748 fallback: attribution is the peer-ID literal when neither agentAddress nor authorAddress is supplied', () => {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -684,26 +684,39 @@ export class DKGQueryEngine implements QueryEngine {
 
   async resolveKA(ual: string): Promise<{
     rootEntity: string;
+    rootEntities: string[];
     contextGraphId: string;
     quads: Quad[];
   }> {
-    // Look up KA metadata across all meta graphs, including subGraphName if recorded
+    // Look up KA metadata across all meta graphs, including subGraphName if recorded.
+    // Design B (OT-RFC-44): one KA can hold MULTIPLE rootEntities, so collect
+    // every `?ka <rootEntity>` binding (not just bindings[0]) — PR #968 salvage.
     const metaResult = await this.store.query(
-      `SELECT ?rootEntity ?ctxGraph ?sgName WHERE {
+      `SELECT ?ka ?rootEntity ?ctxGraph ?sgName WHERE {
         GRAPH ?g {
           ?ka <http://dkg.io/ontology/rootEntity> ?rootEntity .
           ?ka <http://dkg.io/ontology/partOf> <${assertSafeIri(ual)}> .
           <${assertSafeIri(ual)}> <http://dkg.io/ontology/contextGraph> ?ctxGraph .
           OPTIONAL { <${assertSafeIri(ual)}> <http://dkg.io/ontology/subGraphName> ?sgName }
         }
-      }`,
+      } ORDER BY ?ka`,
     );
 
     if (metaResult.type !== 'bindings' || metaResult.bindings.length === 0) {
       throw new Error(`KA not found for UAL: ${ual}`);
     }
 
-    const rootEntity = metaResult.bindings[0]['rootEntity'];
+    const rootEntities = [
+      ...new Set(
+        metaResult.bindings
+          .map((row) => row['rootEntity'])
+          .filter((root): root is string => typeof root === 'string' && root.length > 0),
+      ),
+    ];
+    if (rootEntities.length === 0) {
+      throw new Error(`KA not found for UAL: ${ual}`);
+    }
+    const rootEntity = rootEntities[0];
     const contextGraphUri = metaResult.bindings[0]['ctxGraph'];
     const contextGraphId = contextGraphUri.replace('did:dkg:context-graph:', '');
     const sgNameRaw = metaResult.bindings[0]['sgName'];
@@ -713,15 +726,19 @@ export class DKGQueryEngine implements QueryEngine {
       ? contextGraphSubGraphUri(contextGraphId, subGraphName)
       : contextGraphDataUri(contextGraphId);
 
-    // Fetch all triples for this entity from the correct data graph
+    const rootFilter = rootEntities
+      .map(
+        (root) =>
+          `(?s = <${assertSafeIri(root)}> || STRSTARTS(STR(?s), "${escapeSparqlLiteral(root)}/.well-known/genid/"))`,
+      )
+      .join(' || ');
+
+    // Fetch all triples for every KA member root from the correct data graph.
     const dataResult = await this.store.query(
       `SELECT ?s ?p ?o WHERE {
         GRAPH <${assertSafeIri(dataGraph)}> {
           ?s ?p ?o .
-          FILTER(
-            ?s = <${assertSafeIri(rootEntity)}>
-            || STRSTARTS(STR(?s), "${escapeSparqlLiteral(rootEntity)}/.well-known/genid/")
-          )
+          FILTER(${rootFilter})
         }
       }`,
     );
@@ -736,7 +753,7 @@ export class DKGQueryEngine implements QueryEngine {
           }))
         : [];
 
-    return { rootEntity, contextGraphId, quads };
+    return { rootEntity, rootEntities, contextGraphId, quads };
   }
 
   /**

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -76,5 +76,5 @@ export interface QueryOptions {
 
 export interface QueryEngine {
   query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
-  resolveKA(ual: string): Promise<{ rootEntity: string; contextGraphId: string; quads: Quad[] }>;
+  resolveKA(ual: string): Promise<{ rootEntity: string; rootEntities: string[]; contextGraphId: string; quads: Quad[] }>;
 }

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -95,8 +95,34 @@ describe('DKGQueryEngine', () => {
 
     const result = await engine.resolveKA(ual);
     expect(result.rootEntity).toBe(ENTITY);
+    expect(result.rootEntities).toEqual([ENTITY]);
     expect(result.contextGraphId).toBe(CONTEXT_GRAPH);
     expect(result.quads.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolveKA aggregates every member root of a multi-entity KA (Design B, PR #968)', async () => {
+    const ual = 'did:dkg:mock:31337/42';
+    const ENTITY_2 = 'did:dkg:agent:QmTextBot';
+    await store.insert([
+      // ENTITY data is seeded in beforeEach; add ENTITY_2 to the same data graph.
+      q(ENTITY_2, 'http://schema.org/name', '"TextBot"'),
+      q(`${ENTITY_2}/.well-known/genid/o1`, 'http://ex.org/type', '"TextAnalysis"'),
+      // Two member rows under one UAL (Design B: one KA, many entities).
+      q(`${ual}/1`, 'http://dkg.io/ontology/rootEntity', ENTITY, META),
+      q(`${ual}/1`, 'http://dkg.io/ontology/partOf', ual, META),
+      q(`${ual}/2`, 'http://dkg.io/ontology/rootEntity', ENTITY_2, META),
+      q(`${ual}/2`, 'http://dkg.io/ontology/partOf', ual, META),
+      q(ual, 'http://dkg.io/ontology/contextGraph', `did:dkg:context-graph:${CONTEXT_GRAPH}`, META),
+    ]);
+
+    const result = await engine.resolveKA(ual);
+    // Pre-#968 this returned only bindings[0]; now every member root is read.
+    expect(result.rootEntities).toEqual([ENTITY, ENTITY_2]);
+    expect(result.rootEntity).toBe(ENTITY); // backward-compat: first member root
+    const subjects = new Set(result.quads.map((quad) => quad.subject));
+    expect(subjects).toContain(ENTITY);
+    expect(subjects).toContain(ENTITY_2);
+    expect(subjects).toContain(`${ENTITY_2}/.well-known/genid/o1`);
   });
 
   it('throws on unknown UAL', async () => {


### PR DESCRIPTION
Re-authors the **two genuine read/metadata gaps** from PR #968 onto `integration/v10-devnet`, dropping the 8 commits that would **regress #980** (the N-root→1-KA publish-boundary guards, the `startKAId+tokenIdx` RANGE-tokenId / `metadataTokenId` compatibility-row scheme, and the uint64 gossip wire encoding — all deliberately superseded by #980's Design-B + string-id work).

## Gap 1 — multi-entity `resolveKA` (query)
`resolveKA` read only `bindings[0].rootEntity` and filtered the data query to one root, so a Design-B KA holding **multiple entities** returned only the first entity's triples. Now it collects every `?ka <rootEntity>` binding (dedup, `ORDER BY ?ka`), filters the data graph across **all** member roots, and returns `rootEntities[]` (`rootEntity` retained = first member, backward-compat). `QueryEngine` interface updated.

## Gap 2 — aggregate `<ual>` KnowledgeAsset node (metadata)
`generateKCMetadata` typed the bare `<ual>` only as `dkg:KnowledgeCollection`; the per-row `<ual>/N` subjects were the only `dkg:KnowledgeAsset` nodes. Now it also emits an aggregate node on the bare UAL: `dkg:KnowledgeAsset` + summed `publicTripleCount` + every member `tokenId` + every member entity (dual-written `dkg:rootEntity`/`dkg:entity` per §10.1). Uses `ka.tokenId` (**not** the dropped `metadataTokenId`).

**Deliberate deviation from the original commit:** omits the `<ual> partOf <ual>` self-edge — it would make the bare node match `?x partOf <ual>` member enumeration (including `resolveKA`) and double-count members. The aggregate node is purely self-describing. (The two existing Design-B metadata tests are updated accordingly.)

## Dropped (would regress #980)
8 of #968's 10 commits: publish-boundary guards (`6aaea46`/`022378a`/`d34b145`), tokenId/kaCount range scheme (`627c84d`/`d952b9b`/`4590de2`/`bf751537`), and the uint64 wire encoding (`fa58c58`) — #980 keeps the `kaCount = ?1:0` Design-B shape, the local `BigInt(tokenIdx+1)` ordinal, the storage-ack ⊆ subset check, and string-encoded 256-bit gossip ids.

## Verification
- **query: 260/260.** **publisher: 1143 passed / 0 failed** (incl. both existing Design-B metadata tests updated for the aggregate node).
- agent + cli show **only** failures confirmed **pre-existing on the clean #980 tip** (agent: `e2e-security`, `finalization-handler`; cli: `auto-update-versioned-e2e` — an environmental `git tag` failure) — all unrelated to this change.

## Landing
Targets `integration/v10-devnet` (rc.16 train to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)