### PR TITLE
Fix oversized SWM promote failures and UI loading hangs

### DIFF
--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -38,6 +38,34 @@ export interface PublishRequestBody {
 
 import type { CorsAllowlist } from './state.js';
 
+export function isPayloadTooLargeError(err: unknown): err is PayloadTooLargeError {
+  if (err instanceof PayloadTooLargeError) return true;
+  if (!err || typeof err !== 'object') return false;
+  const shaped = err as { name?: unknown; code?: unknown };
+  return (
+    shaped.name === 'PayloadTooLargeError' ||
+    shaped.name === 'SwmGossipPayloadTooLargeError' ||
+    shaped.code === 'PAYLOAD_TOO_LARGE' ||
+    shaped.code === 'SWM_GOSSIP_PAYLOAD_TOO_LARGE'
+  );
+}
+
+export function payloadTooLargeResponseBody(err: unknown): Record<string, unknown> {
+  const shaped = (err && typeof err === 'object') ? err as Record<string, unknown> : {};
+  const message = err instanceof Error ? err.message : String(err ?? 'Payload too large');
+  const body: Record<string, unknown> = {
+    error: message,
+    code: typeof shaped.code === 'string' ? shaped.code : 'PAYLOAD_TOO_LARGE',
+  };
+  const maxBytes = shaped.maxBytes;
+  if (typeof maxBytes === 'number') body.limitBytes = maxBytes;
+  const actualBytes = shaped.actualBytes;
+  if (typeof actualBytes === 'number') body.actualBytes = actualBytes;
+  const hint = shaped.hint;
+  if (typeof hint === 'string' && hint.length > 0) body.hint = hint;
+  return body;
+}
+
 export async function resolveNameToPeerId(
   agent: DKGAgent,
   nameOrId: string,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -219,6 +219,8 @@ import {
   MAX_UPLOAD_BYTES,
   type ImportFileExtractionPayload,
   buildImportFileResponse,
+  isPayloadTooLargeError,
+  payloadTooLargeResponseBody,
   unregisteredSubGraphError,
   readBody,
   readBodyBuffer,
@@ -2718,8 +2720,8 @@ export async function runDaemonInner(
       );
     } catch (err: any) {
       if (res.headersSent || res.writableEnded) return;
-      if (err instanceof PayloadTooLargeError) {
-        jsonResponse(res, 413, { error: err.message });
+      if (isPayloadTooLargeError(err)) {
+        jsonResponse(res, 413, payloadTooLargeResponseBody(err));
       } else if (err instanceof SyntaxError) {
         jsonResponse(res, 400, { error: err.message });
       } else if (

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -205,6 +205,8 @@ import {
   MAX_UPLOAD_BYTES,
   type ImportFileExtractionPayload,
   buildImportFileResponse,
+  isPayloadTooLargeError,
+  payloadTooLargeResponseBody,
   unregisteredSubGraphError,
   readBody,
   readBodyBuffer,
@@ -1841,6 +1843,9 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
       // branch so the more specific code wins. Duck-type the check by
       // name + code so we don't have to import the publisher's error
       // class into the cli package's compile graph.
+      if (isPayloadTooLargeError(err)) {
+        return jsonResponse(res, 413, payloadTooLargeResponseBody(err));
+      }
       if (err?.name === "AssertionNotPersistedError" || err?.code === "ASSERTION_NOT_PERSISTED") {
         return jsonResponse(res, 409, {
           error: err.message,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -795,16 +795,19 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       // This is one SPARQL round-trip regardless of how many sub-graphs exist.
       const counts = new Map<string, { entityCount: number; tripleCount: number }>();
       try {
+        const prefix = `did:dkg:context-graph:${contextGraphId}/`;
         const sparql = `
           SELECT ?g (COUNT(DISTINCT ?s) AS ?entities) (COUNT(*) AS ?triples)
-          WHERE { GRAPH ?g { ?s ?p ?o } }
+          WHERE {
+            GRAPH ?g { ?s ?p ?o }
+            FILTER(STRSTARTS(STR(?g), ${JSON.stringify(prefix)}))
+          }
           GROUP BY ?g
         `;
         const result = await agent.query(sparql, {
           contextGraphId: contextGraphId!,
           includeContextGraphPartitions: true,
         });
-        const prefix = `did:dkg:context-graph:${contextGraphId}/`;
         const parseCount = (v: any) => {
           if (v === undefined || v === null) return 0;
           const s = typeof v === 'string' ? v : (v && typeof v === 'object' && 'value' in v ? (v as any).value : '');

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -25,7 +25,13 @@
 // `(agent, number)` addressing is layered on by Option 1 later, on these same
 // routes, as an additional accepted identifier form.
 import type { RequestContext } from "./context.js";
-import { jsonResponse, readBody, safeParseJson } from "../http-utils.js";
+import {
+  isPayloadTooLargeError,
+  jsonResponse,
+  payloadTooLargeResponseBody,
+  readBody,
+  safeParseJson,
+} from "../http-utils.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
 
@@ -46,6 +52,10 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
  * publish path, which never down-classified them).
  */
 function respondAssertionError(res: RequestContext["res"], e: any): void {
+  if (isPayloadTooLargeError(e)) {
+    jsonResponse(res, 413, payloadTooLargeResponseBody(e));
+    return;
+  }
   if (e?.name === "AssertionNotPersistedError" || e?.code === "ASSERTION_NOT_PERSISTED") {
     jsonResponse(res, 409, {
       error: e.message,

--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -145,11 +145,17 @@ export type ClassifiedPromoteError = {
 export function classifyPromoteError(err: unknown): ClassifiedPromoteError {
   const raw = err instanceof Error ? err.message : String(err);
   const message = (raw ?? '').toLowerCase();
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? String((err as { code?: unknown }).code ?? '').toLowerCase()
+      : '';
 
   // 1. 10 MB gossip cap — surfaced as
   //    "Promoted assertion too large for gossip (XXXX KB, limit 10 MB)"
   //    by the daemon's promote pipeline.
   if (
+    code === 'swm_gossip_payload_too_large' ||
+    code === 'payload_too_large' ||
     (message.includes('gossip') && (message.includes('limit') || message.includes('too large'))) ||
     message.includes('promoted assertion too large')
   ) {

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -52,6 +52,15 @@ describe('classifyPromoteError', () => {
     expect(verdict).toEqual({ classification: 'cap_exceeded', retryable: false });
   });
 
+  it('classifies typed SWM gossip-cap errors by code', () => {
+    const err = new Error('custom wording') as Error & { code: string };
+    err.code = 'SWM_GOSSIP_PAYLOAD_TOO_LARGE';
+
+    const verdict = classifyPromoteError(err);
+
+    expect(verdict).toEqual({ classification: 'cap_exceeded', retryable: false });
+  });
+
   it('classifies 256 KB body-cap errors as cap_exceeded', () => {
     const verdict = classifyPromoteError(new Error('Request body too large (>262144 bytes)'));
     expect(verdict.classification).toBe('cap_exceeded');

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
+import { SwmGossipPayloadTooLargeError } from '@origintrail-official/dkg-core';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
 
@@ -247,6 +248,34 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ swmShared: true, promotedCount: 3 });
     expect(agent.assertion.promote).toHaveBeenCalledOnce();
+  });
+
+  it('POST .../:name/swm/share returns 413 when the promoted gossip payload is too large', async () => {
+    const agent = makeAssertionAgent({
+      assertion: {
+        promote: vi.fn(async () => {
+          throw new SwmGossipPayloadTooLargeError({
+            actualBytes: 12 * 1024 * 1024,
+            maxBytes: 10 * 1024 * 1024,
+            operation: 'promote',
+            message: 'Promoted assertion too large for gossip (12288 KB, limit 10 MB). Promote fewer entities per call.',
+            hint: 'Promote fewer entities per call.',
+          });
+        }),
+      },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/swm/share', { contextGraphId: 'cg' }, agent);
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect(status(ctx)).toBe(413);
+    expect(body(ctx)).toMatchObject({
+      code: 'SWM_GOSSIP_PAYLOAD_TOO_LARGE',
+      actualBytes: 12 * 1024 * 1024,
+      limitBytes: 10 * 1024 * 1024,
+      hint: 'Promote fewer entities per call.',
+      error: expect.stringContaining('Promoted assertion too large for gossip'),
+    });
   });
 
   it('POST .../:name/vm/publish mints/updates on chain', async () => {

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -23,6 +23,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
+import { SwmGossipPayloadTooLargeError } from '@origintrail-official/dkg-core';
 import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
 
 const CG_ID = 'issue-864-cg';
@@ -192,6 +193,29 @@ describe('POST /api/assertion/:name/promote — issue #864 not-persisted envelop
       contextGraphId: CG_ID,
       assertionGraph: ASSERTION_GRAPH,
       expectedTripleCount: 7,
+    });
+  });
+
+  it('translates oversized SWM gossip payloads to a structured 413', async () => {
+    await startWithPromoteImpl(async () => {
+      throw new SwmGossipPayloadTooLargeError({
+        actualBytes: 12 * 1024 * 1024,
+        maxBytes: 10 * 1024 * 1024,
+        operation: 'promote',
+        message: 'Promoted assertion too large for gossip (12288 KB, limit 10 MB). Promote fewer entities per call.',
+        hint: 'Promote fewer entities per call.',
+      });
+    });
+
+    const res = await postPromote({ contextGraphId: CG_ID, entities: 'all' });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      code: 'SWM_GOSSIP_PAYLOAD_TOO_LARGE',
+      actualBytes: 12 * 1024 * 1024,
+      limitBytes: 10 * 1024 * 1024,
+      hint: 'Promote fewer entities per call.',
+      error: expect.stringContaining('Promoted assertion too large for gossip'),
     });
   });
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -38,13 +38,40 @@ export class DKGInternalError extends DKGError {
 
 /** HTTP request body exceeded the size limit. */
 export class PayloadTooLargeError extends DKGUserError {
-  constructor(maxBytes?: number) {
+  readonly code: string;
+  readonly maxBytes?: number;
+
+  constructor(maxBytes?: number, message?: string, code = 'PAYLOAD_TOO_LARGE') {
     super(
-      maxBytes != null
+      message ??
+      (maxBytes != null
         ? `Request body too large (>${maxBytes} bytes)`
-        : 'Payload too large',
+        : 'Payload too large'),
     );
     this.name = 'PayloadTooLargeError';
+    this.code = code;
+    this.maxBytes = maxBytes;
+  }
+}
+
+/** SWM gossip payload exceeded the network message size limit. */
+export class SwmGossipPayloadTooLargeError extends PayloadTooLargeError {
+  readonly actualBytes: number;
+  readonly hint: string;
+  readonly operation: 'share' | 'promote';
+
+  constructor(args: {
+    actualBytes: number;
+    maxBytes: number;
+    operation: 'share' | 'promote';
+    message: string;
+    hint: string;
+  }) {
+    super(args.maxBytes, args.message, 'SWM_GOSSIP_PAYLOAD_TOO_LARGE');
+    this.name = 'SwmGossipPayloadTooLargeError';
+    this.actualBytes = args.actualBytes;
+    this.operation = args.operation;
+    this.hint = args.hint;
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -193,6 +193,7 @@ export {
   DKGUserError,
   DKGInternalError,
   PayloadTooLargeError,
+  SwmGossipPayloadTooLargeError,
   toErrorMessage,
   hasErrorCode,
 } from './errors.js';

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1,5 +1,6 @@
 const BASE = '';
 const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
+const CONTEXT_GRAPH_LOAD_TIMEOUT_MS = 60000;
 declare global {
   interface Window { __DKG_TOKEN__?: string; }
 }
@@ -66,6 +67,16 @@ async function fetchWithTimeout(input: string, init: RequestInit = {}, timeoutMs
 async function get<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, { headers: authHeaders() });
   if (!res.ok) throw new HttpError(res.status);
+  return res.json() as Promise<T>;
+}
+
+async function getWithTimeout<T>(path: string, timeoutMs: number): Promise<T> {
+  const res = await fetchWithTimeout(`${BASE}${path}`, { headers: authHeaders() }, timeoutMs);
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    const msg = (errBody as { error?: string })?.error ?? `HTTP ${res.status}`;
+    throw new HttpError(res.status, msg, errBody);
+  }
   return res.json() as Promise<T>;
 }
 
@@ -294,7 +305,10 @@ export const fetchNodeLog = (params: { lines?: number; q?: string } = {}) => {
 
 // --- Context graphs (V10) — legacy daemon paths keep working server-side redirects.
 export async function fetchContextGraphs(): Promise<{ contextGraphs: any[] }> {
-  const data = await get<{ contextGraphs?: any[] }>('/api/context-graph/list');
+  const data = await getWithTimeout<{ contextGraphs?: any[] }>(
+    '/api/context-graph/list',
+    CONTEXT_GRAPH_LOAD_TIMEOUT_MS,
+  );
   const list = data.contextGraphs ?? [];
   return { contextGraphs: list.filter((p: any) => !p.isSystem) };
 }
@@ -1296,7 +1310,8 @@ export const promoteAssertion = (
 export type PromoteOutcome =
   | { kind: 'success'; promotedCount: number; message: string }
   | { kind: 'noop'; message: string }
-  | { kind: 'not-persisted'; message: string; expectedTripleCount?: number };
+  | { kind: 'not-persisted'; message: string; expectedTripleCount?: number }
+  | { kind: 'payload-too-large'; message: string; actualBytes?: number; limitBytes?: number };
 
 export function describePromoteResult(
   assertionName: string,
@@ -1319,6 +1334,25 @@ export function describePromoteError(
   assertionName: string,
   err: unknown,
 ): PromoteOutcome | null {
+  if (err instanceof HttpError && err.status === 413) {
+    const body = err.body as {
+      code?: string;
+      actualBytes?: number;
+      limitBytes?: number;
+      hint?: string;
+    } | undefined;
+    if (body?.code === 'SWM_GOSSIP_PAYLOAD_TOO_LARGE') {
+      const hint = typeof body.hint === 'string' && body.hint.length > 0
+        ? body.hint
+        : 'Promote fewer entities per call or split the assertion into smaller root-entity batches.';
+      return {
+        kind: 'payload-too-large',
+        actualBytes: typeof body.actualBytes === 'number' ? body.actualBytes : undefined,
+        limitBytes: typeof body.limitBytes === 'number' ? body.limitBytes : undefined,
+        message: `${assertionName} is too large to promote to Shared Working Memory. ${hint}`,
+      };
+    }
+  }
   if (err instanceof HttpError && err.status === 409) {
     const body = err.body as { code?: string; expectedTripleCount?: number } | undefined;
     if (body?.code === 'ASSERTION_NOT_PERSISTED') {
@@ -2694,6 +2728,7 @@ export interface SubGraphInfo {
   tripleCount: number;
 }
 export const fetchSubGraphs = (contextGraphId: string) =>
-  get<{ contextGraphId: string; subGraphs: SubGraphInfo[] }>(
+  getWithTimeout<{ contextGraphId: string; subGraphs: SubGraphInfo[] }>(
     `/api/sub-graph/list?contextGraphId=${encodeURIComponent(contextGraphId)}`,
+    CONTEXT_GRAPH_LOAD_TIMEOUT_MS,
   );

--- a/packages/node-ui/test/promote-outcome-helpers.test.ts
+++ b/packages/node-ui/test/promote-outcome-helpers.test.ts
@@ -83,6 +83,23 @@ describe('describePromoteError', () => {
     expect(describePromoteError('x', err)).toBeNull();
   });
 
+  it('returns kind="payload-too-large" with a split hint for oversized SWM gossip payloads', () => {
+    const err = new HttpError(413, 'Payload too large', {
+      code: 'SWM_GOSSIP_PAYLOAD_TOO_LARGE',
+      actualBytes: 12 * 1024 * 1024,
+      limitBytes: 10 * 1024 * 1024,
+      hint: 'Promote fewer entities per call.',
+    });
+    const out = describePromoteError('skills-catalog-0001', err);
+    expect(out).not.toBeNull();
+    if (!out || out.kind !== 'payload-too-large') throw new Error('expected payload-too-large outcome');
+    expect(out.actualBytes).toBe(12 * 1024 * 1024);
+    expect(out.limitBytes).toBe(10 * 1024 * 1024);
+    expect(out.message).toContain('skills-catalog-0001');
+    expect(out.message.toLowerCase()).toContain('too large');
+    expect(out.message.toLowerCase()).toContain('fewer entities');
+  });
+
   it('returns null for non-HttpError throwables (network errors, generic Error)', () => {
     expect(describePromoteError('x', new Error('network'))).toBeNull();
     expect(describePromoteError('x', 'string error' as unknown)).toBeNull();

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -922,10 +922,16 @@ export class DKGPublisher implements Publisher {
     );
 
     if (message.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
-      throw new Error(
-        `SWM message too large (${formatBytesAsKb(message.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
-        `Split large writes into multiple share() calls partitioned by root entity.`,
-      );
+      const hint = `Split large writes into multiple share() calls partitioned by root entity.`;
+      throw new SwmGossipPayloadTooLargeError({
+        actualBytes: message.length,
+        maxBytes: DKG_GOSSIP_MAX_MESSAGE_BYTES,
+        operation: 'share',
+        message:
+          `SWM message too large (${formatBytesAsKb(message.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
+          hint,
+        hint,
+      });
     }
 
     // Delete-then-insert for upserted entities (replace old triples).
@@ -4470,10 +4476,16 @@ export class DKGPublisher implements Publisher {
       );
 
       if (wrapped.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
-        throw new Error(
-          `Promoted assertion too large for gossip (${formatBytesAsKb(wrapped.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
-          `Promote fewer entities per call.`,
-        );
+        const hint = `Promote fewer entities per call.`;
+        throw new SwmGossipPayloadTooLargeError({
+          actualBytes: wrapped.length,
+          maxBytes: DKG_GOSSIP_MAX_MESSAGE_BYTES,
+          operation: 'promote',
+          message:
+            `Promoted assertion too large for gossip (${formatBytesAsKb(wrapped.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
+            hint,
+          hint,
+        });
       }
       gossipMessage = wrapped;
     }


### PR DESCRIPTION
## Summary

- Add a typed `SwmGossipPayloadTooLargeError` for SWM gossip payloads that exceed the 10 MB limit, preserving the existing pre-mutation publisher guard while making the failure structured.
- Map oversized promote/share failures to HTTP `413` with stable `code`, byte counts, and recovery hints across legacy assertion promote, Knowledge Asset `swm/share`, and the daemon outer payload-too-large handler.
- Make UI context graph and subgraph requests timeout-aware so stuck project-scoped bootstrap routes reject instead of leaving loaders pending, using a 60s guard for context/subgraph calls.
- Scope `/api/sub-graph/list` best-effort aggregate counts to the requested context graph prefix.

## Related

- Closes #1002
- Closes #1005

## Files changed

- `packages/core/src/errors.ts`, `packages/core/src/index.ts`: typed SWM gossip payload-too-large error.
- `packages/publisher/src/dkg-publisher.ts`: throw the typed error from direct SWM share and WM assertion promote preflight checks.
- `packages/cli/src/daemon/http-utils.ts`, `lifecycle.ts`, `routes/assertion.ts`, `routes/knowledge-assets.ts`: structured 413 serialization and route mappings.
- `packages/cli/src/daemon/routes/context-graph.ts`: context-graph-scoped optional subgraph count query.
- `packages/cli/src/daemon/worker/async-promote-worker.ts`: classify the typed code as terminal `cap_exceeded`.
- `packages/node-ui/src/ui/api.ts`: timeout-aware context/subgraph loading calls and oversized-promote UI outcome.
- Tests for route envelopes, async classifier behavior, and UI promote error translation.

## Test plan

- `pnpm install --frozen-lockfile --ignore-scripts` (Windows local setup; normal install hits unsupported `@cyfrin/aderyn` postinstall on Windows)
- `pnpm run build:runtime:packages`
- `pnpm --dir packages/publisher exec vitest run test/draft-lifecycle.test.ts -t 'promote rejects payloads above 10 MB before mutating WM or SWM' --reporter verbose`
- `pnpm --dir packages/cli exec vitest run test/async-promote-worker.test.ts --reporter verbose`
- `pnpm --dir packages/node-ui run build`
- `pnpm --dir packages/node-ui exec vitest run test/promote-outcome-helpers.test.ts --reporter verbose`
- `git diff --check`

Note: I added route-level regression tests for the legacy promote and Knowledge Asset `swm/share` 413 envelopes, but could not complete those two route tests locally on this Windows worktree because importing the full daemon route modules starts Hardhat deployment/node processes and hangs. The TypeScript runtime package build covers their compilation, and the publisher/worker/UI tests above cover the behavior paths that are practical in this environment.
