### PR TITLE
feat(#972): vm/publish HTTP status reflects publish outcome (200/207/502)

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -134,6 +134,23 @@ function resolveFinalizeOptions(
   };
 }
 
+// PR #972 — classify a finalized-publish result into an HTTP status. On this
+// SYNCHRONOUS route a non-confirmed publish is a failure, not a normal in-flight
+// state ("no silent tentative downgrade"):
+//   confirmed, no contextGraphError → 200 (fully done)
+//   confirmed + contextGraphError   → 207 (partial: KA minted on-chain, context-graph binding failed)
+//   tentative | failed              → 502 (publish did not confirm)
+function classifyVmPublish(pub: unknown): { httpStatus: 200 | 207 | 502; reason?: string } {
+  const p = (pub ?? {}) as { status?: unknown; contextGraphError?: unknown };
+  const cgError = typeof p.contextGraphError === "string" && p.contextGraphError.length > 0 ? p.contextGraphError : undefined;
+  if (p.status === "confirmed" && !cgError) return { httpStatus: 200 };
+  if (p.status === "confirmed") return { httpStatus: 207, reason: cgError };
+  return {
+    httpStatus: 502,
+    reason: cgError ?? `VM publish did not confirm (status: ${typeof p.status === "string" ? p.status : "unknown"})`,
+  };
+}
+
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
   const { req, res, agent, path, url } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
@@ -194,7 +211,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
-          result.status = "vm-confirmed";
+          // PR #972: only a fully-confirmed publish is "vm-confirmed"; a partial
+          // (207) or non-confirmed (502) outcome is flagged as a tail error so
+          // the atomic response is a 207 rather than a misleading success.
+          const { httpStatus, reason } = classifyVmPublish(pub);
+          if (httpStatus === 200) {
+            result.status = "vm-confirmed";
+          } else {
+            result.status = httpStatus === 207 ? "vm-partial" : "vm-failed";
+            errors.push({ phase: "vm-publish", error: reason ?? "VM publish did not confirm" });
+          }
         } catch (e: any) {
           errors.push({ phase: "vm-publish", error: e?.message ?? String(e) });
         }
@@ -316,11 +342,14 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (layer === "vm" && verb === "publish") {
       const opts = parsed.options && typeof parsed.options === "object" ? parsed.options : {};
       const pub: any = await agent.publishFromFinalizedAssertion(contextGraphId, name, { subGraphName, ...opts });
-      return jsonResponse(res, 200, {
+      const { httpStatus, reason } = classifyVmPublish(pub);
+      return jsonResponse(res, httpStatus, {
         kaId: pub?.kaId,
         status: pub?.status,
         ual: pub?.ual,
         txHash: pub?.onChainResult?.txHash,
+        ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
+        ...(reason ? { error: reason } : {}),
       });
     }
   } catch (e: any) {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -239,6 +239,42 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
   });
 
+  // PR #972: vm/publish HTTP status reflects the actual publish outcome.
+  it('POST .../:name/vm/publish returns 207 when the KA minted but the context-graph binding failed', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        contextGraphError: 'CG value bind failed',
+      })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(207);
+    expect(body(ctx)).toMatchObject({ status: 'confirmed', contextGraphError: 'CG value bind failed' });
+  });
+
+  it('POST .../:name/vm/publish returns 502 when the publish is tentative (did not confirm)', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({ kaId: 7n, status: 'tentative', ual: 'did:dkg:hardhat:31337/0xabc/7' })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(502);
+    expect(body(ctx).error).toContain('did not confirm');
+  });
+
+  it('POST .../:name/vm/publish returns 502 when the publish failed', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({ status: 'failed' })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(502);
+  });
+
   it('GET /api/knowledge-assets/:name returns lifecycle state', async () => {
     const agent = makeAssertionAgent();
     const ctx = ctxFor('GET', '/api/knowledge-assets/f?contextGraphId=cg', undefined, agent);


### PR DESCRIPTION
PR #972's `cbb13fb` ("gate KA publish side effects") flagged that #980's `vm/publish` returns **200 for any** publish result. On this **synchronous** route a non-confirmed publish is not a normal in-flight state ("no silent tentative downgrade"). The publish result is a 3-state machine (`status: 'tentative' | 'confirmed' | 'failed'`) plus an orthogonal `contextGraphError`.

## Mapping (owner decision)
| Result | HTTP | Meaning |
|---|---|---|
| `confirmed`, no `contextGraphError` | **200** | fully done |
| `confirmed` + `contextGraphError` | **207** | partial: KA minted on-chain ✓, context-graph binding ✗ |
| `tentative` \| `failed` | **502** | publish did not confirm |

- **vm/publish verb**: returns the mapped status; body carries `kaId`/`ual`/`txHash` + `contextGraphError` + a `reason` on 207/502.
- **atomic `alsoPublishVm` tail**: only a fully-confirmed publish is `vm-confirmed`; partial/non-confirmed is pushed to the tail errors → the existing **207**, not a misleading success.

(#980 has no `emitPublished` in this route, so cbb13fb's event-gating is moot here — only the HTTP-status contract changes.)

## Verification
- `knowledge-assets-route` **24/24** (3 new 207/502 cases + existing).
- cli full suite **1922 passed**; only `auto-update-versioned-e2e` fails — confirmed **pre-existing on clean #980** (environmental `git tag`), unrelated.

## Notes
- **Overlaps [#990](https://github.com/OriginTrail/dkg/pull/990)** (#971 vm/publish input validation) on the same handler — merge #990 first, then this rebases trivially (validation is at the top of the block, this changes the return).
- The **#972 pull-from publisher-internals chain** (`335e8d8` subject-mismatch + validate-before-drop, reopen 409s, VM `subGraph` routing) is the remaining #972 work — tracked separately as the next focused PR.

Targets `integration/v10-devnet` (rc.16 → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)