### PR TITLE
fix(#972): pull-from reads the seal from the correct subject + validates source before dropping the draft

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -4183,43 +4183,53 @@ export class DKGPublisher implements Publisher {
     sourceLayer: 'swm' | 'vm',
     opts?: { subGraphName?: string; onConflict?: 'reject' | 'replace' },
   ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
-    DKGPublisher.validateOptionalSubGraph(opts?.subGraphName);
     const subGraphName = opts?.subGraphName;
+    // PR #972/a6740ac: ensure the (sub)graph is registered so a sub-scoped VM
+    // pull can resolve its data graph below (was a pure name-format validation).
+    await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     const wmGraph = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    const lifecycleSubject = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
     const sourceGraph = sourceLayer === 'swm'
       ? this.graphManager.sharedMemoryUri(contextGraphId, subGraphName)
-      : this.graphManager.dataGraphUri(contextGraphId);
+      // PR #972/a6740ac: a sub-scoped VM pull reads the SUBGRAPH's data graph,
+      // not the root data graph (mirrors the SWM branch's subGraphName handling).
+      : subGraphName
+        ? this.graphManager.subGraphUri(contextGraphId, subGraphName)
+        : this.graphManager.dataGraphUri(contextGraphId);
 
     // onConflict: refuse to clobber a dirty WM draft unless told to replace it.
+    // NB: the actual DROP happens only AFTER the source is validated non-empty
+    // (below) — PR #972/335e8d8: dropping first could destroy an open draft when
+    // the pull turns out to have no source quads.
     const draftProbe = await this.store.query(`ASK { GRAPH <${wmGraph}> { ?s ?p ?o } }`);
     const hasDraft = draftProbe.type === 'boolean' && draftProbe.value === true;
-    if (hasDraft) {
-      const onConflict = opts?.onConflict ?? 'reject';
-      if (onConflict === 'reject') {
-        throw Object.assign(
-          new Error(`A WM draft already exists for "${name}" in context graph "${contextGraphId}"; pass onConflict:"replace" to overwrite it.`),
-          { code: 'WM_DRAFT_CONFLICT' },
-        );
-      }
-      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout
+    if (hasDraft && (opts?.onConflict ?? 'reject') === 'reject') {
+      throw Object.assign(
+        new Error(`A WM draft already exists for "${name}" in context graph "${contextGraphId}"; pass onConflict:"replace" to overwrite it.`),
+        { code: 'WM_DRAFT_CONFLICT' },
+      );
     }
 
-    // Resolve the file's member entities from the seal (dual-read the predicate
-    // rename: dkg:assertionRootEntity OR dkg:assertionEntity, OT-RFC-43 §10.1).
-    const entityRes = await this.store.query(
-      `SELECT DISTINCT ?e WHERE { GRAPH <${metaGraph}> {
-         <${lifecycleSubject}> (<http://dkg.io/ontology/assertionRootEntity>|<http://dkg.io/ontology/assertionEntity>) ?e .
-       } }`,
+    // Resolve the file's member entities from the SEAL. PR #972/335e8d8: the
+    // seal is stamped at finalize under the assertion-graph URI
+    // (`contextGraphAssertionUri`, i.e. wmGraph) in the meta graph — NOT under
+    // the lifecycle URN. The prior code read `assertionLifecycleUri`, a
+    // different subject, so the lookup found nothing and pull-from failed for
+    // EVERY finalized assertion.
+    const sealRes = await this.store.query(
+      `CONSTRUCT { <${wmGraph}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${wmGraph}> ?p ?o } }`,
     );
-    const entities = entityRes.type === 'bindings'
-      ? [...new Set(entityRes.bindings.map((b) => b['e']).filter(Boolean) as string[])]
-      : [];
-    if (entities.length === 0) {
+    const seal = parseAssertionSealQuads(sealRes.type === 'quads' ? sealRes.quads : [], wmGraph);
+    if (!seal) {
       throw new Error(
         `No sealed entity list for "${name}" in context graph "${contextGraphId}" — pull-from `
         + `requires a finalized assertion (its seal records the member entities).`,
+      );
+    }
+    const entities = seal.rootEntities;
+    if (entities.length === 0) {
+      throw new Error(
+        `Sealed assertion "${name}" in context graph "${contextGraphId}" records no member entities; nothing to pull.`,
       );
     }
 
@@ -4238,11 +4248,27 @@ export class DKGPublisher implements Publisher {
       ? gather.quads.filter((q) => !isTrustLevelQuad(q) && q.predicate !== WORKSPACE_OWNER_PREDICATE)
       : [];
 
-    // Open a fresh WM draft (clears stale lifecycle/seal) and seed it.
-    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
-    if (gathered.length > 0) {
-      await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
+    // Validate the source has content BEFORE touching the draft (PR #972/335e8d8:
+    // a drop-before-validate could destroy an open WM draft when the source
+    // turned out empty — e.g. pulling from a layer the file was never shared to).
+    if (gathered.length === 0) {
+      throw Object.assign(
+        new Error(
+          `No ${sourceLayer.toUpperCase()} quads found for "${name}" in context graph "${contextGraphId}" `
+          + `using the assertion seal's ${entities.length} root entit${entities.length === 1 ? 'y' : 'ies'}; `
+          + `WM draft was not modified.`,
+        ),
+        { code: 'PULL_FROM_EMPTY_SOURCE' },
+      );
     }
+
+    // Source validated — now (re)open a fresh WM draft (clears stale
+    // lifecycle/seal) and seed it.
+    if (hasDraft) {
+      await this.store.dropGraph(wmGraph); // 'replace' — git force-checkout, after source validation
+    }
+    await this.assertionCreate(contextGraphId, name, agentAddress, subGraphName);
+    await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
     return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
   }
 

--- a/packages/publisher/test/assertion-pull-from.test.ts
+++ b/packages/publisher/test/assertion-pull-from.test.ts
@@ -3,7 +3,7 @@ import { NoChainAdapter } from '@origintrail-official/dkg-chain';
 import {
   TypedEventBus,
   generateEd25519Keypair,
-  assertionLifecycleUri,
+  buildAssertionSealQuads,
   contextGraphMetaUri,
   contextGraphAssertionUri,
 } from '@origintrail-official/dkg-core';
@@ -41,11 +41,27 @@ function q(subject: string, predicate: string, object: string, graph: string): Q
   return { subject, predicate, object, graph };
 }
 
-/** Seal: record the file's member entities on the lifecycle URN in _meta. */
+/**
+ * Seal: build a REAL assertion seal under the assertion-graph URI
+ * (`contextGraphAssertionUri`) in `_meta`, exactly as `finalize` does — this is
+ * where `assertionPullFrom` reads it via `parseAssertionSealQuads`
+ * (PR #972/335e8d8). The previous helper wrote a bare `assertionRootEntity` on
+ * the lifecycle URN, which only matched the old (buggy) read.
+ */
 function sealEntities(entities: string[]): Quad[] {
-  const lifecycle = assertionLifecycleUri(CG, AGENT, NAME);
-  const meta = contextGraphMetaUri(CG);
-  return entities.map((e) => q(lifecycle, `${DKG}assertionRootEntity`, `<${e}>`, meta));
+  return buildAssertionSealQuads({
+    assertionUri: contextGraphAssertionUri(CG, AGENT, NAME),
+    metaGraph: contextGraphMetaUri(CG),
+    merkleRoot: new Uint8Array(32).fill(7),
+    authorAddress: AGENT,
+    authorAttestationR: new Uint8Array(32).fill(1),
+    authorAttestationVS: new Uint8Array(32).fill(2),
+    authorSchemeVersion: 1,
+    chainId: 31337n,
+    kav10Address: AGENT,
+    finalizedAtIso: '2026-01-01T00:00:00.000Z',
+    rootEntities: entities,
+  }) as Quad[];
 }
 
 async function wmQuads(store: OxigraphStore): Promise<Quad[]> {
@@ -108,6 +124,23 @@ describe('assertionPullFrom (OT-RFC-43 §10.5.3 wm/pull-from)', () => {
     const subjects = new Set(draft.map((d) => d.subject));
     expect(subjects.has(ENTITY_2)).toBe(true);   // the SWM content
     expect(subjects.has(ENTITY_1)).toBe(false);  // the stale local edit is gone
+  });
+
+  it('validates the source BEFORE dropping — an empty-source replace pull preserves the dirty draft (PR #972/335e8d8)', async () => {
+    const { publisher, store } = await makePublisher();
+    // Finalized file whose sealed entity has NO quads in SWM (e.g. never shared
+    // there), plus a dirty WM draft holding a precious local edit.
+    await store.insert([...sealEntities([ENTITY_1])]); // note: no ENTITY_1 quads in SWM_GRAPH
+    await publisher.assertionWrite(CG, NAME, AGENT, [{ subject: ENTITY_1, predicate: SCHEMA, object: '"precious local edit"' }]);
+
+    const err = await publisher.assertionPullFrom(CG, NAME, AGENT, 'swm', { onConflict: 'replace' }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('PULL_FROM_EMPTY_SOURCE');
+
+    // The draft must be UNTOUCHED — the empty pull validated the source before
+    // any drop, so the precious local edit survives.
+    const draft = await wmQuads(store);
+    expect(draft.some((d) => d.subject === ENTITY_1 && d.object === '"precious local edit"')).toBe(true);
   });
 
   it('throws when the file has no sealed entity list (never finalized)', async () => {


### PR DESCRIPTION
## Latent bug
`assertionPullFrom` read the file's member entities from `assertionLifecycleUri` (`urn:dkg:assertion:…`), but `finalize` stamps the seal under `contextGraphAssertionUri` (the assertion-graph URI / `wmGraph`) — confirmed at [dkg-agent-publish.ts:1470](packages/agent/src/dkg-agent-publish.ts#L1470). A **different subject**, so the lookup found nothing and pull-from threw *"No sealed entity list"* for **every properly-finalized assertion**. The existing tests masked it by seeding entities under the lifecycle URN — matching the broken read, not real `finalize`.

## Fixes (re-authored from #972's `335e8d8` + `a6740ac`)
- **Subject mismatch (`335e8d8`):** read the seal from the assertion-graph URI via `parseAssertionSealQuads` (the same subject `finalize` writes); require a real finalized seal.
- **Validate-before-drop (`335e8d8`):** validate the source has content (`PULL_FROM_EMPTY_SOURCE`) **before** dropping the WM draft — a drop-before-validate could destroy an open draft when the source turned out empty (e.g. pulling from a layer the file was never shared to).
- **VM sub-scope (`a6740ac`):** a sub-scoped VM pull reads the **subgraph's** data graph (`subGraphUri`), not the root data graph; `ensureSubGraphRegistered` instead of a pure name-format check.

## Tests
- Rewrote `sealEntities` to build a **real** seal under the assertion-graph URI via `buildAssertionSealQuads` (as `finalize` does) — the prior helper validated the broken read.
- Added a **validate-before-drop** test: an empty-source `replace` pull throws `PULL_FROM_EMPTY_SOURCE` and **preserves the dirty draft**.

## Verification
- `assertion-pull-from` **5/5**; publisher full suite **1144 passed / 0 failed**.
- agent + cli show only failures confirmed **pre-existing/flaky on clean #980** (`e2e-security`, `finalization-handler`; `publish-jsonld` passes **32/32 isolated** — a chain-backed full-suite flake; cli `auto-update-versioned-e2e` env `git tag`).

## Notes
- Independent of [#991](https://github.com/OriginTrail/dkg/pull/991) (vm/publish status) — different files (publisher internals vs the route).
- Deferred: #972's reopen-event refinements (`246012a`/`16006dc` — `PullFromPreconditionError` 409 + suppress the spurious create event on reopen) — smaller observability deltas.

Targets `integration/v10-devnet` (rc.16 → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)