### PR TITLE
feat(#971 salvage): validate + normalize vm/publish options on /api/knowledge-assets

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -134,6 +134,118 @@ function resolveFinalizeOptions(
   };
 }
 
+// uint32 epoch ceiling (matches sibling routes memory.ts / publisher.ts). Not an
+// id encoder — the on-chain endEpoch is a uint40 but the publish API caps at uint32.
+const MAX_PUBLISH_EPOCHS = 0xffffffff;
+
+// Reject finalized-publish request shapes that don't make sense once the URL
+// name + seal already select the assertion and encode the author (PR #971).
+// The seal commits to the whole assertion content + author, so assertionName /
+// author overrides / partial selection on vm/publish are user errors, not
+// silently-ignored fields.
+function validateFinalizedAssertionPublishRequest(
+  parsed: Record<string, unknown>,
+  res: RequestContext["res"],
+): boolean {
+  const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
+    ? parsed.options as Record<string, unknown>
+    : undefined;
+  const assertionName = parsed.assertionName ?? nested?.assertionName;
+  if (assertionName !== undefined) {
+    jsonResponse(res, 400, {
+      error:
+        '"assertionName" is not accepted on /api/knowledge-assets/:name/vm/publish — the URL name selects the assertion.',
+    });
+    return false;
+  }
+  const hasAuthorOverride =
+    parsed.authorAgentAddress != null ||
+    parsed.preSignedAuthorAttestation != null ||
+    nested?.authorAgentAddress != null ||
+    nested?.preSignedAuthorAttestation != null;
+  if (hasAuthorOverride) {
+    jsonResponse(res, 400, {
+      error:
+        '"authorAgentAddress" and "preSignedAuthorAttestation" cannot be supplied on vm/publish — the seal already encodes the author. Re-finalize the assertion if you need to change authorship.',
+    });
+    return false;
+  }
+  const selection = parsed.selection ?? nested?.selection;
+  if (selection !== undefined && selection !== "all") {
+    jsonResponse(res, 400, {
+      error:
+        '"selection" must be omitted or "all" on vm/publish — the seal commits to the entire assertion content.',
+    });
+    return false;
+  }
+  return true;
+}
+
+// Validate + normalize the finalized-publish options BEFORE they reach
+// `publishFromFinalizedAssertion` (PR #971). Without this, malformed epochs /
+// identity overrides / flags flowed straight through and surfaced as opaque
+// 500s deep in the publisher. Returns the normalized options, or null after
+// having already written a 400 response (caller must return).
+function resolveFinalizedPublishOptions(
+  ctx: RequestContext,
+  raw: unknown,
+): Record<string, unknown> | null {
+  const { res } = ctx;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const source = raw as Record<string, unknown>;
+  const { clearAfter, clearSharedMemoryAfter, publisherNodeIdentityIdOverride } = source;
+  const rawPublishEpochs = source.publishEpochs ?? source.epochs;
+  const publishEpochsField = source.publishEpochs !== undefined ? "publishEpochs" : "epochs";
+
+  let resolvedPublisherIdentityOverride: bigint | undefined;
+  if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
+    const v = String(publisherNodeIdentityIdOverride);
+    if (!/^\d+$/.test(v)) {
+      jsonResponse(res, 400, {
+        error: '"publisherNodeIdentityIdOverride" must be a non-negative integer (string or number)',
+      });
+      return null;
+    }
+    resolvedPublisherIdentityOverride = BigInt(v);
+  }
+
+  let resolvedPublishEpochs: number | undefined;
+  if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
+    const v = String(rawPublishEpochs).trim();
+    if (!/^[1-9]\d*$/.test(v)) {
+      jsonResponse(res, 400, { error: `"${publishEpochsField}" must be a positive integer (string or number)` });
+      return null;
+    }
+    const n = Number(v);
+    if (!Number.isSafeInteger(n)) {
+      jsonResponse(res, 400, { error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer` });
+      return null;
+    }
+    if (n > MAX_PUBLISH_EPOCHS) {
+      jsonResponse(res, 400, { error: `"${publishEpochsField}" must be less than or equal to ${MAX_PUBLISH_EPOCHS}` });
+      return null;
+    }
+    resolvedPublishEpochs = n;
+  }
+
+  if (clearAfter !== undefined && typeof clearAfter !== "boolean") {
+    jsonResponse(res, 400, { error: '"clearAfter" must be a boolean when supplied' });
+    return null;
+  }
+  if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== "boolean") {
+    jsonResponse(res, 400, { error: '"clearSharedMemoryAfter" must be a boolean when supplied' });
+    return null;
+  }
+  const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
+  return {
+    ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
+    ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
+    ...(resolvedPublisherIdentityOverride !== undefined
+      ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+      : {}),
+  };
+}
+
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
   const { req, res, agent, path, url } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
@@ -314,7 +426,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── VM verb: publish (SWM/WM → VM; mint or update on chain) ──
     if (layer === "vm" && verb === "publish") {
-      const opts = parsed.options && typeof parsed.options === "object" ? parsed.options : {};
+      // Validate the request shape + normalize options BEFORE the publish (PR
+      // #971): this is a standalone request, so a 400 here mutates nothing.
+      if (!validateFinalizedAssertionPublishRequest(parsed, res)) return;
+      const opts = resolveFinalizedPublishOptions(ctx, parsed.options);
+      if (opts === null) return;
       const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
       return jsonResponse(res, 200, {
         kaId: pub?.kaId,

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -239,6 +239,49 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
   });
 
+  // PR #971: validate + normalize vm/publish options before the publish.
+  it('POST .../:name/vm/publish rejects a non-integer epochs option (400, no publish)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg', options: { epochs: 'soon' } }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('POST .../:name/vm/publish rejects epochs above the uint32 ceiling (400)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg', options: { epochs: 4294967296 } }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('POST .../:name/vm/publish rejects assertionName (the URL name selects the assertion) (400)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg', assertionName: 'other' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('POST .../:name/vm/publish rejects an author override (the seal encodes the author) (400)', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg', authorAgentAddress: '0xdead' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
+  it('POST .../:name/vm/publish normalizes a valid epochs option and publishes', async () => {
+    const agent = makeAssertionAgent();
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg', options: { epochs: 5 } }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+    const passedOpts = (agent.publishFromFinalizedAssertion as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(passedOpts).toMatchObject({ publishEpochs: 5 });
+  });
+
   it('GET /api/knowledge-assets/:name returns lifecycle state', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg', undefined, agent);


### PR DESCRIPTION
PR #971's `/api/knowledge-assets` surface is **largely already on `integration/v10-devnet`** (the route, B3 addressing via `classifyKaIdentifier`/`resolveByKaId`, the implemented `pull-from`, `MAX_PUBLISH_EPOCHS` in sibling routes, `validateAssertionName`, `hasPendingSharedMemoryWrites`). This lands the **confirmed remaining gap**: the `vm/publish` verb passed `parsed.options` straight into `publishFromFinalizedAssertion` with **no validation** — malformed epochs/overrides surfaced as opaque 500s deep in the publisher, and nonsensical fields were silently ignored.

## What
- **`validateFinalizedAssertionPublishRequest`** → 400 on `assertionName` / author overrides / non-`"all"` selection (the URL name + seal already select the assertion and encode the author).
- **`resolveFinalizedPublishOptions`** → validates + normalizes `publishEpochs|epochs` (positive, safe-integer, ≤ uint32 `MAX_PUBLISH_EPOCHS`), `publisherNodeIdentityIdOverride` (non-negative int), `clearAfter`/`clearSharedMemoryAfter` (boolean); returns normalized options or `null` after a 400.
- Wired into the explicit **`vm/publish` verb only** — a standalone request where a 400 mutates nothing. **Deliberately not** wired into the `alsoPublishVm` atomic tail: it runs *after* create+finalize succeed, so a 400 there would abort partial success; its bad options correctly surface as a **207** phase error.

## Re-authored, not cherry-picked
The PR's commits conflict on #980 (they revert `skolemizeByEntity→autoPartition` and drop `kaAllocator`/`createV10UpdateACKProvider`). **Dropped** the superseded owner-model (`dcd6a69` — #980 uses `classifyKaIdentifier`/`resolveByKaId`) and the 501 `pull-from` (`7bcdd4a` — #980 implements it).

## Verification
- `knowledge-assets-route` **26/26** (5 new `vm/publish` validation cases).
- cli full suite **1924 passed**; only `auto-update-versioned-e2e` fails — confirmed **pre-existing on the clean #980 tip** (environmental `git tag` failure), unrelated.

## Follow-up (separate, assessed next)
#971's **seal-field response enrichment** (`88f628c`) and **operation-tracker wiring** (F22) are additional *observability* deltas (not correctness) — tracked separately to keep this PR focused/verifiable.

Targets `integration/v10-devnet` (rc.16 → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)