### PR TITLE
Persist failed local-agent chat turns in Node UI

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -2513,7 +2513,7 @@ export async function fetchLocalAgentHistory(
 async function persistHermesLocalChatFailure(
   opts: LocalAgentChatFailurePersistenceOptions,
 ): Promise<LocalAgentChatFailurePersistenceResponse> {
-  const sessionId = opts.sessionId?.trim() || getDefaultLocalAgentSessionId('hermes');
+  const sessionId = opts.sessionId?.trim();
   if (!sessionId) throw new Error('Missing Hermes session id');
   return post<LocalAgentChatFailurePersistenceResponse>('/api/hermes-channel/persist-turn', {
     sessionId,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1624,7 +1624,6 @@ export interface LocalAgentChatResponse {
 
 export interface LocalAgentChatFailurePersistenceOptions {
   sessionId?: string;
-  turnId?: string;
   correlationId?: string;
   userMessage: string;
   assistantReply?: string;
@@ -2511,23 +2510,6 @@ export async function fetchLocalAgentHistory(
   return fetchLocalAgentHistoryBySessionId(sessionId, limit);
 }
 
-async function persistOpenClawLocalChatFailure(
-  opts: LocalAgentChatFailurePersistenceOptions,
-): Promise<LocalAgentChatFailurePersistenceResponse> {
-  const sessionId = opts.sessionId?.trim() || getDefaultLocalAgentSessionId('openclaw');
-  if (!sessionId) throw new Error('Missing OpenClaw session id');
-  return post<LocalAgentChatFailurePersistenceResponse>('/api/openclaw-channel/persist-turn', {
-    sessionId,
-    userMessage: opts.userMessage,
-    assistantReply: opts.assistantReply ?? '',
-    turnId: opts.turnId ?? opts.correlationId,
-    correlationId: opts.correlationId,
-    attachmentRefs: opts.attachments,
-    persistenceState: 'failed',
-    failureReason: opts.failureReason,
-  });
-}
-
 async function persistHermesLocalChatFailure(
   opts: LocalAgentChatFailurePersistenceOptions,
 ): Promise<LocalAgentChatFailurePersistenceResponse> {
@@ -2537,7 +2519,6 @@ async function persistHermesLocalChatFailure(
     sessionId,
     userMessage: opts.userMessage,
     assistantReply: opts.assistantReply ?? '',
-    turnId: opts.turnId ?? opts.correlationId,
     correlationId: opts.correlationId,
     attachmentRefs: opts.attachments,
     persistenceState: 'failed',
@@ -2553,7 +2534,6 @@ export async function persistLocalAgentChatFailure(
   opts: LocalAgentChatFailurePersistenceOptions,
 ): Promise<LocalAgentChatFailurePersistenceResponse> {
   const normalizedId = id.trim().toLowerCase();
-  if (normalizedId === 'openclaw') return persistOpenClawLocalChatFailure(opts);
   if (normalizedId === 'hermes') return persistHermesLocalChatFailure(opts);
   throw new Error(`${id} local chat persistence is not available yet.`);
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1622,6 +1622,23 @@ export interface LocalAgentChatResponse {
   turnId?: string;
 }
 
+export interface LocalAgentChatFailurePersistenceOptions {
+  sessionId?: string;
+  turnId?: string;
+  correlationId?: string;
+  userMessage: string;
+  assistantReply?: string;
+  failureReason?: string;
+  profile?: string;
+  attachments?: LocalAgentChatAttachmentRef[];
+  contextGraphId?: string;
+}
+
+export interface LocalAgentChatFailurePersistenceResponse {
+  ok?: boolean;
+  turnId?: string;
+}
+
 export async function sendOpenClawLocalChat(
   text: string,
   opts?: LocalAgentChatRequestOptions,
@@ -1996,6 +2013,7 @@ export interface LocalAgentHistoryMessage {
   author: string;
   ts: string;
   turnId?: string;
+  persistStatus?: 'pending' | 'in_progress' | 'stored' | 'failed' | 'skipped';
   failureReason?: string | null;
   attachmentRefs?: LocalAgentChatAttachmentRef[];
   toolCalls?: Array<{ name: string; args: Record<string, unknown>; result: unknown }>;
@@ -2093,6 +2111,7 @@ async function fetchLocalAgentHistoryBySessionId(
         author: message.author,
         ts: message.ts,
         turnId: message.turnId,
+        persistStatus: message.persistStatus,
         failureReason: message.failureReason,
         attachmentRefs: message.attachmentRefs,
         toolCalls: message.toolCalls,
@@ -2490,6 +2509,53 @@ export async function fetchLocalAgentHistory(
   const sessionId = resolveLocalAgentHistorySessionId(id, opts.sessionId);
   if (!sessionId) return [];
   return fetchLocalAgentHistoryBySessionId(sessionId, limit);
+}
+
+async function persistOpenClawLocalChatFailure(
+  opts: LocalAgentChatFailurePersistenceOptions,
+): Promise<LocalAgentChatFailurePersistenceResponse> {
+  const sessionId = opts.sessionId?.trim() || getDefaultLocalAgentSessionId('openclaw');
+  if (!sessionId) throw new Error('Missing OpenClaw session id');
+  return post<LocalAgentChatFailurePersistenceResponse>('/api/openclaw-channel/persist-turn', {
+    sessionId,
+    userMessage: opts.userMessage,
+    assistantReply: opts.assistantReply ?? '',
+    turnId: opts.turnId ?? opts.correlationId,
+    correlationId: opts.correlationId,
+    attachmentRefs: opts.attachments,
+    persistenceState: 'failed',
+    failureReason: opts.failureReason,
+  });
+}
+
+async function persistHermesLocalChatFailure(
+  opts: LocalAgentChatFailurePersistenceOptions,
+): Promise<LocalAgentChatFailurePersistenceResponse> {
+  const sessionId = opts.sessionId?.trim() || getDefaultLocalAgentSessionId('hermes');
+  if (!sessionId) throw new Error('Missing Hermes session id');
+  return post<LocalAgentChatFailurePersistenceResponse>('/api/hermes-channel/persist-turn', {
+    sessionId,
+    userMessage: opts.userMessage,
+    assistantReply: opts.assistantReply ?? '',
+    turnId: opts.turnId ?? opts.correlationId,
+    correlationId: opts.correlationId,
+    attachmentRefs: opts.attachments,
+    persistenceState: 'failed',
+    failureReason: opts.failureReason,
+    contextGraphId: opts.contextGraphId,
+    profile: opts.profile,
+    metadata: { source: 'node-ui-failed-turn' },
+  });
+}
+
+export async function persistLocalAgentChatFailure(
+  id: string,
+  opts: LocalAgentChatFailurePersistenceOptions,
+): Promise<LocalAgentChatFailurePersistenceResponse> {
+  const normalizedId = id.trim().toLowerCase();
+  if (normalizedId === 'openclaw') return persistOpenClawLocalChatFailure(opts);
+  if (normalizedId === 'hermes') return persistHermesLocalChatFailure(opts);
+  throw new Error(`${id} local chat persistence is not available yet.`);
 }
 
 export async function streamLocalAgentChat(

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -524,6 +524,14 @@ export function buildChatContextEntries(
  *
  */
 
+function isPersistedFailureNotice(text: string, failureReason?: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (/^error:/i.test(trimmed)) return true;
+  if (trimmed === 'Request cancelled.') return true;
+  return Boolean(failureReason && trimmed.toLowerCase().includes(failureReason.toLowerCase()));
+}
+
 function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
   const author = message.author.toLowerCase();
   const role: LocalAgentMessage['role'] = author.includes('assistant') || author.includes('agent') ? 'assistant' : 'user';
@@ -533,7 +541,13 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
   const failed = role === 'assistant' && (message.persistStatus === 'failed' || Boolean(failedReason));
   const failureContent = `Error: ${failedReason ?? 'The local agent turn failed.'}`;
   const content = failed
-    ? (message.text ? `${message.text}\n\n${failureContent}` : failureContent)
+    ? (message.text
+      ? (
+        isPersistedFailureNotice(message.text, failedReason)
+          ? message.text
+          : `${message.text}\n\n${failureContent}`
+      )
+      : failureContent)
     : message.text || buildAttachmentSummary(message.attachmentRefs ?? []);
   // KNOWN ISSUE — persisted messages whose newlines were escape-
   // encoded by the DKG-memory persistence layer (stored as literal
@@ -2722,12 +2736,11 @@ export function PanelRight() {
           ),
         );
       }
-      if (!isUserAbort && assistantId && messageText) {
+      if (!isUserAbort && integrationId === 'hermes' && assistantId && messageText) {
         void (async () => {
           try {
             const persisted = await persistLocalAgentChatFailure(integrationId, {
               sessionId: conversation.sessionId ?? undefined,
-              turnId: correlationId || undefined,
               correlationId: correlationId || undefined,
               userMessage: messageText,
               assistantReply: assistantPartialText,

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -68,6 +68,12 @@ export interface LocalAgentMessage {
   streaming?: boolean;
   attachments?: LocalAgentChatAttachmentRef[];
   /**
+   * UI-generated failed-turn notice rendered as literal text after any real
+   * agent output. Kept separate from `content` so markdown can stay enabled
+   * for partial agent text without parsing local error bodies.
+   */
+  failureNotice?: string;
+  /**
    * True when `content` is locally synthesized by the UI (e.g. an
    * attachment summary fallback from `mapHistoryMessage`, or a local
    * error/cancel string), NOT real agent-authored markdown. The chat
@@ -531,14 +537,24 @@ function isPersistedFailureNotice(text: string, failureContent: string, failureR
   return failureReason === 'Request cancelled.' && trimmed === failureReason;
 }
 
-function buildFailedAgentContent(text: string, failureContent: string, failureReason?: string): string {
-  if (!text) return failureContent;
-  return isPersistedFailureNotice(text, failureContent, failureReason)
-    ? text
-    : `${text}\n\n${failureContent}`;
+function buildFailedTurnDisplay(
+  text: string,
+  failureContent: string,
+  failureReason: string | undefined,
+  integrationId: string,
+): Pick<LocalAgentMessage, 'content' | 'failureNotice' | 'synthesized'> {
+  if (text && isPersistedFailureNotice(text, failureContent, failureReason)) {
+    return { content: text, synthesized: true };
+  }
+  if (text) {
+    return integrationId === 'hermes'
+      ? { content: text, failureNotice: failureContent, synthesized: false }
+      : { content: text, synthesized: false };
+  }
+  return { content: '', failureNotice: failureContent, synthesized: true };
 }
 
-function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
+function mapHistoryMessage(message: LocalAgentHistoryMessage, integrationId = ''): LocalAgentMessage {
   const author = message.author.toLowerCase();
   const role: LocalAgentMessage['role'] = author.includes('assistant') || author.includes('agent') ? 'assistant' : 'user';
   const failedReason = typeof message.failureReason === 'string' && message.failureReason.trim()
@@ -546,12 +562,11 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     : undefined;
   const failed = role === 'assistant' && (message.persistStatus === 'failed' || Boolean(failedReason));
   const failureContent = `Error: ${failedReason ?? 'The local agent turn failed.'}`;
-  const alreadyFailureNotice = failed && message.text
-    ? isPersistedFailureNotice(message.text, failureContent, failedReason)
-    : false;
-  const content = failed
-    ? buildFailedAgentContent(message.text, failureContent, failedReason)
-    : message.text || buildAttachmentSummary(message.attachmentRefs ?? []);
+  const failedDisplay = failed
+    ? buildFailedTurnDisplay(message.text, failureContent, failedReason, integrationId)
+    : null;
+  const content = failedDisplay?.content
+    ?? (message.text || buildAttachmentSummary(message.attachmentRefs ?? []));
   // KNOWN ISSUE — persisted messages whose newlines were escape-
   // encoded by the DKG-memory persistence layer (stored as literal
   // backslash-n, two characters, not real newline characters)
@@ -576,7 +591,7 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
   // instead of escape-encoding them, or carry an explicit "escaped"
   // marker on encoded payloads so the UI can decode only confirmed-
   // escaped content. Tracked as a follow-up.
-  const hasAgentText = Boolean(message.text) && !alreadyFailureNotice;
+  const hasAgentText = Boolean(message.text);
   return {
     id: message.uri || `local-history:${++localMessageId}`,
     uri: message.uri,
@@ -586,10 +601,11 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     ts: formatLocalTimestamp(message.ts),
     tsRaw: toIsoTimestamp(message.ts),
     attachments: message.attachmentRefs,
+    failureNotice: failedDisplay?.failureNotice,
     // Attachment summaries and exact persisted failure notices are UI-generated
     // strings. Mark them synthesized so the renderer skips markdown; real agent
     // partial text keeps markdown enabled even when the turn failed.
-    synthesized: !hasAgentText,
+    synthesized: failedDisplay?.synthesized ?? !hasAgentText,
   };
 }
 
@@ -647,8 +663,10 @@ function renderMessageContent(
   role: 'user' | 'assistant',
   synthesized: boolean,
   streaming: boolean,
+  failureNotice?: string,
 ): React.ReactNode {
   const normalized = normalizeMessageContent(content);
+  const normalizedFailure = failureNotice ? normalizeMessageContent(failureNotice) : '';
   // Pre-first-token wait: an assistant turn starts as `{ streaming:
   // true, content: '' }`. The inline streaming caret lives inside the
   // last text node, so with no content yet there is nothing to anchor
@@ -656,7 +674,7 @@ function renderMessageContent(
   // "Thinking…" indicator until the first token arrives, at which
   // point this falls through to the markdown path (whose inline caret
   // then takes over). `role=status`/`aria-live` announces it to AT.
-  if (role === 'assistant' && streaming && normalized.trim() === '') {
+  if (role === 'assistant' && streaming && normalized.trim() === '' && !normalizedFailure) {
     return (
       <span className="v10-chat-thinking" role="status" aria-live="polite">
         Thinking…
@@ -675,14 +693,25 @@ function renderMessageContent(
   //     otherwise render as a live external link in an assistant-styled
   //     bubble (CFNsU / CFXYU / CGpe9). The CFThj relative-link guard
   //     doesn't help — those hrefs are absolute and allowed.
-  if (role === 'assistant' && !synthesized) {
-    return <MarkdownMessage content={normalized} streaming={streaming} />;
+  if (role === 'assistant' && !synthesized && normalized.trim() !== '') {
+    return (
+      <>
+        <MarkdownMessage content={normalized} streaming={streaming && !normalizedFailure} />
+        {normalizedFailure && (
+          <span className="v10-chat-plaintext v10-chat-failure-notice">
+            {normalizedFailure}
+            {streaming && <span className="v10-chat-cursor" />}
+          </span>
+        )}
+      </>
+    );
   }
   // Plaintext path (user / synthetic): keep the caret inline with the
   // text rather than as a block sibling that drops to a new line.
+  const plainText = [normalized, normalizedFailure].filter(Boolean).join('\n\n');
   return (
     <span className="v10-chat-plaintext">
-      {normalized}
+      {plainText}
       {streaming && <span className="v10-chat-cursor" />}
     </span>
   );
@@ -1632,6 +1661,7 @@ export function ConnectedAgentsTab(props: {
                       message.role,
                       Boolean(message.synthesized),
                       Boolean(message.streaming),
+                      message.failureNotice,
                     )}
                   </div>
                   {message.attachments && message.attachments.length > 0 && (
@@ -2505,7 +2535,7 @@ export function PanelRight() {
       const history = await fetchLocalAgentHistory(integrationId, 100, {
         sessionId: conversation.sessionId ?? undefined,
       });
-      const loaded = history.map(mapHistoryMessage);
+      const loaded = history.map((message) => mapHistoryMessage(message, integrationId));
       updateLocalMessages(conversation.stateKey, (prev) => mergeLocalAgentMessages(prev, loaded));
     } catch {
       updateLocalMessages(conversation.stateKey, (prev) => prev);
@@ -2728,7 +2758,8 @@ export function PanelRight() {
             message.id === assistantId
               ? {
                   ...message,
-                  content: buildFailedAgentContent(assistantPartialText, failureContent, failureReason),
+                  content: assistantPartialText,
+                  failureNotice: failureContent,
                   streaming: false,
                   synthesized: !assistantPartialText,
                 }
@@ -2896,7 +2927,7 @@ export function PanelRight() {
         setConnectError((refreshOutcome.reason as Error)?.message ?? 'Failed to refresh integration.');
       }
       if (historyOutcome.status === 'fulfilled') {
-        const loaded = historyOutcome.value.map(mapHistoryMessage);
+        const loaded = historyOutcome.value.map((message) => mapHistoryMessage(message, integrationId));
         updateLocalMessages(conversation.stateKey, (prev) => mergeLocalAgentMessages(prev, loaded));
         setLocalHistoryLoadedByConversation((prev) => ({
           ...prev,

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -524,12 +524,18 @@ export function buildChatContextEntries(
  *
  */
 
-function isPersistedFailureNotice(text: string, failureReason?: string): boolean {
+function isPersistedFailureNotice(text: string, failureContent: string, failureReason?: string): boolean {
   const trimmed = text.trim();
   if (!trimmed) return false;
-  if (/^error:/i.test(trimmed)) return true;
-  if (trimmed === 'Request cancelled.') return true;
-  return Boolean(failureReason && trimmed.toLowerCase().includes(failureReason.toLowerCase()));
+  if (trimmed === failureContent) return true;
+  return failureReason === 'Request cancelled.' && trimmed === failureReason;
+}
+
+function buildFailedAssistantContent(text: string, failureContent: string, failureReason?: string): string {
+  if (!text) return failureContent;
+  return isPersistedFailureNotice(text, failureContent, failureReason)
+    ? text
+    : `${text}\n\n${failureContent}`;
 }
 
 function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
@@ -540,14 +546,11 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     : undefined;
   const failed = role === 'assistant' && (message.persistStatus === 'failed' || Boolean(failedReason));
   const failureContent = `Error: ${failedReason ?? 'The local agent turn failed.'}`;
+  const alreadyFailureNotice = failed && message.text
+    ? isPersistedFailureNotice(message.text, failureContent, failedReason)
+    : false;
   const content = failed
-    ? (message.text
-      ? (
-        isPersistedFailureNotice(message.text, failedReason)
-          ? message.text
-          : `${message.text}\n\n${failureContent}`
-      )
-      : failureContent)
+    ? buildFailedAssistantContent(message.text, failureContent, failedReason)
     : message.text || buildAttachmentSummary(message.attachmentRefs ?? []);
   // KNOWN ISSUE — persisted messages whose newlines were escape-
   // encoded by the DKG-memory persistence layer (stored as literal
@@ -573,7 +576,7 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
   // instead of escape-encoding them, or carry an explicit "escaped"
   // marker on encoded payloads so the UI can decode only confirmed-
   // escaped content. Tracked as a follow-up.
-  const hasAgentText = Boolean(message.text);
+  const hasAgentText = Boolean(message.text) && !alreadyFailureNotice;
   return {
     id: message.uri || `local-history:${++localMessageId}`,
     uri: message.uri,
@@ -583,11 +586,10 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     ts: formatLocalTimestamp(message.ts),
     tsRaw: toIsoTimestamp(message.ts),
     attachments: message.attachmentRefs,
-    // The fallback path embeds raw filenames into a synthesized summary
-    // string. Mark synthesized so the renderer skips markdown for those —
-    // a filename like `[spec](https://attacker.example)` would otherwise
-    // render as a live external link in an assistant-styled bubble.
-    synthesized: failed || !hasAgentText,
+    // Attachment summaries and exact persisted failure notices are UI-generated
+    // strings. Mark them synthesized so the renderer skips markdown; real agent
+    // partial text keeps markdown enabled even when the turn failed.
+    synthesized: !hasAgentText,
   };
 }
 
@@ -2719,18 +2721,16 @@ export function PanelRight() {
     } catch (err: any) {
       const isUserAbort = err?.name === 'AbortError';
       const failureReason = isUserAbort ? 'Request cancelled.' : formatLocalAgentErrorMessage(integration, err);
+      const failureContent = isUserAbort ? failureReason : `Error: ${failureReason}`;
       if (assistantId) {
         updateLocalMessages(conversationKey, (prev) =>
           prev.map((message) =>
             message.id === assistantId
               ? {
                   ...message,
-                  content: isUserAbort ? failureReason : `Error: ${failureReason}`,
+                  content: buildFailedAssistantContent(assistantPartialText, failureContent, failureReason),
                   streaming: false,
-                  // Error / cancel strings are locally synthesized and may
-                  // surface details the agent didn't author (URLs in error
-                  // bodies, raw filenames). Render as plain text.
-                  synthesized: true,
+                  synthesized: !assistantPartialText,
                 }
               : message,
           ),

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -531,7 +531,7 @@ function isPersistedFailureNotice(text: string, failureContent: string, failureR
   return failureReason === 'Request cancelled.' && trimmed === failureReason;
 }
 
-function buildFailedAssistantContent(text: string, failureContent: string, failureReason?: string): string {
+function buildFailedAgentContent(text: string, failureContent: string, failureReason?: string): string {
   if (!text) return failureContent;
   return isPersistedFailureNotice(text, failureContent, failureReason)
     ? text
@@ -550,7 +550,7 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     ? isPersistedFailureNotice(message.text, failureContent, failedReason)
     : false;
   const content = failed
-    ? buildFailedAssistantContent(message.text, failureContent, failedReason)
+    ? buildFailedAgentContent(message.text, failureContent, failedReason)
     : message.text || buildAttachmentSummary(message.attachmentRefs ?? []);
   // KNOWN ISSUE — persisted messages whose newlines were escape-
   // encoded by the DKG-memory persistence layer (stored as literal
@@ -2728,7 +2728,7 @@ export function PanelRight() {
             message.id === assistantId
               ? {
                   ...message,
-                  content: buildFailedAssistantContent(assistantPartialText, failureContent, failureReason),
+                  content: buildFailedAgentContent(assistantPartialText, failureContent, failureReason),
                   streaming: false,
                   synthesized: !assistantPartialText,
                 }

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -20,6 +20,7 @@ import {
   getDefaultLocalAgentSessionId,
   fetchLocalAgentHistory,
   fetchLocalAgentIntegrations,
+  persistLocalAgentChatFailure,
   refreshLocalAgentIntegration,
   streamLocalAgentChat,
 } from '../../api.js';
@@ -525,6 +526,15 @@ export function buildChatContextEntries(
 
 function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
   const author = message.author.toLowerCase();
+  const role: LocalAgentMessage['role'] = author.includes('assistant') || author.includes('agent') ? 'assistant' : 'user';
+  const failedReason = typeof message.failureReason === 'string' && message.failureReason.trim()
+    ? message.failureReason.trim()
+    : undefined;
+  const failed = role === 'assistant' && (message.persistStatus === 'failed' || Boolean(failedReason));
+  const failureContent = `Error: ${failedReason ?? 'The local agent turn failed.'}`;
+  const content = failed
+    ? (message.text ? `${message.text}\n\n${failureContent}` : failureContent)
+    : message.text || buildAttachmentSummary(message.attachmentRefs ?? []);
   // KNOWN ISSUE — persisted messages whose newlines were escape-
   // encoded by the DKG-memory persistence layer (stored as literal
   // backslash-n, two characters, not real newline characters)
@@ -554,8 +564,8 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     id: message.uri || `local-history:${++localMessageId}`,
     uri: message.uri,
     turnId: message.turnId,
-    role: author.includes('assistant') || author.includes('agent') ? 'assistant' : 'user',
-    content: message.text || buildAttachmentSummary(message.attachmentRefs ?? []),
+    role,
+    content,
     ts: formatLocalTimestamp(message.ts),
     tsRaw: toIsoTimestamp(message.ts),
     attachments: message.attachmentRefs,
@@ -563,7 +573,7 @@ function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage
     // string. Mark synthesized so the renderer skips markdown for those —
     // a filename like `[spec](https://attacker.example)` would otherwise
     // render as a live external link in an assistant-styled bubble.
-    synthesized: !hasAgentText,
+    synthesized: failed || !hasAgentText,
   };
 }
 
@@ -2577,6 +2587,10 @@ export function PanelRight() {
     setConnectError(null);
     let controller: AbortController | null = null;
     let assistantId = '';
+    let correlationId = '';
+    let messageText = '';
+    let assistantPartialText = '';
+    let failureAttachmentRefs: LocalAgentChatAttachmentRef[] = [];
     // Hoisted so the `catch` path can restore the optimistically-cleared
     // drafts without a TypeScript scope error and without a runtime
     // ReferenceError when send fails before they're assigned.
@@ -2593,13 +2607,14 @@ export function PanelRight() {
         return;
       }
 
-      const correlationId = crypto.randomUUID();
+      correlationId = crypto.randomUUID();
       const importSummary = buildAttachmentImportSummary(importContext.results);
       const textWithImportSummary = [text, importSummary].filter((part) => part.length > 0).join('\n\n');
-      const messageText = text
+      messageText = text
         ? textWithImportSummary
         : buildAttachmentTurnSummary(attachments, importContext.results);
       const outboundText = text ? textWithImportSummary : '';
+      failureAttachmentRefs = attachments;
       const attachmentIds = attachments
         .map((attachment) => attachment.id)
         .filter((attachmentId): attachmentId is string => typeof attachmentId === 'string' && attachmentId.length > 0);
@@ -2651,6 +2666,7 @@ export function PanelRight() {
         contextGraphId: activeProjectId ?? undefined,
         onEvent: (event: LocalAgentStreamEvent) => {
           if (event.type === 'text_delta') {
+            assistantPartialText += event.delta;
             updateLocalMessages(conversationKey, (prev) =>
               prev.map((message) =>
                 message.id === assistantId ? { ...message, content: message.content + event.delta } : message,
@@ -2687,15 +2703,15 @@ export function PanelRight() {
       loadSessions();
       if (stage === 0) advance();
     } catch (err: any) {
+      const isUserAbort = err?.name === 'AbortError';
+      const failureReason = isUserAbort ? 'Request cancelled.' : formatLocalAgentErrorMessage(integration, err);
       if (assistantId) {
         updateLocalMessages(conversationKey, (prev) =>
           prev.map((message) =>
             message.id === assistantId
               ? {
                   ...message,
-                  content: err?.name === 'AbortError'
-                    ? 'Request cancelled.'
-                    : `Error: ${formatLocalAgentErrorMessage(integration, err)}`,
+                  content: isUserAbort ? failureReason : `Error: ${failureReason}`,
                   streaming: false,
                   // Error / cancel strings are locally synthesized and may
                   // surface details the agent didn't author (URLs in error
@@ -2705,6 +2721,32 @@ export function PanelRight() {
               : message,
           ),
         );
+      }
+      if (!isUserAbort && assistantId && messageText) {
+        void (async () => {
+          try {
+            const persisted = await persistLocalAgentChatFailure(integrationId, {
+              sessionId: conversation.sessionId ?? undefined,
+              turnId: correlationId || undefined,
+              correlationId: correlationId || undefined,
+              userMessage: messageText,
+              assistantReply: assistantPartialText,
+              failureReason,
+              profile: integration.profile,
+              attachments: failureAttachmentRefs,
+              contextGraphId: activeProjectId ?? undefined,
+            });
+            if (persisted.turnId) {
+              updateLocalMessages(conversationKey, (prev) =>
+                adoptLocalAgentTurnId(prev, correlationId, persisted.turnId),
+              );
+            }
+            loadSessions();
+          } catch {
+            // The in-memory error bubble remains useful even if durable failure
+            // persistence is temporarily unavailable.
+          }
+        })();
       }
       // Restore the attachment drafts we optimistically cleared so the user
       // can retry the same files without re-uploading. Merge instead of

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -2374,6 +2374,10 @@ button.v10-notif-row:hover { background: var(--bg-hover); }
      handles long unbroken tokens. */
   white-space: pre-wrap;
 }
+.v10-chat-failure-notice {
+  display: block;
+  margin-top: 8px;
+}
 .v10-chat-bubble.user {
   /* User pill — right-aligned, capped width, distinct surface. */
   padding: 10px 14px;

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -301,7 +301,7 @@ describe('PanelRight UI - connected agent flow', () => {
 
   it('keeps attachment-only summary text UI-only instead of sending it back through the bridge', () => {
     expect(panelRight).toContain('buildAttachmentSummary(message.attachmentRefs ?? [])');
-    expect(panelRight).toContain('const hasAgentText = Boolean(message.text) && !alreadyFailureNotice;');
+    expect(panelRight).toContain('const hasAgentText = Boolean(message.text);');
     expect(panelRight).toContain("let messageText = '';");
     expect(panelRight).toContain('messageText = text');
     expect(panelRight).toContain(': buildAttachmentTurnSummary(attachments, importContext.results);');

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -300,8 +300,11 @@ describe('PanelRight UI - connected agent flow', () => {
   });
 
   it('keeps attachment-only summary text UI-only instead of sending it back through the bridge', () => {
-    expect(panelRight).toContain('content: message.text || buildAttachmentSummary(message.attachmentRefs ?? [])');
-    expect(panelRight).toContain('const messageText = text');
+    expect(panelRight).toContain('buildAttachmentSummary(message.attachmentRefs ?? [])');
+    expect(panelRight).toContain('const hasAgentText = Boolean(message.text);');
+    expect(panelRight).toContain("let messageText = '';");
+    expect(panelRight).toContain('messageText = text');
+    expect(panelRight).toContain(': buildAttachmentTurnSummary(attachments, importContext.results);');
     expect(panelRight).toContain("const outboundText = text ? textWithImportSummary : '';");
     expect(panelRight).toContain('streamLocalAgentChat(integrationId, outboundText, {');
   });

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -301,7 +301,7 @@ describe('PanelRight UI - connected agent flow', () => {
 
   it('keeps attachment-only summary text UI-only instead of sending it back through the bridge', () => {
     expect(panelRight).toContain('buildAttachmentSummary(message.attachmentRefs ?? [])');
-    expect(panelRight).toContain('const hasAgentText = Boolean(message.text);');
+    expect(panelRight).toContain('const hasAgentText = Boolean(message.text) && !alreadyFailureNotice;');
     expect(panelRight).toContain("let messageText = '';");
     expect(panelRight).toContain('messageText = text');
     expect(panelRight).toContain(': buildAttachmentTurnSummary(attachments, importContext.results);');

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -446,6 +446,76 @@ describe('PanelRight component', () => {
     container.remove();
   });
 
+  it('renders live Hermes failure notices as plain text while preserving partial markdown', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
+      id: 'hermes',
+      name: 'Hermes',
+      description: 'Hermes bridge',
+      connectSupported: true,
+      chatSupported: true,
+      chatReady: true,
+      chatAttachments: true,
+      persistentChat: true,
+      bridgeOnline: true,
+      bridgeStatusLabel: 'Connected',
+      configured: true,
+      detected: true,
+      status: 'connected',
+      statusLabel: 'Connected',
+      detail: 'ready',
+      defaultSessionId: 'hermes:dkg-ui:profile-dkg-smoke',
+      profile: 'dkg-smoke',
+      target: 'bridge',
+    }] });
+    streamLocalAgentChatMock.mockImplementation(async (_integrationId: string, _text: string, options: any) => {
+      options?.onEvent?.({ type: 'text_delta', delta: '**Partial Hermes output**' });
+      throw new Error('Backend returned [unsafe](https://attacker.example)');
+    });
+    persistLocalAgentChatFailureMock.mockResolvedValue({ ok: true, turnId: 'corr-unsafe' });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Run the unsafe Hermes task');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const sendButton = container.querySelector('button[aria-label="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).toBeTruthy();
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(persistLocalAgentChatFailureMock).toHaveBeenCalled();
+    });
+    expect(container.querySelector('strong')?.textContent).toBe('Partial Hermes output');
+    expect(container.textContent).toContain('Error: Backend returned [unsafe](https://attacker.example)');
+    const unsafeLinks = Array.from(container.querySelectorAll('a'))
+      .filter((link) => link.textContent === 'unsafe');
+    expect(unsafeLinks).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it('imports skipped chat attachments as context entries and clears the composer after send', async () => {
     importFileMock.mockResolvedValue({
       assertionUri: 'urn:dkg:assertion:epub',

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -318,6 +318,48 @@ describe('PanelRight component', () => {
     container.remove();
   });
 
+  it('does not client-persist failed OpenClaw turns', async () => {
+    streamLocalAgentChatMock.mockRejectedValue(new Error('OpenClaw bridge unreachable'));
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Run the OpenClaw task');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const sendButton = container.querySelector('button[aria-label="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).toBeTruthy();
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain('Error: OpenClaw is unavailable right now.');
+    });
+    expect(persistLocalAgentChatFailureMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it('persists failed Hermes turns so timeout sessions survive refresh', async () => {
     fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
       id: 'hermes',
@@ -387,7 +429,6 @@ describe('PanelRight component', () => {
     });
     expect(persistLocalAgentChatFailureMock).toHaveBeenCalledWith('hermes', expect.objectContaining({
       sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
-      turnId: expect.any(String),
       correlationId: expect.any(String),
       userMessage: 'Run the slow Hermes task',
       assistantReply: 'Partial Hermes output',
@@ -395,6 +436,7 @@ describe('PanelRight component', () => {
       profile: 'dkg-smoke',
       contextGraphId: 'testing',
     }));
+    expect(persistLocalAgentChatFailureMock.mock.calls[0]?.[1]).not.toHaveProperty('turnId');
     expect(container.textContent).toContain('Error: Hermes took too long to respond.');
 
     await act(async () => {

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -20,6 +20,7 @@ const fetchLocalAgentIntegrationsMock = vi.fn();
 const fetchLocalAgentHistoryMock = vi.fn();
 const fetchCurrentAgentMock = vi.fn();
 const importFileMock = vi.fn();
+const persistLocalAgentChatFailureMock = vi.fn();
 const streamLocalAgentChatMock = vi.fn();
 const connectLocalAgentIntegrationMock = vi.fn();
 const disconnectLocalAgentIntegrationMock = vi.fn();
@@ -35,6 +36,7 @@ vi.mock('../src/ui/api.js', async () => {
     fetchLocalAgentHistory: fetchLocalAgentHistoryMock,
     fetchCurrentAgent: fetchCurrentAgentMock,
     importFile: importFileMock,
+    persistLocalAgentChatFailure: persistLocalAgentChatFailureMock,
     streamLocalAgentChat: streamLocalAgentChatMock,
     connectLocalAgentIntegration: connectLocalAgentIntegrationMock,
     disconnectLocalAgentIntegration: disconnectLocalAgentIntegrationMock,
@@ -119,6 +121,7 @@ describe('PanelRight component', () => {
       nodeIdentityId: 'node-self',
     });
     streamLocalAgentChatMock.mockResolvedValue({ text: 'Roger that', correlationId: 'corr-1' });
+    persistLocalAgentChatFailureMock.mockResolvedValue({ ok: true, turnId: 'corr-1' });
     importFileMock.mockResolvedValue({
       assertionUri: 'urn:dkg:assertion:completed',
       fileHash: 'sha256:completed',
@@ -308,6 +311,91 @@ describe('PanelRight component', () => {
       ],
     }));
     expect(container.textContent).toContain('Roger that');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('persists failed Hermes turns so timeout sessions survive refresh', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
+      id: 'hermes',
+      name: 'Hermes',
+      description: 'Hermes bridge',
+      connectSupported: true,
+      chatSupported: true,
+      chatReady: true,
+      chatAttachments: true,
+      persistentChat: true,
+      bridgeOnline: true,
+      bridgeStatusLabel: 'Connected',
+      configured: true,
+      detected: true,
+      status: 'connected',
+      statusLabel: 'Connected',
+      detail: 'ready',
+      defaultSessionId: 'hermes:dkg-ui:profile-dkg-smoke',
+      profile: 'dkg-smoke',
+      target: 'bridge',
+    }] });
+    streamLocalAgentChatMock.mockImplementation(async (_integrationId: string, _text: string, options: any) => {
+      options?.onEvent?.({ type: 'text_delta', delta: 'Partial Hermes output' });
+      throw new Error('Agent response timeout');
+    });
+    persistLocalAgentChatFailureMock.mockResolvedValue({ ok: true, turnId: 'corr-timeout' });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+
+    act(() => {
+      useProjectsStore.setState({
+        contextGraphs: [{ id: 'testing', name: 'Testing' }],
+        loading: false,
+        activeProjectId: 'testing',
+      });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Run the slow Hermes task');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const sendButton = container.querySelector('button[aria-label="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).toBeTruthy();
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(persistLocalAgentChatFailureMock).toHaveBeenCalled();
+    });
+    expect(persistLocalAgentChatFailureMock).toHaveBeenCalledWith('hermes', expect.objectContaining({
+      sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
+      turnId: expect.any(String),
+      correlationId: expect.any(String),
+      userMessage: 'Run the slow Hermes task',
+      assistantReply: 'Partial Hermes output',
+      failureReason: 'Hermes took too long to respond.',
+      profile: 'dkg-smoke',
+      contextGraphId: 'testing',
+    }));
+    expect(container.textContent).toContain('Error: Hermes took too long to respond.');
 
     await act(async () => {
       root.unmount();

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -437,6 +437,7 @@ describe('PanelRight component', () => {
       contextGraphId: 'testing',
     }));
     expect(persistLocalAgentChatFailureMock.mock.calls[0]?.[1]).not.toHaveProperty('turnId');
+    expect(container.textContent).toContain('Partial Hermes output');
     expect(container.textContent).toContain('Error: Hermes took too long to respond.');
 
     await act(async () => {

--- a/packages/node-ui/test/panel-right.refresh-history.test.ts
+++ b/packages/node-ui/test/panel-right.refresh-history.test.ts
@@ -232,6 +232,90 @@ describe('PanelRight chat history rehydration on mount (issue #255)', () => {
     container.remove();
   });
 
+  it('appends the failure notice when rehydrated partial Hermes text starts with Error', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'hermes') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:failed-user',
+          text: 'please run the slow task',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-timeout',
+        },
+        {
+          uri: 'urn:m:failed-agent',
+          text: 'Error: partial diagnostic from Hermes',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-timeout',
+          persistStatus: 'failed',
+          failureReason: 'Hermes took too long to respond.',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    expect(container.textContent).toContain('Error: partial diagnostic from Hermes');
+    expect(container.textContent).toContain('Error: Hermes took too long to respond.');
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('keeps markdown enabled for rehydrated partial failed Hermes text', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'hermes') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:failed-user',
+          text: 'please run the slow task',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-timeout',
+        },
+        {
+          uri: 'urn:m:failed-agent',
+          text: '**Partial Hermes output**',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-timeout',
+          persistStatus: 'failed',
+          failureReason: 'Hermes took too long to respond.',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    expect(container.querySelector('strong')?.textContent).toBe('Partial Hermes output');
+    expect(container.textContent).toContain('Error: Hermes took too long to respond.');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('does not duplicate rehydrated failure notices that already include the failure reason', async () => {
     fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
     fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {

--- a/packages/node-ui/test/panel-right.refresh-history.test.ts
+++ b/packages/node-ui/test/panel-right.refresh-history.test.ts
@@ -189,4 +189,46 @@ describe('PanelRight chat history rehydration on mount (issue #255)', () => {
     root.unmount();
     container.remove();
   });
+
+  it('renders rehydrated failed Hermes turns as recoverable error messages', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'hermes') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:failed-user',
+          text: 'please run the slow task',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-timeout',
+        },
+        {
+          uri: 'urn:m:failed-agent',
+          text: '',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-timeout',
+          persistStatus: 'failed',
+          failureReason: 'Hermes took too long to respond.',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    expect(container.textContent).toContain('please run the slow task');
+    expect(container.textContent).toContain('Error: Hermes took too long to respond.');
+
+    root.unmount();
+    container.remove();
+  });
 });

--- a/packages/node-ui/test/panel-right.refresh-history.test.ts
+++ b/packages/node-ui/test/panel-right.refresh-history.test.ts
@@ -231,4 +231,46 @@ describe('PanelRight chat history rehydration on mount (issue #255)', () => {
     root.unmount();
     container.remove();
   });
+
+  it('does not duplicate rehydrated failure notices that already include the failure reason', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'hermes') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:failed-user',
+          text: 'please run the slow task',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-timeout',
+        },
+        {
+          uri: 'urn:m:failed-agent',
+          text: 'Error: Hermes took too long to respond.',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-timeout',
+          persistStatus: 'failed',
+          failureReason: 'Hermes took too long to respond.',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    const matches = container.textContent?.match(/Error: Hermes took too long to respond\./g) ?? [];
+    expect(matches).toHaveLength(1);
+
+    root.unmount();
+    container.remove();
+  });
 });

--- a/packages/node-ui/test/panel-right.refresh-history.test.ts
+++ b/packages/node-ui/test/panel-right.refresh-history.test.ts
@@ -316,6 +316,93 @@ describe('PanelRight chat history rehydration on mount (issue #255)', () => {
     container.remove();
   });
 
+  it('renders rehydrated Hermes failure notices as plain text while preserving partial markdown', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'hermes') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:failed-user',
+          text: 'please run the slow task',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-timeout',
+        },
+        {
+          uri: 'urn:m:failed-agent',
+          text: '**Partial Hermes output**',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-timeout',
+          persistStatus: 'failed',
+          failureReason: 'Hermes returned [unsafe](https://attacker.example).',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    expect(container.querySelector('strong')?.textContent).toBe('Partial Hermes output');
+    expect(container.textContent).toContain('Error: Hermes returned [unsafe](https://attacker.example).');
+    const unsafeLinks = Array.from(container.querySelectorAll('a'))
+      .filter((link) => link.textContent === 'unsafe');
+    expect(unsafeLinks).toHaveLength(0);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('does not append Hermes failure notices to rehydrated OpenClaw failure banners', async () => {
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyOpenclawIntegration()] });
+    fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {
+      if (integrationId !== 'openclaw') return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          uri: 'urn:m:openclaw-failed-user',
+          text: 'please ask openclaw',
+          author: 'user',
+          ts: '2026-04-23T01:00:00Z',
+          turnId: 'turn-openclaw-failed',
+        },
+        {
+          uri: 'urn:m:openclaw-failed-agent',
+          text: '[OpenClaw reply failed before completion: timed out]',
+          author: 'agent',
+          ts: '2026-04-23T01:00:01Z',
+          turnId: 'turn-openclaw-failed',
+          persistStatus: 'failed',
+          failureReason: 'timed out',
+        },
+      ]);
+    });
+
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+    await flushAll();
+
+    expect(container.textContent).toContain('[OpenClaw reply failed before completion: timed out]');
+    expect(container.textContent).not.toContain('Error: timed out');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('does not duplicate rehydrated failure notices that already include the failure reason', async () => {
     fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [readyHermesIntegration()] });
     fetchLocalAgentHistoryMock.mockImplementation((integrationId: string) => {

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -475,7 +475,6 @@ describe('ui local-agent stream api', () => {
     try {
       const result = await persistLocalAgentChatFailure('hermes', {
         sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
-        turnId: 'corr-timeout',
         correlationId: 'corr-timeout',
         userMessage: 'slow question',
         failureReason: 'Hermes took too long to respond.',
@@ -490,13 +489,13 @@ describe('ui local-agent stream api', () => {
         sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
         userMessage: 'slow question',
         assistantReply: '',
-        turnId: 'corr-timeout',
         correlationId: 'corr-timeout',
         persistenceState: 'failed',
         failureReason: 'Hermes took too long to respond.',
         profile: 'dkg-smoke',
         contextGraphId: 'project-1',
       });
+      expect(payload).not.toHaveProperty('turnId');
     } finally {
       globalThis.fetch = savedFetch;
     }

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -500,4 +500,13 @@ describe('ui local-agent stream api', () => {
       globalThis.fetch = savedFetch;
     }
   });
+
+  it('requires an explicit Hermes session id when persisting failed turns', async () => {
+    await expect(persistLocalAgentChatFailure('hermes', {
+      correlationId: 'corr-timeout',
+      userMessage: 'slow question',
+      failureReason: 'Hermes took too long to respond.',
+      profile: 'dkg-smoke',
+    })).rejects.toThrow('Missing Hermes session id');
+  });
 });

--- a/packages/node-ui/test/ui-api-stream.test.ts
+++ b/packages/node-ui/test/ui-api-stream.test.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from 'node:http';
 import {
   fetchMemorySessionGraphDelta,
   importFile,
+  persistLocalAgentChatFailure,
   sendHermesLocalChat,
   streamHermesLocalChat,
   streamLocalAgentChat,
@@ -455,6 +456,47 @@ describe('ui local-agent stream api', () => {
       expect(payload.contextEntries).toEqual(contextEntries);
       expect(payload.contextGraphId).toBe('project-1');
       expect(payload.text).toBe('hello');
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+
+  it('persists failed Hermes local-agent turns through the durable turn endpoint', async () => {
+    const fetchCalls: [string | URL | Request, RequestInit | undefined][] = [];
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      fetchCalls.push([url, init]);
+      return new Response(
+        JSON.stringify({ ok: true, turnId: 'corr-timeout' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof globalThis.fetch;
+
+    try {
+      const result = await persistLocalAgentChatFailure('hermes', {
+        sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
+        turnId: 'corr-timeout',
+        correlationId: 'corr-timeout',
+        userMessage: 'slow question',
+        failureReason: 'Hermes took too long to respond.',
+        profile: 'dkg-smoke',
+        contextGraphId: 'project-1',
+      });
+
+      expect(result.turnId).toBe('corr-timeout');
+      expect(String(fetchCalls[0]?.[0])).toBe('/api/hermes-channel/persist-turn');
+      const payload = JSON.parse(String(fetchCalls[0]?.[1]?.body));
+      expect(payload).toMatchObject({
+        sessionId: 'hermes:dkg-ui:profile-dkg-smoke',
+        userMessage: 'slow question',
+        assistantReply: '',
+        turnId: 'corr-timeout',
+        correlationId: 'corr-timeout',
+        persistenceState: 'failed',
+        failureReason: 'Hermes took too long to respond.',
+        profile: 'dkg-smoke',
+        contextGraphId: 'project-1',
+      });
     } finally {
       globalThis.fetch = savedFetch;
     }


### PR DESCRIPTION
﻿## Summary

- Treat timed-out Hermes Node UI sessions as a durability bug, not intentional full-turn-only persistence.
- Persist non-user-aborted Hermes send failures through `/api/hermes-channel/persist-turn` with `persistenceState: failed`, preserving the user message, explicit selected session, profile/context metadata, attachments, failure reason, and partial streamed assistant text when present.
- Omit client-side `turnId` for failed Hermes persistence so the daemon derives the canonical stable turn id from correlation/session/profile/context and can deduplicate retries.
- Keep failed-turn rendering consistent and safe between live sends and hard-refresh rehydration: real partial output stays markdown-enabled, UI-generated failure notices render as separate plaintext segments, exact synthetic notices are not duplicated, and OpenClaw persisted failure banners reload unchanged.

## Related

- Fixes #1001
- Related to #1003, which improves timeout attribution/copy but does not persist failed sessions

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/api.ts` | Adds Hermes failed-turn persistence helper, carries persisted turn status into local-agent history rows, lets Hermes derive failed-turn IDs, and requires an explicit Hermes session id for failed persistence. |
| `packages/node-ui/src/ui/components/Shell/PanelRight.tsx` | Persists failed Hermes sends in the background, stores failure notices separately from agent content, and maps live/rehydrated failed turns consistently. |
| `packages/node-ui/src/ui/styles.css` | Adds a small block style for plaintext failed-turn notices. |
| `packages/node-ui/test/ui-api-stream.test.ts` | Covers failed Hermes turn persistence payloads, no client-supplied `turnId`, and missing-session protection. |
| `packages/node-ui/test/panel-right.component.test.ts` | Covers the Hermes timeout send path, partial streamed output preservation, plaintext failure notices for unsafe error markdown, and the OpenClaw no-client-persistence guardrail. |
| `packages/node-ui/test/panel-right.refresh-history.test.ts` | Covers hard-refresh rehydration of failed Hermes turns, exact failure-notice dedupe, `Error:` partial text, markdown-preserved partial output, plaintext unsafe failure reasons, and unchanged OpenClaw failure banners. |
| `packages/node-ui/test/openclaw-bridge.test.ts` | Updates the source-contract assertion for the final history mapping shape. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core run build`
- [x] `pnpm --dir packages/node-ui exec vitest run test/ui-api-stream.test.ts test/panel-right.component.test.ts --reporter=verbose`
- [x] `pnpm --dir packages/node-ui exec vitest run test/panel-right.refresh-history.test.ts --reporter=verbose`
- [x] `pnpm --dir packages/node-ui exec vitest run test/openclaw-bridge.test.ts test/ui-compat.test.ts --reporter=verbose`
- [x] `pnpm --dir packages/node-ui exec tsc --noEmit`
- [x] `git diff --check`

Note: `panel-right.refresh-history.test.ts` passes when run serially. Running it concurrently with other happy-dom suites can trip its existing 5s timeout/React act-overlap flake.
