### PR TITLE
fix(agent): auto-finalize before promote so SWM→VM publish works

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -30,7 +30,7 @@ import {
   isTrustLevelQuad,
   buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, type AuthorAttestationTypedData,
   buildAssertionSealQuads, buildAssertionPublishReceiptQuads,
-  parseAssertionSealQuads, type AssertionSeal,
+  type AssertionSeal,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   WORKSPACE_RECIPIENT_ENCRYPTION_KEY_PURPOSE,
   computeWorkspaceAgentEncryptionKeyProofPayload,
@@ -1706,50 +1706,59 @@ export class DKGAgent extends DKGAgentBase {
       ): Promise<{ seeded: number; fromLayer: 'swm' | 'vm'; entities: number }> {
         return agent.publisher.assertionPullFrom(contextGraphId, name, agentAddress, sourceLayer, opts);
       },
-      async promote(contextGraphId: string, name: string, opts?: { entities?: string[] | 'all'; subGraphName?: string }): Promise<{ promotedCount: number }> {
+      async promote(contextGraphId: string, name: string, opts?: { entities?: string[] | 'all'; subGraphName?: string; authorAgentAddress?: string; preSignedAuthorAttestation?: PreSignedAuthorAttestation }): Promise<{ promotedCount: number }> {
         // Seal-before-share: the on-chain publish path
         // (`publishFromFinalizedAssertion`) requires a FINALIZED assertion, and
         // the seal must be computed over the Working-Memory content BEFORE
-        // promote moves it to SWM and empties WM — you cannot finalize
-        // afterwards (no quads left to hash). The canonical
-        // create→finalize→promote→publish flow already finalizes; this makes
-        // the UI/HTTP promote→publish flow — which has no explicit finalize
-        // step — work too. Idempotent: skipped when a seal already exists (and
-        // `assertionFinalize` itself returns the existing seal on same
-        // content). Best-effort: if the node cannot sign for this author (a
-        // self-sovereign agent with no local key, or a non-V10 chain adapter),
-        // we log and promote UNSEALED exactly as before — never regressing an
-        // existing caller — and the later publish surfaces the explicit
-        // finalize requirement.
-        // Auto-finalize seals the WHOLE Working-Memory assertion (all root
-        // entities). That matches a FULL promote, but NOT a selective one: when
-        // `opts.entities` is a subset, promote ships only those roots to SWM
-        // while the seal still claims every root — so
-        // `publishFromFinalizedAssertion` reloads SWM scoped to the sealed (full)
-        // root set, recomputes a different merkleRoot, and the seal guard fails.
-        // `assertionFinalize` has no per-subset scope, so only auto-finalize a
-        // FULL promote; a selective promote must be finalized explicitly (with a
-        // matching scope) before it can publish. (Mirrors the publisher's own
-        // `opts.entities && opts.entities !== 'all'` selective filter.)
+        // promote moves it to SWM and empties WM (you cannot finalize afterwards
+        // — no quads left to hash). The canonical create→finalize→promote→publish
+        // flow already finalizes; this makes the UI/HTTP promote→publish flow —
+        // which has no explicit finalize step — work too.
+        //
+        // ALWAYS call `assertionFinalize`, never a "does a seal already exist?"
+        // short-circuit. assertionFinalize is itself idempotent: it returns the
+        // EXISTING seal untouched when its merkleRoot still matches the current
+        // WM (so an explicit finalize's author signature is preserved, never
+        // clobbered with the daemon signer), and it THROWS if the assertion was
+        // edited after finalize (stale seal) or the seal is corrupt. The old
+        // existence-only skip bypassed that check and would promote stale content
+        // that fails later at publish with a confusing merkleRoot mismatch.
+        // Thread the caller's author through (mirroring the explicit finalize
+        // route) so the seal attests the intended author rather than silently
+        // falling back to the daemon signer.
+        //
+        // Only auto-finalize a FULL promote: the seal covers ALL roots, but a
+        // selective promote (`opts.entities` subset) ships only some — sealing
+        // all then promoting a subset makes `publishFromFinalizedAssertion`
+        // recompute a different merkleRoot. A selective promote must be finalized
+        // explicitly with a matching scope.
         const promotingAllEntities = !opts?.entities || opts.entities === 'all';
-        try {
-          if (promotingAllEntities) {
-            const assertionUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-            const metaGraph = contextGraphMetaUri(contextGraphId);
-            const sealResult = await agent.store.query(
-              `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
-            );
-            const sealQuads = sealResult.type === 'quads' ? sealResult.quads : [];
-            if (parseAssertionSealQuads(sealQuads, assertionUri) == null) {
-              await agent.assertionFinalize(contextGraphId, name, agentAddress, { subGraphName: opts?.subGraphName });
+        if (promotingAllEntities) {
+          try {
+            await agent.assertionFinalize(contextGraphId, name, agentAddress, {
+              subGraphName: opts?.subGraphName,
+              authorAgentAddress: opts?.authorAgentAddress,
+              preSignedAuthorAttestation: opts?.preSignedAuthorAttestation,
+            });
+          } catch (err: any) {
+            const msg = err?.message ?? String(err);
+            // Seal-integrity failures — the assertion was edited after finalize
+            // (stale seal) or the seal is corrupt — MUST fail fast: promoting
+            // unsealed would empty WM and leave only a later, confusing publish
+            // error. Re-throw so the caller re-finalizes (or discards) first.
+            if (/already finalized with a different merkleRoot|seal for .* is corrupt/i.test(msg)) {
+              throw err;
             }
+            // Deliberate no-regression fallback for CAPABILITY gaps only — the
+            // node can't sign for this author (no local key / non-V10 adapter /
+            // unregistered CG): warn and promote UNSEALED exactly as before; the
+            // later publish surfaces the explicit-finalize requirement.
+            agent.log.warn(
+              createOperationContext('share'),
+              `Auto-finalize before promote skipped for "${name}": ${msg}. ` +
+                `Promoting unsealed; publishing to Verifiable Memory will require an explicit finalize first.`,
+            );
           }
-        } catch (err: any) {
-          agent.log.warn(
-            createOperationContext('share'),
-            `Auto-finalize before promote skipped for "${name}": ${err?.message ?? err}. ` +
-              `Promoting unsealed; publishing to Verifiable Memory will require an explicit finalize first.`,
-          );
         }
         // Resolve the gossip signer up-front (mirrors `share()` /
         // `conditionalShare()` patterns) so the publisher can wrap the

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1707,6 +1707,37 @@ export class DKGAgent extends DKGAgentBase {
         return agent.publisher.assertionPullFrom(contextGraphId, name, agentAddress, sourceLayer, opts);
       },
       async promote(contextGraphId: string, name: string, opts?: { entities?: string[] | 'all'; subGraphName?: string }): Promise<{ promotedCount: number }> {
+        // Seal-before-share: the on-chain publish path
+        // (`publishFromFinalizedAssertion`) requires a FINALIZED assertion, and
+        // the seal must be computed over the Working-Memory content BEFORE
+        // promote moves it to SWM and empties WM — you cannot finalize
+        // afterwards (no quads left to hash). The canonical
+        // create→finalize→promote→publish flow already finalizes; this makes
+        // the UI/HTTP promote→publish flow — which has no explicit finalize
+        // step — work too. Idempotent: skipped when a seal already exists (and
+        // `assertionFinalize` itself returns the existing seal on same
+        // content). Best-effort: if the node cannot sign for this author (a
+        // self-sovereign agent with no local key, or a non-V10 chain adapter),
+        // we log and promote UNSEALED exactly as before — never regressing an
+        // existing caller — and the later publish surfaces the explicit
+        // finalize requirement.
+        try {
+          const assertionUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, opts?.subGraphName);
+          const metaGraph = contextGraphMetaUri(contextGraphId);
+          const sealResult = await agent.store.query(
+            `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
+          );
+          const sealQuads = sealResult.type === 'quads' ? sealResult.quads : [];
+          if (parseAssertionSealQuads(sealQuads, assertionUri) == null) {
+            await agent.assertionFinalize(contextGraphId, name, agentAddress, { subGraphName: opts?.subGraphName });
+          }
+        } catch (err: any) {
+          agent.log.warn(
+            createOperationContext('share'),
+            `Auto-finalize before promote skipped for "${name}": ${err?.message ?? err}. ` +
+              `Promoting unsealed; publishing to Verifiable Memory will require an explicit finalize first.`,
+          );
+        }
         // Resolve the gossip signer up-front (mirrors `share()` /
         // `conditionalShare()` patterns) so the publisher can wrap the
         // promoted SWM gossip in the Sender Key encrypted envelope.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1721,15 +1721,28 @@ export class DKGAgent extends DKGAgentBase {
         // we log and promote UNSEALED exactly as before — never regressing an
         // existing caller — and the later publish surfaces the explicit
         // finalize requirement.
+        // Auto-finalize seals the WHOLE Working-Memory assertion (all root
+        // entities). That matches a FULL promote, but NOT a selective one: when
+        // `opts.entities` is a subset, promote ships only those roots to SWM
+        // while the seal still claims every root — so
+        // `publishFromFinalizedAssertion` reloads SWM scoped to the sealed (full)
+        // root set, recomputes a different merkleRoot, and the seal guard fails.
+        // `assertionFinalize` has no per-subset scope, so only auto-finalize a
+        // FULL promote; a selective promote must be finalized explicitly (with a
+        // matching scope) before it can publish. (Mirrors the publisher's own
+        // `opts.entities && opts.entities !== 'all'` selective filter.)
+        const promotingAllEntities = !opts?.entities || opts.entities === 'all';
         try {
-          const assertionUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, opts?.subGraphName);
-          const metaGraph = contextGraphMetaUri(contextGraphId);
-          const sealResult = await agent.store.query(
-            `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
-          );
-          const sealQuads = sealResult.type === 'quads' ? sealResult.quads : [];
-          if (parseAssertionSealQuads(sealQuads, assertionUri) == null) {
-            await agent.assertionFinalize(contextGraphId, name, agentAddress, { subGraphName: opts?.subGraphName });
+          if (promotingAllEntities) {
+            const assertionUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, opts?.subGraphName);
+            const metaGraph = contextGraphMetaUri(contextGraphId);
+            const sealResult = await agent.store.query(
+              `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
+            );
+            const sealQuads = sealResult.type === 'quads' ? sealResult.quads : [];
+            if (parseAssertionSealQuads(sealQuads, assertionUri) == null) {
+              await agent.assertionFinalize(contextGraphId, name, agentAddress, { subGraphName: opts?.subGraphName });
+            }
           }
         } catch (err: any) {
           agent.log.warn(

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -229,6 +229,38 @@ describe('WM → SWM → VM pipeline (single agent)', () => {
     ).rejects.toThrow(/not finalized/i);
   }, 20_000);
 
+  it('promote fails fast when the draft was edited after finalize (stale seal, not a silent publish mismatch)', async () => {
+    // Regression for the #1004 review: the old auto-finalize only checked whether
+    // a seal EXISTED, not whether it matched the current WM. A finalize → edit →
+    // promote sequence skipped re-finalize, promoted the new content under the
+    // STALE seal, and failed only later at publish with a confusing merkleRoot
+    // mismatch. promote now ALWAYS calls assertionFinalize, which detects the
+    // post-finalize mutation and throws — so promote fails fast, BEFORE emptying
+    // WM, with an actionable "already finalized with a different merkleRoot" error.
+    const agent = await createAgent('StaleSealBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Stale Seal E2E' });
+    await agent.registerContextGraph(CG_ID);
+
+    await agent.assertion.create(CG_ID, 'stale');
+    await agent.assertion.write(CG_ID, 'stale', [
+      { subject: `${ENTITY_BASE}:s1`, predicate: 'http://schema.org/name', object: '"First"' },
+    ]);
+    await agent.assertion.finalize(CG_ID, 'stale');
+
+    // Edit the draft AFTER finalize — the seal is now stale.
+    await agent.assertion.write(CG_ID, 'stale', [
+      { subject: `${ENTITY_BASE}:s2`, predicate: 'http://schema.org/name', object: '"Added after finalize"' },
+    ]);
+
+    // promote must fail fast (assertionFinalize detects the mutation), NOT
+    // silently promote the stale-sealed content.
+    await expect(agent.assertion.promote(CG_ID, 'stale')).rejects.toThrow(/different merkleRoot/i);
+
+    // WM is intact — the failed promote did not empty it.
+    const wm = await agent.assertion.query(CG_ID, 'stale');
+    expect(wm.length).toBeGreaterThan(0);
+  }, 20_000);
+
   it('WM is empty after promote; SWM clear after publishFromSWM with flag', async () => {
     const agent = await createAgent('CleanupBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Cleanup E2E' });

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -197,6 +197,38 @@ describe('WM → SWM → VM pipeline (single agent)', () => {
     expect(pub.seal).toBeDefined();
   }, 20_000);
 
+  it('selective promote does NOT auto-finalize (avoids the seal-all vs promote-subset merkleRoot mismatch)', async () => {
+    // Regression for the #1004 review: auto-finalize seals the WHOLE assertion
+    // (all root entities), but a SELECTIVE promote (opts.entities subset) ships
+    // only the chosen roots to SWM. If promote auto-sealed ALL roots here,
+    // publishFromFinalizedAssertion would reload SWM scoped to the sealed (full)
+    // root set, recompute a different merkleRoot, and fail the seal guard. So a
+    // selective promote must NOT auto-finalize — the assertion stays unsealed
+    // until an explicit, matching-scope finalize.
+    const agent = await createAgent('SelectivePromoteBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Selective Promote E2E' });
+    await agent.registerContextGraph(CG_ID);
+
+    await agent.assertion.create(CG_ID, 'selective');
+    await agent.assertion.write(CG_ID, 'selective', [
+      { subject: `${ENTITY_BASE}:a`, predicate: 'http://schema.org/name', object: '"Entity A"' },
+      { subject: `${ENTITY_BASE}:b`, predicate: 'http://schema.org/name', object: '"Entity B"' },
+    ]);
+
+    // Promote ONLY entity A — a subset of the assertion's roots.
+    const promoteResult = await agent.assertion.promote(CG_ID, 'selective', {
+      entities: [`${ENTITY_BASE}:a`],
+    });
+    expect(promoteResult.promotedCount).toBeGreaterThan(0);
+
+    // The selective promote must have left the assertion UNSEALED, so publish
+    // surfaces the explicit-finalize requirement — NOT a (pre-fix) seal-all-vs-
+    // promote-subset merkleRoot mismatch.
+    await expect(
+      agent.publishFromFinalizedAssertion(CG_ID, 'selective'),
+    ).rejects.toThrow(/not finalized/i);
+  }, 20_000);
+
   it('WM is empty after promote; SWM clear after publishFromSWM with flag', async () => {
     const agent = await createAgent('CleanupBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Cleanup E2E' });

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -169,6 +169,34 @@ describe('WM → SWM → VM pipeline (single agent)', () => {
     expect(dataResult.bindings.length).toBe(1);
   }, 20_000);
 
+  it('promote auto-finalizes: publishFromFinalizedAssertion works after a bare promote (no explicit finalize)', async () => {
+    // Regression for the UI/HTTP flow: "Promote All → Shared" then "Publish to
+    // Verifiable Memory" promotes WM→SWM with NO explicit finalize, and the
+    // publish runs publishFromFinalizedAssertion, which requires a seal.
+    // Because promote empties WM, you cannot finalize afterwards — so promote
+    // now seals BEFORE moving WM→SWM. Pre-fix this threw
+    // "publishFromFinalizedAssertion: assertion <...> is not finalized".
+    const agent = await createAgent('AutoFinalizeBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'AutoFinalize E2E' });
+    await agent.registerContextGraph(CG_ID);
+
+    await agent.assertion.create(CG_ID, 'auto-final');
+    await agent.assertion.write(CG_ID, 'auto-final', [
+      { subject: `${ENTITY_BASE}:auto`, predicate: 'http://schema.org/name', object: '"Auto Finalized"' },
+    ]);
+
+    // Promote WITHOUT an explicit finalize() — the exact gap that broke the UI.
+    const promoteResult = await agent.assertion.promote(CG_ID, 'auto-final');
+    expect(promoteResult.promotedCount).toBeGreaterThan(0);
+
+    // publishFromFinalizedAssertion hard-requires the seal; it must now find
+    // the one promote stamped, instead of throwing "is not finalized".
+    const pub = await agent.publishFromFinalizedAssertion(CG_ID, 'auto-final');
+    expect(pub.status).toBe('confirmed');
+    expect(pub.ual).toBeDefined();
+    expect(pub.seal).toBeDefined();
+  }, 20_000);
+
   it('WM is empty after promote; SWM clear after publishFromSWM with flag', async () => {
     const agent = await createAgent('CleanupBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Cleanup E2E' });


### PR DESCRIPTION
## Symptom

In the node UI: create entities → **Promote All → Shared** (WM→SWM) → **Publish to Verifiable Memory** (SWM→VM) fails with:

```
publishFromFinalizedAssertion: assertion <…> is not finalized.
Call /api/assertion/<name>/finalize before publishing.
```

## Root cause — a lifecycle gap, not the blank-node bug

- The publish path (`publishFromFinalizedAssertion`, and `publishFromSharedMemory` which reuses the seal/`reservedKaId`) **requires a finalized assertion**.
- The UI exposes **no finalize action**, and `promote` did **not** seal — so a promoted assertion has `state = promoted` with no seal, and publish rejects it.
- You can't just "finalize at publish time": **promote empties Working Memory** (it moves quads to SWM), and `assertionFinalize` hashes the WM content — there's nothing left to hash afterward. The seal must be computed **before** the WM→SWM move.

The canonical `create → finalize → promote → publish` flow (used by the agents/SDK) already finalizes first. UI/HTTP callers skip it.

## Fix

`agent.assertion.promote` finalizes the assertion (if not already sealed) **before** moving WM→SWM.

- **Idempotent** — a pre-read seal guard skips finalize when a seal already exists, and `assertionFinalize` itself returns the existing seal on identical content. The canonical already-finalized flow is unchanged.
- **Best-effort** — if the node can't sign for the author (a self-sovereign agent with no local key, or a non-V10 chain adapter in tests), it logs and promotes **unsealed exactly as before** — never regressing an existing caller. The later publish still surfaces the explicit-finalize requirement.

## Tests

New regression in `e2e-memory-layers`: a **bare promote (no explicit finalize)** followed by `publishFromFinalizedAssertion` now mints a **confirmed** KA on the V10 hardhat chain (pre-fix: threw "is not finalized").

Verified green:
- `e2e-assertion-lifecycle` (7) — create/write/promote/discard, gossip replication
- `e2e-memory-layers` (8, incl. the new case) — full WM→SWM→VM, WM-empty-after-promote, two-node publish
- `e2e-sub-graphs` (15) — sub-graph promote (the `subGraphName` path)

## Follow-up (out of scope)

The UI should also surface a Finalize affordance / show the seal state; this PR makes the existing promote→publish path *work*, but a clearer UX (or chaining finalize into the publish button) is worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)