### PR TITLE
fix(storage): blank-node-safe SPARQL delete + backend conformance matrix + rc.17

### DIFF
--- a/docs/UPGRADE_RC11_TO_RC13.md
+++ b/docs/UPGRADE_RC11_TO_RC13.md
@@ -1,0 +1,291 @@
+# Upgrading from `v10.0.0-rc.11` to `v10.0.0-rc.13`
+
+**Audience:** builders and operators who were running `v10.0.0-rc.11` and skipped rc.12. This is the consolidated guide for jumping straight to **rc.13**.
+
+**The one thing you must internalise:** rc.13 is an off-chain stabilization release with **no contract changes since rc.12** — but the jump from **rc.11 → rc.12 was a hard, forward-only breaking change**: the move to the **simplified single Knowledge Asset model** (replacing the old multi-asset "Knowledge Collection" batch), plus a testnet redeploy. If you are on rc.11, you inherit **all** of that in one hop. There are no shims and no fallback resolvers. Your node will not boot against rc.13 contracts, and your integration code will not compile or publish, until you do the work below.
+
+This is not a cosmetic terminology change. It came directly out of feedback from the red-team builders integrating against the DKG, and it buys two concrete things: a **better build-time UX** (one asset per publish, one stable identifier that survives updates — no more "collection vs asset" mental overhead) and a **performance win** (lower on-chain cost and less operational complexity per publish). The work on your side happens to be largely mechanical, but the change itself is a model improvement, not a search-and-replace for its own sake.
+
+> If you have already migrated to rc.12, the rc.12 → rc.13 delta is small and additive — skip to [§7 rc.13 deltas](#7-whats-new-in-rc13-on-top-of-rc12). Everything in §2–§6 is the rc.11→rc.12 work you still owe.
+
+The good news: ~95% of the integration-side churn is a mechanical search-and-replace, and the whole thing is well-bounded. The fastest path is to hand this document to your coding agent and let it drive — see the next section.
+
+---
+
+## 0. Use this guide as an agent prompt
+
+Most of you build with an AI agent (Cursor, Claude Code, Codex CLI, or any `AGENTS.md`-honouring tool). Don't hand-migrate. Point the agent at this doc and your repo. There are **two** prompts below because there are two separable jobs: **(A) upgrade the node/runtime** and **(B) migrate your integration logic** (the old Knowledge Collection model → the new Knowledge Asset model). Run A first if you operate a node; run B for any code that talks to the DKG.
+
+### Prompt A — upgrade the node / runtime (operators)
+
+```
+You are upgrading a DKG node from @origintrail-official/dkg v10.0.0-rc.11 to
+v10.0.0-rc.13. Read docs/UPGRADE_RC11_TO_RC13.md from the dkg repo
+(https://github.com/OriginTrail/dkg/blob/main/docs/UPGRADE_RC11_TO_RC13.md)
+end to end before doing anything.
+
+Then:
+1. Confirm whether this is an Edge node or a Core node (check nodeRole in
+   ~/.dkg/config.json). Edge nodes update via npm; Core nodes via the git-build
+   path. Do NOT git pull on an npm-managed node.
+2. Stop the daemon.
+3. Bump @origintrail-official/dkg to 10.0.0-rc.13 (npm: `npm install -g
+   @origintrail-official/dkg@10.0.0-rc.13`).
+4. Because we are crossing the rc.12 chainResetMarker (v10-rc12-ka-rename),
+   first boot wipes per-node chain-derived state and re-derives it against the
+   redeployed Base Sepolia contracts. This is expected — do NOT treat the
+   re-sync as data loss. Staked positions (conviction NFTs) are preserved.
+5. Start the daemon, then run `dkg doctor` and confirm it is green and
+   /api/build-info reports 10.0.0-rc.13.
+6. Confirm rs.tick.data-corrupted is zero on the updated-KA cohort (Core nodes).
+
+Report the before/after version, the doctor output, and anything that looks off.
+```
+
+### Prompt B — migrate your integration logic (builders)
+
+```
+You are upgrading a DKG integration from @origintrail-official/dkg v10.0.0-rc.11
+to v10.0.0-rc.13. Read docs/UPGRADE_RC11_TO_RC13.md from the dkg repo
+(https://github.com/OriginTrail/dkg/blob/main/docs/UPGRADE_RC11_TO_RC13.md) end
+to end before changing any code. The headline change is conceptual, not just a
+rename: the old "Knowledge Collection" (an ERC-1155 batch of many assets per
+publish) is GONE. The new unit is a single "Knowledge Asset" — exactly one
+ERC-721 per publish, with a stable UAL and owner-sealed updates. Treat every
+place your code assumed "a collection of N assets" as now meaning "one asset".
+
+Do this in order:
+1. Bump every @origintrail-official/dkg* dependency in every package.json in this
+   workspace to ^10.0.0-rc.13.
+2. Apply the mechanical TypeScript renames in §3 (Knowledge Collection ->
+   Knowledge Asset). Use a workspace-wide case-sensitive search-and-replace
+   (the regex sweep is in §3.3), then run tsc to find the residual call sites.
+3. Migrate publish/update logic to the greenfield KA model in §4: one KA per
+   publish; kaId == the ERC-721 tokenId; UAL is
+   did:dkg:{chainId}/{DKGKnowledgeAssetsAddress}/{kaId} and is STABLE across
+   updates; every update needs a fresh precomputedUpdateAttestation signed by the
+   CURRENT ERC-721 owner. Remove any kcSize / batch-of-N assumptions.
+4. Enforce the economic floor in §5: every tokenAmount you send must be >= 1.
+   Zero-cost / "free publish on a dust CG" flows now revert.
+5. If you call the Solidity surface directly (ethers/viem/subgraph), re-fetch
+   ABIs from packages/chain/abi/ at rc.13 — every renamed function has a new
+   4-byte selector and old calldata reverts (§3.4).
+6. Update any SPARQL that reads publish receipts: publishedAtKcId ->
+   publishedAtKaId (§3.5).
+7. Review the rc.13 behavioural deltas in §7 — in particular, publishes that
+   don't specify a lifetime now default to 12 epochs.
+8. Run the integration's full test suite against a freshly-upgraded daemon or
+   local devnet. For each failure, find the matching row in the §3 rename tables
+   before debugging — most breakage is rename-induced.
+
+When done, summarise every change and flag any site where the right migration
+was ambiguous (especially anywhere the old code assumed multiple assets per
+publish).
+```
+
+---
+
+## 1. Why this is breaking even though rc.13 "changed no contracts"
+
+rc.13's own changelog says, correctly, *"No Solidity changes since rc.12 … no contract redeploy is required. Nodes upgrade in place; no local-state wipe."* That sentence is written **relative to rc.12**. Coming from **rc.11**, you cross the rc.12 cutover on the way through:
+
+- The Base Sepolia (chainId 84532) contract surface was fully redeployed at rc.12. The `chainResetMarker` is `v10-rc12-ka-rename-2026-06-01`. Your first boot on rc.13 crosses that marker and **wipes per-node chain-derived state** to re-derive it against the new contracts. (Stakes/identities are preserved — see §6.)
+- The on-chain and off-chain API was renamed (`KnowledgeCollection*` → `KnowledgeAsset*`) with **no compatibility layer**.
+- The KA lifecycle model changed shape (ERC-1155 batch → single ERC-721).
+- A `tokenAmount >= 1` economic floor was added; zero-cost publishes revert.
+
+So: treat this as "do the entire rc.12 migration, then pick up the rc.13 niceties." This guide folds both into one pass.
+
+---
+
+## 2. TL;DR breaking-change matrix (rc.11 → rc.13)
+
+| # | Area | Change | Affects | Source RC |
+|---|------|--------|---------|-----------|
+| 1 | Model + API | Simplified single **Knowledge Asset** model replaces the old multi-asset "Knowledge Collection"; type/method/property names and the API surface change to match, on-chain and off-chain | Everyone: TS, Solidity, ABIs, predicate URIs, daemon API | rc.12 |
+| 2 | KA model | Greenfield: exactly **one** ERC-721 KA per publish; stable UAL; owner-sealed updates via `precomputedUpdateAttestation` | Publishers, updaters | rc.12 |
+| 3 | Solidity ABI | New 4-byte selectors on every renamed function; old calldata reverts | Direct chain consumers (scripts, dApps, subgraphs) | rc.12 |
+| 4 | Hub resolution | Legacy `KnowledgeAssetsV10` fallback resolver removed; adapter raises if V10.1 surface isn't registered | Operators on older Hub deploys | rc.12 |
+| 5 | Economic | Strict-positive `tokenAmount >= 1` floor; zero-cost publishes revert | Any caller sending `tokenAmount: 0` | rc.12 |
+| 6 | Economic | Protocol treasury fee skim (default 300 bps = 3%, dormant until governance enables) | Stakers (net reward); publishers pay gross | rc.12 |
+| 7 | Profile | `Profile.recreateProfile` drops `initialOperatorFee` arg | Operator recovery scripts | rc.12 |
+| 8 | Chain | Base Sepolia full contract redeploy; first-boot state wipe | Operators; chain readers caching addresses | rc.12 |
+| 9 | Behaviour | Default publish lifetime is now **12 epochs** when none is specified | Publishers not setting an explicit lifetime | **rc.13** |
+| 10 | Sync | Core-preferred sync + chain-driven verified-memory reconciliation | Operators (re-sync behaviour) | **rc.13** |
+
+Rows 1–8 are the rc.12 work. Rows 9–10 are the rc.13 deltas. The rest of this doc is the concrete migration.
+
+---
+
+## 3. API surface migration (mechanical, ~95% of builder churn)
+
+The model change in §1 surfaces in your code as updated type, method, and property names. This part is genuinely mechanical: a workspace-wide case-sensitive search-and-replace, then let `tsc` find the rest. (The *why* behind the change is in §1 and §4 — this section is just the code-level sweep.)
+
+### 3.1 Identifier rename table
+
+| rc.11 | rc.13 | Where |
+|-------|-------|-------|
+| `ChainAdapter.createKnowledgeAssetsV10` | `ChainAdapter.createKnowledgeAssets` | `@origintrail-official/dkg-chain` |
+| `ChainAdapter.getKnowledgeAssetsV10Address` | `ChainAdapter.getKnowledgeAssetsLifecycleAddress` | `@origintrail-official/dkg-chain` |
+| `ChainAdapter.getKCContextGraphId` | `ChainAdapter.getKAContextGraphId` | `@origintrail-official/dkg-chain` |
+| `NodeChallenge.knowledgeCollectionId` | `NodeChallenge.knowledgeAssetId` | `@origintrail-official/dkg-random-sampling` |
+| `PublishResult.kcId` | `PublishResult.kaId` | `@origintrail-official/dkg-publisher` |
+| `ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_KC_ID` | `…PUBLISHED_AT_KA_ID` | `@origintrail-official/dkg-publisher` |
+| RDF predicate `<…/publishedAtKcId>` | `<…/publishedAtKaId>` | Any receipt-triple consumer |
+
+### 3.2 Method / param renames
+
+| rc.11 | rc.13 |
+|-------|-------|
+| `createKnowledgeCollection(...)` | `createKnowledgeAsset(...)` |
+| `getKnowledgeCollection(...)` | `getKnowledgeAsset(...)` |
+| `updateKnowledgeCollection(...)` | `updateKnowledgeAsset(...)` |
+| `extendKnowledgeCollectionLifetime(...)` | `extendKnowledgeAssetLifetime(...)` |
+| `isPartOfKnowledgeCollection(...)` | `isPartOfKnowledgeAsset(...)` |
+| `isOwnerOfKnowledgeCollection(...)` | `isOwnerOfKnowledgeAsset(...)` |
+| `kcId` | `kaId` |
+| `knowledgeCollectionId` | `knowledgeAssetId` |
+
+### 3.3 The regex sweep
+
+```bash
+# CASE-SENSITIVE — preserves TitleCase / camelCase / SCREAMING_SNAKE
+git grep -l 'KnowledgeCollection'  | while IFS= read -r f; do perl -pi -e 's/KnowledgeCollection/KnowledgeAsset/g' "$f"; done
+git grep -l 'knowledgeCollection'  | while IFS= read -r f; do perl -pi -e 's/knowledgeCollection/knowledgeAsset/g' "$f"; done
+git grep -l 'KNOWLEDGE_COLLECTION' | while IFS= read -r f; do perl -pi -e 's/KNOWLEDGE_COLLECTION/KNOWLEDGE_ASSET/g' "$f"; done
+git grep -l 'kcId'                 | while IFS= read -r f; do perl -pi -e 's/\bkcId\b/kaId/g' "$f"; done
+git grep -l 'KCId'                 | while IFS= read -r f; do perl -pi -e 's/\bKCId\b/KAId/g' "$f"; done
+git grep -l 'publishedAtKcId'      | while IFS= read -r f; do perl -pi -e 's/publishedAtKcId/publishedAtKaId/g' "$f"; done
+```
+
+`BOUND_CONTRACT_INVALIDATORS` and `ERROR_ABI_CONTRACTS` (in `@origintrail-official/dkg-chain`) dropped their legacy entries. If you extended those maps, drop the `KnowledgeAssetsV10` / `KnowledgeCollectionStorage` keys.
+
+### 3.4 Solidity / ABI
+
+If you call contracts directly (ethers / viem / web3.js / subgraphs): every renamed function has a fresh 4-byte selector and **old calldata reverts**. Active V10.1 lives on **`KnowledgeAssetsLifecycle`** (call surface) and **`DKGKnowledgeAssets`** (ERC-721 mint/storage), both resolved via `Hub.getContractAddress(...)`. The legacy `KnowledgeAssetsV10.sol`, `KnowledgeCollectionStorage.sol`, and the V8 `KnowledgeCollection.sol` are **deleted**. Re-fetch ABIs at rc.13:
+
+```bash
+ls packages/chain/abi/
+cat packages/chain/abi/KnowledgeAssetsLifecycle.json
+cat packages/chain/abi/DKGKnowledgeAssets.json
+```
+
+Config-key renames in `deployments/parameters.json`: `KnowledgeCollectionStorage.knowledgeCollectionSize` → `DKGKnowledgeAssets.knowledgeAssetBatchSize`; `ContextGraphStorage.kcToContextGraph` → `kaToContextGraph`; `registerKnowledgeCollection` → `registerKnowledgeAsset`.
+
+### 3.5 SPARQL predicate
+
+| rc.11 | rc.13 |
+|-------|-------|
+| `<…/publishedAtKcId>` | `<…/publishedAtKaId>` |
+
+Other on-chain-derived RDF surfaces (`dkg:authoredBy`, `dkg:trustLevel`, …) are unchanged.
+
+---
+
+## 4. Greenfield Knowledge Asset model (the conceptual change)
+
+This is the heart of the release, and the reason for everything in §3. It came out of red-team builder feedback: the old "a publish creates a Knowledge Collection that batches N assets (ERC-1155)" model added mental overhead and on-chain cost without buying integrators much. The new model trades it for one asset per publish with a stable identifier — simpler to reason about, cheaper to publish, and less to operate.
+
+### 4.1 What's new
+
+- **One KA per publish** — `publish` mints exactly one ERC-721 `DKGKnowledgeAssets` token. `knowledgeAssetsAmount == 1` is the only valid value. ERC-1155 batching is gone.
+- **Stable UAL** — `did:dkg:{chainId}/{DKGKnowledgeAssetsAddress}/{kaId}`, where `kaId` equals the ERC-721 `tokenId`. The UAL **no longer changes when the KA is updated.**
+- **ERC-721 minted to the author at publish** — the author (recovered from the EIP-712 author attestation) holds the NFT; the publisher pays TRAC.
+- **Owner-sealed updates** — only the current ERC-721 holder can update. Every update needs a fresh EIP-712 `UpdateAuthorAttestation(kaId, newMerkleRoot, authorAddress, schemeVersion)` (domain `KnowledgeAssetsLifecycle` v2.0.0), passed as `precomputedUpdateAttestation` on the same `publisher.update(kaId, options)` call. `newMerkleRoot` is recomputed from the update's quads, so seals aren't reusable across updates. The publisher (any node operator) does the chain write; the chain validates the seal against `ownerOf(kaId)`.
+
+### 4.2 Code shape
+
+```ts
+// rc.11: ERC-1155 batched, kcId
+const result = await publisher.publish({ kcSize: 1, /* ...old fields */ });
+const kcId = result.kcId;
+
+// rc.13: ERC-721 singleton, kaId, stable UAL
+const result = await publisher.publish({ /* knowledgeAssetsAmount fixed at 1 */ });
+const kaId = result.kaId;                 // == ERC-721 tokenId
+const ual = buildKnowledgeAssetUal(chainId, dkgKnowledgeAssetsAddress, kaId);
+
+// rc.13: every update needs a fresh owner-signed attestation
+const precomputedUpdateAttestation = await signUpdateAuthorAttestation({
+  kaId, quads: updateQuads, privateQuads: updatePrivateQuads,
+  owner: ownerWallet,                     // CURRENT ERC-721 owner of kaId
+});
+await publisher.update(kaId, {
+  contextGraphId, quads: updateQuads, privateQuads: updatePrivateQuads,
+  precomputedUpdateAttestation,
+});
+```
+
+Use the canonical UAL builder `buildKnowledgeAssetUal(chainId, dkgKnowledgeAssetsAddress, kaId)` from `@origintrail-official/dkg-chain` rather than templating the URN yourself. Reference: `packages/evm-module/docs/greenfield-ka-ual.md`. Devnet smokes: `pnpm test:devnet:greenfield-10min`, `pnpm test:devnet:rich-scenario`.
+
+---
+
+## 5. Economic floors (mandatory)
+
+- **`tokenAmount >= 1` — BREAKING.** Direct-spend reverts `InvalidTokenAmount(1, 0)` on `tokenAmount == 0`; the PCA branch floors a truncated `discountedCost` at 1 wei TRAC when `baseCost > 0`. **Every off-chain caller must encode `tokenAmount >= 1`.** Any "free publish on a dust CG" pattern is gone. Same floor applies to `update` and `extendKnowledgeAssetLifetime`.
+- **Protocol treasury fee — dormant by default.** A governance-set bps cut (default 300 bps = 3%, capped at 1000 bps) skims from the staker-bound TRAC on paid publish/update/extend. The publisher pays the same gross price; the fee comes out of the staker reward pool. `treasury == address(0) ⇒ fee == 0`, so it's inert until governance opts in. If you display estimated staker yield, net the fee out once enabled.
+- **Reentrancy guard.** `publish` / `update` / `extendKnowledgeAssetLifetime` carry `nonReentrant` (~50 gas/call). Decode `ReentrancyGuardReentrantCall()` in any error-surfacing UI.
+
+---
+
+## 6. Node operator upgrade
+
+1. **Edge vs Core.** Edge nodes update via `npm install -g @origintrail-official/dkg@10.0.0-rc.13`. Core nodes retain the git-build path. Do **not** `git pull` on an npm-managed node — set `autoUpdate.source: "npm"` if a stray `.git` is routing you down the git path.
+2. **First-boot state wipe is expected.** Crossing the rc.12 `chainResetMarker` (`v10-rc12-ka-rename-2026-06-01`) wipes per-node chain-derived state and re-derives it against the redeployed Base Sepolia surface. **Stakers with V10 conviction NFTs are unaffected** — positions live on `ConvictionStakingStorage` keyed by `identityId`, which is preserved across the contract-address rotation.
+3. **Hub registration (self-hosted only).** `KnowledgeAssetsLifecycle` and `DKGKnowledgeAssets` are the *only* V10.1 entries the daemon resolves. The legacy `KnowledgeAssetsV10` fallback resolver is removed — the adapter now **raises on init** if the V10.1 surface isn't registered. Re-deploy/re-register the V10.1 surface before upgrading. (Base Sepolia on the OriginTrail-managed Hub is already done — just bump and restart.)
+4. **Verify.** `dkg doctor` green; `/api/build-info` reports `10.0.0-rc.13`; on Core nodes, `rs.tick.data-corrupted` is zero on the updated-KA cohort (the GH #842 fix makes updated KAs provable again).
+
+Unchanged sanity anchors: Base Sepolia **Hub** `0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6` and **Token** `0x2A58BdD13176D85906D804cdbFFA0D9119282DC8`; the MCP tool surface for AI agents (`dkg_memory_search`, `dkg_assertion_create/write/promote`, `dkg_query`, …); and the EIP-712 domain hash pinned at `KnowledgeAssetsLifecycle@2.0.0` so prior author attestations keep verifying.
+
+---
+
+## 7. What's new in rc.13 (on top of rc.12)
+
+Additive unless flagged. If you're already on rc.12, this section *is* your upgrade.
+
+### 7.1 Default publish lifetime is now 12 epochs (behavioural)
+
+Publishes that don't specify a lifetime now default to **12 epochs** instead of the previous default. If you relied on the old implicit lifetime, set the lifetime explicitly or budget for 12 epochs of TRAC.
+
+### 7.2 Core-preferred sync + chain-driven verified-memory reconciliation
+
+The sync path now prefers Core peers and reconciles verified-memory against on-chain state, including host-mode catch-up. Operator-visible as healthier catch-up; no action required.
+
+### 7.3 Kafka route-plugin MVP (`@origintrail-official/kafka-plugin`)
+
+A new daemon **route plugin** that registers Kafka **stream metadata** as private-by-default `dkg-streams:KafkaStream` Knowledge Assets and exposes discovery endpoints under `/api/kafka/streams`. Note: it registers/discovers stream *descriptors* (name, bootstrap URL, topic, format) — it does not itself connect to brokers or move messages. Enable via `routePlugins` + `kafka.contextGraphId` in your daemon config. Demo: `demo/kafka-streams/`.
+
+### 7.4 Publish / SWM / sync runtime hardening
+
+Single-root SWM publish boundary, plaintext SWM for on-chain-public CGs with an allowed-agent list, sub-graph SWM catch-up + approve-time race fixes, sender-key setup after joined-CG approval, publish ACK / allowance race fixes, per-publish allowance auto-replenish, and a SPARQL parse-error classifier. All daemon-side; no caller action.
+
+### 7.5 Node UI fixes
+
+Canonical-triple derivation unification, WM Assertions subtab fix, markdown-import root partitioning, several QA-found bug fixes, and a settings-page cleanup.
+
+---
+
+## 8. Verification checklist
+
+- [ ] `pnpm tsc` (or your build) is clean — no residual `kcId` / `KnowledgeCollection*`.
+- [ ] Test suite passes against a freshly-upgraded daemon or local devnet.
+- [ ] Every `tokenAmount` you send is `>= 1`.
+- [ ] Update flow signs `precomputedUpdateAttestation` with the **current ERC-721 owner's** key, not the publisher's.
+- [ ] No code path still assumes multiple assets per publish (`kcSize` / batch semantics removed).
+- [ ] Operators: `dkg doctor` green, `/api/build-info` = `10.0.0-rc.13`, `rs.tick.data-corrupted` zero on updated KAs.
+- [ ] Chain-error UIs handle `InvalidTokenAmount`, `ReentrancyGuardReentrantCall`, `OperationalWalletDuplicate`.
+- [ ] SPARQL receipt queries use `publishedAtKaId`.
+- [ ] Publishes either set an explicit lifetime or are budgeted for the new 12-epoch default.
+
+---
+
+## 9. Where to get help
+
+- **Full per-PR detail:** [`CHANGELOG.md`](../CHANGELOG.md), sections `[10.0.0-rc.12]` and `[10.0.0-rc.13]`.
+- **The focused rc.11 → rc.12 guide** (deeper on each rename row): [`docs/UPGRADE_RC11_TO_RC12.md`](UPGRADE_RC11_TO_RC12.md).
+- **Greenfield KA reference:** [`packages/evm-module/docs/greenfield-ka-ual.md`](../packages/evm-module/docs/greenfield-ka-ual.md).
+- **Kafka plugin:** [`packages/kafka-plugin/README.md`](../packages/kafka-plugin/README.md) and [`demo/kafka-streams/`](../demo/kafka-streams/).
+- **GitHub issues:** [`OriginTrail/dkg`](https://github.com/OriginTrail/dkg/issues) — tag with `rc.13-upgrade` so we can triage as a group.
+- **Discord** `#builders` — maintainers monitor it for upgrade questions.
+
+If you hit a snag this doc doesn't cover, open an issue or PR against this file so the next builder benefits.

--- a/docs/announcements/v10.0.0-rc.13-telegram.md
+++ b/docs/announcements/v10.0.0-rc.13-telegram.md
@@ -1,0 +1,26 @@
+# DKG v10.0.0-rc.13 — Telegram announcement
+
+> Paste-ready for Telegram. Telegram renders **bold**, _italics_, `code`, and links. Emojis intentional.
+
+---
+
+🚀 **DKG v10 — rc.13 is the feature-complete release candidate**
+
+All the major v10 pieces are now in place — from here it's stabilization toward release. Quick honest note: many of you are on **rc.11** and we moved ahead without announcing. Fixing that now. ⚠️ **Upgrading from rc.11 is breaking** (guide below).
+
+Here's what's now live:
+
+🧠 **Verified Memory publishing works** — commit knowledge through three layers: **private** (just you) → **shared** (your team/agents) → **Verified Memory** (anchored on-chain, replicated, provable). Promoting all the way to Verified Memory now works reliably.
+
+💬 **Agents can chat** — agents on different nodes message each other directly: encrypted, reliable, survives restarts. Plus a chat panel in the Node UI for humans.
+
+📡 **The DKG Core node network** — like the always-on servers behind Telegram/Signal, DKG runs on **Core nodes** that store Verified Memory and relay traffic, so an **Edge node** (your laptop behind a home router) can fully participate. Your node auto-syncs from the Core network and can rebuild anything it missed from the on-chain record. **Nothing to configure.**
+
+🪙 **A simpler Knowledge Asset model** — thanks to red-team builder feedback 🙌: **one clean asset per publish** with a **stable ID that survives updates**, **lower on-chain cost**, and **owner-sealed updates**. A real UX + performance win.
+
+🎨 **A much-improved Node UI** — redesigned project overview, clearer memory-layer views, inline approve/deny for join requests, plus lots of fixes. Also: external **Blazegraph/SPARQL** store support, a `dkg doctor` health check, and a new 🧩 **Kafka plugin (MVP)**.
+
+🤖 **Upgrading?** It's breaking from rc.11 (new Knowledge Asset model + a testnet redeploy; your stake & identity are safe). We wrote the guide **as ready-to-paste agent prompts** — one for your node, one for your code. Point Cursor / Claude Code / Codex at it:
+👉 https://github.com/OriginTrail/dkg/blob/main/docs/UPGRADE_RC11_TO_RC13.md
+
+Then run `dkg doctor`. Questions → **#builders** or tag issues `rc.13-upgrade`. 💬

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/e2e/fixtures/single-entity-fixture.md
+++ b/packages/node-ui/e2e/fixtures/single-entity-fixture.md
@@ -1,0 +1,31 @@
+---
+id: urn:e2e:fixture:single-entity
+type: Article
+name: Migrate To NPM
+description: Trimmed single-root fixture for the WM to SWM to VM e2e.
+keywords: [migration, npm]
+---
+
+# Migrate To NPM
+
+A deliberately small Markdown document used by the WM -> SWM -> VM
+end-to-end test. The deterministic Markdown extractor turns this into
+exactly one NAMED root entity (`urn:e2e:fixture:single-entity`) plus a
+handful of BLANK-NODE section subjects (`_:dkg-md-section-N`, linked via
+`dkg:hasSection`).
+
+The blank nodes are the whole point: promoting this assertion exercises
+the WM-cleanup `DELETE` over blank-node-bearing triples, which strict
+SPARQL servers (oxigraph-server — the rc.15 fresh-install default) reject
+inside `DELETE DATA`. Keep at least one `##` section heading here so the
+extractor always emits blank nodes.
+
+## Background
+
+This section becomes a blank-node subject linked from the root via
+`dkg:hasSection`, with a `schema:name` of "Background".
+
+## Steps
+
+A second blank-node section so the fixture covers more than one blank
+subject. Do not remove these headings.

--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -262,17 +262,37 @@ export async function publishToVm(opts: {
    */
   allowPartial?: boolean;
 }): Promise<{ httpStatus: number; status?: string; kaId?: string; txHash?: string; contextGraphError?: string }> {
-  const res = await devnetApiFetch('/api/shared-memory/publish', {
-    method: 'POST',
-    nodeNum: opts.nodeNum ?? 1,
-    body: JSON.stringify({
-      contextGraphId: opts.contextGraphId,
-      assertionName: opts.assertionName,
-      clearAfter: opts.clearAfter ?? false,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`publish failed: ${res.status} ${await res.text()}`);
+  // LU-5 (OT-RFC-38): the publish-access-policy gate refuses to publish until
+  // the CG's curation policy is CHAIN-CONFIRMED. On a freshly-created/registered
+  // CG that confirmation lags the registration tx by a few blocks, so the first
+  // publish can race ahead and 500 with "publish access-policy is unknown …
+  // curated=unknown". That's a transient, not a failure — retry that SPECIFIC
+  // error with backoff (the devnet mines ~1 block/s), so the global-setup VM
+  // seed (and every other publish caller) waits for the policy instead of
+  // flaking. Any other non-ok status still throws immediately.
+  const POLICY_CONFIRM_BUDGET_MS = 45_000;
+  const policyDeadline = Date.now() + POLICY_CONFIRM_BUDGET_MS;
+  let res: Response;
+  for (;;) {
+    res = await devnetApiFetch('/api/shared-memory/publish', {
+      method: 'POST',
+      nodeNum: opts.nodeNum ?? 1,
+      body: JSON.stringify({
+        contextGraphId: opts.contextGraphId,
+        assertionName: opts.assertionName,
+        clearAfter: opts.clearAfter ?? false,
+      }),
+    });
+    if (res.ok) break;
+    const errText = await res.text();
+    const policyNotConfirmed =
+      res.status === 500 &&
+      /publish access-policy is unknown|curated=unknown/i.test(errText);
+    if (policyNotConfirmed && Date.now() < policyDeadline) {
+      await new Promise((r) => setTimeout(r, 3_000));
+      continue;
+    }
+    throw new Error(`publish failed: ${res.status} ${errText}`);
   }
   const body = (await res.json()) as { status?: string; kaId?: string; txHash?: string; contextGraphError?: string };
   // `res.ok` is true for 207 too. The daemon returns 207 when the SWM/VM publish

--- a/packages/node-ui/e2e/helpers/layer-counts.ts
+++ b/packages/node-ui/e2e/helpers/layer-counts.ts
@@ -214,9 +214,13 @@ export async function readMemoryLayerMarker(
   markerUri: string,
   nodeNum = 1,
 ): Promise<string | null> {
+  // The `_meta` partition must be addressed with a HARDCODED `GRAPH <iri>` under
+  // the scoped-query guard (see file header) — a `GRAPH ?mg` variable + filter is
+  // only legal for the data / `_shared_memory` partitions and 400s on a strict
+  // daemon. Build the exact meta-graph IRI and query it directly.
+  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
   const sparql = `SELECT ?layer WHERE {
-    GRAPH ?mg { <${markerUri}> <${META_LAYER_PREDICATE}> ?layer }
-    FILTER(CONTAINS(STR(?mg), "/_meta"))
+    GRAPH <${metaGraph}> { <${markerUri}> <${META_LAYER_PREDICATE}> ?layer }
   }`;
   const values = bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 'layer');
   if (values.length === 0) return null;

--- a/packages/node-ui/e2e/helpers/layer-counts.ts
+++ b/packages/node-ui/e2e/helpers/layer-counts.ts
@@ -1,0 +1,211 @@
+/**
+ * Per-graph SPARQL count + discovery helpers for the UI-driven
+ * WM → SWM → VM lifecycle e2e. These let the spec assert the ACTUAL triple
+ * migration across memory layers (not just UI affordances): that promote
+ * empties the WM assertion graph of blank-node sections and populates
+ * `_shared_memory`, and that the lifecycle marker flips WM → SWM.
+ *
+ * Two hard-won constraints shape every query here (verified against a live
+ * rc.15 oxigraph-server devnet node):
+ *
+ *  1. URI duality. An assertion is identified by TWO URIs:
+ *       - DATA graph : did:dkg:context-graph:<cg>/assertion/<agent>/<name>
+ *                      (holds the triples; the named root subject IS this URI)
+ *       - MARKER      : urn:dkg:assertion:<cg>:<agent>:<name>
+ *                      (subject of the `dkg:memoryLayer` lifecycle marker in
+ *                       `<cg>/_meta`)
+ *     Triple counts key off the DATA graph; layer reads key off the MARKER.
+ *
+ *  2. Scoped-query guard. With a `contextGraphId` set, the daemon only allows a
+ *     hardcoded `GRAPH <iri>` for `<cg>/_meta`; every other partition (assertion
+ *     data graphs, `_shared_memory`) is reachable ONLY via a top-level GRAPH
+ *     VARIABLE (`GRAPH ?g { … } FILTER(STR(?g) = "<iri>")`) with
+ *     `includeContextGraphPartitions: true`. Hardcoding those IRIs returns a
+ *     "Scoped query violation" 400. So all data/SWM access below uses a
+ *     variable + equality FILTER.
+ */
+import { devnetApiFetch } from './devnet.js';
+
+const META_LAYER_PREDICATE = 'http://dkg.io/ontology/memoryLayer';
+
+function parseCount(json: any): number {
+  const bindings = json?.result?.bindings ?? json?.results?.bindings ?? [];
+  const raw = bindings[0]?.c ?? bindings[0]?.cnt;
+  const value = typeof raw === 'string' ? raw : raw?.value;
+  const m = String(value ?? '').match(/\d+/);
+  return m ? parseInt(m[0], 10) : 0;
+}
+
+function bindingValues(json: any, key: string): string[] {
+  const bindings: any[] = json?.result?.bindings ?? json?.results?.bindings ?? [];
+  return bindings
+    .map((b) => (typeof b[key] === 'string' ? b[key] : b[key]?.value))
+    .filter((v): v is string => !!v);
+}
+
+async function runQuery(contextGraphId: string, sparql: string, nodeNum = 1): Promise<any> {
+  const res = await devnetApiFetch('/api/query', {
+    method: 'POST',
+    nodeNum,
+    body: JSON.stringify({ sparql, contextGraphId, includeContextGraphPartitions: true }),
+  });
+  if (!res.ok) {
+    throw new Error(`SPARQL query failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/** Count all triples in a specific named graph (graph-variable + FILTER). */
+export async function countTriplesInGraph(
+  contextGraphId: string,
+  graphUri: string,
+  nodeNum = 1,
+): Promise<number> {
+  const sparql = `SELECT (COUNT(*) AS ?c) WHERE {
+    GRAPH ?g { ?s ?p ?o }
+    FILTER(STR(?g) = "${graphUri}")
+  }`;
+  return parseCount(await runQuery(contextGraphId, sparql, nodeNum));
+}
+
+/** Count triples in a graph that carry a blank node in subject or object. */
+export async function countBlankNodeTriplesInGraph(
+  contextGraphId: string,
+  graphUri: string,
+  nodeNum = 1,
+): Promise<number> {
+  const sparql = `SELECT (COUNT(*) AS ?c) WHERE {
+    GRAPH ?g { ?s ?p ?o FILTER(isBlank(?s) || isBlank(?o)) }
+    FILTER(STR(?g) = "${graphUri}")
+  }`;
+  return parseCount(await runQuery(contextGraphId, sparql, nodeNum));
+}
+
+export interface WmAssertion {
+  name: string;
+  /** did:dkg:context-graph:<cg>/assertion/<agent>/<name> — holds the triples. */
+  dataGraphUri: string;
+  /** urn:dkg:assertion:<cg>:<agent>:<name> — subject of the layer marker. */
+  markerUri: string;
+}
+
+/** did data-graph URI → urn marker URI (the `_meta` memoryLayer subject). */
+function deriveMarkerUri(dataGraphUri: string): string {
+  // Greedy `(.+)` for the cg segment so a cg that itself contains slashes
+  // (e.g. `0xabc…/ninja`) is captured whole, splitting on the LAST `/assertion/`.
+  const m = dataGraphUri.match(/^did:dkg:context-graph:(.+)\/assertion\/([^/]+)\/(.+)$/);
+  if (!m) throw new Error(`deriveMarkerUri: unexpected data graph shape "${dataGraphUri}"`);
+  return `urn:dkg:assertion:${m[1]}:${m[2]}:${m[3]}`;
+}
+
+/**
+ * Find the most recent WM assertion DATA graph whose URI contains
+ * `nameSubstring` (e.g. the sanitized fixture filename). Assertion names are
+ * timestamp-prefixed, so lexical max is newest. Returns both the data-graph URI
+ * (for triple counts) and the derived marker URI (for layer reads).
+ */
+export async function findWmAssertion(
+  contextGraphId: string,
+  nameSubstring: string,
+  nodeNum = 1,
+): Promise<WmAssertion> {
+  const cgPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const sparql = `SELECT DISTINCT ?g WHERE {
+    GRAPH ?g { ?s ?p ?o }
+    FILTER(STRSTARTS(STR(?g), "${cgPrefix}")
+      && CONTAINS(STR(?g), "/assertion/")
+      && CONTAINS(STR(?g), "${nameSubstring}")
+      && !CONTAINS(STR(?g), "/meta/assertion/"))
+  }`;
+  const graphs = bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 'g').sort();
+  const dataGraphUri = graphs[graphs.length - 1];
+  if (!dataGraphUri) {
+    throw new Error(`findWmAssertion: no assertion data graph contains "${nameSubstring}" in CG ${contextGraphId}`);
+  }
+  const name = dataGraphUri.split('/').pop() ?? dataGraphUri;
+  return { name, dataGraphUri, markerUri: deriveMarkerUri(dataGraphUri) };
+}
+
+/**
+ * Distinct NAMED (non-blank-node) subjects in a graph, excluding the reserved
+ * `urn:dkg:file:` / `urn:dkg:extraction:` import bookkeeping. For a
+ * markdown-extracted assertion this is the single root subject (which equals
+ * the assertion data-graph URI); blank-node section subjects are excluded.
+ */
+export async function namedRootsInGraph(
+  contextGraphId: string,
+  graphUri: string,
+  nodeNum = 1,
+): Promise<string[]> {
+  const sparql = `SELECT DISTINCT ?s WHERE {
+    GRAPH ?g { ?s ?p ?o }
+    FILTER(STR(?g) = "${graphUri}"
+      && !isBlank(?s)
+      && !STRSTARTS(STR(?s), "urn:dkg:file:")
+      && !STRSTARTS(STR(?s), "urn:dkg:extraction:"))
+  }`;
+  return bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 's');
+}
+
+/**
+ * Count triples in `_shared_memory` whose subject is `rootUri` OR one of its
+ * skolemized blank-node children (`<rootUri>/.well-known/genid/...`). A
+ * non-zero result after promote proves the root + its (formerly blank-node)
+ * section structure migrated WM → SWM.
+ */
+export async function countRootInSharedMemory(
+  contextGraphId: string,
+  rootUri: string,
+  nodeNum = 1,
+): Promise<number> {
+  const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+  const genidPrefix = `${rootUri}/.well-known/genid/`;
+  const sparql = `SELECT (COUNT(*) AS ?c) WHERE {
+    GRAPH ?g { ?s ?p ?o }
+    FILTER(STR(?g) = "${swmGraph}"
+      && (STR(?s) = "${rootUri}" || STRSTARTS(STR(?s), "${genidPrefix}")))
+  }`;
+  return parseCount(await runQuery(contextGraphId, sparql, nodeNum));
+}
+
+/**
+ * Count triples in the VM scope (CG partitions that are NOT assertion /
+ * shared-memory / meta bookkeeping) attributable to `rootUri` or its
+ * skolemized children. A non-zero result means the published entity is visible
+ * in Verifiable Memory.
+ */
+export async function countRootInVmScope(
+  contextGraphId: string,
+  rootUri: string,
+  nodeNum = 1,
+): Promise<number> {
+  const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+  const genidPrefix = `${rootUri}/.well-known/genid/`;
+  const sparql = `SELECT (COUNT(*) AS ?c) WHERE {
+    GRAPH ?g { ?s ?p ?o }
+    FILTER(
+      STRSTARTS(STR(?g), "${cgUri}") &&
+      !CONTAINS(STR(?g), "/assertion/") &&
+      !CONTAINS(STR(?g), "/_shared_memory") &&
+      !CONTAINS(STR(?g), "/_meta") &&
+      !CONTAINS(STR(?g), "/meta")
+    )
+    FILTER(STR(?s) = "${rootUri}" || STRSTARTS(STR(?s), "${genidPrefix}"))
+  }`;
+  return parseCount(await runQuery(contextGraphId, sparql, nodeNum));
+}
+
+/** Read the assertion's memoryLayer marker ("WM" | "SWM" | absent). */
+export async function readMemoryLayerMarker(
+  contextGraphId: string,
+  markerUri: string,
+  nodeNum = 1,
+): Promise<string | null> {
+  const sparql = `SELECT ?layer WHERE {
+    GRAPH ?mg { <${markerUri}> <${META_LAYER_PREDICATE}> ?layer }
+    FILTER(CONTAINS(STR(?mg), "/_meta"))
+  }`;
+  const values = bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 'layer');
+  if (values.length === 0) return null;
+  return String(values[0]).replace(/^"/, '').replace(/"$/, '');
+}

--- a/packages/node-ui/e2e/helpers/layer-counts.ts
+++ b/packages/node-ui/e2e/helpers/layer-counts.ts
@@ -117,7 +117,20 @@ export async function findWmAssertion(
       && CONTAINS(STR(?g), "${nameSubstring}")
       && !CONTAINS(STR(?g), "/meta/assertion/"))
   }`;
-  const graphs = bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 'g').sort();
+  // Sort by the assertion-NAME segment (the last path component), NOT the full
+  // graph URI. URIs are `.../assertion/<agent>/<name>`, so a raw string sort
+  // orders by the <agent> segment first and could pick an older assertion from
+  // a DIFFERENT agent on a shared devnet — the rest of the spec would then read
+  // counts/markers from the wrong graph. The trailing name is the stable
+  // per-import key (and the only field that varies for this test's own imports).
+  const assertionNameOf = (uri: string) => uri.split('/').pop() ?? uri;
+  const graphs = bindingValues(await runQuery(contextGraphId, sparql, nodeNum), 'g').sort(
+    (a, b) => {
+      const an = assertionNameOf(a);
+      const bn = assertionNameOf(b);
+      return an < bn ? -1 : an > bn ? 1 : 0;
+    },
+  );
   const dataGraphUri = graphs[graphs.length - 1];
   if (!dataGraphUri) {
     throw new Error(`findWmAssertion: no assertion data graph contains "${nameSubstring}" in CG ${contextGraphId}`);

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -64,7 +64,20 @@ const run: {
 test.beforeAll(async () => {
   await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
-  const cgs = await listContextGraphs(1);
+
+  // `/api/status` answering does NOT mean the seeded primary context graph has
+  // finished registering — on a cold boot `listContextGraphs()` can briefly
+  // return [] and make this spec falsely skip with "No context graphs". Poll for
+  // a bounded window so a still-propagating CG isn't mistaken for an empty
+  // devnet; a genuinely-empty operator devnet still falls through to the skip.
+  let cgs = await listContextGraphs(1);
+  if (cgs.length === 0) {
+    const deadline = Date.now() + 30_000;
+    while (cgs.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1_000));
+      cgs = await listContextGraphs(1);
+    }
+  }
   requireDevnetPrecondition(test, cgs.length === 0, 'No context graphs on devnet');
   run.cgId = cgs[0]!.id;
   run.cgName = cgs[0]!.name;

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -32,6 +32,7 @@ import {
   waitForDevnetStatus,
   requireDevnetPrecondition,
   requireDevnetNode,
+  devnetApiFetch,
 } from '../../helpers/devnet.js';
 import { listContextGraphs } from '../../helpers/devnet-publish.js';
 import {
@@ -64,6 +65,20 @@ const run: {
 test.beforeAll(async () => {
   await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
+
+  // HARD precondition (NOT a skip): this spec only reproduces #996 on a
+  // SPARQL-over-HTTP backend. If node 1 isn't on `oxigraph-server`, the
+  // blank-node DELETE-DATA path is never exercised and the spec would pass
+  // trivially — the exact silent-degradation trap that hid the bug in rc.16.
+  // Fail loudly so the devnet backend wiring (scripts/devnet.sh: node 1-2 →
+  // oxigraph-server) can never regress unnoticed.
+  const statusRes = await devnetApiFetch('/api/status', { nodeNum: 1 });
+  const status = (await statusRes.json()) as { storeBackend?: string };
+  expect(
+    status.storeBackend,
+    'node 1 must run the oxigraph-server backend for this spec to exercise #996 ' +
+      '(set in scripts/devnet.sh); got a non-SPARQL-over-HTTP backend instead',
+  ).toBe('oxigraph-server');
 
   // `/api/status` answering does NOT mean the seeded primary context graph has
   // finished registering — on a cold boot `listContextGraphs()` can briefly

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -199,17 +199,21 @@ test.describe('WM → SWM → VM via the UI', () => {
     expect(await readMemoryLayerMarker(run.cgId!, run.markerUri!)).toBe('SWM');
   });
 
-  // DEFERRED (OriginTrail/dkg#966): the SWM → VM publish step is blocked by a
-  // SEPARATE product gap, not the promote bug this spec proves. On a CG with
-  // multiple SWM roots (the seeded devnet CG has ~25), the project-view
-  // "Publish all → VM" control is CORRECTLY rejected by the daemon — V10
-  // on-chain publish mints one Knowledge Asset per root and requires exactly
-  // one root per request. The per-root `PublishPanel` (checkbox-select a single
-  // root) exists in `MemoryLayerView` but is NOT wired into any UI navigation,
-  // so there is no click-path to single-root publish. Kept as `fixme` (living
-  // documentation) until either (a) the PublishPanel is wired into nav, or
-  // (b) this spec provisions its own dedicated single-root CG. The import →
-  // promote steps above are the asserting cycle for the blank-node fix.
+  // DEFERRED (OriginTrail/dkg#966): the SWM → VM publish step is a browser-
+  // coverage gap, NOT the promote bug this spec proves. The project-view bulk
+  // "Publish to Verifiable Memory" control (`widget-publish-vm-btn`) publishes
+  // EVERY SWM assertion on the CG as its own on-chain Knowledge Asset (Design B,
+  // any entity count). On the shared seeded devnet CG (~25 SWM roots) that fires
+  // ~25 real on-chain mints — too slow/flaky for a browser e2e, and it touches
+  // roots this spec doesn't own. The single-root surface (`PublishPanel` in
+  // `MemoryLayerView`, gated by `publishSharedMemory`'s one-root client guard)
+  // is NOT wired into ProjectView navigation, so there is no click-path to
+  // publish ONLY this spec's imported root. End-to-end on-chain mint is already
+  // verified by the API-driven sibling spec (`wm-swm-vm-lifecycle.devnet.spec`).
+  // Kept as `fixme` until either (a) PublishPanel is wired into nav, or (b) this
+  // spec provisions its own dedicated single-assertion CG so the bulk publish
+  // maps 1:1 to our root. The import → promote steps above are the asserting
+  // cycle for the blank-node fix.
   test.fixme('publishes SWM → VM via the UI and the entity lands in Verifiable Memory', async ({ shell, page }) => {
     test.skip(!run.rootUri, 'Promote step did not run');
     await shell.goto();

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * UI-driven WM → SWM → VM lifecycle against a live devnet.
+ *
+ * Unlike `wm-swm-vm-lifecycle.devnet.spec.ts` (which drives the pipeline over
+ * the HTTP API), this spec exercises the REAL user journey through the browser:
+ *
+ *   1. Import a Markdown file into Working Memory via the Import modal.
+ *   2. Click the Promote control to move WM → SWM.
+ *   3. Click the Publish control to move SWM → VM.
+ *
+ * It asserts BOTH that the UI is functional AND — the critical part — that the
+ * triples actually migrate across layers, verified by per-graph SPARQL counts
+ * (surface-independent, so the spec doesn't depend on which layer-view variant
+ * renders the buttons).
+ *
+ * WHY THIS REPRODUCES THE BUG: the fixture is a Markdown doc that the
+ * deterministic extractor turns into one NAMED root entity plus BLANK-NODE
+ * section subjects. Promote's WM-cleanup deletes those blank-node-bearing
+ * triples; on the rc.15 fresh-install default backend (oxigraph-server, which
+ * devnet nodes 1-2 now run) a `DELETE DATA` with blank nodes is rejected, so a
+ * pre-fix promote left WM populated and surfaced the "No triples were promoted"
+ * no-op in the UI. The blank-node-safe adapter `delete()` is what makes this
+ * spec go green.
+ *
+ * Run: `pnpm test:e2e` — the Playwright webServer boots (or reuses) the devnet.
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { test, expect } from '../../fixtures/base.js';
+import type { Page } from '@playwright/test';
+import {
+  waitForDevnetStatus,
+  requireDevnetPrecondition,
+  requireDevnetNode,
+} from '../../helpers/devnet.js';
+import { listContextGraphs } from '../../helpers/devnet-publish.js';
+import {
+  findWmAssertion,
+  namedRootsInGraph,
+  countTriplesInGraph,
+  countBlankNodeTriplesInGraph,
+  countRootInSharedMemory,
+  countRootInVmScope,
+  readMemoryLayerMarker,
+} from '../../helpers/layer-counts.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(__dir, '..', '..', 'fixtures', 'single-entity-fixture.md');
+// The import modal sanitizes the filename into the assertion name
+// (`[^a-zA-Z0-9._-]` → `_`), so the dot in `.md` is preserved and the WM
+// assertion graph URI contains this substring.
+const FIXTURE_NAME_PART = 'single-entity-fixture';
+
+test.describe.configure({ mode: 'serial' });
+
+const run: {
+  cgId?: string;
+  cgName?: string;
+  dataGraph?: string;
+  markerUri?: string;
+  rootUri?: string;
+} = {};
+
+test.beforeAll(async () => {
+  await requireDevnetNode(test, 1);
+  await waitForDevnetStatus(1);
+  const cgs = await listContextGraphs(1);
+  requireDevnetPrecondition(test, cgs.length === 0, 'No context graphs on devnet');
+  run.cgId = cgs[0]!.id;
+  run.cgName = cgs[0]!.name;
+});
+
+async function openProjectTab(page: Page, name: string) {
+  await page
+    .locator('.v10-panel-left')
+    .first()
+    .locator('.v10-tree-section-header')
+    .filter({ hasText: name })
+    .first()
+    .click();
+}
+
+async function openImportModal(page: Page) {
+  const importBtn = page.locator('button[aria-label="Import into Context Graph"]');
+  await expect(importBtn).toBeVisible({ timeout: 10_000 });
+  await importBtn.click();
+}
+
+/** A promote control on whichever layer-view surface renders (testid-agnostic). */
+function promoteControl(page: Page) {
+  return page
+    .getByTestId('widget-promote-all-btn')
+    .or(page.getByTestId('list-promote-all-btn'))
+    .or(page.getByTestId('mlv-promote-all-btn'));
+}
+
+/** A publish control on whichever layer-view surface renders. */
+function publishControl(page: Page) {
+  return page
+    .getByTestId('widget-publish-vm-btn')
+    .or(page.getByTestId('list-publish-all-btn'))
+    .or(page.getByTestId('mlv-publish-all-btn'));
+}
+
+/** Any rendered promote/publish result container's combined text. */
+async function resultText(page: Page): Promise<string> {
+  const containers = page
+    .getByTestId('layer-action-result')
+    .or(page.getByTestId('list-action-result'))
+    .or(page.getByTestId('mlv-promote-result'));
+  const n = await containers.count();
+  let text = '';
+  for (let i = 0; i < n; i++) {
+    text += (await containers.nth(i).textContent()) ?? '';
+  }
+  return text;
+}
+
+test.describe('WM → SWM → VM via the UI', () => {
+  test('imports a Markdown file into Working Memory', async ({ shell, leftPanel, page, importFilesModal }) => {
+    await shell.goto();
+    await expect(async () => {
+      const names = await leftPanel.getProjectNames();
+      expect(names.length).toBeGreaterThan(0);
+    }).toPass({ timeout: 12_000, intervals: [250, 500, 1000] });
+
+    await openProjectTab(page, run.cgName!);
+    await openImportModal(page);
+    await expect(importFilesModal.overlay).toBeVisible();
+
+    await importFilesModal.selectFile(FIXTURE);
+    expect(await importFilesModal.isImportDisabled()).toBe(false);
+    await importFilesModal.startImport();
+
+    // Import result surfaces with a non-zero extracted-triple count.
+    const result = page.getByTestId('import-result');
+    await expect(result).toBeVisible({ timeout: 30_000 });
+    await expect(result).toHaveAttribute('data-import-status', 'success');
+    const triples = Number(await result.getAttribute('data-import-triples'));
+    expect(triples, 'extractor wrote >0 triples for the fixture').toBeGreaterThan(0);
+    await importFilesModal.clickDone();
+
+    // The assertion now exists in WM. Discover its data graph + marker URI.
+    await expect(async () => {
+      const a = await findWmAssertion(run.cgId!, FIXTURE_NAME_PART);
+      run.dataGraph = a.dataGraphUri;
+      run.markerUri = a.markerUri;
+    }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
+
+    const roots = await namedRootsInGraph(run.cgId!, run.dataGraph!);
+    expect(roots.length, 'fixture extracts exactly one named root entity').toBe(1);
+    run.rootUri = roots[0];
+
+    // Pre-promote invariants: the WM assertion holds content INCLUDING
+    // blank-node section subjects, and SWM has none of it yet.
+    expect(await countTriplesInGraph(run.cgId!, run.dataGraph!)).toBeGreaterThan(0);
+    expect(
+      await countBlankNodeTriplesInGraph(run.cgId!, run.dataGraph!),
+      'fixture must contain blank-node section triples (the bug trigger)',
+    ).toBeGreaterThan(0);
+    expect(await countRootInSharedMemory(run.cgId!, run.rootUri!)).toBe(0);
+    expect(await readMemoryLayerMarker(run.cgId!, run.markerUri!)).toBe('WM');
+  });
+
+  test('promotes WM → SWM via the UI and the triples actually migrate', async ({ shell, page }) => {
+    test.skip(!run.dataGraph || !run.rootUri, 'Import step did not produce an assertion');
+    await shell.goto();
+    await openProjectTab(page, run.cgName!);
+
+    // Switch to the Working Memory layer where the promote control lives.
+    await page.locator('button.v10-layer-switch-btn[data-layer="wm"]').first().click();
+
+    const promote = promoteControl(page);
+    await expect(promote).toBeVisible({ timeout: 15_000 });
+    await promote.click();
+
+    // UI contract: the result must NOT be the misleading "No triples were
+    // promoted" no-op that the blank-node DELETE bug produced. Wait for a
+    // result to render, then assert it isn't the no-op message.
+    await expect(async () => {
+      const text = await resultText(page);
+      expect(text.length, 'a promote result must render').toBeGreaterThan(0);
+      expect(text, 'promote must not report the no-op (the bug symptom)').not.toMatch(
+        /No triples were promoted/i,
+      );
+    }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
+
+    // Migration contract (surface-independent): the assertion's content left
+    // WM (blank nodes included), landed in SWM (root + skolemized children),
+    // and the memoryLayer marker flipped to SWM.
+    await expect(async () => {
+      expect(await countRootInSharedMemory(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
+    }).toPass({ timeout: 20_000, intervals: [500, 1000, 2000] });
+
+    expect(
+      await countBlankNodeTriplesInGraph(run.cgId!, run.dataGraph!),
+      'all blank-node triples must be removed from the WM assertion graph',
+    ).toBe(0);
+    expect(await readMemoryLayerMarker(run.cgId!, run.markerUri!)).toBe('SWM');
+  });
+
+  // DEFERRED (OriginTrail/dkg#966): the SWM → VM publish step is blocked by a
+  // SEPARATE product gap, not the promote bug this spec proves. On a CG with
+  // multiple SWM roots (the seeded devnet CG has ~25), the project-view
+  // "Publish all → VM" control is CORRECTLY rejected by the daemon — V10
+  // on-chain publish mints one Knowledge Asset per root and requires exactly
+  // one root per request. The per-root `PublishPanel` (checkbox-select a single
+  // root) exists in `MemoryLayerView` but is NOT wired into any UI navigation,
+  // so there is no click-path to single-root publish. Kept as `fixme` (living
+  // documentation) until either (a) the PublishPanel is wired into nav, or
+  // (b) this spec provisions its own dedicated single-root CG. The import →
+  // promote steps above are the asserting cycle for the blank-node fix.
+  test.fixme('publishes SWM → VM via the UI and the entity lands in Verifiable Memory', async ({ shell, page }) => {
+    test.skip(!run.rootUri, 'Promote step did not run');
+    await shell.goto();
+    await openProjectTab(page, run.cgName!);
+
+    // Switch to the Shared Working Memory layer where Publish lives.
+    await page.locator('button.v10-layer-switch-btn[data-layer="swm"]').first().click();
+
+    const publish = publishControl(page);
+    await expect(publish).toBeVisible({ timeout: 15_000 });
+    await publish.click();
+
+    // Outcome contract: the published entity becomes visible in the VM scope
+    // (context-graph root graphs, excluding assertion/_shared_memory/meta).
+    // This is the authoritative "did it publish" assertion; on-chain mint is
+    // verified by the API-driven sibling spec.
+    await expect(async () => {
+      expect(await countRootInVmScope(run.cgId!, run.rootUri!)).toBeGreaterThan(0);
+    }).toPass({ timeout: 60_000, intervals: [1000, 2000, 5000] });
+  });
+});

--- a/packages/node-ui/e2e/specs/import-data-display.spec.ts
+++ b/packages/node-ui/e2e/specs/import-data-display.spec.ts
@@ -43,7 +43,11 @@ test.describe('Import data display', () => {
 
   test('import modal shows supported format hint', async ({ page, importFilesModal }) => {
     await page.locator('button[title*="Import"], button[aria-label*="Import"]').first().click();
-    await expect(page.getByText(/\.md|\.pdf|\.docx/i)).toBeVisible();
+    // Scope to the import modal: a page-wide getByText(/\.md/) also matches any
+    // `.md` document the shared devnet already holds (e.g. another spec's
+    // import), which trips strict-mode with multiple matches. The hint lives in
+    // the modal, so assert there.
+    await expect(importFilesModal.overlay.getByText(/\.md|\.pdf|\.docx/i)).toBeVisible();
     await importFilesModal.cancel();
   });
 });

--- a/packages/node-ui/e2e/specs/import-files.spec.ts
+++ b/packages/node-ui/e2e/specs/import-files.spec.ts
@@ -110,11 +110,14 @@ test.describe('Import Files Modal', () => {
     expect(await importFilesModal.isImportDisabled()).toBe(false);
   });
 
-  test('dropzone shows the supported-format hint', async ({ page }) => {
+  test('dropzone shows the supported-format hint', async ({ importFilesModal }) => {
     // The hint text was reformatted in rc11 to include the leading
     // "Supported:" prefix — assert against a substring that's stable
     // across both the legacy (`.md, .docx, .pdf`) and rc11 surface.
-    await expect(page.getByText(/\.md/)).toBeVisible();
+    // Scope to the modal: a page-wide getByText(/\.md/) also matches any `.md`
+    // document the shared devnet already holds (another spec's import), tripping
+    // strict-mode. The hint lives in the dropzone inside the modal.
+    await expect(importFilesModal.overlay.getByText(/\.md/)).toBeVisible();
   });
 
   test('dropzone shows the drag instruction', async ({ page }) => {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
@@ -241,7 +241,12 @@ export function ImportFilesModal({ open, onClose, contextGraphId, contextGraphNa
 
           {(status === 'done' || status === 'error') && (
             <>
-              <div className={`v10-import-result ${errorCount > 0 ? 'error' : 'success'}`}>
+              <div
+                className={`v10-import-result ${errorCount > 0 ? 'error' : 'success'}`}
+                data-testid="import-result"
+                data-import-status={errorCount > 0 ? 'error' : 'success'}
+                data-import-triples={totalTriples}
+              >
                 {errorCount === 0 ? (
                   <>
                     Successfully imported {successCount} file{successCount !== 1 ? 's' : ''}.

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -202,10 +202,11 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete }:
       <div className="v10-decision-context" style={{ marginBottom: 10 }}>
         {count} {noun} in this layer can be {isWm ? 'promoted to Shared Working Memory for collaborative review' : 'published to Verifiable Memory on-chain'}.
       </div>
-      {result && <div style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
-      {error && <div style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
+      {result && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
+      {error && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
       <div className="v10-decision-actions">
         <button
+          data-testid={isWm ? 'widget-promote-all-btn' : 'widget-publish-vm-btn'}
           className={isWm ? 'v10-decision-btn approve' : 'v10-decision-btn primary-cta publish-vm'}
           style={isWm
             ? { borderColor: `${color}50`, color: 'var(--text-warning)', background: `${color}15`, opacity: busy ? 0.5 : 1 }

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.0-rc.17",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -7,6 +7,7 @@ import type {
   AskResult,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { buildBlankNodeSafeDelete } from './sparql-http.js';
 
 /**
  * BlazegraphStore — TripleStore adapter backed by a remote Blazegraph
@@ -44,12 +45,12 @@ export class BlazegraphStore implements TripleStore {
 
   async delete(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
-    const body = quads.map((q) => {
-      const g = q.graph ? `GRAPH <${escapeUri(q.graph)}>` : '';
-      const triple = `${formatTerm(q.subject)} <${q.predicate}> ${formatTerm(q.object)} .`;
-      return g ? `${g} { ${triple} }` : triple;
-    }).join('\n');
-    await this.sparqlUpdate(`DELETE DATA {\n${body}\n}`);
+    // Blazegraph is SPARQL 1.1, so blank nodes are illegal in `DELETE DATA`
+    // (same constraint as Oxigraph). Reuse the shared blank-node-safe builder
+    // so blank-node quads are removed via `DELETE { … } WHERE { … }`.
+    const update = buildBlankNodeSafeDelete(quads);
+    if (!update) return;
+    await this.sparqlUpdate(update);
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -64,8 +64,10 @@ export class BlazegraphStore implements TripleStore {
         `DELETE { GRAPH <${escapeUri(pattern.graph)}> { ${triple} } } WHERE { GRAPH <${escapeUri(pattern.graph)}> { ${triple} } }`,
       );
     } else {
+      // `DELETE { ?g_ctx { … } }` is a syntax error — the template needs the
+      // `GRAPH` keyword. Rejected with HTTP 400 by a spec-compliant endpoint.
       await this.sparqlUpdate(
-        `DELETE { ?g_ctx { ${triple} } } WHERE { GRAPH ?g_ctx { ${triple} } }`,
+        `DELETE { GRAPH ?g_ctx { ${triple} } } WHERE { GRAPH ?g_ctx { ${triple} } }`,
       );
     }
     const after = await this.countQuads(pattern.graph);

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -121,11 +121,15 @@ export class SparqlHttpStore implements TripleStore {
 
   async delete(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
-    const body = quads.map((q) => {
-      const g = q.graph ? `GRAPH <${escapeUri(q.graph)}> ` : '';
-      return `${g}{ ${formatTerm(q.subject)} <${escapeUri(q.predicate)}> ${formatTerm(q.object)} . }`;
-    }).join('\n');
-    const update = `DELETE DATA {\n${body}\n}`;
+    // SPARQL forbids blank nodes in `DELETE DATA` — a spec-compliant endpoint
+    // (Oxigraph, Fuseki, …) rejects the whole statement with HTTP 400 if any
+    // quad's subject or object is a blank node. `buildBlankNodeSafeDelete`
+    // keeps ground quads on the fast `DELETE DATA` path and removes
+    // blank-node quads with `DELETE { … } WHERE { … }` (blank nodes rewritten
+    // to variables) — the only spec-legal way to target existing blank-node
+    // structure over the SPARQL protocol. See the helper for details.
+    const update = buildBlankNodeSafeDelete(quads);
+    if (!update) return;
     const res = await this.postUpdate(update);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -337,6 +341,130 @@ function escapeUri(uri: string): string {
 
 function escapeString(s: string): string {
   return s.replace(/[\\"]/g, '\\$&');
+}
+
+/** True when an N-Quads term string denotes an RDF blank node (`_:label`). */
+export function isBlankNodeTerm(term: string): boolean {
+  return typeof term === 'string' && term.startsWith('_:');
+}
+
+/**
+ * Partition blank-node-bearing quads into connected components: two quads are
+ * connected when they share a blank-node label (directly or transitively). A
+ * union-find over the blank-node labels does the grouping.
+ *
+ * Each component is later deleted as ONE `DELETE … WHERE …` so its shared
+ * blank-node variables join correctly and any ground terms anchor the match.
+ * Disjoint components must be emitted as SEPARATE statements: a single WHERE
+ * holding two independent patterns is a cross-product, so if one pattern has
+ * no match the whole row is empty and NOTHING is deleted — a silent
+ * data-retention bug. Splitting by component avoids that.
+ */
+function connectedBlankNodeComponents(quads: DKGQuad[]): DKGQuad[][] {
+  const parent = new Map<string, string>();
+  const add = (x: string) => { if (!parent.has(x)) parent.set(x, x); };
+  const find = (x: string): string => {
+    while (parent.get(x) !== x) {
+      parent.set(x, parent.get(parent.get(x)!)!); // path halving
+      x = parent.get(x)!;
+    }
+    return x;
+  };
+  const union = (a: string, b: string) => { parent.set(find(a), find(b)); };
+
+  for (const q of quads) {
+    const labels: string[] = [];
+    if (isBlankNodeTerm(q.subject)) labels.push(q.subject);
+    if (isBlankNodeTerm(q.object)) labels.push(q.object);
+    labels.forEach(add);
+    if (labels.length === 2) union(labels[0], labels[1]);
+  }
+
+  const groups = new Map<string, DKGQuad[]>();
+  for (const q of quads) {
+    const label = isBlankNodeTerm(q.subject) ? q.subject : q.object;
+    const root = find(label);
+    let arr = groups.get(root);
+    if (!arr) { arr = []; groups.set(root, arr); }
+    arr.push(q);
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Build a spec-legal SPARQL Update that deletes exactly `quads`, including any
+ * whose subject or object is a blank node. Returns `null` for empty input.
+ *
+ * Strategy:
+ *  - Ground quads (no blank nodes) → a single `DELETE DATA { … }` block —
+ *    exact and fast (identical to the legacy behaviour for the common case).
+ *  - Blank-node quads → grouped into connected components ({@link
+ *    connectedBlankNodeComponents}); each component becomes a
+ *    `DELETE { … } WHERE { … }` with every blank node rewritten to a fresh
+ *    query variable. This is the only spec-legal way to remove existing
+ *    blank-node structure over the SPARQL protocol (`DELETE DATA` forbids
+ *    blank nodes outright).
+ *
+ * Caveat (inherent to SPARQL): a blank node has no stable name across the
+ * protocol, so a component is matched by *shape* + ground anchors, not
+ * identity. A truly isolated blank-node triple with no ground anchor (e.g. a
+ * lone `_:b <p> <o>`) matches every subject with that predicate/object; in
+ * practice such triples are part of a larger entity component anchored by a
+ * real IRI, so the match is precise. Two byte-for-byte isomorphic anchored
+ * components are indistinguishable in RDF and both delete — which is correct.
+ *
+ * Exported for unit testing of the generated SPARQL.
+ */
+export function buildBlankNodeSafeDelete(quads: DKGQuad[]): string | null {
+  if (quads.length === 0) return null;
+
+  const ground: DKGQuad[] = [];
+  const bnode: DKGQuad[] = [];
+  for (const q of quads) {
+    if (isBlankNodeTerm(q.subject) || isBlankNodeTerm(q.object)) bnode.push(q);
+    else ground.push(q);
+  }
+
+  const statements: string[] = [];
+
+  if (ground.length > 0) {
+    const body = ground.map((q) => {
+      const g = q.graph ? `GRAPH <${escapeUri(q.graph)}> ` : '';
+      return `${g}{ ${formatTerm(q.subject)} <${escapeUri(q.predicate)}> ${formatTerm(q.object)} . }`;
+    }).join('\n');
+    statements.push(`DELETE DATA {\n${body}\n}`);
+  }
+
+  if (bnode.length > 0) {
+    // Group by graph first — never join components across graphs.
+    const byGraph = new Map<string, DKGQuad[]>();
+    for (const q of bnode) {
+      const g = q.graph || '';
+      let arr = byGraph.get(g);
+      if (!arr) { arr = []; byGraph.set(g, arr); }
+      arr.push(q);
+    }
+    for (const [graph, list] of byGraph) {
+      for (const component of connectedBlankNodeComponents(list)) {
+        const vars = new Map<string, string>();
+        const render = (t: string): string => {
+          if (!isBlankNodeTerm(t)) return formatTerm(t);
+          let v = vars.get(t);
+          if (!v) { v = `?b${vars.size}`; vars.set(t, v); }
+          return v;
+        };
+        const triples = component
+          .map((q) => `${render(q.subject)} <${escapeUri(q.predicate)}> ${render(q.object)} .`)
+          .join('\n    ');
+        const inner = graph
+          ? `GRAPH <${escapeUri(graph)}> {\n    ${triples}\n  }`
+          : triples;
+        statements.push(`DELETE { ${inner} } WHERE { ${inner} }`);
+      }
+    }
+  }
+
+  return statements.join(';\n');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -148,7 +148,9 @@ export class SparqlHttpStore implements TripleStore {
     if (graphUri) {
       update = `DELETE { GRAPH <${escapeUri(graphUri)}> { ${triple} } } WHERE { GRAPH <${escapeUri(graphUri)}> { ${triple} } }`;
     } else {
-      update = `DELETE { ?g_ctx { ${triple} } } WHERE { GRAPH ?g_ctx { ${triple} } }`;
+      // The DELETE template must use the `GRAPH` keyword — `{ ?g_ctx { … } }`
+      // is a syntax error that a spec-compliant endpoint rejects with HTTP 400.
+      update = `DELETE { GRAPH ?g_ctx { ${triple} } } WHERE { GRAPH ?g_ctx { ${triple} } }`;
     }
     const res = await this.postUpdate(update);
     if (!res.ok) {

--- a/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
+++ b/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
@@ -108,8 +108,13 @@ export async function startOxigraphSparqlEndpoint(): Promise<OxigraphSparqlEndpo
         res.end(JSON.stringify({ head: { vars: [...vars] }, results: { bindings } }));
       } catch (e) {
         // Mirror oxigraph-server: a malformed/illegal update or query is a 400.
-        res.writeHead(400);
-        res.end(String((e as Error)?.message ?? e));
+        // The adapter only inspects the status code, never the body, so return a
+        // constant text/plain message instead of reflecting the caught exception
+        // text into the HTTP response (CodeQL: exception text reinterpreted as
+        // HTML + stack-trace info exposure). Log the real reason to stderr.
+        console.error('[oxigraph-sparql-endpoint] request rejected:', (e as Error)?.message ?? e);
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('SPARQL request rejected');
       }
     });
   });

--- a/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
+++ b/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
@@ -1,0 +1,126 @@
+/**
+ * In-process SPARQL 1.1 Protocol endpoint backed by an embedded Oxigraph store.
+ *
+ * It is faithful to `oxigraph-server` for SPARQL *parsing and execution* — it
+ * runs the very same engine — so it reproduces server-only behaviour such as
+ * the rejection of blank nodes in `DELETE DATA`, WITHOUT needing the server
+ * binary or a network service. This lets the `sparql-http` adapter participate
+ * in the storage conformance matrix BY DEFAULT, on every CI run, hermetically.
+ *
+ * Speaks exactly what `SparqlHttpStore` expects:
+ *   - POST /update                                  → store.update(), 204 / 400
+ *   - POST /query  Accept: sparql-results+json      → SELECT (W3C JSON) / ASK
+ *   - POST /query  Accept: n-quads | n-triples      → CONSTRUCT (N-Quads text)
+ */
+import { createServer, type Server } from 'node:http';
+import oxigraph from 'oxigraph';
+
+const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
+
+function escapeLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+
+function termToNT(t: oxigraph.Term): string {
+  switch (t.termType) {
+    case 'NamedNode':
+      return `<${t.value}>`;
+    case 'BlankNode':
+      return `_:${t.value}`;
+    case 'Literal': {
+      const lit = t as oxigraph.Literal;
+      let s = `"${escapeLiteral(lit.value)}"`;
+      if (lit.language) s += `@${lit.language}`;
+      else if (lit.datatype && lit.datatype.value !== XSD_STRING) s += `^^<${lit.datatype.value}>`;
+      return s;
+    }
+    default:
+      return `<${t.value}>`;
+  }
+}
+
+function termToJson(t: oxigraph.Term): Record<string, string> {
+  switch (t.termType) {
+    case 'NamedNode':
+      return { type: 'uri', value: t.value };
+    case 'BlankNode':
+      return { type: 'bnode', value: t.value };
+    case 'Literal': {
+      const lit = t as oxigraph.Literal;
+      const cell: Record<string, string> = { type: 'literal', value: lit.value };
+      if (lit.language) cell['xml:lang'] = lit.language;
+      else if (lit.datatype && lit.datatype.value !== XSD_STRING) cell.datatype = lit.datatype.value;
+      return cell;
+    }
+    default:
+      return { type: 'uri', value: t.value };
+  }
+}
+
+function quadToNQ(q: oxigraph.Quad): string {
+  const g = q.graph && q.graph.termType !== 'DefaultGraph' ? ` <${q.graph.value}>` : '';
+  return `${termToNT(q.subject)} <${q.predicate.value}> ${termToNT(q.object)}${g} .`;
+}
+
+export interface OxigraphSparqlEndpoint {
+  queryEndpoint: string;
+  updateEndpoint: string;
+  store: InstanceType<typeof oxigraph.Store>;
+  close: () => Promise<void>;
+}
+
+export async function startOxigraphSparqlEndpoint(): Promise<OxigraphSparqlEndpoint> {
+  const store = new oxigraph.Store();
+  const server: Server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      try {
+        if (req.url?.includes('/update')) {
+          store.update(body);
+          res.writeHead(204);
+          res.end();
+          return;
+        }
+        const accept = String(req.headers['accept'] ?? '');
+        const result = store.query(body);
+
+        if (typeof result === 'boolean') {
+          res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
+          res.end(JSON.stringify({ boolean: result }));
+          return;
+        }
+        if (accept.includes('n-quads') || accept.includes('n-triples')) {
+          const quads = (Array.isArray(result) ? (result as oxigraph.Quad[]) : []);
+          res.writeHead(200, { 'Content-Type': 'application/n-quads' });
+          res.end(quads.map(quadToNQ).join('\n') + '\n');
+          return;
+        }
+        const rows = (Array.isArray(result) ? result : []) as Map<string, oxigraph.Term>[];
+        const vars = new Set<string>();
+        for (const row of rows) for (const k of row.keys()) vars.add(k);
+        const bindings = rows.map((row) => {
+          const obj: Record<string, Record<string, string>> = {};
+          for (const [k, v] of row.entries()) obj[k] = termToJson(v);
+          return obj;
+        });
+        res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
+        res.end(JSON.stringify({ head: { vars: [...vars] }, results: { bindings } }));
+      } catch (e) {
+        // Mirror oxigraph-server: a malformed/illegal update or query is a 400.
+        res.writeHead(400);
+        res.end(String((e as Error)?.message ?? e));
+      }
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+  const base = `http://127.0.0.1:${port}`;
+  return {
+    queryEndpoint: `${base}/query`,
+    updateEndpoint: `${base}/update`,
+    store,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}

--- a/packages/storage/test/sparql-http-blank-nodes.test.ts
+++ b/packages/storage/test/sparql-http-blank-nodes.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Blank-node deletion regression suite for the `sparql-http` adapter.
+ *
+ * BACKGROUND (rc.16 ship-blocker): `SparqlHttpStore.delete(quads)` used to
+ * serialize every quad into a single `DELETE DATA { … }` block. SPARQL forbids
+ * blank nodes in `DELETE DATA`, so the moment any quad carried a blank node
+ * (`_:b`) a spec-compliant endpoint — Oxigraph, Fuseki, … — rejected the whole
+ * statement with HTTP 400 ("Variables and blank nodes are not allowed in
+ * DELETE DATA"). This broke "Promote All → Shared" (WM→SWM) for any entity
+ * containing nested/anonymous RDF, which is the common case.
+ *
+ * WHY IT WASN'T CAUGHT: every promote/share unit test used the embedded
+ * `OxigraphStore` (native object delete — blank-node-safe), and the lone
+ * `sparql-http.test.ts` used a mock HTTP server that *records* the update
+ * string but never parses or executes it. Invalid SPARQL therefore passed.
+ *
+ * THIS SUITE closes both gaps:
+ *   1. Unit-asserts the SPARQL that `buildBlankNodeSafeDelete` emits.
+ *   2. Executes that SPARQL through a REAL embedded Oxigraph engine — the same
+ *      engine `oxigraph-server` runs — across a broad matrix of blank-node
+ *      shapes, proving it parses, executes, and deletes exactly the right
+ *      triples. A control test proves the legacy `DELETE DATA`-with-bnode form
+ *      still throws on that engine, so a regression can't slip back in.
+ *   3. Drives the full `SparqlHttpStore.delete()` path over HTTP against an
+ *      in-process endpoint backed by that same engine.
+ */
+import { createServer, type Server } from 'node:http';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import oxigraph from 'oxigraph';
+import { SparqlHttpStore, type Quad } from '../src/index.js';
+import { buildBlankNodeSafeDelete, isBlankNodeTerm } from '../src/adapters/sparql-http.js';
+
+const G = 'http://example.org/graph/wm';
+const G2 = 'http://example.org/graph/wm2';
+const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function escapeLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+
+/** oxigraph Term → the N-Quads string form used by DKGQuad. */
+function termToStr(t: oxigraph.Term): string {
+  switch (t.termType) {
+    case 'NamedNode':
+      return t.value;
+    case 'BlankNode':
+      return `_:${t.value}`;
+    case 'Literal': {
+      const lit = t as oxigraph.Literal;
+      if (lit.language) return `"${escapeLiteral(lit.value)}"@${lit.language}`;
+      const dt = lit.datatype?.value;
+      if (dt && dt !== 'http://www.w3.org/2001/XMLSchema#string') {
+        return `"${escapeLiteral(lit.value)}"^^<${dt}>`;
+      }
+      return `"${escapeLiteral(lit.value)}"`;
+    }
+    default:
+      return t.value;
+  }
+}
+
+/** Read every quad of `graph` from an embedded store as DKGQuads (real bnode labels). */
+function readGraph(store: InstanceType<typeof oxigraph.Store>, graph: string): Quad[] {
+  const out: Quad[] = [];
+  for (const q of store.match(null, null, null, oxigraph.namedNode(graph))) {
+    out.push({
+      subject: termToStr(q.subject),
+      predicate: q.predicate.value,
+      object: termToStr(q.object),
+      graph,
+    });
+  }
+  return out;
+}
+
+function countGraph(store: InstanceType<typeof oxigraph.Store>, graph: string): number {
+  return [...store.match(null, null, null, oxigraph.namedNode(graph))].length;
+}
+
+function loaded(nquads: string): InstanceType<typeof oxigraph.Store> {
+  const store = new oxigraph.Store();
+  store.load(nquads, { format: 'application/n-quads' });
+  return store;
+}
+
+// ── blank-node fixtures (a broad matrix of "rich" shapes) ────────────────────
+
+const FIXTURES: Array<{ name: string; nquads: string; minQuads: number }> = [
+  {
+    name: 'blank node as object',
+    nquads: `<http://ex/s> <http://ex/p> _:b0 <${G}> .`,
+    minQuads: 1,
+  },
+  {
+    name: 'blank node as subject',
+    nquads: `_:b0 <http://ex/p> <http://ex/o> <${G}> .`,
+    minQuads: 1,
+  },
+  {
+    name: 'nested entity → address bnode → values (incl. typed literal)',
+    nquads: [
+      `<http://ex/alice> <http://ex/address> _:addr <${G}> .`,
+      `_:addr <http://ex/street> "Main St" <${G}> .`,
+      `_:addr <http://ex/city> "Springfield"@en <${G}> .`,
+      `_:addr <http://ex/geo> _:geo <${G}> .`,
+      `_:geo <http://ex/lat> "1.5"^^<${XSD_DECIMAL}> <${G}> .`,
+      `_:geo <http://ex/long> "2.5"^^<${XSD_DECIMAL}> <${G}> .`,
+    ].join('\n'),
+    minQuads: 6,
+  },
+  {
+    name: 'RDF collection (rdf:first/rdf:rest list with bnode cells)',
+    nquads: [
+      `<http://ex/s> <http://ex/items> _:l0 <${G}> .`,
+      `_:l0 <${RDF}first> <http://ex/a> <${G}> .`,
+      `_:l0 <${RDF}rest> _:l1 <${G}> .`,
+      `_:l1 <${RDF}first> <http://ex/b> <${G}> .`,
+      `_:l1 <${RDF}rest> <${RDF}nil> <${G}> .`,
+    ].join('\n'),
+    minQuads: 5,
+  },
+  {
+    name: 'bnode shared by two distinct subjects (one component)',
+    nquads: [
+      `<http://ex/a> <http://ex/knows> _:shared <${G}> .`,
+      `<http://ex/c> <http://ex/knows> _:shared <${G}> .`,
+      `_:shared <http://ex/name> "Bob" <${G}> .`,
+    ].join('\n'),
+    minQuads: 3,
+  },
+  {
+    name: 'two disjoint blank-node structures in one graph',
+    nquads: [
+      `<http://ex/x> <http://ex/p> _:b0 <${G}> .`,
+      `_:b0 <http://ex/v> "first" <${G}> .`,
+      `<http://ex/y> <http://ex/p> _:b1 <${G}> .`,
+      `_:b1 <http://ex/v> "second" <${G}> .`,
+    ].join('\n'),
+    minQuads: 4,
+  },
+  {
+    name: 'deep bnode chain (b0→b1→b2→b3)',
+    nquads: [
+      `<http://ex/root> <http://ex/n> _:b0 <${G}> .`,
+      `_:b0 <http://ex/n> _:b1 <${G}> .`,
+      `_:b1 <http://ex/n> _:b2 <${G}> .`,
+      `_:b2 <http://ex/n> _:b3 <${G}> .`,
+      `_:b3 <http://ex/leaf> "end" <${G}> .`,
+    ].join('\n'),
+    minQuads: 5,
+  },
+  {
+    name: 'mixed ground + blank-node quads',
+    nquads: [
+      `<http://ex/s1> <http://ex/p> <http://ex/o1> <${G}> .`,
+      `<http://ex/s2> <http://ex/label> "ground literal" <${G}> .`,
+      `<http://ex/s3> <http://ex/nested> _:b0 <${G}> .`,
+      `_:b0 <http://ex/v> "blank" <${G}> .`,
+    ].join('\n'),
+    minQuads: 4,
+  },
+];
+
+// ── 1. builder: structural assertions on the generated SPARQL ────────────────
+
+describe('buildBlankNodeSafeDelete — generated SPARQL shape', () => {
+  it('ground-only quads → a single DELETE DATA, no variables, no blank nodes', () => {
+    const update = buildBlankNodeSafeDelete([
+      { subject: 'http://ex/s', predicate: 'http://ex/p', object: 'http://ex/o', graph: G },
+    ])!;
+    expect(update).toContain('DELETE DATA');
+    expect(update).not.toContain('WHERE');
+    expect(update).not.toContain('_:');
+    expect(update).not.toMatch(/\?b\d/);
+  });
+
+  it('blank-node quad → DELETE … WHERE with the bnode rewritten to a variable; never DELETE DATA, never a raw _:', () => {
+    const update = buildBlankNodeSafeDelete([
+      { subject: 'http://ex/s', predicate: 'http://ex/p', object: '_:b0', graph: G },
+    ])!;
+    expect(update).toContain('DELETE {');
+    expect(update).toContain('WHERE {');
+    expect(update).toMatch(/\?b0/);
+    // A blank node must NEVER appear in the generated update text.
+    expect(update).not.toContain('_:');
+  });
+
+  it('disjoint components emit SEPARATE DELETE/WHERE statements (no cross-product)', () => {
+    const update = buildBlankNodeSafeDelete([
+      { subject: 'http://ex/x', predicate: 'http://ex/p', object: '_:b0', graph: G },
+      { subject: '_:b0', predicate: 'http://ex/v', object: '"first"', graph: G },
+      { subject: 'http://ex/y', predicate: 'http://ex/p', object: '_:b1', graph: G },
+      { subject: '_:b1', predicate: 'http://ex/v', object: '"second"', graph: G },
+    ])!;
+    const stmts = update.split(';').filter((s) => s.includes('DELETE'));
+    expect(stmts.length).toBe(2);
+    expect(update).not.toContain('_:');
+  });
+
+  it('mixed input → both a DELETE DATA block and a DELETE/WHERE block', () => {
+    const update = buildBlankNodeSafeDelete([
+      { subject: 'http://ex/s1', predicate: 'http://ex/p', object: 'http://ex/o1', graph: G },
+      { subject: 'http://ex/s3', predicate: 'http://ex/nested', object: '_:b0', graph: G },
+      { subject: '_:b0', predicate: 'http://ex/v', object: '"blank"', graph: G },
+    ])!;
+    expect(update).toContain('DELETE DATA');
+    expect(update).toContain('DELETE {');
+    expect(update).not.toContain('_:');
+  });
+
+  it('empty input → null', () => {
+    expect(buildBlankNodeSafeDelete([])).toBeNull();
+  });
+
+  it('isBlankNodeTerm distinguishes blank nodes from IRIs and literals', () => {
+    expect(isBlankNodeTerm('_:b0')).toBe(true);
+    expect(isBlankNodeTerm('http://ex/s')).toBe(false);
+    expect(isBlankNodeTerm('"a literal"')).toBe(false);
+  });
+});
+
+// ── 2. control: the legacy form must still be rejected by the real engine ────
+
+describe('control — legacy DELETE DATA with a blank node is rejected by the SPARQL engine', () => {
+  it('store.update(DELETE DATA { … _:b … }) throws (the exact rc.16 bug)', () => {
+    const store = loaded(`<http://ex/s> <http://ex/p> _:b0 <${G}> .`);
+    const legacy = `DELETE DATA {\nGRAPH <${G}> { <http://ex/s> <http://ex/p> _:b0 . }\n}`;
+    expect(() => store.update(legacy)).toThrow();
+  });
+});
+
+// ── 3. engine execution: generated SPARQL parses, runs, and deletes exactly ──
+
+describe('buildBlankNodeSafeDelete — executes correctly on a real Oxigraph engine', () => {
+  for (const fx of FIXTURES) {
+    it(`deletes the full graph for: ${fx.name}`, () => {
+      const store = loaded(fx.nquads);
+      expect(countGraph(store, G)).toBeGreaterThanOrEqual(fx.minQuads);
+
+      const quads = readGraph(store, G);
+      const update = buildBlankNodeSafeDelete(quads)!;
+
+      // Must not throw — this is what the legacy DELETE DATA did.
+      expect(() => store.update(update)).not.toThrow();
+      // And every quad must be gone.
+      expect(countGraph(store, G)).toBe(0);
+    });
+  }
+
+  it('partial delete: removes one entity component and leaves the rest intact', () => {
+    const store = loaded([
+      `<http://ex/alice> <http://ex/address> _:a <${G}> .`,
+      `_:a <http://ex/city> "Springfield" <${G}> .`,
+      `<http://ex/bob> <http://ex/address> _:b <${G}> .`,
+      `_:b <http://ex/city> "Portland" <${G}> .`,
+    ].join('\n'));
+    expect(countGraph(store, G)).toBe(4);
+
+    // Delete only Alice's component (entity IRI + its bnode subtree).
+    const aliceQuads = readGraph(store, G).filter(
+      (q) => q.subject === 'http://ex/alice' ||
+        // the bnode whose city is Springfield
+        [...store.match(null, oxigraph.namedNode('http://ex/city'), oxigraph.literal('Springfield'), oxigraph.namedNode(G))]
+          .some((m) => `_:${(m.subject as oxigraph.BlankNode).value}` === q.subject),
+    );
+    const update = buildBlankNodeSafeDelete(aliceQuads)!;
+    expect(() => store.update(update)).not.toThrow();
+
+    // Bob survives intact.
+    expect(countGraph(store, G)).toBe(2);
+    const remaining = readGraph(store, G);
+    expect(remaining.some((q) => q.subject === 'http://ex/bob')).toBe(true);
+    expect(remaining.some((q) => q.object === '"Portland"')).toBe(true);
+    expect(remaining.some((q) => q.object === '"Springfield"')).toBe(false);
+  });
+
+  it('cross-graph delete: blank-node structures in two graphs in one call', () => {
+    const store = loaded([
+      `<http://ex/s> <http://ex/p> _:b0 <${G}> .`,
+      `_:b0 <http://ex/v> "g1" <${G}> .`,
+      `<http://ex/s> <http://ex/p> _:b1 <${G2}> .`,
+      `_:b1 <http://ex/v> "g2" <${G2}> .`,
+    ].join('\n'));
+    const quads = [...readGraph(store, G), ...readGraph(store, G2)];
+    const update = buildBlankNodeSafeDelete(quads)!;
+    expect(() => store.update(update)).not.toThrow();
+    expect(countGraph(store, G)).toBe(0);
+    expect(countGraph(store, G2)).toBe(0);
+  });
+
+  it('reproduces the promote bug end-to-end: CONSTRUCT a WM graph then delete the result', () => {
+    // Mirrors assertionPromote(): CONSTRUCT all quads from the source graph,
+    // then delete them. Pre-fix this CONSTRUCT→delete round-trip 400'd.
+    const store = loaded(FIXTURES[2].nquads); // nested entity w/ bnodes
+    const construct = store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${G}> { ?s ?p ?o } }`,
+    ) as oxigraph.Quad[];
+    const quads: Quad[] = construct.map((q) => ({
+      subject: termToStr(q.subject),
+      predicate: q.predicate.value,
+      object: termToStr(q.object),
+      graph: G,
+    }));
+    const update = buildBlankNodeSafeDelete(quads)!;
+    expect(() => store.update(update)).not.toThrow();
+    expect(countGraph(store, G)).toBe(0);
+  });
+});
+
+// ── 4. full adapter path: SparqlHttpStore.delete() over HTTP, real engine ────
+
+describe('SparqlHttpStore.delete() — full HTTP path against a real Oxigraph engine', () => {
+  let server: Server;
+  let store: InstanceType<typeof oxigraph.Store>;
+  let updateUrl: string;
+  let adapter: SparqlHttpStore;
+
+  beforeAll(async () => {
+    store = new oxigraph.Store();
+    // Minimal SPARQL endpoint: /update runs the real engine and returns 400 on
+    // any parse/exec error — exactly how oxigraph-server behaves.
+    server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url?.endsWith('/update')) {
+          try {
+            store.update(body);
+            res.writeHead(204);
+            res.end();
+          } catch (e) {
+            res.writeHead(400);
+            res.end(String((e as Error)?.message ?? e));
+          }
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    updateUrl = `http://127.0.0.1:${port}/update`;
+    adapter = new SparqlHttpStore({
+      queryEndpoint: `http://127.0.0.1:${port}/query`,
+      updateEndpoint: updateUrl,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('deletes blank-node entities through the adapter without a 400', async () => {
+    store.load(FIXTURES[2].nquads, { format: 'application/n-quads' });
+    expect(countGraph(store, G)).toBeGreaterThan(0);
+
+    const quads = readGraph(store, G);
+    // Pre-fix this rejected with "SPARQL HTTP delete failed (400)".
+    await expect(adapter.delete(quads)).resolves.toBeUndefined();
+    expect(countGraph(store, G)).toBe(0);
+  });
+
+  it('still deletes ground-only quads exactly (no regression to the fast path)', async () => {
+    store.load(
+      [
+        `<http://ex/g1> <http://ex/p> <http://ex/o> <${G}> .`,
+        `<http://ex/g2> <http://ex/p> "lit" <${G}> .`,
+      ].join('\n'),
+      { format: 'application/n-quads' },
+    );
+    const before = countGraph(store, G);
+    expect(before).toBe(2);
+    await expect(
+      adapter.delete([
+        { subject: 'http://ex/g1', predicate: 'http://ex/p', object: 'http://ex/o', graph: G },
+      ]),
+    ).resolves.toBeUndefined();
+    expect(countGraph(store, G)).toBe(1); // only the targeted ground quad removed
+  });
+});

--- a/packages/storage/test/sparql-http-blank-nodes.test.ts
+++ b/packages/storage/test/sparql-http-blank-nodes.test.ts
@@ -332,8 +332,15 @@ describe('SparqlHttpStore.delete() — full HTTP path against a real Oxigraph en
             res.writeHead(204);
             res.end();
           } catch (e) {
-            res.writeHead(400);
-            res.end(String((e as Error)?.message ?? e));
+            // Mirror oxigraph-server's "400 on bad update" behaviour. The
+            // adapter only inspects the status code, never the body, so return a
+            // constant text/plain message instead of reflecting the caught
+            // exception text into the HTTP response (CodeQL: exception text
+            // reinterpreted as HTML + stack-trace info exposure). Surface the
+            // real reason to the test runner via stderr for debuggability.
+            console.error('[mock-sparql] update rejected:', (e as Error)?.message ?? e);
+            res.writeHead(400, { 'Content-Type': 'text/plain' });
+            res.end('SPARQL update rejected');
           }
           return;
         }

--- a/packages/storage/test/sparql-http-blank-nodes.test.ts
+++ b/packages/storage/test/sparql-http-blank-nodes.test.ts
@@ -25,7 +25,7 @@
  *      in-process endpoint backed by that same engine.
  */
 import { createServer, type Server } from 'node:http';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import oxigraph from 'oxigraph';
 import { SparqlHttpStore, type Quad } from '../src/index.js';
 import { buildBlankNodeSafeDelete, isBlankNodeTerm } from '../src/adapters/sparql-http.js';
@@ -360,6 +360,14 @@ describe('SparqlHttpStore.delete() — full HTTP path against a real Oxigraph en
 
   afterAll(async () => {
     await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  beforeEach(() => {
+    // The long-lived endpoint serves whatever `store` currently points at, so
+    // give each case a FRESH embedded graph. Without this, data left behind (or
+    // an early failure before cleanup) in one case would leak into the next and
+    // produce a misleading failure.
+    store = new oxigraph.Store();
   });
 
   it('deletes blank-node entities through the adapter without a 400', async () => {

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
 import {
   OxigraphStore,
   BlazegraphStore,
+  SparqlHttpStore,
   GraphManager,
   PrivateContentStore,
   createTripleStore,
@@ -9,6 +10,7 @@ import {
   type Quad,
   type TripleStore,
 } from '../src/index.js';
+import { startOxigraphSparqlEndpoint, type OxigraphSparqlEndpoint } from './helpers/oxigraph-sparql-endpoint.js';
 
 // ---------------------------------------------------------------------------
 // Shared TripleStore conformance suite — runs against every backend
@@ -75,6 +77,50 @@ function tripleStoreConformanceSuite(name: string, factory: () => Promise<Triple
       const removed = await store.deleteBySubjectPrefix(g, 'did:dkg:agent:Bot');
       expect(removed).toBe(2);
       expect(await store.countQuads(g)).toBe(1);
+    });
+
+    // ── blank-node coverage ──────────────────────────────────────────────
+    // These run against EVERY backend in the matrix. On the SPARQL-over-HTTP
+    // adapters (oxigraph-server, blazegraph) they exercise the code path that
+    // shipped broken in rc.16: deleting quads with blank nodes via DELETE DATA
+    // (illegal SPARQL → HTTP 400). The embedded backends were always safe;
+    // running both side by side is what catches adapter divergence.
+
+    it('round-trips a quad whose object is a blank node', async () => {
+      const g = 'http://ex.org/g';
+      await store.insert([{ subject: 'http://ex.org/s', predicate: 'http://ex.org/p', object: '_:b0', graph: g }]);
+      expect(await store.countQuads(g)).toBe(1);
+      const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${g}> { ?s ?p ?o } }`);
+      expect(r.type).toBe('quads');
+      if (r.type === 'quads') {
+        expect(r.quads.length).toBe(1);
+        expect(r.quads[0].object.startsWith('_:')).toBe(true);
+      }
+    });
+
+    it('deletes a quad whose object is a blank node (read-back then delete)', async () => {
+      const g = 'http://ex.org/g';
+      await store.insert([{ subject: 'http://ex.org/s', predicate: 'http://ex.org/p', object: '_:b0', graph: g }]);
+      const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${g}> { ?s ?p ?o } }`);
+      const quads = r.type === 'quads' ? r.quads.map((q) => ({ ...q, graph: g })) : [];
+      await store.delete(quads); // pre-fix: HTTP 400 on the SPARQL backends
+      expect(await store.countQuads(g)).toBe(0);
+    });
+
+    it('deletes a nested entity with blank-node children (the WM→SWM promote shape)', async () => {
+      const g = 'http://ex.org/g';
+      await store.insert([
+        { subject: 'http://ex.org/alice', predicate: 'http://ex.org/address', object: '_:addr', graph: g },
+        { subject: '_:addr', predicate: 'http://ex.org/city', object: '"Springfield"', graph: g },
+        { subject: '_:addr', predicate: 'http://ex.org/geo', object: '_:geo', graph: g },
+        { subject: '_:geo', predicate: 'http://ex.org/lat', object: '"1.5"^^<http://www.w3.org/2001/XMLSchema#decimal>', graph: g },
+      ]);
+      // CONSTRUCT the whole graph then delete it — exactly what assertionPromote does.
+      const r = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${g}> { ?s ?p ?o } }`);
+      const quads = r.type === 'quads' ? r.quads.map((q) => ({ ...q, graph: g })) : [];
+      expect(quads.length).toBe(4);
+      await store.delete(quads);
+      expect(await store.countQuads(g)).toBe(0);
     });
 
     it('listGraphs', async () => {
@@ -159,6 +205,24 @@ tripleStoreConformanceSuite('OxigraphStore (direct)', async () => new OxigraphSt
 
 // Run conformance suite against OxigraphStore via factory (validates adapter registration)
 tripleStoreConformanceSuite('OxigraphStore (factory)', async () => createTripleStore({ backend: 'oxigraph' }));
+
+// Run the SAME suite against the `sparql-http` adapter (the oxigraph-server
+// backend a fresh `dkg init` defaults to) by default, on every run. Backed by
+// an in-process SPARQL endpoint running the real Oxigraph engine — so it
+// reproduces server-only behaviour (e.g. blank nodes illegal in DELETE DATA)
+// without the server binary. This is the matrix entry that would have caught
+// the rc.16 blank-node delete bug.
+let sparqlHttpEndpoint: OxigraphSparqlEndpoint | undefined;
+beforeAll(async () => { sparqlHttpEndpoint = await startOxigraphSparqlEndpoint(); });
+afterAll(async () => { await sparqlHttpEndpoint?.close(); });
+tripleStoreConformanceSuite('SparqlHttpStore (oxigraph-server, in-process)', async () => {
+  // Fresh state per test: every backend factory yields an empty store.
+  sparqlHttpEndpoint!.store.update('DROP ALL');
+  return new SparqlHttpStore({
+    queryEndpoint: sparqlHttpEndpoint!.queryEndpoint,
+    updateEndpoint: sparqlHttpEndpoint!.updateEndpoint,
+  });
+});
 
 // BlazegraphStore conformance runs only when Blazegraph is reachable.
 // Set BLAZEGRAPH_URL=http://127.0.0.1:9999/bigdata/namespace/test/sparql to enable.

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -755,6 +755,25 @@ cmd_start() {
   start_blazegraph
   start_oxigraph_servers
 
+  # ── backend coverage summary + optional strict gate ───────────────────────
+  # The devnet runs a store-backend matrix (nodes 1-2 oxigraph-worker, 3-4
+  # blazegraph, 5-6 sparql-http/oxigraph-server). When Docker is unavailable
+  # the SPARQL-over-HTTP backends SILENTLY fall back to the embedded store —
+  # which is exactly how the rc.16 blank-node DELETE-DATA bug slipped past
+  # devnet (no node actually ran sparql-http). Make the degradation loud, and
+  # let CI demand the full matrix via DEVNET_REQUIRE_ALL_BACKENDS=1.
+  local bg_state ox_state
+  if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then bg_state="blazegraph"; else bg_state="DEGRADED → oxigraph in-process (blazegraph unavailable)"; fi
+  if [ "$OXIGRAPH_SERVER_AVAILABLE" = true ]; then ox_state="sparql-http / oxigraph-server"; else ox_state="DEGRADED → oxigraph-worker (oxigraph-server unavailable)"; fi
+  log "Store-backend matrix:  nodes 1-2: oxigraph-worker  |  nodes 3-4: $bg_state  |  nodes 5-6: $ox_state"
+  if [ "$BLAZEGRAPH_AVAILABLE" != true ] || [ "$OXIGRAPH_SERVER_AVAILABLE" != true ]; then
+    if [ "${DEVNET_REQUIRE_ALL_BACKENDS:-0}" = "1" ]; then
+      log "ERROR: DEVNET_REQUIRE_ALL_BACKENDS=1 but a SPARQL-over-HTTP backend could not be provisioned (needs Docker + the oxigraph/oxigraph and blazegraph images). Aborting rather than silently shrinking the backend matrix."
+      exit 1
+    fi
+    log "WARNING: SPARQL-over-HTTP backend coverage is REDUCED for this devnet run. The hermetic storage conformance matrix still exercises sparql-http on every test run; set DEVNET_REQUIRE_ALL_BACKENDS=1 to make this a hard failure in CI."
+  fi
+
   # Stop any already-running devnet nodes so they pick up the config we are about to write
   stop_devnet_nodes_only
 

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -414,12 +414,26 @@ create_node_config() {
   # start_node() to point at node 1's local multiaddr.
   local relay_value='"relay": "none",'
 
-  # Backend assignment:
-  #   Node 1-2: oxigraph-worker  (worker thread, file-persisted — production default)
-  #   Node 3-4: oxigraph          (in-process, no worker thread — comparison baseline)
-  #   Node 5-6: blazegraph        (remote SPARQL, if Docker available — else oxigraph-worker)
+  # Backend assignment (production parity + hermetic — no Docker required for the
+  # primary coverage):
+  #   Node 1-2: oxigraph-server  (DAEMON-MANAGED local server — the actual
+  #             fresh-install production default since rc.12. The daemon
+  #             auto-downloads + SHA-256-verifies + caches the Oxigraph binary
+  #             and spawns it on its own port — NO Docker. Node 1 is the node the
+  #             UI/e2e suite drives, so the suite now exercises the REAL default
+  #             backend and deterministically reproduces SPARQL-over-HTTP-only
+  #             bugs such as #996 — which the old `oxigraph-worker` default hid.)
+  #   Node 3-4: blazegraph (if Docker) else oxigraph  (in-process baseline)
+  #   Node 5-6: sparql-http → external Dockerized Oxigraph  (EXTRA coverage of the
+  #             generic external-endpoint path; Docker-only, optional)
   local store_block=""
-  if [ "$node_num" -ge 3 ] && [ "$node_num" -le 4 ]; then
+  if [ "$node_num" -ge 1 ] && [ "$node_num" -le 2 ]; then
+    # The managed oxigraph-server defaults to port 7878; multiple nodes on one
+    # host must pin DISTINCT ports or the second collides ("Address already in
+    # use"). Give each node its own (7900 + node_num), clear of the Dockerized
+    # external Oxigraph on 7878/7879 (nodes 5-6) and a real node's 7878.
+    store_block="\"store\": { \"backend\": \"oxigraph-server\", \"options\": { \"port\": $((7900 + node_num)) } },"
+  elif [ "$node_num" -ge 3 ] && [ "$node_num" -le 4 ]; then
     if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then
       store_block="\"store\": { \"backend\": \"blazegraph\", \"options\": { \"url\": \"http://127.0.0.1:${BLAZEGRAPH_PORT}/bigdata/namespace/node${node_num}/sparql\" } },"
     else
@@ -756,26 +770,49 @@ cmd_start() {
   start_oxigraph_servers
 
   # ── backend coverage summary + optional strict gate ───────────────────────
-  # The devnet runs a store-backend matrix (nodes 1-2 oxigraph-worker, 3-4
-  # blazegraph, 5-6 sparql-http/oxigraph-server). When Docker is unavailable
-  # the SPARQL-over-HTTP backends SILENTLY fall back to the embedded store —
-  # which is exactly how the rc.16 blank-node DELETE-DATA bug slipped past
-  # devnet (no node actually ran sparql-http). Make the degradation loud, and
-  # let CI demand the full matrix via DEVNET_REQUIRE_ALL_BACKENDS=1.
-  local bg_state ox_state
-  if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then bg_state="blazegraph"; else bg_state="DEGRADED → oxigraph in-process (blazegraph unavailable)"; fi
-  if [ "$OXIGRAPH_SERVER_AVAILABLE" = true ]; then ox_state="sparql-http / oxigraph-server"; else ox_state="DEGRADED → oxigraph-worker (oxigraph-server unavailable)"; fi
-  log "Store-backend matrix:  nodes 1-2: oxigraph-worker  |  nodes 3-4: $bg_state  |  nodes 5-6: $ox_state"
+  # Nodes 1-2 run the daemon-managed `oxigraph-server` (the production default)
+  # with NO Docker — the binary is auto-downloaded/cached by the daemon — so the
+  # SPARQL-over-HTTP path, AND the node the UI/e2e suite drives, is ALWAYS
+  # exercised. That closes the rc.16 gap where the matrix silently fell back to
+  # the embedded store and the blank-node DELETE-DATA bug slipped past devnet.
+  # The Docker-gated entries below (blazegraph on 3-4, an EXTERNAL Oxigraph
+  # server on 5-6) are EXTRA matrix coverage; DEVNET_REQUIRE_ALL_BACKENDS=1 makes
+  # their absence a hard failure for full-matrix CI.
+  local bg_state ox_extra
+  if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then bg_state="blazegraph"; else bg_state="oxigraph in-process (blazegraph Docker unavailable)"; fi
+  if [ "$OXIGRAPH_SERVER_AVAILABLE" = true ]; then ox_extra="sparql-http → external Oxigraph"; else ox_extra="(skipped — external Oxigraph Docker unavailable)"; fi
+  log "Store-backend matrix:  nodes 1-2: oxigraph-server (managed, no Docker)  |  nodes 3-4: $bg_state  |  nodes 5-6: $ox_extra"
   if [ "$BLAZEGRAPH_AVAILABLE" != true ] || [ "$OXIGRAPH_SERVER_AVAILABLE" != true ]; then
     if [ "${DEVNET_REQUIRE_ALL_BACKENDS:-0}" = "1" ]; then
-      log "ERROR: DEVNET_REQUIRE_ALL_BACKENDS=1 but a SPARQL-over-HTTP backend could not be provisioned (needs Docker + the oxigraph/oxigraph and blazegraph images). Aborting rather than silently shrinking the backend matrix."
+      log "ERROR: DEVNET_REQUIRE_ALL_BACKENDS=1 but an EXTRA Docker backend (blazegraph and/or external Oxigraph) is missing. The core oxigraph-server path IS covered on nodes 1-2, but full-matrix CI also requires the Docker images. Aborting."
       exit 1
     fi
-    log "WARNING: SPARQL-over-HTTP backend coverage is REDUCED for this devnet run. The hermetic storage conformance matrix still exercises sparql-http on every test run; set DEVNET_REQUIRE_ALL_BACKENDS=1 to make this a hard failure in CI."
+    log "NOTE: EXTRA Docker backends (blazegraph / external Oxigraph) are not provisioned this run. The production-default oxigraph-server path IS covered on nodes 1-2; set DEVNET_REQUIRE_ALL_BACKENDS=1 to require the Docker extras too."
   fi
 
   # Stop any already-running devnet nodes so they pick up the config we are about to write
   stop_devnet_nodes_only
+
+  # The chain was just freshly deployed (start_hardhat wiped the deployment
+  # artifacts + marker above), so ANY persisted per-node store state is STALE —
+  # it references the OLD chain. The critical case: a node's store still holds
+  # the `dkg:contextGraphOnChainId` triple from a previous run, so
+  # `registerContextGraph` below short-circuits on a stale "already registered"
+  # view and never creates the CG on the NEW chain. The CG then reads back
+  # `isContextGraphActive=false` / `publishPolicy=0`, the post-boot policy
+  # assertion fails, and every VM publish hits LU-5 ("publish access-policy is
+  # unknown"). Wipe each node's persisted state now that the nodes are stopped —
+  # but KEEP the cached Oxigraph binary (`oxigraph/`) so we don't re-download it.
+  # Nodes re-register identities + CGs and re-sync from scratch against the fresh
+  # chain, which is exactly the e2e seed-from-clean model.
+  if [ -d "$DEVNET_DIR" ]; then
+    local nd
+    for nd in "$DEVNET_DIR"/node*/; do
+      [ -d "$nd" ] || continue
+      find "$nd" -mindepth 1 -maxdepth 1 ! -name oxigraph -exec rm -rf {} + 2>/dev/null || true
+    done
+    log "Cleared stale per-node store state for the freshly-deployed chain (kept cached Oxigraph binaries)"
+  fi
 
   # Generate a shared auth token for all devnet nodes
   local shared_token


### PR DESCRIPTION
## rc.17 — SPARQL-backend correctness + the test coverage that gates it

### Bug 1 — blank nodes in `DELETE DATA` (the ship-blocker)
`SparqlHttpStore.delete(quads)` / `BlazegraphStore.delete` serialized quads into `DELETE DATA { … }`. SPARQL forbids blank nodes there, so any quad with a blank-node subject/object → **HTTP 400** on a spec-compliant endpoint. Broke "Promote All → Shared" (WM→SWM: `assertionPromote` CONSTRUCTs the source graph then `store.delete`s it) for any entity with nested/anonymous RDF, and exposed every other `store.delete(quads)` caller on the oxigraph-server backend.

**Fix:** shared `buildBlankNodeSafeDelete()` — ground quads keep the fast `DELETE DATA` path; blank-node quads delete via per-connected-component `DELETE { … } WHERE { … }` with bnodes rewritten to variables (the only spec-legal way over SPARQL).

### Bug 2 — `deleteByPattern` no-graph branch (found by the new matrix)
Emitted `DELETE { ?g_ctx { … } }` — missing the `GRAPH` keyword → invalid SPARQL, HTTP 400 on any real endpoint. Never executed by a test before. Fixed in both adapters.

### Why CI/devnet were green (the coverage gap)
- Only the **SPARQL-over-HTTP** adapters are affected; the embedded `OxigraphStore`/`oxigraph-worker` delete via the native object API.
- The conformance suite had **zero blank-node cases** and **never ran against `sparql-http`**.
- The lone `sparql-http` test used a mock server that recorded SPARQL without executing it.
- devnet *has* a per-node backend matrix, but **silently fell back to embedded** when Docker was absent — so no node ran `sparql-http` during rc.16 validation.

### Tests
- `sparql-http-blank-nodes.test.ts` (20 cases): broad blank-node matrix executed against a **real Oxigraph engine** + full HTTP path; control proves the legacy form still throws. Verified: 20/20 pass on the fix, **16/20 fail on the legacy code**.
- **Conformance matrix now includes `sparql-http`** (in-process, real engine, runs by default) + **blank-node cases in the shared body** → every backend exercised with blank nodes. This is the entry that would have caught both bugs. Storage suite: **181 passed**.
- `devnet.sh`: loud backend-coverage summary + opt-in `DEVNET_REQUIRE_ALL_BACKENDS=1` strict gate so CI can't silently shrink the matrix.

### Release
Bumps root + 18 packages `10.0.0-rc.16` → `10.0.0-rc.17`. **No contract changes** — contracts stay `10.0.3`, no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)