### PR TITLE
Fix local agent chat timeout attribution

### DIFF
--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -45,7 +45,7 @@ import {
 export const CHANNEL_NAME = 'dkg-ui';
 const DEFAULT_CHANNEL_ACCOUNT_ID = 'default';
 const TURN_PERSIST_RETRY_DELAYS_MS = [250, 1_000] as const;
-const CHANNEL_RESPONSE_TIMEOUT_MS = 180_000;
+const CHANNEL_RESPONSE_TIMEOUT_MS = 15 * 60_000;
 const STOP_DRAIN_TIMEOUT_MS = 1_500;
 const FINAL_MARKER_FLUSH_TIMEOUT_MS = 250;
 const NO_TEXT_RESPONSE_ERROR = 'Agent returned no text response';

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -66,6 +66,12 @@ function buildAgentTimeoutResponseBody(): Record<string, unknown> {
   };
 }
 
+function buildStreamErrorEvent(err: any): Record<string, unknown> {
+  return isAgentResponseTimeoutError(err)
+    ? { type: 'error', ...buildAgentTimeoutResponseBody() }
+    : { type: 'error', error: err?.message ?? String(err) };
+}
+
 /** Strip identity to safe characters and cap length to prevent injection into session keys / URIs. */
 function sanitizeIdentity(raw: string): string {
   return raw.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'unknown';
@@ -2487,7 +2493,7 @@ export class DkgChannelPlugin {
         }
       } catch (err: any) {
         if (!clientDisconnected) {
-          res.write(`data: ${JSON.stringify({ type: 'error', error: err.message })}\n\n`);
+          res.write(`data: ${JSON.stringify(buildStreamErrorEvent(err))}\n\n`);
         }
       }
       if (!res.writableEnded) res.end();

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -49,8 +49,22 @@ const CHANNEL_RESPONSE_TIMEOUT_MS = 15 * 60_000;
 const STOP_DRAIN_TIMEOUT_MS = 1_500;
 const FINAL_MARKER_FLUSH_TIMEOUT_MS = 250;
 const NO_TEXT_RESPONSE_ERROR = 'Agent returned no text response';
+const AGENT_RESPONSE_TIMEOUT_ERROR = 'Agent response timeout';
 const CANCELLED_TURN_MESSAGE = '[OpenClaw reply cancelled before completion]';
 const FAILED_TURN_MESSAGE_PREFIX = '[OpenClaw reply failed before completion';
+
+function isAgentResponseTimeoutError(err: any): boolean {
+  return err?.message === AGENT_RESPONSE_TIMEOUT_ERROR;
+}
+
+function buildAgentTimeoutResponseBody(): Record<string, unknown> {
+  return {
+    error: AGENT_RESPONSE_TIMEOUT_ERROR,
+    code: 'AGENT_TIMEOUT',
+    source: 'openclaw-agent',
+    details: 'OpenClaw agent runtime did not produce a response before its deadline',
+  };
+}
 
 /** Strip identity to safe characters and cap length to prevent injection into session keys / URIs. */
 function sanitizeIdentity(raw: string): string {
@@ -1570,7 +1584,7 @@ export class DkgChannelPlugin {
     return new Promise<ChannelOutboundReplyWithMarkerAliases>((resolve, reject) => {
       const TIMEOUT_MS = CHANNEL_RESPONSE_TIMEOUT_MS;
       const timer = setTimeout(() => {
-        reject(new Error('Agent response timeout'));
+        reject(new Error(AGENT_RESPONSE_TIMEOUT_ERROR));
       }, TIMEOUT_MS);
 
       const replyChunks: string[] = [];
@@ -1630,7 +1644,7 @@ export class DkgChannelPlugin {
     return new Promise<ChannelOutboundReplyWithMarkerAliases>((resolve, reject) => {
       const TIMEOUT_MS = CHANNEL_RESPONSE_TIMEOUT_MS;
       const timer = setTimeout(() => {
-        reject(new Error('Agent response timeout'));
+        reject(new Error(AGENT_RESPONSE_TIMEOUT_ERROR));
       }, TIMEOUT_MS);
 
       const replyChunks: string[] = [];
@@ -1786,7 +1800,7 @@ export class DkgChannelPlugin {
     };
 
     const TIMEOUT_MS = CHANNEL_RESPONSE_TIMEOUT_MS;
-    const timer = setTimeout(() => push({ type: 'error', error: new Error('Agent response timeout') }), TIMEOUT_MS);
+    const timer = setTimeout(() => push({ type: 'error', error: new Error(AGENT_RESPONSE_TIMEOUT_ERROR) }), TIMEOUT_MS);
 
     let replyText = '';
     let dispatchTerminal: 'done' | 'error' | null = null;
@@ -2384,9 +2398,10 @@ export class DkgChannelPlugin {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(reply));
       } catch (err: any) {
-        const status = err.message === 'Agent response timeout' ? 504 : 500;
+        const isAgentTimeout = isAgentResponseTimeoutError(err);
+        const status = isAgentTimeout ? 504 : 500;
         res.writeHead(status, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: err.message }));
+        res.end(JSON.stringify(isAgentTimeout ? buildAgentTimeoutResponseBody() : { error: err.message }));
       }
     } finally {
       this.inFlight--;
@@ -2522,9 +2537,10 @@ export class DkgChannelPlugin {
       res.writeHead?.(200, { 'Content-Type': 'application/json' });
       res.end?.(JSON.stringify(reply));
     } catch (err: any) {
-      const status = err.message === 'Agent response timeout' ? 504 : 500;
+      const isAgentTimeout = isAgentResponseTimeoutError(err);
+      const status = isAgentTimeout ? 504 : 500;
       res.writeHead?.(status, { 'Content-Type': 'application/json' });
-      res.end?.(JSON.stringify({ error: err.message }));
+      res.end?.(JSON.stringify(isAgentTimeout ? buildAgentTimeoutResponseBody() : { error: err.message }));
     }
   }
 

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -3587,6 +3587,38 @@ describe('DkgChannelPlugin', () => {
     });
   });
 
+  it('standalone bridge stream returns structured agent timeout events', async () => {
+    const routeInboundMessage = vi.fn().mockRejectedValue(new Error('Agent response timeout'));
+    const api = makeApi({ routeInboundMessage });
+    plugin.register(api);
+    const port = await waitForBridgePort(plugin);
+
+    const res = await fetch(`http://127.0.0.1:${port}/inbound/stream`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'text/event-stream',
+        'x-dkg-bridge-token': 'test-token',
+      },
+      body: JSON.stringify({
+        text: 'Slow task',
+        correlationId: 'corr-agent-timeout-stream',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    const dataLine = body.split(/\r?\n/).find((line) => line.startsWith('data: '));
+    expect(dataLine).toBeTruthy();
+    expect(JSON.parse(dataLine!.slice('data: '.length))).toMatchObject({
+      type: 'error',
+      error: 'Agent response timeout',
+      code: 'AGENT_TIMEOUT',
+      source: 'openclaw-agent',
+      details: 'OpenClaw agent runtime did not produce a response before its deadline',
+    });
+  });
+
   it('standalone bridge streaming accepts attachment-only inbound requests', async () => {
     const routeInboundMessage = vi.fn().mockResolvedValue({
       correlationId: 'corr-attachment-stream',

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -3550,6 +3550,43 @@ describe('DkgChannelPlugin', () => {
     }));
   });
 
+  it('gateway route returns structured agent timeout payloads', async () => {
+    const routeInboundMessage = vi.fn().mockRejectedValue(new Error('Agent response timeout'));
+    const registerHttpRoute = trackFn();
+    const api = makeApi({ registerHttpRoute, routeInboundMessage });
+    plugin.register(api);
+    const route = registerHttpRoute.calls
+      .map(([entry]) => entry as any)
+      .find((entry) => entry.path === '/api/dkg-channel/inbound');
+    let statusCode = 0;
+    let responseBody = '';
+    let resolveEnd!: () => void;
+    const ended = new Promise<void>((resolve) => { resolveEnd = resolve; });
+    const res = {
+      writeHead: vi.fn((status: number) => { statusCode = status; }),
+      end: vi.fn((body: string) => {
+        responseBody = String(body);
+        resolveEnd();
+      }),
+    };
+
+    route.handler({
+      body: {
+        text: 'Slow task',
+        correlationId: 'corr-agent-timeout',
+      },
+    }, res);
+    await ended;
+
+    expect(statusCode).toBe(504);
+    expect(JSON.parse(responseBody)).toMatchObject({
+      error: 'Agent response timeout',
+      code: 'AGENT_TIMEOUT',
+      source: 'openclaw-agent',
+      details: 'OpenClaw agent runtime did not produce a response before its deadline',
+    });
+  });
+
   it('standalone bridge streaming accepts attachment-only inbound requests', async () => {
     const routeInboundMessage = vi.fn().mockResolvedValue({
       correlationId: 'corr-attachment-stream',

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -34,7 +34,7 @@ import {
   type OpenClawStreamResponse,
 } from './openclaw.js';
 
-export const HERMES_CHANNEL_RESPONSE_TIMEOUT_MS = 180_000;
+export const HERMES_CHANNEL_RESPONSE_TIMEOUT_MS = 15 * 60_000;
 export const DEFAULT_HERMES_BRIDGE_URL = 'http://127.0.0.1:9202';
 export const DEFAULT_HERMES_API_SERVER_URL = 'http://127.0.0.1:8642';
 
@@ -60,6 +60,17 @@ export interface HermesChannelHealthReport {
   bridge?: HermesHealthState;
   gateway?: HermesHealthState;
   error?: string;
+}
+
+function isAbortSignalTimeoutError(err: any): boolean {
+  const message = String(err?.message ?? err ?? '');
+  return err?.name === 'TimeoutError'
+    || err?.cause?.name === 'TimeoutError'
+    || /aborted due to timeout/i.test(message);
+}
+
+function formatHermesHealthTimeout(target: Pick<HermesChannelTarget, 'name'>, timeoutMs: number): string {
+  return `Hermes ${target.name} health probe timed out after ${timeoutMs}ms`;
 }
 
 export interface HermesChatPayload {
@@ -489,10 +500,15 @@ export async function probeHermesChannelHealth(
           ? 'Health endpoint reported not ready'
           : `Health endpoint responded ${healthRes.status}`;
     } catch (err: any) {
-      const result = { ok: false, error: err.message };
+      const result = {
+        ok: false,
+        error: isAbortSignalTimeoutError(err)
+          ? formatHermesHealthTimeout(target, timeoutMs)
+          : err.message,
+      };
       if (target.name === 'bridge') bridge = result;
       else gateway = result;
-      lastError = err.message;
+      lastError = result.error;
     }
   }
 
@@ -558,7 +574,13 @@ export async function ensureHermesBridgeAvailable(
     }
     return { ok: true };
   } catch (err: any) {
-    return { ok: false, details: err.message, offline: true };
+    return {
+      ok: false,
+      details: isAbortSignalTimeoutError(err)
+        ? formatHermesHealthTimeout(target, 3_000)
+        : err.message,
+      offline: true,
+    };
   }
 }
 

--- a/packages/cli/src/daemon/hermes.ts
+++ b/packages/cli/src/daemon/hermes.ts
@@ -585,7 +585,9 @@ export async function ensureHermesBridgeAvailable(
 }
 
 export function shouldTryNextHermesTarget(status: number): boolean {
-  return status === 404 || status === 405 || (status >= 500 && status < 600);
+  // Availability-only fallback. Once a chat request may have been dispatched,
+  // replay requires turn idempotency before bridge-to-gateway retry is safe.
+  return status === 404 || status === 405 || status === 501 || status === 503;
 }
 
 export function normalizeHermesChatPayload(raw: unknown): HermesChatPayload | { error: string } {

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -66,7 +66,7 @@ const BRIDGE_HEALTH_CACHE_OK_TTL_MS = 10_000;
 const BRIDGE_HEALTH_CACHE_ERROR_TTL_MS = 1_000;
 export const OPENCLAW_UI_CONNECT_TIMEOUT_MS = 150_000;
 export const OPENCLAW_UI_CONNECT_POLL_MS = 1_500;
-export const OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS = 16 * 60_000;
+export const OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS = 15 * 60_000;
 // Per-integration UI attach-job machinery moved to
 // `./local-agent-attach-jobs.ts` in S1 of issue #386 so adapter-hermes'
 // S3 work can reuse the same scheduler keyed on `'hermes'` instead of

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -66,7 +66,7 @@ const BRIDGE_HEALTH_CACHE_OK_TTL_MS = 10_000;
 const BRIDGE_HEALTH_CACHE_ERROR_TTL_MS = 1_000;
 export const OPENCLAW_UI_CONNECT_TIMEOUT_MS = 150_000;
 export const OPENCLAW_UI_CONNECT_POLL_MS = 1_500;
-export const OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS = 180_000;
+export const OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS = 16 * 60_000;
 // Per-integration UI attach-job machinery moved to
 // `./local-agent-attach-jobs.ts` in S1 of issue #386 so adapter-hermes'
 // S3 work can reuse the same scheduler keyed on `'hermes'` instead of
@@ -86,6 +86,17 @@ export function isOpenClawBridgeHealthCacheValid(cache: { ok: boolean; ts: numbe
   if (!cache) return false;
   const ttl = cache.ok ? BRIDGE_HEALTH_CACHE_OK_TTL_MS : BRIDGE_HEALTH_CACHE_ERROR_TTL_MS;
   return Date.now() - cache.ts < ttl;
+}
+
+function isAbortSignalTimeoutError(err: any): boolean {
+  const message = String(err?.message ?? err ?? '');
+  return err?.name === 'TimeoutError'
+    || err?.cause?.name === 'TimeoutError'
+    || /aborted due to timeout/i.test(message);
+}
+
+function formatOpenClawHealthTimeout(target: Pick<OpenClawChannelTarget, 'name'>, timeoutMs: number): string {
+  return `OpenClaw ${target.name} health probe timed out after ${timeoutMs}ms`;
 }
 
 export interface OpenClawChannelTarget {
@@ -333,14 +344,19 @@ export async function probeOpenClawChannelHealth(
         ? result.error
         : `Health endpoint responded ${healthRes.status}`;
     } catch (err: any) {
-      const result = { ok: false, error: err.message };
+      const result = {
+        ok: false,
+        error: isAbortSignalTimeoutError(err)
+          ? formatOpenClawHealthTimeout(target, timeoutMs)
+          : err.message,
+      };
       if (target.name === 'bridge') {
         daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
         bridge = result;
       } else {
         gateway = result;
       }
-      lastError = err.message;
+      lastError = result.error;
     }
   }
 
@@ -503,12 +519,12 @@ export async function ensureOpenClawBridgeAvailable(
     };
   }
 
-      const cachedBridgeHealth = daemonState.openClawBridgeHealth;
-      const cacheValid = isOpenClawBridgeHealthCacheValid(cachedBridgeHealth);
-      if (cacheValid && cachedBridgeHealth) {
-        return cachedBridgeHealth.ok
-          ? { ok: true }
-          : {
+  const cachedBridgeHealth = daemonState.openClawBridgeHealth;
+  const cacheValid = isOpenClawBridgeHealthCacheValid(cachedBridgeHealth);
+  if (cacheValid && cachedBridgeHealth) {
+    return cachedBridgeHealth.ok
+      ? { ok: true }
+      : {
           ok: false,
           details: "Bridge health check cached as unavailable",
           offline: true,
@@ -535,7 +551,13 @@ export async function ensureOpenClawBridgeAvailable(
     return { ok: true };
   } catch (err: any) {
     daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
-    return { ok: false, details: err.message, offline: true };
+    return {
+      ok: false,
+      details: isAbortSignalTimeoutError(err)
+        ? formatOpenClawHealthTimeout(target, 3_000)
+        : err.message,
+      offline: true,
+    };
   }
 }
 

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -66,6 +66,9 @@ const BRIDGE_HEALTH_CACHE_OK_TTL_MS = 10_000;
 const BRIDGE_HEALTH_CACHE_ERROR_TTL_MS = 1_000;
 export const OPENCLAW_UI_CONNECT_TIMEOUT_MS = 150_000;
 export const OPENCLAW_UI_CONNECT_POLL_MS = 1_500;
+// Agent response deadline for an already-dispatched OpenClaw chat turn. This
+// is not a retryable transport timeout; replay requires correlation-id
+// idempotency before bridge-to-gateway fallback can be safe.
 export const OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS = 15 * 60_000;
 // Per-integration UI attach-job machinery moved to
 // `./local-agent-attach-jobs.ts` in S1 of issue #386 so adapter-hermes'
@@ -489,7 +492,7 @@ export function isOpenClawUiAttachCancelled(job: PendingOpenClawUiAttachJob): bo
 
 
 export function shouldTryNextOpenClawTarget(status: number): boolean {
-  return status === 404 || status === 405 || status === 501 || status === 503 || status === 504;
+  return status === 404 || status === 405 || status === 501 || status === 503;
 }
 
 export function buildOpenClawChannelHeaders(

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -489,7 +489,7 @@ export function isOpenClawUiAttachCancelled(job: PendingOpenClawUiAttachJob): bo
 
 
 export function shouldTryNextOpenClawTarget(status: number): boolean {
-  return status === 404 || status === 405 || status === 501 || status === 503;
+  return status === 404 || status === 405 || status === 501 || status === 503 || status === 504;
 }
 
 export function buildOpenClawChannelHeaders(

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -78,18 +78,32 @@ function buildHermesChannelTimeoutBody(
   };
 }
 
-function isHermesChannelTimeoutDetails(details: string): boolean {
-  if (!details.trim()) return false;
+function parseHermesChannelTimeoutDetails(details: string): Record<string, unknown> | null {
+  if (!details.trim()) return null;
   try {
-    const parsed = JSON.parse(details) as { code?: unknown; source?: unknown };
-    return parsed.source === 'hermes-channel'
-      && (
-        parsed.code === 'HERMES_BRIDGE_RESPONSE_TIMEOUT'
-        || parsed.code === 'HERMES_GATEWAY_RESPONSE_TIMEOUT'
-      );
+    const parsed = JSON.parse(details);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function isHermesChannelTimeoutDetails(details: string): boolean {
+  const parsed = parseHermesChannelTimeoutDetails(details);
+  return parsed?.source === 'hermes-channel'
+    && (
+      parsed.code === 'HERMES_BRIDGE_RESPONSE_TIMEOUT'
+      || parsed.code === 'HERMES_GATEWAY_RESPONSE_TIMEOUT'
+    );
+}
+
+function hermesStructuredTimeoutDetails(details: string): string | undefined {
+  const parsed = parseHermesChannelTimeoutDetails(details);
+  return typeof parsed?.details === 'string' && parsed.details.trim()
+    ? parsed.details
+    : undefined;
 }
 
 function withVerifiedAttachmentImportContextEntries(
@@ -219,7 +233,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
-              details || `${target.name} response timeout`,
+              hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
             ));
           }
           if (isHermesApiKeyRejection(target, forwardRes.status)) {
@@ -348,7 +362,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
-              details || `${target.name} response timeout`,
+              hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
             ));
           }
           if (isHermesApiKeyRejection(target, transportRes.status)) {

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -9,7 +9,11 @@ import {
   SMALL_BODY_BYTES,
 } from '../http-utils.js';
 import { daemonState } from '../state.js';
-import { hasConfiguredLocalAgentChat } from '../local-agents.js';
+import {
+  getLocalAgentIntegration,
+  hasConfiguredLocalAgentChat,
+  updateLocalAgentIntegration,
+} from '../local-agents.js';
 import type { OpenClawAttachmentRef } from '../openclaw.js';
 import {
   HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
@@ -27,6 +31,7 @@ import {
   probeHermesChannelHealth,
   resolveHermesApiServerKey,
   shouldTryNextHermesTarget,
+  transportPatchFromHermesTarget,
   verifyHermesAttachmentRefsProvenance,
   verifyHermesAttachmentImportResultsProvenance,
   type HermesChatPayload,
@@ -44,6 +49,33 @@ type HermesPersistRouteResult = {
 type NormalizedHermesPersistTurnPayload = Exclude<ReturnType<typeof normalizeHermesPersistTurnPayload>, { error: string }>;
 
 const hermesPersistTurnInflight = new Map<string, Promise<HermesPersistRouteResult>>();
+
+function isHermesBridgeTimeoutError(err: any): boolean {
+  const message = String(err?.message ?? err ?? '');
+  return err?.name === 'TimeoutError'
+    || err?.cause?.name === 'TimeoutError'
+    || /agent response timeout|response timeout|aborted due to timeout/i.test(message);
+}
+
+function formatTimeoutMs(timeoutMs: number): string {
+  return `${Math.round(timeoutMs / 1000)}s`;
+}
+
+function buildHermesBridgeTimeoutBody(
+  correlationId: string,
+  target: { name?: string } | undefined,
+  details?: string,
+): Record<string, unknown> {
+  const targetLabel = target?.name ? `${target.name} target` : 'Hermes bridge';
+  return {
+    error: 'Hermes bridge response timeout',
+    code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+    source: 'hermes-channel',
+    details: details || `${targetLabel} did not produce an agent response within ${formatTimeoutMs(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS)}`,
+    correlationId,
+    timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+  };
+}
 
 function withVerifiedAttachmentImportContextEntries(
   payload: HermesChatPayload,
@@ -164,6 +196,13 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         });
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
+          if (forwardRes.status === 504) {
+            return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
+              payload.correlationId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
+          }
           if (isHermesApiKeyRejection(target, forwardRes.status)) {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
@@ -204,12 +243,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         const reply = await forwardRes.json();
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
-        if (err.name === 'TimeoutError') {
-          lastFailure = {
-            details: `${target.name} response timeout`,
-            offline: true,
-          };
-          continue;
+        if (isHermesBridgeTimeoutError(err)) {
+          return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
       }
@@ -282,6 +317,13 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
 
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
+          if (transportRes.status === 504) {
+            return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
+              payload.correlationId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
+          }
           if (isHermesApiKeyRejection(target, transportRes.status)) {
             return jsonResponse(res, 502, {
               error: 'Hermes API server rejected the API_SERVER_KEY',
@@ -341,7 +383,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             }
           } catch (err: any) {
             if (!res.writableEnded) {
-              res.write(`data: ${JSON.stringify({ type: 'error', error: err.message })}\n\n`);
+              const event = isHermesBridgeTimeoutError(err)
+                ? { type: 'error', ...buildHermesBridgeTimeoutBody(payload.correlationId, target) }
+                : { type: 'error', error: err.message };
+              res.write(`data: ${JSON.stringify(event)}\n\n`);
             }
           }
           if (!res.writableEnded) res.end();
@@ -372,12 +417,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         res.end();
         return;
       } catch (err: any) {
-        if (err.name === 'TimeoutError') {
-          lastFailure = {
-            details: `${target.name} response timeout`,
-            offline: true,
-          };
-          continue;
+        if (isHermesBridgeTimeoutError(err)) {
+          return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
       }
@@ -420,8 +461,28 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
   }
 
   if (req.method === 'GET' && path === '/api/hermes-channel/health') {
-    return jsonResponse(res, 200, await probeHermesChannelHealth(config, bridgeAuthToken));
+    const health = await probeHermesChannelHealth(config, bridgeAuthToken);
+    reconcileHermesRuntimeFromHealth(config, health);
+    return jsonResponse(res, 200, health);
   }
+}
+
+function reconcileHermesRuntimeFromHealth(
+  config: RequestContext['config'],
+  health: Awaited<ReturnType<typeof probeHermesChannelHealth>>,
+): void {
+  if (!health.ok) return;
+  const integration = getLocalAgentIntegration(config, 'hermes');
+  if (!integration?.enabled) return;
+  if (integration.runtime.ready === true && integration.runtime.status === 'ready') return;
+  updateLocalAgentIntegration(config, 'hermes', {
+    transport: transportPatchFromHermesTarget(config, health.target),
+    runtime: {
+      status: 'ready',
+      ready: true,
+      lastError: null,
+    },
+  });
 }
 
 function ensureHermesIntegrationEnabled(config: RequestContext['config'], res: RequestContext['res']): boolean {

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -10,9 +10,7 @@ import {
 } from '../http-utils.js';
 import { daemonState } from '../state.js';
 import {
-  getLocalAgentIntegration,
   hasConfiguredLocalAgentChat,
-  updateLocalAgentIntegration,
 } from '../local-agents.js';
 import type { OpenClawAttachmentRef } from '../openclaw.js';
 import {
@@ -174,7 +172,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
-    for (const target of targets) {
+    for (const [targetIndex, target] of targets.entries()) {
+      const isLastTarget = targetIndex === targets.length - 1;
       const availability = await ensureHermesBridgeAvailable(target, bridgeAuthToken);
       if (!availability.ok) {
         lastFailure = availability;
@@ -196,10 +195,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
           if (forwardRes.status === 504) {
-            // A request-level timeout may mean the agent accepted the turn and
-            // is still working. Do not retry another transport and risk a
-            // duplicate chat turn; keep fallback for immediate availability
-            // failures such as 5xx responses below.
+            // An upstream 504 means the selected target classified its own
+            // timeout. Do not replay the turn on another transport.
             return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
               payload.correlationId,
               target,
@@ -247,7 +244,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
-          // See the 504 handling above: timeout fallback can duplicate a turn.
+          if (!isLastTarget) {
+            lastFailure = { details: `${target.name} response timeout`, offline: true };
+            continue;
+          }
           return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
@@ -297,7 +297,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
-    for (const target of targets) {
+    for (const [targetIndex, target] of targets.entries()) {
+      const isLastTarget = targetIndex === targets.length - 1;
       const availability = await ensureHermesBridgeAvailable(target, bridgeAuthToken);
       if (!availability.ok) {
         lastFailure = availability;
@@ -322,10 +323,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
           if (transportRes.status === 504) {
-            // A request-level timeout may mean the agent accepted the turn and
-            // is still working. Do not retry another transport and risk a
-            // duplicate chat turn; keep fallback for immediate availability
-            // failures such as 5xx responses below.
+            // An upstream 504 means the selected target classified its own
+            // timeout. Do not replay the turn on another transport.
             return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
               payload.correlationId,
               target,
@@ -426,7 +425,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
-          // See the 504 handling above: timeout fallback can duplicate a turn.
+          if (!isLastTarget) {
+            lastFailure = { details: `${target.name} response timeout`, offline: true };
+            continue;
+          }
           return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
@@ -471,26 +473,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
 
   if (req.method === 'GET' && path === '/api/hermes-channel/health') {
     const health = await probeHermesChannelHealth(config, bridgeAuthToken);
-    reconcileHermesRuntimeFromHealth(config, health);
     return jsonResponse(res, 200, health);
   }
-}
-
-function reconcileHermesRuntimeFromHealth(
-  config: RequestContext['config'],
-  health: Awaited<ReturnType<typeof probeHermesChannelHealth>>,
-): void {
-  if (!health.ok) return;
-  const integration = getLocalAgentIntegration(config, 'hermes');
-  if (!integration?.enabled) return;
-  if (integration.runtime.ready === true && integration.runtime.status === 'ready') return;
-  updateLocalAgentIntegration(config, 'hermes', {
-    runtime: {
-      status: 'ready',
-      ready: true,
-      lastError: null,
-    },
-  });
 }
 
 function ensureHermesIntegrationEnabled(config: RequestContext['config'], res: RequestContext['res']): boolean {

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -107,11 +107,23 @@ function isHermesChannelTimeoutDetails(details: string): boolean {
     );
 }
 
-function hermesStructuredTimeoutDetails(details: string): string | undefined {
+function buildHermesStructuredChannelTimeoutBody(
+  correlationId: string,
+  details: string,
+): Record<string, unknown> | null {
   const parsed = parseHermesChannelTimeoutDetails(details);
-  return typeof parsed?.details === 'string' && parsed.details.trim()
-    ? parsed.details
-    : undefined;
+  if (parsed?.source !== 'hermes-channel'
+    || (
+      parsed.code !== 'HERMES_BRIDGE_RESPONSE_TIMEOUT'
+      && parsed.code !== 'HERMES_GATEWAY_RESPONSE_TIMEOUT'
+    )
+  ) {
+    return null;
+  }
+  return {
+    ...parsed,
+    correlationId,
+  };
 }
 
 function withVerifiedAttachmentImportContextEntries(
@@ -234,14 +246,13 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
           if (forwardRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
-            // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s keep timeout
-            // semantics below but are not replayed without idempotency.
-            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
+            // Only our structured timeout payload proves a DKG local-agent
+            // channel classified the timeout. Preserve its target/source fields;
+            // anonymous 504s keep timeout semantics below without replay.
+            return jsonResponse(res, 504, buildHermesStructuredChannelTimeoutBody(
               payload.correlationId,
-              target,
-              hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
-            ));
+              details,
+            ) ?? buildHermesChannelTimeoutBody(payload.correlationId, target));
           }
           if (forwardRes.status === 504) {
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
@@ -370,14 +381,13 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
           if (transportRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
-            // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s keep timeout
-            // semantics below but are not replayed without idempotency.
-            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
+            // Only our structured timeout payload proves a DKG local-agent
+            // channel classified the timeout. Preserve its target/source fields;
+            // anonymous 504s keep timeout semantics below without replay.
+            return jsonResponse(res, 504, buildHermesStructuredChannelTimeoutBody(
               payload.correlationId,
-              target,
-              hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
-            ));
+              details,
+            ) ?? buildHermesChannelTimeoutBody(payload.correlationId, target));
           }
           if (transportRes.status === 504) {
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -197,6 +197,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
           if (forwardRes.status === 504) {
+            // A request-level timeout may mean the agent accepted the turn and
+            // is still working. Do not retry another transport and risk a
+            // duplicate chat turn; keep fallback for immediate availability
+            // failures such as 5xx responses below.
             return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
               payload.correlationId,
               target,
@@ -244,6 +248,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
+          // See the 504 handling above: timeout fallback can duplicate a turn.
           return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
@@ -318,6 +323,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
           if (transportRes.status === 504) {
+            // A request-level timeout may mean the agent accepted the turn and
+            // is still working. Do not retry another transport and risk a
+            // duplicate chat turn; keep fallback for immediate availability
+            // failures such as 5xx responses below.
             return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
               payload.correlationId,
               target,
@@ -418,6 +427,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
+          // See the 504 handling above: timeout fallback can duplicate a turn.
           return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -31,7 +31,6 @@ import {
   probeHermesChannelHealth,
   resolveHermesApiServerKey,
   shouldTryNextHermesTarget,
-  transportPatchFromHermesTarget,
   verifyHermesAttachmentRefsProvenance,
   verifyHermesAttachmentImportResultsProvenance,
   type HermesChatPayload,
@@ -486,7 +485,6 @@ function reconcileHermesRuntimeFromHealth(
   if (!integration?.enabled) return;
   if (integration.runtime.ready === true && integration.runtime.status === 'ready') return;
   updateLocalAgentIntegration(config, 'hermes', {
-    transport: transportPatchFromHermesTarget(config, health.target),
     runtime: {
       status: 'ready',
       ready: true,

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -78,6 +78,20 @@ function buildHermesChannelTimeoutBody(
   };
 }
 
+function isHermesChannelTimeoutDetails(details: string): boolean {
+  if (!details.trim()) return false;
+  try {
+    const parsed = JSON.parse(details) as { code?: unknown; source?: unknown };
+    return parsed.source === 'hermes-channel'
+      && (
+        parsed.code === 'HERMES_BRIDGE_RESPONSE_TIMEOUT'
+        || parsed.code === 'HERMES_GATEWAY_RESPONSE_TIMEOUT'
+      );
+  } catch {
+    return false;
+  }
+}
+
 function withVerifiedAttachmentImportContextEntries(
   payload: HermesChatPayload,
   attachmentImportResults: HermesChatPayload['attachmentImportResults'],
@@ -198,9 +212,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         });
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => '');
-          if (forwardRes.status === 504) {
-            // An upstream 504 means the selected target classified its own
-            // timeout. Do not replay the turn on another transport.
+          if (forwardRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
+            // Only our structured timeout payload proves the selected target
+            // classified its own timeout. Anonymous 504s may be infrastructure
+            // failures and remain eligible for fallback below.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
@@ -326,9 +341,10 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
 
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => '');
-          if (transportRes.status === 504) {
-            // An upstream 504 means the selected target classified its own
-            // timeout. Do not replay the turn on another transport.
+          if (transportRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
+            // Only our structured timeout payload proves the selected target
+            // classified its own timeout. Anonymous 504s may be infrastructure
+            // failures and remain eligible for fallback below.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -58,16 +58,20 @@ function formatTimeoutMs(timeoutMs: number): string {
   return `${Math.round(timeoutMs / 1000)}s`;
 }
 
-function buildHermesBridgeTimeoutBody(
+function buildHermesChannelTimeoutBody(
   correlationId: string,
   target: { name?: string } | undefined,
   details?: string,
 ): Record<string, unknown> {
-  const targetLabel = target?.name ? `${target.name} target` : 'Hermes bridge';
+  const targetName = target?.name === 'gateway' ? 'gateway' : 'bridge';
+  const targetLabel = targetName === 'gateway' ? 'Hermes gateway' : 'Hermes bridge';
   return {
-    error: 'Hermes bridge response timeout',
-    code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+    error: `${targetLabel} response timeout`,
+    code: targetName === 'gateway'
+      ? 'HERMES_GATEWAY_RESPONSE_TIMEOUT'
+      : 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
     source: 'hermes-channel',
+    target: targetName,
     details: details || `${targetLabel} did not produce an agent response within ${formatTimeoutMs(HERMES_CHANNEL_RESPONSE_TIMEOUT_MS)}`,
     correlationId,
     timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
@@ -197,7 +201,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           if (forwardRes.status === 504) {
             // An upstream 504 means the selected target classified its own
             // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
+            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
               details || `${target.name} response timeout`,
@@ -248,7 +252,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             lastFailure = { details: `${target.name} response timeout`, offline: true };
             continue;
           }
-          return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
+          return jsonResponse(res, 504, buildHermesChannelTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
       }
@@ -325,7 +329,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           if (transportRes.status === 504) {
             // An upstream 504 means the selected target classified its own
             // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(
+            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
               details || `${target.name} response timeout`,
@@ -391,7 +395,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           } catch (err: any) {
             if (!res.writableEnded) {
               const event = isHermesBridgeTimeoutError(err)
-                ? { type: 'error', ...buildHermesBridgeTimeoutBody(payload.correlationId, target) }
+                ? { type: 'error', ...buildHermesChannelTimeoutBody(payload.correlationId, target) }
                 : { type: 'error', error: err.message };
               res.write(`data: ${JSON.stringify(event)}\n\n`);
             }
@@ -429,7 +433,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
             lastFailure = { details: `${target.name} response timeout`, offline: true };
             continue;
           }
-          return jsonResponse(res, 504, buildHermesBridgeTimeoutBody(payload.correlationId, target));
+          return jsonResponse(res, 504, buildHermesChannelTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
       }

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -204,8 +204,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
-    for (const [targetIndex, target] of targets.entries()) {
-      const isLastTarget = targetIndex === targets.length - 1;
+    for (const target of targets) {
       const availability = await ensureHermesBridgeAvailable(target, bridgeAuthToken);
       if (!availability.ok) {
         lastFailure = availability;
@@ -228,8 +227,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           const details = await forwardRes.text().catch(() => '');
           if (forwardRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
             // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s may be infrastructure
-            // failures and remain eligible for fallback below.
+            // classified its own timeout. Anonymous 504s may have reached the
+            // agent, so they fall through without bridge-to-gateway replay.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
@@ -277,10 +276,6 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
-          if (!isLastTarget) {
-            lastFailure = { details: `${target.name} response timeout`, offline: true };
-            continue;
-          }
           return jsonResponse(res, 504, buildHermesChannelTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };
@@ -330,8 +325,7 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
     const apiServerKey = resolveHermesApiServerKey(config);
     let lastFailure: { status?: number; details?: string; offline?: boolean } | null = null;
 
-    for (const [targetIndex, target] of targets.entries()) {
-      const isLastTarget = targetIndex === targets.length - 1;
+    for (const target of targets) {
       const availability = await ensureHermesBridgeAvailable(target, bridgeAuthToken);
       if (!availability.ok) {
         lastFailure = availability;
@@ -357,8 +351,8 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           const details = await transportRes.text().catch(() => '');
           if (transportRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
             // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s may be infrastructure
-            // failures and remain eligible for fallback below.
+            // classified its own timeout. Anonymous 504s may have reached the
+            // agent, so they fall through without bridge-to-gateway replay.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
@@ -459,10 +453,6 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isHermesBridgeTimeoutError(err)) {
-          if (!isLastTarget) {
-            lastFailure = { details: `${target.name} response timeout`, offline: true };
-            continue;
-          }
           return jsonResponse(res, 504, buildHermesChannelTimeoutBody(payload.correlationId, target));
         }
         lastFailure = { details: err.message, offline: true };

--- a/packages/cli/src/daemon/routes/hermes.ts
+++ b/packages/cli/src/daemon/routes/hermes.ts
@@ -78,6 +78,14 @@ function buildHermesChannelTimeoutBody(
   };
 }
 
+function buildHermesUiPersistenceErrorBody(err: any): Record<string, unknown> {
+  return {
+    error: 'Hermes UI chat persistence failed',
+    code: 'HERMES_UI_PERSISTENCE_ERROR',
+    details: err?.message ?? String(err),
+  };
+}
+
 function parseHermesChannelTimeoutDetails(details: string): Record<string, unknown> | null {
   if (!details.trim()) return null;
   try {
@@ -227,12 +235,19 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           const details = await forwardRes.text().catch(() => '');
           if (forwardRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
             // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s may have reached the
-            // agent, so they fall through without bridge-to-gateway replay.
+            // classified its own timeout. Anonymous 504s keep timeout
+            // semantics below but are not replayed without idempotency.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
               hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
+            ));
+          }
+          if (forwardRes.status === 504) {
+            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
+              payload.correlationId,
+              target,
+              details || `${target.name} response timeout`,
             ));
           }
           if (isHermesApiKeyRejection(target, forwardRes.status)) {
@@ -258,13 +273,18 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         }
         if (target.protocol === 'hermes-openai') {
           const reply = await readHermesOpenAiReply(forwardRes, verifiedPayload);
-          const persisted = await persistHermesOpenAiUiTurn(
-            ctx,
-            verifiedPayload,
-            attachmentRefs,
-            reply.text,
-            reply.sessionId,
-          );
+          let persisted: { sessionId: string; turnId: string };
+          try {
+            persisted = await persistHermesOpenAiUiTurn(
+              ctx,
+              verifiedPayload,
+              attachmentRefs,
+              reply.text,
+              reply.sessionId,
+            );
+          } catch (err: any) {
+            return jsonResponse(res, 500, buildHermesUiPersistenceErrorBody(err));
+          }
           return jsonResponse(res, 200, {
             ...reply,
             sessionId: persisted.sessionId,
@@ -351,12 +371,19 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
           const details = await transportRes.text().catch(() => '');
           if (transportRes.status === 504 && isHermesChannelTimeoutDetails(details)) {
             // Only our structured timeout payload proves the selected target
-            // classified its own timeout. Anonymous 504s may have reached the
-            // agent, so they fall through without bridge-to-gateway replay.
+            // classified its own timeout. Anonymous 504s keep timeout
+            // semantics below but are not replayed without idempotency.
             return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
               payload.correlationId,
               target,
               hermesStructuredTimeoutDetails(details) || `${target.name} response timeout`,
+            ));
+          }
+          if (transportRes.status === 504) {
+            return jsonResponse(res, 504, buildHermesChannelTimeoutBody(
+              payload.correlationId,
+              target,
+              details || `${target.name} response timeout`,
             ));
           }
           if (isHermesApiKeyRejection(target, transportRes.status)) {
@@ -397,13 +424,25 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
                 verifiedPayload,
                 transportRes,
               );
-              const persisted = await persistHermesOpenAiUiTurn(
-                ctx,
-                verifiedPayload,
-                attachmentRefs,
-                streamed.text,
-                streamed.sessionId,
-              );
+              let persisted: { sessionId: string; turnId: string };
+              try {
+                persisted = await persistHermesOpenAiUiTurn(
+                  ctx,
+                  verifiedPayload,
+                  attachmentRefs,
+                  streamed.text,
+                  streamed.sessionId,
+                );
+              } catch (err: any) {
+                if (!res.writableEnded) {
+                  res.write(`data: ${JSON.stringify({
+                    type: 'error',
+                    ...buildHermesUiPersistenceErrorBody(err),
+                  })}\n\n`);
+                  res.end();
+                }
+                return;
+              }
               if (!res.writableEnded) {
                 res.write(`data: ${JSON.stringify({
                   type: 'final',
@@ -431,9 +470,14 @@ export async function handleHermesRoutes(ctx: RequestContext): Promise<void> {
         const reply = target.protocol === 'hermes-openai'
           ? await readHermesOpenAiReply(transportRes, verifiedPayload)
           : await transportRes.json();
-        const persisted = target.protocol === 'hermes-openai'
-          ? await persistHermesOpenAiUiTurn(ctx, verifiedPayload, attachmentRefs, reply.text ?? '', reply.sessionId)
-          : null;
+        let persisted: { sessionId: string; turnId: string } | null = null;
+        if (target.protocol === 'hermes-openai') {
+          try {
+            persisted = await persistHermesOpenAiUiTurn(ctx, verifiedPayload, attachmentRefs, reply.text ?? '', reply.sessionId);
+          } catch (err: any) {
+            return jsonResponse(res, 500, buildHermesUiPersistenceErrorBody(err));
+          }
+        }
         res.writeHead(200, {
           'Content-Type': 'text/event-stream; charset=utf-8',
           'Cache-Control': 'no-cache',

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -738,14 +738,19 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s may have reached
-              // the agent, so they fall through without bridge-to-gateway replay.
+              // classified its own timeout. Anonymous 504s keep timeout
+              // semantics below but are not replayed without idempotency.
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
                 openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
               ));
             }
+            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+              corrId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
           }
           if (shouldTryNextOpenClawTarget(forwardRes.status)) {
             lastFailure = {
@@ -873,14 +878,19 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s may have reached
-              // the agent, so they fall through without bridge-to-gateway replay.
+              // classified its own timeout. Anonymous 504s keep timeout
+              // semantics below but are not replayed without idempotency.
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
                 openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
               ));
             }
+            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+              corrId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
           }
           if (shouldTryNextOpenClawTarget(transportRes.status)) {
             lastFailure = {

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -391,6 +391,25 @@ function openClawStructuredTimeoutDetails(details: string): string | undefined {
     : undefined;
 }
 
+function buildOpenClawStructuredChannelTimeoutBody(
+  correlationId: string,
+  details: string,
+): Record<string, unknown> | null {
+  const parsed = parseOpenClawUpstreamDetails(details);
+  if (parsed?.source !== 'openclaw-channel'
+    || (
+      parsed.code !== 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT'
+      && parsed.code !== 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT'
+    )
+  ) {
+    return null;
+  }
+  return {
+    ...parsed,
+    correlationId,
+  };
+}
+
 function buildOpenClawAgentTimeoutBody(
   correlationId: string,
   details?: string,
@@ -737,14 +756,13 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId, openClawStructuredTimeoutDetails(details)));
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
-              // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s keep timeout
-              // semantics below but are not replayed without idempotency.
-              return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+              // Only our structured timeout payload proves a DKG local-agent
+              // channel classified the timeout. Preserve its target/source fields;
+              // anonymous 504s keep timeout semantics below without replay.
+              return jsonResponse(res, 504, buildOpenClawStructuredChannelTimeoutBody(
                 corrId,
-                target,
-                openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
-              ));
+                details,
+              ) ?? buildOpenClawChannelTimeoutBody(corrId, target));
             }
             return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
               corrId,
@@ -874,14 +892,13 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId, openClawStructuredTimeoutDetails(details)));
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
-              // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s keep timeout
-              // semantics below but are not replayed without idempotency.
-              return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+              // Only our structured timeout payload proves a DKG local-agent
+              // channel classified the timeout. Preserve its target/source fields;
+              // anonymous 504s keep timeout semantics below without replay.
+              return jsonResponse(res, 504, buildOpenClawStructuredChannelTimeoutBody(
                 corrId,
-                target,
-                openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
-              ));
+                details,
+              ) ?? buildOpenClawChannelTimeoutBody(corrId, target));
             }
             return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
               corrId,

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -701,8 +701,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
       offline?: boolean;
     } | null = null;
 
-    for (const [targetIndex, target] of targets.entries()) {
-      const isLastTarget = targetIndex === targets.length - 1;
+    for (const target of targets) {
       const availability = await ensureOpenClawBridgeAvailable(
         target,
         bridgeAuthToken,
@@ -739,8 +738,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s may be
-              // infrastructure failures and remain eligible for fallback below.
+              // classified its own timeout. Anonymous 504s may have reached
+              // the agent, so they fall through without bridge-to-gateway replay.
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
@@ -771,10 +770,6 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         if (isOpenClawBridgeTimeoutError(err)) {
           if (target.name === "bridge") {
             daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
-          }
-          if (!isLastTarget) {
-            lastFailure = { details: `${target.name} response timeout`, offline: true };
-            continue;
           }
           return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }
@@ -835,8 +830,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
       offline?: boolean;
     } | null = null;
 
-    for (const [targetIndex, target] of targets.entries()) {
-      const isLastTarget = targetIndex === targets.length - 1;
+    for (const target of targets) {
       const availability = await ensureOpenClawBridgeAvailable(
         target,
         bridgeAuthToken,
@@ -879,8 +873,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
-              // classified its own timeout. Anonymous 504s may be
-              // infrastructure failures and remain eligible for fallback below.
+              // classified its own timeout. Anonymous 504s may have reached
+              // the agent, so they fall through without bridge-to-gateway replay.
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
@@ -952,10 +946,6 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         if (isOpenClawBridgeTimeoutError(err)) {
           if (target.name === "bridge") {
             daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
-          }
-          if (!isLastTarget) {
-            lastFailure = { details: `${target.name} response timeout`, offline: true };
-            continue;
           }
           return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -369,7 +369,32 @@ function openClawUpstreamErrorMessage(details: string): string {
   return details;
 }
 
+function parseOpenClawUpstreamDetails(details: string): Record<string, unknown> | null {
+  if (!details.trim()) return null;
+  try {
+    const parsed = JSON.parse(details);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isOpenClawChannelTimeoutDetails(details: string): boolean {
+  const parsed = parseOpenClawUpstreamDetails(details);
+  return parsed?.source === 'openclaw-channel'
+    && (
+      parsed.code === 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT'
+      || parsed.code === 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT'
+    );
+}
+
 function isOpenClawAgentTimeoutDetails(details: string): boolean {
+  const parsed = parseOpenClawUpstreamDetails(details);
+  if (parsed?.source === 'openclaw-agent' && parsed.code === 'AGENT_TIMEOUT') {
+    return true;
+  }
   return /Agent response timeout/i.test(openClawUpstreamErrorMessage(details));
 }
 
@@ -719,13 +744,16 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
-            // An upstream 504 means the selected target classified its own
-            // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
-              corrId,
-              target,
-              details || `${target.name} response timeout`,
-            ));
+            if (isOpenClawChannelTimeoutDetails(details)) {
+              // Only our structured timeout payload proves the selected target
+              // classified its own timeout. Anonymous 504s may be
+              // infrastructure failures and remain eligible for fallback below.
+              return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+                corrId,
+                target,
+                details || `${target.name} response timeout`,
+              ));
+            }
           }
           if (shouldTryNextOpenClawTarget(forwardRes.status)) {
             lastFailure = {
@@ -856,13 +884,16 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
-            // An upstream 504 means the selected target classified its own
-            // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
-              corrId,
-              target,
-              details || `${target.name} response timeout`,
-            ));
+            if (isOpenClawChannelTimeoutDetails(details)) {
+              // Only our structured timeout payload proves the selected target
+              // classified its own timeout. Anonymous 504s may be
+              // infrastructure failures and remain eligible for fallback below.
+              return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
+                corrId,
+                target,
+                details || `${target.name} response timeout`,
+              ));
+            }
           }
           if (shouldTryNextOpenClawTarget(transportRes.status)) {
             lastFailure = {

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -679,7 +679,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
       offline?: boolean;
     } | null = null;
 
-    for (const target of targets) {
+    for (const [targetIndex, target] of targets.entries()) {
+      const isLastTarget = targetIndex === targets.length - 1;
       const availability = await ensureOpenClawBridgeAvailable(
         target,
         bridgeAuthToken,
@@ -714,10 +715,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
-            // A bridge timeout may mean the agent accepted the turn and is
-            // still working. Do not retry another transport and risk a
-            // duplicate chat turn; keep fallback for immediate availability
-            // failures such as 503 below.
+            // An upstream 504 means the selected target classified its own
+            // timeout. Do not replay the turn on another transport.
             return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
               corrId,
               target,
@@ -745,7 +744,13 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
-          // See the 504 handling above: timeout fallback can duplicate a turn.
+          if (target.name === "bridge") {
+            daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
+          }
+          if (!isLastTarget) {
+            lastFailure = { details: `${target.name} response timeout`, offline: true };
+            continue;
+          }
           return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
@@ -805,7 +810,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
       offline?: boolean;
     } | null = null;
 
-    for (const target of targets) {
+    for (const [targetIndex, target] of targets.entries()) {
+      const isLastTarget = targetIndex === targets.length - 1;
       const availability = await ensureOpenClawBridgeAvailable(
         target,
         bridgeAuthToken,
@@ -846,10 +852,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
-            // A bridge timeout may mean the agent accepted the turn and is
-            // still working. Do not retry another transport and risk a
-            // duplicate chat turn; keep fallback for immediate availability
-            // failures such as 503 below.
+            // An upstream 504 means the selected target classified its own
+            // timeout. Do not replay the turn on another transport.
             return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
               corrId,
               target,
@@ -918,7 +922,13 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
-          // See the 504 handling above: timeout fallback can duplicate a turn.
+          if (target.name === "bridge") {
+            daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
+          }
+          if (!isLastTarget) {
+            lastFailure = { details: `${target.name} response timeout`, offline: true };
+            continue;
+          }
           return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -773,9 +773,6 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
-          if (target.name === "bridge") {
-            daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
-          }
           return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
@@ -954,9 +951,6 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
-          if (target.name === "bridge") {
-            daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
-          }
           return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -338,16 +338,20 @@ function formatTimeoutMs(timeoutMs: number): string {
   return `${Math.round(timeoutMs / 1000)}s`;
 }
 
-function buildOpenClawBridgeTimeoutBody(
+function buildOpenClawChannelTimeoutBody(
   correlationId: string,
   target: Pick<OpenClawChannelTarget, 'name'> | undefined,
   details?: string,
 ): Record<string, unknown> {
-  const targetLabel = target?.name ? `${target.name} target` : 'OpenClaw bridge';
+  const targetName = target?.name === 'gateway' ? 'gateway' : 'bridge';
+  const targetLabel = targetName === 'gateway' ? 'OpenClaw gateway' : 'OpenClaw bridge';
   return {
-    error: 'OpenClaw bridge response timeout',
-    code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+    error: `${targetLabel} response timeout`,
+    code: targetName === 'gateway'
+      ? 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT'
+      : 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
     source: 'openclaw-channel',
+    target: targetName,
     details: details || `${targetLabel} did not produce an agent response within ${formatTimeoutMs(OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS)}`,
     correlationId,
     timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
@@ -717,7 +721,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             // An upstream 504 means the selected target classified its own
             // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
+            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
               corrId,
               target,
               details || `${target.name} response timeout`,
@@ -751,7 +755,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             lastFailure = { details: `${target.name} response timeout`, offline: true };
             continue;
           }
-          return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
+          return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
           daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
@@ -854,7 +858,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             }
             // An upstream 504 means the selected target classified its own
             // timeout. Do not replay the turn on another transport.
-            return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
+            return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
               corrId,
               target,
               details || `${target.name} response timeout`,
@@ -899,7 +903,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
           } catch (err: any) {
             if (!res.writableEnded) {
               const event = isOpenClawBridgeTimeoutError(err)
-                ? { type: "error", ...buildOpenClawBridgeTimeoutBody(corrId, target) }
+                ? { type: "error", ...buildOpenClawChannelTimeoutBody(corrId, target) }
                 : { type: "error", error: err.message };
               res.write(`data: ${JSON.stringify(event)}\n\n`);
             }
@@ -929,7 +933,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             lastFailure = { details: `${target.name} response timeout`, offline: true };
             continue;
           }
-          return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
+          return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
           daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -358,17 +358,6 @@ function buildOpenClawChannelTimeoutBody(
   };
 }
 
-function openClawUpstreamErrorMessage(details: string): string {
-  if (!details.trim()) return '';
-  try {
-    const parsed = JSON.parse(details) as { error?: unknown };
-    if (typeof parsed.error === 'string') return parsed.error;
-  } catch {
-    // Plain text upstream details are fine.
-  }
-  return details;
-}
-
 function parseOpenClawUpstreamDetails(details: string): Record<string, unknown> | null {
   if (!details.trim()) return null;
   try {
@@ -392,10 +381,14 @@ function isOpenClawChannelTimeoutDetails(details: string): boolean {
 
 function isOpenClawAgentTimeoutDetails(details: string): boolean {
   const parsed = parseOpenClawUpstreamDetails(details);
-  if (parsed?.source === 'openclaw-agent' && parsed.code === 'AGENT_TIMEOUT') {
-    return true;
-  }
-  return /Agent response timeout/i.test(openClawUpstreamErrorMessage(details));
+  return parsed?.source === 'openclaw-agent' && parsed.code === 'AGENT_TIMEOUT';
+}
+
+function openClawStructuredTimeoutDetails(details: string): string | undefined {
+  const parsed = parseOpenClawUpstreamDetails(details);
+  return typeof parsed?.details === 'string' && parsed.details.trim()
+    ? parsed.details
+    : undefined;
 }
 
 function buildOpenClawAgentTimeoutBody(
@@ -742,7 +735,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
           const details = await forwardRes.text().catch(() => "");
           if (forwardRes.status === 504) {
             if (isOpenClawAgentTimeoutDetails(details)) {
-              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
+              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId, openClawStructuredTimeoutDetails(details)));
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
@@ -751,7 +744,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
-                details || `${target.name} response timeout`,
+                openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
               ));
             }
           }
@@ -882,7 +875,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
           const details = await transportRes.text().catch(() => "");
           if (transportRes.status === 504) {
             if (isOpenClawAgentTimeoutDetails(details)) {
-              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
+              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId, openClawStructuredTimeoutDetails(details)));
             }
             if (isOpenClawChannelTimeoutDetails(details)) {
               // Only our structured timeout payload proves the selected target
@@ -891,7 +884,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
               return jsonResponse(res, 504, buildOpenClawChannelTimeoutBody(
                 corrId,
                 target,
-                details || `${target.name} response timeout`,
+                openClawStructuredTimeoutDetails(details) || `${target.name} response timeout`,
               ));
             }
           }

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -714,6 +714,10 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
+            // A bridge timeout may mean the agent accepted the turn and is
+            // still working. Do not retry another transport and risk a
+            // duplicate chat turn; keep fallback for immediate availability
+            // failures such as 503 below.
             return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
               corrId,
               target,
@@ -741,6 +745,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
+          // See the 504 handling above: timeout fallback can duplicate a turn.
           return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
@@ -841,6 +846,10 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             if (isOpenClawAgentTimeoutDetails(details)) {
               return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
             }
+            // A bridge timeout may mean the agent accepted the turn and is
+            // still working. Do not retry another transport and risk a
+            // duplicate chat turn; keep fallback for immediate availability
+            // failures such as 503 below.
             return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
               corrId,
               target,
@@ -909,6 +918,7 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         return;
       } catch (err: any) {
         if (isOpenClawBridgeTimeoutError(err)) {
+          // See the 504 handling above: timeout fallback can duplicate a turn.
           return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -327,6 +327,61 @@ import {
 
 import type { RequestContext } from './context.js';
 
+function isOpenClawBridgeTimeoutError(err: any): boolean {
+  const message = String(err?.message ?? err ?? '');
+  return err?.name === 'TimeoutError'
+    || err?.cause?.name === 'TimeoutError'
+    || /agent response timeout|response timeout|aborted due to timeout/i.test(message);
+}
+
+function formatTimeoutMs(timeoutMs: number): string {
+  return `${Math.round(timeoutMs / 1000)}s`;
+}
+
+function buildOpenClawBridgeTimeoutBody(
+  correlationId: string,
+  target: Pick<OpenClawChannelTarget, 'name'> | undefined,
+  details?: string,
+): Record<string, unknown> {
+  const targetLabel = target?.name ? `${target.name} target` : 'OpenClaw bridge';
+  return {
+    error: 'OpenClaw bridge response timeout',
+    code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+    source: 'openclaw-channel',
+    details: details || `${targetLabel} did not produce an agent response within ${formatTimeoutMs(OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS)}`,
+    correlationId,
+    timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+  };
+}
+
+function openClawUpstreamErrorMessage(details: string): string {
+  if (!details.trim()) return '';
+  try {
+    const parsed = JSON.parse(details) as { error?: unknown };
+    if (typeof parsed.error === 'string') return parsed.error;
+  } catch {
+    // Plain text upstream details are fine.
+  }
+  return details;
+}
+
+function isOpenClawAgentTimeoutDetails(details: string): boolean {
+  return /Agent response timeout/i.test(openClawUpstreamErrorMessage(details));
+}
+
+function buildOpenClawAgentTimeoutBody(
+  correlationId: string,
+  details?: string,
+): Record<string, unknown> {
+  return {
+    error: 'Agent response timeout',
+    code: 'AGENT_TIMEOUT',
+    source: 'openclaw-agent',
+    details: details || 'OpenClaw agent runtime did not produce a response before its deadline',
+    correlationId,
+  };
+}
+
 
 export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
   const {
@@ -655,6 +710,16 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         });
         if (!forwardRes.ok) {
           const details = await forwardRes.text().catch(() => "");
+          if (forwardRes.status === 504) {
+            if (isOpenClawAgentTimeoutDetails(details)) {
+              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
+            }
+            return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
+              corrId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
+          }
           if (shouldTryNextOpenClawTarget(forwardRes.status)) {
             lastFailure = {
               status: forwardRes.status,
@@ -675,12 +740,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         const reply = await forwardRes.json();
         return jsonResponse(res, 200, reply);
       } catch (err: any) {
-        if (err.name === "TimeoutError") {
-          return jsonResponse(res, 504, {
-            error: "Agent response timeout",
-            code: "AGENT_TIMEOUT",
-            correlationId: corrId,
-          });
+        if (isOpenClawBridgeTimeoutError(err)) {
+          return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
           daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };
@@ -776,6 +837,16 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
 
         if (!transportRes.ok) {
           const details = await transportRes.text().catch(() => "");
+          if (transportRes.status === 504) {
+            if (isOpenClawAgentTimeoutDetails(details)) {
+              return jsonResponse(res, 504, buildOpenClawAgentTimeoutBody(corrId));
+            }
+            return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(
+              corrId,
+              target,
+              details || `${target.name} response timeout`,
+            ));
+          }
           if (shouldTryNextOpenClawTarget(transportRes.status)) {
             lastFailure = {
               status: transportRes.status,
@@ -814,9 +885,10 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
             );
           } catch (err: any) {
             if (!res.writableEnded) {
-              res.write(
-                `data: ${JSON.stringify({ type: "error", error: err.message })}\n\n`,
-              );
+              const event = isOpenClawBridgeTimeoutError(err)
+                ? { type: "error", ...buildOpenClawBridgeTimeoutBody(corrId, target) }
+                : { type: "error", error: err.message };
+              res.write(`data: ${JSON.stringify(event)}\n\n`);
             }
           }
           if (!res.writableEnded) res.end();
@@ -836,12 +908,8 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
         res.end();
         return;
       } catch (err: any) {
-        if (err.name === "TimeoutError") {
-          return jsonResponse(res, 504, {
-            error: "Agent response timeout",
-            code: "AGENT_TIMEOUT",
-            correlationId: corrId,
-          });
+        if (isOpenClawBridgeTimeoutError(err)) {
+          return jsonResponse(res, 504, buildOpenClawBridgeTimeoutBody(corrId, target));
         }
         if (target.name === "bridge") {
           daemonState.openClawBridgeHealth = { ok: false, ts: Date.now() };

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1630,14 +1630,14 @@ describe('Hermes daemon routes', () => {
     });
   });
 
-  it('promotes stale Hermes runtime to ready when the health route succeeds', async () => {
+  it('keeps Hermes health reads from mutating stale runtime state', async () => {
     const config = makeConfig({
       localAgentIntegrations: {
         hermes: {
           enabled: true,
           capabilities: { localChat: true },
           transport: { kind: 'hermes-channel', bridgeUrl: 'http://127.0.0.1:9444' },
-          runtime: { status: 'configured' },
+          runtime: { status: 'configured', ready: false, lastError: 'setup still pending' },
         },
       },
     });
@@ -1663,9 +1663,9 @@ describe('Hermes daemon routes', () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toMatchObject({ ok: true, target: 'bridge' });
     const integration = getLocalAgentIntegration(config, 'hermes');
-    expect(integration?.runtime.status).toBe('ready');
-    expect(integration?.runtime.ready).toBe(true);
-    expect(integration?.runtime.lastError).toBeNull();
+    expect(integration?.runtime.status).toBe('configured');
+    expect(integration?.runtime.ready).toBe(false);
+    expect(integration?.runtime.lastError).toBe('setup still pending');
   });
 
   it.each(['/api/hermes-channel/send', '/api/hermes-channel/stream'])(
@@ -2503,7 +2503,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('does not retry Hermes chat send on another target after the bridge times out', async () => {
+  it('falls back to the gateway when Hermes bridge send fetch times out locally', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2515,6 +2515,55 @@ describe('Hermes daemon routes', () => {
         const err = new Error('timed out');
         (err as any).name = 'TimeoutError';
         throw err;
+      }
+      if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
+        return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('unexpected target', { status: 418 });
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-channel',
+            bridgeUrl: 'http://127.0.0.1:9444',
+            gatewayUrl: 'https://hermes.example.com',
+          },
+        },
+      },
+    }, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply', correlationId: 'corr-1' });
+    expect(urls).toEqual([
+      'http://127.0.0.1:9444/health',
+      'http://127.0.0.1:9444/send',
+      'https://hermes.example.com/api/hermes-channel/send',
+    ]);
+  });
+
+  it('does not retry Hermes chat send after an upstream bridge 504', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl === 'http://127.0.0.1:9444/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9444/send') {
+        return new Response('bridge timed out', { status: 504 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
         return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
@@ -2616,7 +2665,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('does not retry Hermes chat stream on another target after the bridge times out', async () => {
+  it('falls back to the gateway when Hermes bridge stream fetch times out locally', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2661,17 +2710,14 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(504);
-    expect(JSON.parse(res.body)).toMatchObject({
-      error: 'Hermes bridge response timeout',
-      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
-      source: 'hermes-channel',
-      correlationId: 'corr-1',
-      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
-    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toContain('text/event-stream');
+    expect(res.body).toContain('"text":"gateway stream"');
+    expect(res.body).toContain('"correlationId":"corr-1"');
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/stream',
+      'https://hermes.example.com/api/hermes-channel/stream',
     ]);
   });
 

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -2615,7 +2615,9 @@ describe('Hermes daemon routes', () => {
           error: 'Hermes bridge response timeout',
           code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
           source: 'hermes-channel',
+          target: 'bridge',
           details: 'Hermes bridge did not produce an agent response',
+          timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
         }), { status: 504 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
@@ -2656,6 +2658,67 @@ describe('Hermes daemon routes', () => {
       details: 'Hermes bridge did not produce an agent response',
       correlationId: 'corr-1',
       timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
+    expect(urls).toEqual([
+      'http://127.0.0.1:9444/health',
+      'http://127.0.0.1:9444/send',
+    ]);
+  });
+
+  it('preserves structured Hermes timeout metadata returned through a bridge proxy', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl === 'http://127.0.0.1:9444/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9444/send') {
+        return new Response(JSON.stringify({
+          error: 'Hermes gateway response timeout',
+          code: 'HERMES_GATEWAY_RESPONSE_TIMEOUT',
+          source: 'hermes-channel',
+          target: 'gateway',
+          details: 'Nested Hermes gateway did not produce an agent response',
+          correlationId: 'upstream-corr',
+          timeoutMs: 1234,
+        }), { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-channel',
+            bridgeUrl: 'http://127.0.0.1:9444',
+            gatewayUrl: 'https://hermes.example.com',
+          },
+        },
+      },
+    }, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes gateway response timeout',
+      code: 'HERMES_GATEWAY_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'gateway',
+      details: 'Nested Hermes gateway did not produce an agent response',
+      correlationId: 'corr-1',
+      timeoutMs: 1234,
     });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
@@ -2825,6 +2888,67 @@ describe('Hermes daemon routes', () => {
       details: 'gateway timeout from proxy',
       correlationId: 'corr-1',
       timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
+    expect(urls).toEqual([
+      'http://127.0.0.1:9444/health',
+      'http://127.0.0.1:9444/stream',
+    ]);
+  });
+
+  it('preserves structured Hermes stream timeout metadata returned through a bridge proxy', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl === 'http://127.0.0.1:9444/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9444/stream') {
+        return new Response(JSON.stringify({
+          error: 'Hermes gateway response timeout',
+          code: 'HERMES_GATEWAY_RESPONSE_TIMEOUT',
+          source: 'hermes-channel',
+          target: 'gateway',
+          details: 'Nested Hermes gateway stream did not produce an agent response',
+          correlationId: 'upstream-corr',
+          timeoutMs: 5678,
+        }), { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway stream', correlationId: 'corr-1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-channel',
+            bridgeUrl: 'http://127.0.0.1:9444',
+            gatewayUrl: 'https://hermes.example.com',
+          },
+        },
+      },
+    }, '/api/hermes-channel/stream');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes gateway response timeout',
+      code: 'HERMES_GATEWAY_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'gateway',
+      details: 'Nested Hermes gateway stream did not produce an agent response',
+      correlationId: 'corr-1',
+      timeoutMs: 5678,
     });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -9,6 +9,7 @@ import {
   buildStableHermesTurnId,
   ensureHermesBridgeAvailable,
   getHermesChannelTargets,
+  HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
   isHermesLoopbackUrl,
   normalizeHermesChatPayload,
   normalizeHermesPersistTurnPayload,
@@ -749,6 +750,27 @@ describe('Hermes channel helpers', () => {
     expect(report.ok).toBe(false);
     expect(report.error).toContain('API_SERVER_KEY');
     expect(report.error).toContain('dkg hermes setup');
+  });
+
+  it('normalizes Hermes health timeout messages before refresh can store them', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw timeoutError;
+    }));
+
+    const report = await probeHermesChannelHealth(makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: { kind: 'hermes-channel', bridgeUrl: 'http://127.0.0.1:9444' },
+        },
+      },
+    }), 'bridge-token', { timeoutMs: 50 });
+
+    expect(report.ok).toBe(false);
+    expect(report.error).toBe('Hermes bridge health probe timed out after 50ms');
+    expect(report.error).not.toContain('aborted due to timeout');
   });
 
   it('normalizes profile for send and persist payloads', () => {
@@ -1573,6 +1595,77 @@ describe('Hermes daemon routes', () => {
     expect(JSON.parse(res.body)).toMatchObject({
       code: 'INTEGRATION_DISABLED',
     });
+  });
+
+  it('returns a source-specific timeout when the Hermes bridge does not answer chat send', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    let calls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      calls += 1;
+      const requestUrl = String(url);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      throw timeoutError;
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'slow task',
+      correlationId: 'corr-timeout',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {}, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(calls).toBe(2);
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      correlationId: 'corr-timeout',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
+  });
+
+  it('promotes stale Hermes runtime to ready when the health route succeeds', async () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          capabilities: { localChat: true },
+          transport: { kind: 'hermes-channel', bridgeUrl: 'http://127.0.0.1:9444' },
+          runtime: { status: 'configured' },
+        },
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })));
+    const req = makeJsonRequest('GET', '/api/hermes-channel/health', {});
+    const res = makeJsonResponse();
+
+    await handleHermesRoutes({
+      req,
+      res,
+      agent: { store: { query: vi.fn(async () => ({ bindings: [] })) } },
+      config,
+      memoryManager: {
+        hasChatTurn: vi.fn(async () => false),
+        storeChatExchange: vi.fn(async () => {}),
+      },
+      bridgeAuthToken: 'bridge-token',
+      extractionStatus: new Map(),
+      path: '/api/hermes-channel/health',
+      requestAgentAddress: '0x0000000000000000000000000000000000000001',
+    } as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ ok: true, target: 'bridge' });
+    const integration = getLocalAgentIntegration(config, 'hermes');
+    expect(integration?.runtime.status).toBe('ready');
+    expect(integration?.runtime.ready).toBe(true);
+    expect(integration?.runtime.lastError).toBeNull();
   });
 
   it.each(['/api/hermes-channel/send', '/api/hermes-channel/stream'])(
@@ -2410,7 +2503,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when bridge send times out', async () => {
+  it('does not retry Hermes chat send on another target after the bridge times out', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2452,12 +2545,17 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply', correlationId: 'corr-1' });
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/send',
-      'https://hermes.example.com/api/hermes-channel/send',
     ]);
   });
 
@@ -2518,7 +2616,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when bridge stream times out', async () => {
+  it('does not retry Hermes chat stream on another target after the bridge times out', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2563,13 +2661,17 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.headers['Content-Type']).toContain('text/event-stream');
-    expect(res.body).toContain('"text":"gateway stream"');
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/stream',
-      'https://hermes.example.com/api/hermes-channel/stream',
     ]);
   });
 

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -2568,6 +2568,7 @@ describe('Hermes daemon routes', () => {
           error: 'Hermes bridge response timeout',
           code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
           source: 'hermes-channel',
+          details: 'Hermes bridge did not produce an agent response',
         }), { status: 504 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
@@ -2605,6 +2606,7 @@ describe('Hermes daemon routes', () => {
       code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
       source: 'hermes-channel',
       target: 'bridge',
+      details: 'Hermes bridge did not produce an agent response',
       correlationId: 'corr-1',
       timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
     });

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -2206,6 +2206,47 @@ describe('Hermes daemon routes', () => {
     });
   });
 
+  it('reports Hermes OpenAI persistence timeout separately from response timeout', async () => {
+    const persistTimeout = new Error('persist timed out') as Error & { name: string };
+    persistTimeout.name = 'TimeoutError';
+    const storeChatExchange = vi.fn(async () => {
+      throw persistTimeout;
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: 'Hermes API reply' } }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'x-hermes-session-id': 'api-session-1' },
+    })));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-openai-persist-timeout',
+      sessionId: 'hermes:dkg-ui:profile-default',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange,
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-openai',
+            gatewayUrl: 'http://127.0.0.1:8642',
+          },
+        },
+      },
+    }, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes UI chat persistence failed',
+      code: 'HERMES_UI_PERSISTENCE_ERROR',
+      details: 'Hermes UI chat persistence failed: persist timed out',
+    });
+  });
+
   it('surfaces attachment metadata and skipped import results in the Hermes OpenAI system prompt', async () => {
     const calls: Array<{ url: string; body: any }> = [];
     const storeChatExchange = vi.fn(async () => {});
@@ -2662,11 +2703,15 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(502);
+    expect(res.statusCode).toBe(504);
     expect(JSON.parse(res.body)).toMatchObject({
-      error: 'Hermes bridge error',
-      code: 'BRIDGE_ERROR',
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'bridge',
       details: 'gateway timeout from proxy',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
     });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
@@ -2771,11 +2816,15 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(502);
+    expect(res.statusCode).toBe(504);
     expect(JSON.parse(res.body)).toMatchObject({
-      error: 'Hermes bridge error',
-      code: 'BRIDGE_ERROR',
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'bridge',
       details: 'gateway timeout from proxy',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
     });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -2455,7 +2455,7 @@ describe('Hermes daemon routes', () => {
     );
   });
 
-  it('falls back to the gateway when bridge send returns retryable 5xx', async () => {
+  it('falls back to the gateway when bridge send reports unavailable', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2464,7 +2464,7 @@ describe('Hermes daemon routes', () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       if (requestUrl === 'http://127.0.0.1:9444/send') {
-        return new Response('bridge failed', { status: 500 });
+        return new Response('bridge unavailable', { status: 503 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
         return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
@@ -2504,7 +2504,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when Hermes bridge send fetch times out locally', async () => {
+  it('does not replay Hermes chat send when the bridge fetch times out locally', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2546,12 +2546,18 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply', correlationId: 'corr-1' });
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'bridge',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/send',
-      'https://hermes.example.com/api/hermes-channel/send',
     ]);
   });
 
@@ -2616,7 +2622,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when Hermes bridge send returns an unknown upstream 504', async () => {
+  it('does not replay Hermes chat send when the bridge returns an unknown upstream 504', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2656,12 +2662,15 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply', correlationId: 'corr-1' });
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge error',
+      code: 'BRIDGE_ERROR',
+      details: 'gateway timeout from proxy',
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/send',
-      'https://hermes.example.com/api/hermes-channel/send',
     ]);
   });
 
@@ -2673,8 +2682,8 @@ describe('Hermes daemon routes', () => {
       if (requestUrl === 'http://127.0.0.1:9444/health') {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
-      if (requestUrl === 'https://hermes.example.com/api/hermes-channel/health') {
-        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      if (requestUrl === 'http://127.0.0.1:9444/send') {
+        return new Response('bridge unavailable', { status: 503 });
       }
       const err = new Error('timed out');
       (err as any).name = 'TimeoutError';
@@ -2717,7 +2726,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when bridge stream returns an unknown upstream 504', async () => {
+  it('does not replay Hermes stream when the bridge returns an unknown upstream 504', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2762,19 +2771,19 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.headers['Content-Type']).toContain('text/event-stream');
-    expect(res.body).toContain('"text":"gateway stream"');
-    expect(res.body).toContain('"sessionId":"bridge-session"');
-    expect(res.body).toContain('"turnId":"bridge-turn"');
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge error',
+      code: 'BRIDGE_ERROR',
+      details: 'gateway timeout from proxy',
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/stream',
-      'https://hermes.example.com/api/hermes-channel/stream',
     ]);
   });
 
-  it('falls back to the gateway when Hermes bridge stream fetch times out locally', async () => {
+  it('does not replay Hermes stream when the bridge fetch times out locally', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2819,14 +2828,18 @@ describe('Hermes daemon routes', () => {
 
     await handleHermesRoutes(ctx);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.headers['Content-Type']).toContain('text/event-stream');
-    expect(res.body).toContain('"text":"gateway stream"');
-    expect(res.body).toContain('"correlationId":"corr-1"');
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes bridge response timeout',
+      code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'bridge',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/stream',
-      'https://hermes.example.com/api/hermes-channel/stream',
     ]);
   });
 

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -2555,7 +2555,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('does not retry Hermes chat send after an upstream bridge 504', async () => {
+  it('does not retry Hermes chat send after a structured upstream bridge timeout', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2564,7 +2564,11 @@ describe('Hermes daemon routes', () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       if (requestUrl === 'http://127.0.0.1:9444/send') {
-        return new Response('bridge timed out', { status: 504 });
+        return new Response(JSON.stringify({
+          error: 'Hermes bridge response timeout',
+          code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+          source: 'hermes-channel',
+        }), { status: 504 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
         return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
@@ -2607,6 +2611,55 @@ describe('Hermes daemon routes', () => {
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/send',
+    ]);
+  });
+
+  it('falls back to the gateway when Hermes bridge send returns an unknown upstream 504', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl === 'http://127.0.0.1:9444/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9444/send') {
+        return new Response('gateway timeout from proxy', { status: 504 });
+      }
+      if (requestUrl === 'https://hermes.example.com/api/hermes-channel/send') {
+        return new Response(JSON.stringify({ text: 'gateway reply', correlationId: 'corr-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('unexpected target', { status: 418 });
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-channel',
+            bridgeUrl: 'http://127.0.0.1:9444',
+            gatewayUrl: 'https://hermes.example.com',
+          },
+        },
+      },
+    }, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply', correlationId: 'corr-1' });
+    expect(urls).toEqual([
+      'http://127.0.0.1:9444/health',
+      'http://127.0.0.1:9444/send',
+      'https://hermes.example.com/api/hermes-channel/send',
     ]);
   });
 
@@ -2662,7 +2715,7 @@ describe('Hermes daemon routes', () => {
     ]);
   });
 
-  it('falls back to the gateway when bridge stream returns retryable 5xx', async () => {
+  it('falls back to the gateway when bridge stream returns an unknown upstream 504', async () => {
     const urls: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);
@@ -2671,7 +2724,7 @@ describe('Hermes daemon routes', () => {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       if (requestUrl === 'http://127.0.0.1:9444/stream') {
-        return new Response('bridge failed', { status: 502 });
+        return new Response('gateway timeout from proxy', { status: 504 });
       }
       if (requestUrl === 'https://hermes.example.com/api/hermes-channel/stream') {
         return new Response(JSON.stringify({

--- a/packages/cli/test/daemon-hermes.test.ts
+++ b/packages/cli/test/daemon-hermes.test.ts
@@ -1625,6 +1625,7 @@ describe('Hermes daemon routes', () => {
       error: 'Hermes bridge response timeout',
       code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
       source: 'hermes-channel',
+      target: 'bridge',
       correlationId: 'corr-timeout',
       timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
     });
@@ -2599,12 +2600,65 @@ describe('Hermes daemon routes', () => {
       error: 'Hermes bridge response timeout',
       code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
       source: 'hermes-channel',
+      target: 'bridge',
       correlationId: 'corr-1',
       timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
     });
     expect(urls).toEqual([
       'http://127.0.0.1:9444/health',
       'http://127.0.0.1:9444/send',
+    ]);
+  });
+
+  it('returns a target-aware timeout when the Hermes gateway is the final timed-out target', async () => {
+    const urls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl === 'http://127.0.0.1:9444/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (requestUrl === 'https://hermes.example.com/api/hermes-channel/health') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      const err = new Error('timed out');
+      (err as any).name = 'TimeoutError';
+      throw err;
+    }));
+    const { ctx, res } = makeHermesRouteContext({
+      text: 'hello',
+      correlationId: 'corr-1',
+    }, {
+      hasChatTurn: vi.fn(async () => false),
+      storeChatExchange: vi.fn(async () => {}),
+    }, {
+      localAgentIntegrations: {
+        hermes: {
+          enabled: true,
+          transport: {
+            kind: 'hermes-channel',
+            bridgeUrl: 'http://127.0.0.1:9444',
+            gatewayUrl: 'https://hermes.example.com',
+          },
+        },
+      },
+    }, '/api/hermes-channel/send');
+
+    await handleHermesRoutes(ctx);
+
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Hermes gateway response timeout',
+      code: 'HERMES_GATEWAY_RESPONSE_TIMEOUT',
+      source: 'hermes-channel',
+      target: 'gateway',
+      correlationId: 'corr-1',
+      timeoutMs: HERMES_CHANNEL_RESPONSE_TIMEOUT_MS,
+    });
+    expect(urls).toEqual([
+      'http://127.0.0.1:9444/health',
+      'http://127.0.0.1:9444/send',
+      'https://hermes.example.com/api/hermes-channel/send',
     ]);
   });
 

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -612,7 +612,7 @@ describe('OpenClaw channel routing helpers', () => {
     }
   });
 
-  it('does not retry OpenClaw chat send after an upstream bridge 504', async () => {
+  it('does not retry OpenClaw chat send after a structured upstream bridge timeout', async () => {
     const urls: string[] = [];
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -622,7 +622,11 @@ describe('OpenClaw channel routing helpers', () => {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
       }
       if (requestUrl === 'http://127.0.0.1:9301/inbound') {
-        return new Response('bridge timed out', { status: 504 });
+        return new Response(JSON.stringify({
+          error: 'OpenClaw bridge response timeout',
+          code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+          source: 'openclaw-channel',
+        }), { status: 504 });
       }
       return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
     }) as typeof fetch;
@@ -659,6 +663,52 @@ describe('OpenClaw channel routing helpers', () => {
         correlationId: 'corr-timeout',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
       });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('falls back to the gateway when OpenClaw bridge send returns an unknown upstream 504', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        return new Response('gateway timeout from proxy', { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+        'https://openclaw.example.com/api/dkg-channel/inbound',
+      ]);
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply' });
     } finally {
       globalThis.fetch = origFetch;
     }
@@ -1112,6 +1162,57 @@ describe('OpenClaw channel routing helpers', () => {
         fileHash: attachmentImportResult.fileHash,
         extractionStatus: 'skipped',
       });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('falls back to the gateway when OpenClaw bridge stream returns an unknown upstream 504', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound/stream') {
+        return new Response('gateway timeout from proxy', { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway stream', correlationId: 'corr-stream' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-stream',
+      }, '/api/openclaw-channel/stream', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound/stream',
+        'https://openclaw.example.com/api/dkg-channel/inbound',
+      ]);
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Type']).toContain('text/event-stream');
+      expect(res.body).toContain('"text":"gateway stream"');
+      expect(res.body).toContain('"correlationId":"corr-stream"');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -568,12 +568,23 @@ describe('OpenClaw channel routing helpers', () => {
     const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
     timeoutError.name = 'TimeoutError';
     const urls: string[] = [];
+    let bridgeInboundCalls = 0;
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request) => {
       const requestUrl = String(url);
       urls.push(requestUrl);
       if (requestUrl.endsWith('/health')) {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        bridgeInboundCalls += 1;
+        if (bridgeInboundCalls === 1) {
+          throw timeoutError;
+        }
+        return new Response(JSON.stringify({
+          text: 'bridge recovered',
+          correlationId: 'corr-timeout-next',
+        }), { status: 200 });
       }
       if (requestUrl === 'https://openclaw.example.com/api/dkg-channel/inbound') {
         return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
@@ -612,6 +623,36 @@ describe('OpenClaw channel routing helpers', () => {
         target: 'bridge',
         correlationId: 'corr-timeout',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+
+      const { ctx: nextCtx, res: nextRes } = makeOpenClawRouteContext({
+        text: 'next task',
+        correlationId: 'corr-timeout-next',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(nextCtx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+        'http://127.0.0.1:9301/inbound',
+      ]);
+      expect(nextRes.statusCode).toBe(200);
+      expect(JSON.parse(nextRes.body)).toMatchObject({
+        text: 'bridge recovered',
+        correlationId: 'corr-timeout-next',
       });
     } finally {
       globalThis.fetch = origFetch;
@@ -1292,6 +1333,106 @@ describe('OpenClaw channel routing helpers', () => {
         correlationId: 'corr-stream',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
       });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not mark OpenClaw stream bridge unhealthy when the local bridge fetch times out', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    const urls: string[] = [];
+    let bridgeStreamCalls = 0;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound/stream') {
+        bridgeStreamCalls += 1;
+        if (bridgeStreamCalls === 1) {
+          throw timeoutError;
+        }
+        return new Response(JSON.stringify({
+          text: 'stream bridge recovered',
+          correlationId: 'corr-stream-timeout-next',
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({
+        text: 'gateway stream',
+        correlationId: 'corr-stream-timeout-next',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow stream task',
+        correlationId: 'corr-stream-timeout',
+      }, '/api/openclaw-channel/stream', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound/stream',
+      ]);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw bridge response timeout',
+        code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'bridge',
+        correlationId: 'corr-stream-timeout',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+
+      const { ctx: nextCtx, res: nextRes } = makeOpenClawRouteContext({
+        text: 'next stream task',
+        correlationId: 'corr-stream-timeout-next',
+      }, '/api/openclaw-channel/stream', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(nextCtx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound/stream',
+        'http://127.0.0.1:9301/inbound/stream',
+      ]);
+      expect(nextRes.statusCode).toBe(200);
+      expect(nextRes.headers['Content-Type']).toContain('text/event-stream');
+      expect(nextRes.body).toContain('"text":"stream bridge recovered"');
+      expect(nextRes.body).toContain('"correlationId":"corr-stream-timeout-next"');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -770,11 +770,15 @@ describe('OpenClaw channel routing helpers', () => {
         'http://127.0.0.1:9301/health',
         'http://127.0.0.1:9301/inbound',
       ]);
-      expect(res.statusCode).toBe(502);
+      expect(res.statusCode).toBe(504);
       expect(JSON.parse(res.body)).toMatchObject({
-        error: 'Bridge error',
-        code: 'BRIDGE_ERROR',
+        error: 'OpenClaw bridge response timeout',
+        code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'bridge',
         details: 'Agent response timeout from proxy',
+        correlationId: 'corr-timeout',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
       });
     } finally {
       globalThis.fetch = origFetch;
@@ -1278,11 +1282,15 @@ describe('OpenClaw channel routing helpers', () => {
         'http://127.0.0.1:9301/health',
         'http://127.0.0.1:9301/inbound/stream',
       ]);
-      expect(res.statusCode).toBe(502);
+      expect(res.statusCode).toBe(504);
       expect(JSON.parse(res.body)).toMatchObject({
-        error: 'Bridge error',
-        code: 'BRIDGE_ERROR',
+        error: 'OpenClaw bridge response timeout',
+        code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'bridge',
         details: 'gateway timeout from proxy',
+        correlationId: 'corr-stream',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
       });
     } finally {
       globalThis.fetch = origFetch;

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -567,13 +567,16 @@ describe('OpenClaw channel routing helpers', () => {
   it('returns a source-specific timeout when the OpenClaw bridge does not answer chat send', async () => {
     const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
     timeoutError.name = 'TimeoutError';
-    let calls = 0;
+    const urls: string[] = [];
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request) => {
-      calls += 1;
       const requestUrl = String(url);
+      urls.push(requestUrl);
       if (requestUrl.endsWith('/health')) {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl.includes('openclaw.example.com')) {
+        return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
       }
       throw timeoutError;
     }) as typeof fetch;
@@ -581,11 +584,26 @@ describe('OpenClaw channel routing helpers', () => {
       const { ctx, res } = makeOpenClawRouteContext({
         text: 'slow task',
         correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
       });
 
       await handleOpenclawRoutes(ctx);
 
-      expect(calls).toBe(2);
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+      ]);
       expect(res.statusCode).toBe(504);
       expect(JSON.parse(res.body)).toMatchObject({
         error: 'OpenClaw bridge response timeout',

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -564,7 +564,7 @@ describe('OpenClaw channel routing helpers', () => {
     }
   });
 
-  it('returns a source-specific timeout when the OpenClaw bridge does not answer chat send', async () => {
+  it('falls back to the OpenClaw gateway when the local bridge fetch times out', async () => {
     const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
     timeoutError.name = 'TimeoutError';
     const urls: string[] = [];
@@ -579,6 +579,52 @@ describe('OpenClaw channel routing helpers', () => {
         return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
       }
       throw timeoutError;
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+        'https://openclaw.example.com/api/dkg-channel/inbound',
+      ]);
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply' });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not retry OpenClaw chat send after an upstream bridge 504', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        return new Response('bridge timed out', { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
     }) as typeof fetch;
     try {
       const { ctx, res } = makeOpenClawRouteContext({

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -575,7 +575,7 @@ describe('OpenClaw channel routing helpers', () => {
       if (requestUrl.endsWith('/health')) {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
       }
-      if (requestUrl.includes('openclaw.example.com')) {
+      if (requestUrl === 'https://openclaw.example.com/api/dkg-channel/inbound') {
         return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
       }
       throw timeoutError;

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -564,7 +564,7 @@ describe('OpenClaw channel routing helpers', () => {
     }
   });
 
-  it('falls back to the OpenClaw gateway when the local bridge fetch times out', async () => {
+  it('does not replay OpenClaw chat send when the local bridge fetch times out', async () => {
     const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
     timeoutError.name = 'TimeoutError';
     const urls: string[] = [];
@@ -603,10 +603,16 @@ describe('OpenClaw channel routing helpers', () => {
       expect(urls).toEqual([
         'http://127.0.0.1:9301/health',
         'http://127.0.0.1:9301/inbound',
-        'https://openclaw.example.com/api/dkg-channel/inbound',
       ]);
-      expect(res.statusCode).toBe(200);
-      expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply' });
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw bridge response timeout',
+        code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'bridge',
+        correlationId: 'corr-timeout',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
     } finally {
       globalThis.fetch = origFetch;
     }
@@ -726,7 +732,7 @@ describe('OpenClaw channel routing helpers', () => {
     }
   });
 
-  it('falls back to the gateway when OpenClaw bridge send returns an unknown upstream 504', async () => {
+  it('does not replay OpenClaw chat send when the bridge returns an unknown upstream 504', async () => {
     const urls: string[] = [];
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -763,10 +769,13 @@ describe('OpenClaw channel routing helpers', () => {
       expect(urls).toEqual([
         'http://127.0.0.1:9301/health',
         'http://127.0.0.1:9301/inbound',
-        'https://openclaw.example.com/api/dkg-channel/inbound',
       ]);
-      expect(res.statusCode).toBe(200);
-      expect(JSON.parse(res.body)).toMatchObject({ text: 'gateway reply' });
+      expect(res.statusCode).toBe(502);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'Bridge error',
+        code: 'BRIDGE_ERROR',
+        details: 'Agent response timeout from proxy',
+      });
     } finally {
       globalThis.fetch = origFetch;
     }
@@ -782,6 +791,9 @@ describe('OpenClaw channel routing helpers', () => {
       urls.push(requestUrl);
       if (requestUrl.endsWith('/health')) {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        return new Response('bridge unavailable', { status: 503 });
       }
       throw timeoutError;
     }) as typeof fetch;
@@ -1225,7 +1237,7 @@ describe('OpenClaw channel routing helpers', () => {
     }
   });
 
-  it('falls back to the gateway when OpenClaw bridge stream returns an unknown upstream 504', async () => {
+  it('does not replay OpenClaw stream when the bridge returns an unknown upstream 504', async () => {
     const urls: string[] = [];
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -1265,12 +1277,13 @@ describe('OpenClaw channel routing helpers', () => {
       expect(urls).toEqual([
         'http://127.0.0.1:9301/health',
         'http://127.0.0.1:9301/inbound/stream',
-        'https://openclaw.example.com/api/dkg-channel/inbound',
       ]);
-      expect(res.statusCode).toBe(200);
-      expect(res.headers['Content-Type']).toContain('text/event-stream');
-      expect(res.body).toContain('"text":"gateway stream"');
-      expect(res.body).toContain('"correlationId":"corr-stream"');
+      expect(res.statusCode).toBe(502);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'Bridge error',
+        code: 'BRIDGE_ERROR',
+        details: 'gateway timeout from proxy',
+      });
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -673,7 +673,9 @@ describe('OpenClaw channel routing helpers', () => {
           error: 'OpenClaw bridge response timeout',
           code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
           source: 'openclaw-channel',
+          target: 'bridge',
           details: 'OpenClaw bridge did not produce an agent response',
+          timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
         }), { status: 504 });
       }
       return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
@@ -711,6 +713,67 @@ describe('OpenClaw channel routing helpers', () => {
         details: 'OpenClaw bridge did not produce an agent response',
         correlationId: 'corr-timeout',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('preserves structured OpenClaw timeout metadata returned through a bridge proxy', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        return new Response(JSON.stringify({
+          error: 'OpenClaw gateway response timeout',
+          code: 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT',
+          source: 'openclaw-channel',
+          target: 'gateway',
+          details: 'Nested OpenClaw gateway did not produce an agent response',
+          correlationId: 'upstream-corr',
+          timeoutMs: 1234,
+        }), { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+      ]);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw gateway response timeout',
+        code: 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'gateway',
+        details: 'Nested OpenClaw gateway did not produce an agent response',
+        correlationId: 'corr-timeout',
+        timeoutMs: 1234,
       });
     } finally {
       globalThis.fetch = origFetch;
@@ -1433,6 +1496,70 @@ describe('OpenClaw channel routing helpers', () => {
       expect(nextRes.headers['Content-Type']).toContain('text/event-stream');
       expect(nextRes.body).toContain('"text":"stream bridge recovered"');
       expect(nextRes.body).toContain('"correlationId":"corr-stream-timeout-next"');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('preserves structured OpenClaw stream timeout metadata returned through a bridge proxy', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound/stream') {
+        return new Response(JSON.stringify({
+          error: 'OpenClaw gateway response timeout',
+          code: 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT',
+          source: 'openclaw-channel',
+          target: 'gateway',
+          details: 'Nested OpenClaw gateway stream did not produce an agent response',
+          correlationId: 'upstream-corr',
+          timeoutMs: 5678,
+        }), { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway stream', correlationId: 'corr-stream' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-stream',
+      }, '/api/openclaw-channel/stream', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound/stream',
+      ]);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw gateway response timeout',
+        code: 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'gateway',
+        details: 'Nested OpenClaw gateway stream did not produce an agent response',
+        correlationId: 'corr-stream',
+        timeoutMs: 5678,
+      });
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -8,6 +8,7 @@ import {
   cancelPendingLocalAgentAttachJob,
   connectLocalAgentIntegrationFromUi,
   connectLocalAgentIntegration,
+  daemonState,
   getLocalAgentIntegration,
   getOpenClawChannelTargets,
   hasConfiguredLocalAgentChat,
@@ -19,6 +20,7 @@ import {
   normalizeOpenClawChatContextEntries,
   isValidOpenClawPersistTurnPayload,
   listLocalAgentIntegrations,
+  OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
   parseRequiredSignatures,
   pipeOpenClawStream,
   probeOpenClawChannelHealth,
@@ -128,6 +130,10 @@ function makeOpenClawRouteContext(
 }
 
 describe('OpenClaw channel routing helpers', () => {
+  beforeEach(() => {
+    daemonState.openClawBridgeHealth = null;
+  });
+
   it('keeps the public context normalizer backward-compatible with legacy attachment import entries', () => {
     const contextEntry = {
       key: 'target_context_graph',
@@ -553,6 +559,66 @@ describe('OpenClaw channel routing helpers', () => {
         pipelineUsed: 'none',
         error: 'No extractor; reason=unsupported',
       });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns a source-specific timeout when the OpenClaw bridge does not answer chat send', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    let calls = 0;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      calls += 1;
+      const requestUrl = String(url);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      throw timeoutError;
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(calls).toBe(2);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw bridge response timeout',
+        code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        correlationId: 'corr-timeout',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('normalizes OpenClaw health timeout messages before refresh can store them', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw timeoutError;
+    }) as typeof fetch;
+    try {
+      const report = await probeOpenClawChannelHealth(makeConfig({
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            transport: { kind: 'openclaw-channel', bridgeUrl: 'http://127.0.0.1:9301' },
+          },
+        },
+      }), 'bridge-token', { ignoreBridgeCache: true, timeoutMs: 50 });
+
+      expect(report.ok).toBe(false);
+      expect(report.error).toBe('OpenClaw bridge health probe timed out after 50ms');
+      expect(report.error).not.toContain('aborted due to timeout');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -655,6 +655,59 @@ describe('OpenClaw channel routing helpers', () => {
         error: 'OpenClaw bridge response timeout',
         code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
         source: 'openclaw-channel',
+        target: 'bridge',
+        correlationId: 'corr-timeout',
+        timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns a target-aware timeout when the OpenClaw gateway is the final timed-out target', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout') as Error & { name: string };
+    timeoutError.name = 'TimeoutError';
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      throw timeoutError;
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+        'https://openclaw.example.com/api/dkg-channel/inbound',
+      ]);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'OpenClaw gateway response timeout',
+        code: 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT',
+        source: 'openclaw-channel',
+        target: 'gateway',
         correlationId: 'corr-timeout',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
       });

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -626,6 +626,7 @@ describe('OpenClaw channel routing helpers', () => {
           error: 'OpenClaw bridge response timeout',
           code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
           source: 'openclaw-channel',
+          details: 'OpenClaw bridge did not produce an agent response',
         }), { status: 504 });
       }
       return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
@@ -660,8 +661,65 @@ describe('OpenClaw channel routing helpers', () => {
         code: 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT',
         source: 'openclaw-channel',
         target: 'bridge',
+        details: 'OpenClaw bridge did not produce an agent response',
         correlationId: 'corr-timeout',
         timeoutMs: OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS,
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not retry OpenClaw chat send after a structured upstream agent timeout', async () => {
+    const urls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      urls.push(requestUrl);
+      if (requestUrl.endsWith('/health')) {
+        return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
+      }
+      if (requestUrl === 'http://127.0.0.1:9301/inbound') {
+        return new Response(JSON.stringify({
+          error: 'Agent response timeout',
+          code: 'AGENT_TIMEOUT',
+          source: 'openclaw-agent',
+          details: 'OpenClaw agent runtime did not produce a response before its deadline',
+        }), { status: 504 });
+      }
+      return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const { ctx, res } = makeOpenClawRouteContext({
+        text: 'slow task',
+        correlationId: 'corr-timeout',
+      }, '/api/openclaw-channel/send', {
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            capabilities: { localChat: true },
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'https://openclaw.example.com',
+            },
+          },
+        },
+      });
+
+      await handleOpenclawRoutes(ctx);
+
+      expect(urls).toEqual([
+        'http://127.0.0.1:9301/health',
+        'http://127.0.0.1:9301/inbound',
+      ]);
+      expect(res.statusCode).toBe(504);
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: 'Agent response timeout',
+        code: 'AGENT_TIMEOUT',
+        source: 'openclaw-agent',
+        details: 'OpenClaw agent runtime did not produce a response before its deadline',
+        correlationId: 'corr-timeout',
       });
     } finally {
       globalThis.fetch = origFetch;
@@ -678,7 +736,7 @@ describe('OpenClaw channel routing helpers', () => {
         return new Response(JSON.stringify({ ok: true, channel: 'dkg-ui' }), { status: 200 });
       }
       if (requestUrl === 'http://127.0.0.1:9301/inbound') {
-        return new Response('gateway timeout from proxy', { status: 504 });
+        return new Response('Agent response timeout from proxy', { status: 504 });
       }
       return new Response(JSON.stringify({ text: 'gateway reply' }), { status: 200 });
     }) as typeof fetch;

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -62,8 +62,8 @@ export default defineConfig({
           // Notifications-pane redesign (A4) — scoped GET/POST route. Real
           // DashboardDB + mocked agent; no hardhat.
           'test/notifications-route.test.ts',
-          // Local-agent bridge routes are mocked HTTP/runtime tests; keep the
-          // timeout attribution regressions out of the Hardhat-backed lane.
+          // Local-agent bridge routes are mocked HTTP/runtime tests; include
+          // timeout attribution regressions in the fast unit lane too.
           'test/daemon-openclaw.test.ts',
           'test/daemon-hermes.test.ts',
         ],

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -62,6 +62,10 @@ export default defineConfig({
           // Notifications-pane redesign (A4) — scoped GET/POST route. Real
           // DashboardDB + mocked agent; no hardhat.
           'test/notifications-route.test.ts',
+          // Local-agent bridge routes are mocked HTTP/runtime tests; keep the
+          // timeout attribution regressions out of the Hardhat-backed lane.
+          'test/daemon-openclaw.test.ts',
+          'test/daemon-hermes.test.ts',
         ],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -52,6 +52,25 @@ export class HttpError extends Error {
   }
 }
 
+export class LocalAgentApiError extends Error {
+  status?: number;
+  code?: string;
+  source?: string;
+  details?: string;
+  correlationId?: string;
+  timeoutMs?: number;
+  target?: string;
+  route?: string;
+  integrationId?: string;
+  retryable?: boolean;
+
+  constructor(message: string, metadata: Partial<LocalAgentApiError> = {}) {
+    super(message);
+    this.name = 'LocalAgentApiError';
+    Object.assign(this, metadata);
+  }
+}
+
 async function fetchWithTimeout(input: string, init: RequestInit = {}, timeoutMs = 10000): Promise<Response> {
   try {
     return await fetch(input, { ...init, signal: AbortSignal.timeout(timeoutMs) });
@@ -1634,7 +1653,7 @@ export async function sendOpenClawLocalChat(
   });
   if (!res.ok) {
     const errBody = await res.json().catch(() => ({}));
-    throw new Error((errBody as { error?: string })?.error ?? `Request failed (${res.status})`);
+    throw buildLocalAgentApiError(errBody, `Request failed (${res.status})`, res.status);
   }
   return res.json();
 }
@@ -1642,7 +1661,19 @@ export async function sendOpenClawLocalChat(
 export type OpenClawStreamEvent =
   | { type: 'text_delta'; delta: string }
   | ({ type: 'final' } & LocalAgentChatResponse)
-  | { type: 'error'; error: string };
+  | ({
+      type: 'error';
+      error: string;
+      code?: string;
+      source?: string;
+      details?: string;
+      correlationId?: string;
+      timeoutMs?: number;
+      target?: string;
+      route?: string;
+      integrationId?: string;
+      retryable?: boolean;
+    });
 
 type HermesRawStreamEvent =
   | OpenClawStreamEvent
@@ -1708,7 +1739,7 @@ export async function streamOpenClawLocalChat(
 
   if (!res.ok) {
     const errBody = await res.json().catch(() => ({}));
-    throw new Error((errBody as { error?: string })?.error ?? `Request failed (${res.status})`);
+    throw buildLocalAgentApiError(errBody, `Request failed (${res.status})`, res.status);
   }
 
   const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
@@ -1730,7 +1761,7 @@ export async function streamOpenClawLocalChat(
   const handleEvent = (event: OpenClawStreamEvent): void => {
     opts.onEvent?.(event);
     if (event.type === 'error') {
-      streamError = new Error(event.error || 'Stream failed');
+      streamError = buildLocalAgentApiError(event, event.error || 'Stream failed');
     } else if (event.type === 'final') {
       finalPayload = {
         text: event.text,
@@ -1800,7 +1831,7 @@ export async function sendHermesLocalChat(
   });
   if (!res.ok) {
     const errBody = await res.json().catch(() => ({}));
-    throw new Error(formatLocalAgentError(errBody, `Request failed (${res.status})`));
+    throw buildLocalAgentApiError(errBody, `Request failed (${res.status})`, res.status);
   }
   return res.json();
 }
@@ -1824,7 +1855,7 @@ export async function streamHermesLocalChat(
 
   if (!res.ok) {
     const errBody = await res.json().catch(() => ({}));
-    throw new Error(formatLocalAgentError(errBody, `Request failed (${res.status})`));
+    throw buildLocalAgentApiError(errBody, `Request failed (${res.status})`, res.status);
   }
 
   const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
@@ -1851,7 +1882,7 @@ export async function streamHermesLocalChat(
   const handleEvent = (event: OpenClawStreamEvent): void => {
     opts.onEvent?.(event);
     if (event.type === 'error') {
-      streamError = new Error(event.error || 'Stream failed');
+      streamError = buildLocalAgentApiError(event, event.error || 'Stream failed');
     } else if (event.type === 'final') {
       finalPayload = {
         text: event.text,
@@ -1916,6 +1947,38 @@ function formatLocalAgentError(body: unknown, fallback: string): string {
     : JSON.stringify(record.details);
   if (!details || details === error) return error;
   return `${error}: ${details}`;
+}
+
+function buildLocalAgentApiError(body: unknown, fallback: string, status?: number): LocalAgentApiError {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return new LocalAgentApiError(fallback, { status });
+  }
+  const record = body as Record<string, unknown>;
+  const message = formatLocalAgentError(record, fallback);
+  const stringField = (key: string): string | undefined => {
+    const value = record[key];
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  };
+  const numberField = (key: string): number | undefined => {
+    const value = record[key];
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  };
+  const booleanField = (key: string): boolean | undefined => {
+    const value = record[key];
+    return typeof value === 'boolean' ? value : undefined;
+  };
+  return new LocalAgentApiError(message, {
+    status,
+    code: stringField('code'),
+    source: stringField('source'),
+    details: stringField('details'),
+    correlationId: stringField('correlationId'),
+    timeoutMs: numberField('timeoutMs'),
+    target: stringField('target'),
+    route: stringField('route'),
+    integrationId: stringField('integrationId'),
+    retryable: booleanField('retryable'),
+  });
 }
 
 interface LocalAgentIntegrationRecord {

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -1138,8 +1138,14 @@ function formatLocalAgentErrorMessage(
     if (err.code === 'HERMES_BRIDGE_RESPONSE_TIMEOUT') {
       return `${integration.name} bridge response timed out.`;
     }
+    if (err.code === 'HERMES_GATEWAY_RESPONSE_TIMEOUT') {
+      return `${integration.name} gateway response timed out.`;
+    }
     if (err.code === 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT') {
       return `${integration.name} bridge response timed out.`;
+    }
+    if (err.code === 'OPENCLAW_GATEWAY_RESPONSE_TIMEOUT') {
+      return `${integration.name} gateway response timed out.`;
     }
     if (err.code === 'SWM_SYNC_TIMEOUT' || err.source === 'background-sync') {
       return 'Background sync timed out. The chat request was not marked as failed by the local-agent bridge.';
@@ -1150,6 +1156,9 @@ function formatLocalAgentErrorMessage(
   }
   if (/Hermes bridge unreachable/i.test(message)) {
     return `${integration.name} is unavailable right now.`;
+  }
+  if (/gateway response timeout/i.test(message)) {
+    return `${integration.name} gateway response timed out.`;
   }
   if (/bridge response timeout/i.test(message) || /aborted due to timeout/i.test(message)) {
     return `${integration.name} bridge response timed out.`;

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -8,6 +8,7 @@ import {
   type LocalAgentChatAttachmentImportResult,
   type LocalAgentChatAttachmentRef,
   type LocalAgentChatContextEntry,
+  LocalAgentApiError,
   type LocalAgentIntegration,
   type LocalAgentHistoryMessage,
   type LocalAgentStreamEvent,
@@ -1133,8 +1134,25 @@ function formatLocalAgentErrorMessage(
   err: unknown,
 ): string {
   const message = err instanceof Error ? err.message : String(err ?? 'Unknown error');
+  if (err instanceof LocalAgentApiError) {
+    if (err.code === 'HERMES_BRIDGE_RESPONSE_TIMEOUT') {
+      return `${integration.name} bridge response timed out.`;
+    }
+    if (err.code === 'OPENCLAW_BRIDGE_RESPONSE_TIMEOUT') {
+      return `${integration.name} bridge response timed out.`;
+    }
+    if (err.code === 'SWM_SYNC_TIMEOUT' || err.source === 'background-sync') {
+      return 'Background sync timed out. The chat request was not marked as failed by the local-agent bridge.';
+    }
+  }
   if (/OpenClaw bridge unreachable/i.test(message)) {
     return `${integration.name} is unavailable right now.`;
+  }
+  if (/Hermes bridge unreachable/i.test(message)) {
+    return `${integration.name} is unavailable right now.`;
+  }
+  if (/bridge response timeout/i.test(message) || /aborted due to timeout/i.test(message)) {
+    return `${integration.name} bridge response timed out.`;
   }
   if (/Agent response timeout/i.test(message)) {
     return `${integration.name} took too long to respond.`;

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -315,6 +315,74 @@ describe('PanelRight component', () => {
     container.remove();
   });
 
+  it('renders structured local-agent timeout errors without raw abort text', async () => {
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+    const { LocalAgentApiError } = await import('../src/ui/api.js');
+
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
+      id: 'hermes',
+      name: 'Hermes',
+      description: 'Local bridge',
+      connectSupported: true,
+      chatSupported: true,
+      chatReady: true,
+      chatAttachments: true,
+      persistentChat: true,
+      bridgeOnline: true,
+      bridgeStatusLabel: 'Connected',
+      configured: true,
+      detected: true,
+      status: 'connected',
+      statusLabel: 'Connected',
+      detail: 'ready',
+      target: 'local',
+    }] });
+    streamLocalAgentChatMock.mockRejectedValueOnce(new LocalAgentApiError(
+      'Hermes bridge response timeout: The operation was aborted due to timeout',
+      {
+        code: 'HERMES_BRIDGE_RESPONSE_TIMEOUT',
+        source: 'hermes-channel',
+        correlationId: 'corr-timeout',
+        timeoutMs: 900000,
+      },
+    ));
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Run a long task');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const sendButton = container.querySelector('button[aria-label="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).toBeTruthy();
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain('Error: Hermes bridge response timed out.');
+    });
+    expect(container.textContent).not.toContain('The operation was aborted due to timeout');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it('imports skipped chat attachments as context entries and clears the composer after send', async () => {
     importFileMock.mockResolvedValue({
       assertionUri: 'urn:dkg:assertion:epub',

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -176,7 +176,7 @@ describe('ui local-agent stream api', () => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode(
-            'data: {"type":"error","error":"Hermes bridge response timeout","code":"HERMES_BRIDGE_RESPONSE_TIMEOUT","source":"hermes-channel","details":"gateway target did not produce an agent response","correlationId":"h-timeout","timeoutMs":900000}\n\n',
+            'data: {"type":"error","error":"Hermes gateway response timeout","code":"HERMES_GATEWAY_RESPONSE_TIMEOUT","source":"hermes-channel","target":"gateway","details":"Hermes gateway did not produce an agent response","correlationId":"h-timeout","timeoutMs":900000}\n\n',
           ));
           controller.close();
         },
@@ -191,9 +191,10 @@ describe('ui local-agent stream api', () => {
       let caught: any;
       await streamHermesLocalChat('hi').catch((err) => { caught = err; });
       expect(caught).toBeInstanceOf(LocalAgentApiError);
-      expect(caught.message).toBe('Hermes bridge response timeout: gateway target did not produce an agent response');
-      expect(caught.code).toBe('HERMES_BRIDGE_RESPONSE_TIMEOUT');
+      expect(caught.message).toBe('Hermes gateway response timeout: Hermes gateway did not produce an agent response');
+      expect(caught.code).toBe('HERMES_GATEWAY_RESPONSE_TIMEOUT');
       expect(caught.source).toBe('hermes-channel');
+      expect(caught.target).toBe('gateway');
       expect(caught.correlationId).toBe('h-timeout');
       expect(caught.timeoutMs).toBe(900000);
     } finally {

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from 'node:http';
 import {
   fetchMemorySessionGraphDelta,
   importFile,
+  LocalAgentApiError,
   sendHermesLocalChat,
   streamHermesLocalChat,
   streamLocalAgentChat,
@@ -165,6 +166,38 @@ describe('ui local-agent stream api', () => {
       await expect(streamHermesLocalChat('hi')).rejects.toThrow('Hermes bridge error: gateway health does not match /api/hermes-channel');
     } finally {
       globalThis.fetch = savedFetch;
+    }
+  });
+
+  it('preserves structured Hermes stream timeout metadata', async () => {
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(
+            'data: {"type":"error","error":"Hermes bridge response timeout","code":"HERMES_BRIDGE_RESPONSE_TIMEOUT","source":"hermes-channel","details":"gateway target did not produce an agent response","correlationId":"h-timeout","timeoutMs":900000}\n\n',
+          ));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof globalThis.fetch;
+
+    try {
+      let caught: any;
+      await streamHermesLocalChat('hi').catch((err) => { caught = err; });
+      expect(caught).toBeInstanceOf(LocalAgentApiError);
+      expect(caught.message).toBe('Hermes bridge response timeout: gateway target did not produce an agent response');
+      expect(caught.code).toBe('HERMES_BRIDGE_RESPONSE_TIMEOUT');
+      expect(caught.source).toBe('hermes-channel');
+      expect(caught.correlationId).toBe('h-timeout');
+      expect(caught.timeoutMs).toBe(900000);
+    } finally {
+      globalThis.fetch = prevFetch;
     }
   });
 


### PR DESCRIPTION
## Summary

- Increase Hermes/OpenClaw local-agent chat response budgets for long-running operations.
- Return source-specific bridge timeout metadata from Hermes and OpenClaw daemon routes instead of leaking raw `AbortSignal.timeout` text.
- Preserve local-agent timeout metadata through Node UI and render bridge/agent/background timeout copy distinctly.
- Reconcile stale enabled Hermes runtime state to ready when the Hermes health route succeeds.

## Related

- Fixes #1000

## Files changed

| Path | Notes |
| --- | --- |
| `packages/adapter-openclaw/src/DkgChannelPlugin.ts` | Extends OpenClaw adapter runtime response budget to 15 minutes. |
| `packages/cli/src/daemon/openclaw.ts` | Extends daemon proxy budget and normalizes OpenClaw health timeout text. |
| `packages/cli/src/daemon/hermes.ts` | Extends Hermes daemon response budget and normalizes Hermes health timeout text. |
| `packages/cli/src/daemon/routes/openclaw.ts` | Adds structured bridge timeout responses and preserves adapter agent timeouts separately. |
| `packages/cli/src/daemon/routes/hermes.ts` | Adds structured bridge timeout responses, prevents timeout fallback duplicate sends, and reconciles health-ready runtime state. |
| `packages/node-ui/src/ui/api.ts` | Introduces `LocalAgentApiError` so daemon metadata survives send/stream error handling. |
| `packages/node-ui/src/ui/components/Shell/PanelRight.tsx` | Renders local-agent bridge and agent timeout messages without raw abort text. |
| `packages/cli/test/*`, `packages/node-ui/test/*`, `packages/cli/vitest.unit.config.ts` | Adds timeout attribution, health normalization, runtime reconciliation, and UI rendering regression coverage. |

## Test plan

- `pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts test/daemon-openclaw.test.ts test/daemon-hermes.test.ts --reporter=verbose`
- `pnpm --dir packages/node-ui exec vitest run test/ui-api-stream.test.ts test/panel-right.component.test.ts --reporter=verbose`
- `pnpm --dir packages/adapter-openclaw exec vitest run test/dkg-channel.test.ts --reporter=verbose`
- `pnpm run build:runtime:packages`
- `git diff --cached --check`