### PR TITLE
chore(evm): record rc.16 Base Sepolia redeploy (3 contracts)

### DIFF
--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -190,12 +190,12 @@
             "deployed": false
         },
         "RandomSampling": {
-            "evmAddress": "0x950D8E6fa4d0351f73219a300026C35497cd1BF0",
-            "version": "10.0.2",
+            "evmAddress": "0xC069C93D3A779fE7671A3650029fe4D425629AD7",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265761,
-            "deploymentTimestamp": 1780299811977,
+            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
+            "deploymentBlock": 42413915,
+            "deploymentTimestamp": 1780596121051,
             "deployed": true
         },
         "KnowledgeAssetsStorage": {
@@ -325,21 +325,21 @@
             "deployed": true
         },
         "DKGKnowledgeAssets": {
-            "evmAddress": "0x85a04440645d4a7CF1844cdb9A34C598e2F75b85",
-            "version": "2.0.0",
+            "evmAddress": "0xB049694500233300369F69E5c8C3AC9418880008",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265736,
-            "deploymentTimestamp": 1780299763226,
+            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
+            "deploymentBlock": 42413912,
+            "deploymentTimestamp": 1780596115673,
             "deployed": true
         },
         "KnowledgeAssetsLifecycle": {
-            "evmAddress": "0x7558E9B30BeFA87F68C808c1f705b30507d19146",
-            "version": "2.0.1",
+            "evmAddress": "0x63Aa3D0D305e66fB9797802A0E0a00CDD0e5224b",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265772,
-            "deploymentTimestamp": 1780299836348,
+            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
+            "deploymentBlock": 42413918,
+            "deploymentTimestamp": 1780596126512,
             "deployed": true
         },
         "V8MigrationEligibility": {


### PR DESCRIPTION
## What

Records the canonical addresses from the targeted rc.16 testnet redeploy on **Base Sepolia (84532)**. Only the three contracts that changed in rc.16 were redeployed; Hub and everything else were reused.

| Contract | Old | New | Version |
|---|---|---|---|
| `DKGKnowledgeAssets` (asset-storage) | `0x85a0…b85` | `0xB049694500233300369F69E5c8C3AC9418880008` | 10.0.3 |
| `KnowledgeAssetsLifecycle` | `0x7558…146` | `0x63Aa3D0D305e66fB9797802A0E0a00CDD0e5224b` | 10.0.3 |
| `RandomSampling` | `0x950D…BF0` | `0xC069C93D3A779fE7671A3650029fe4D425629AD7` | 10.0.3 |

Hub: `0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6` (unchanged).

## Verified on-chain

- `Hub.getAssetStorageAddress("DKGKnowledgeAssets")` → new address ✓
- `Hub.getContractAddress("KnowledgeAssetsLifecycle" / "RandomSampling")` → new addresses ✓
- live `version()` on all three → `10.0.3` ✓
- registration + dependent reinitialization done in a single `setAndReinitializeContracts` tx ✓

## Operational impact

None for node operators: node config carries only `hubAddress`, all contracts resolve via Hub, and the resolution cache self-heals on the `Hub.ContractChanged` / `NewContract` / `AssetStorageChanged` events (TTL backstop). No config edit or restart required.

Existing pre-rc.16 KAs at the old `DKGKnowledgeAssets` are intentionally not carried over (incompatible generation — counter-based ids, old `createKnowledgeAsset` ABI). From this deploy on, `DKGKnowledgeAssets` is the permanent storage contract (R3 versioned-coexistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)