### PR TITLE
chore: update GitHub bug-report issue template to V10

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,62 +1,119 @@
 name: Bug Report
-description: Report a bug in DKG V9
+description: Report a reproducible bug in DKG V10 (daemon, Node UI, CLI, chain, or workspace packages)
+title: "<area>: <concise summary of the bug>"
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting a bug. Please fill in as much detail as possible.
+        Thanks for reporting a bug. Please fill in as much detail as possible —
+        paste error text **verbatim** and pin the exact version **and commit hash**.
+        Search existing issues first to avoid duplicates.
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: A clear description of the bug.
-    validations:
-      required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to Reproduce
-      description: Step-by-step instructions to reproduce the issue.
-      placeholder: |
-        1. Run `dkg init`
-        2. Run `dkg start`
-        3. ...
+      label: Bug Description
+      description: A clear, self-contained description of what is broken and the user-facing impact. Say what you were doing when it happened.
+      placeholder: One short paragraph describing the bug and its impact.
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected Behavior
-      description: What did you expect to happen?
+      description: What should happen. Use bullets for distinct expectations or sub-cases.
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
       label: Actual Behavior
-      description: What actually happened?
+      description: What actually happens. Reference the exact error/messages (paste raw output in "Relevant Logs" below).
     validations:
       required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Error Output
+      description: Paste the exact error text or relevant logs (e.g. from `dkg logs`). Do not paraphrase.
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal, numbered, deterministic steps so anyone can reproduce it. Include exact commands and any required state/setup.
+      placeholder: |
+        1. Run `dkg start`
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: root-causes
+    attributes:
+      label: Possible Root Causes
+      description: Optional but strongly encouraged. Concrete hypotheses, ideally pointing at specific files / functions / endpoints, so whoever picks it up starts from evidence.
+    validations:
+      required: false
   - type: input
     id: version
     attributes:
-      label: DKG Version
-      description: Output of `dkg status` or the version from package.json.
-      placeholder: "9.0.0-beta.2"
+      label: DKG daemon / version
+      description: Output of `dkg status` (or the version from package.json). Include the commit hash if you have it.
+      placeholder: "10.0.0-rc.16, commit 3aae056b"
+    validations:
+      required: true
+  - type: input
+    id: surface
+    attributes:
+      label: Surface / Component
+      placeholder: "Node UI / CLI / daemon HTTP / chain adapter / package name"
+    validations:
+      required: false
   - type: input
     id: os
     attributes:
       label: Operating System
       placeholder: "macOS 15.2 / Ubuntu 24.04"
+    validations:
+      required: false
   - type: input
     id: node-version
     attributes:
       label: Node.js Version
       placeholder: "22.x"
+    validations:
+      required: false
   - type: textarea
-    id: logs
+    id: environment
     attributes:
-      label: Relevant Logs
-      description: Paste any relevant logs from `dkg logs`.
-      render: text
+      label: Environment — endpoints, config, health checks
+      description: Relevant endpoints/config and the results of any health probes you ran.
+      placeholder: |
+        - http://127.0.0.1:9200/ui
+        - Hermes gateway :8642 — /api/hermes-channel/health OK
+    validations:
+      required: false
+  - type: textarea
+    id: investigation
+    attributes:
+      label: Suggested Investigation
+      description: Optional. A numbered plan a maintainer (or agent) can follow to confirm the root cause and verify a fix.
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / Related Issues
+      description: Link related issues/PRs (e.g. #123) and clarify scope vs. similar issues. If found during a QA/test pass, note the version/commit it was found on.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -107,7 +107,7 @@ body:
     id: notes
     attributes:
       label: Notes / Related Issues
-      description: Link related issues/PRs (e.g. #123) and clarify scope vs. similar issues. If found during a QA/test pass, note the version/commit it was found on.
+      description: "Link related issues/PRs (e.g. #123) and clarify scope vs. similar issues. If found during a QA/test pass, note the version/commit it was found on."
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a reproducible bug in DKG V10 (daemon, Node UI, CLI, chain, or workspace packages)
-title: "<area>: <concise summary of the bug>"
+title: "bug: "
 labels: ["bug"]
 body:
   - type: markdown
@@ -45,8 +45,8 @@ body:
       label: Steps to Reproduce
       description: Minimal, numbered, deterministic steps so anyone can reproduce it. Include exact commands and any required state/setup.
       placeholder: |
-        1. Run `dkg start`
-        2. ...
+        1. Run `dkg init` (fresh install)
+        2. Run `dkg start`
         3. ...
     validations:
       required: true


### PR DESCRIPTION
## Summary

- Modernizes `.github/ISSUE_TEMPLATE/bug_report.yml` from the legacy **"Report a bug in DKG V9"** form to **V10**.
- Expands it to the richer structure used by recent high-signal issues (e.g. #1001) so both humans and agents file consistent, actionable bug reports.

This edits the **existing** `bug_report.yml` in place (1 file changed) — it replaces the V9 form rather than adding a second template, so the "New issue" chooser still shows a single **Bug Report** entry, now V10.

### Template fields
Bug Description → Expected Behavior → Actual Behavior → Relevant Logs → Steps to Reproduce → Possible Root Causes → Environment (version + commit, surface, OS, Node, endpoints/health) → Suggested Investigation → Notes / Related Issues → "searched for duplicates" checkbox.

Required: Bug Description, Expected, Actual, Steps to Reproduce, DKG version, duplicate-check. Everything else optional.

## Why
GitHub reads issue templates from the **default branch**, so the chooser currently still advertises "DKG V9". Merging this updates the chooser to the V10 template.

## Test plan
- [x] `bug_report.yml` parses as valid YAML.
- [x] Diff vs `origin/main` is exactly 1 file (`.github/ISSUE_TEMPLATE/bug_report.yml`).
- [ ] After merge to `main`: open *New issue* and confirm the chooser shows the V10 **Bug Report** template with all sections.

Made with [Cursor](https://cursor.com)