### PR TITLE
test(e2e): drive the WM→SWM→VM UI spec on the production-default oxigraph-server backend (no Docker)

### DIFF
--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -262,17 +262,37 @@ export async function publishToVm(opts: {
    */
   allowPartial?: boolean;
 }): Promise<{ httpStatus: number; status?: string; kaId?: string; txHash?: string; contextGraphError?: string }> {
-  const res = await devnetApiFetch('/api/shared-memory/publish', {
-    method: 'POST',
-    nodeNum: opts.nodeNum ?? 1,
-    body: JSON.stringify({
-      contextGraphId: opts.contextGraphId,
-      assertionName: opts.assertionName,
-      clearAfter: opts.clearAfter ?? false,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`publish failed: ${res.status} ${await res.text()}`);
+  // LU-5 (OT-RFC-38): the publish-access-policy gate refuses to publish until
+  // the CG's curation policy is CHAIN-CONFIRMED. On a freshly-created/registered
+  // CG that confirmation lags the registration tx by a few blocks, so the first
+  // publish can race ahead and 500 with "publish access-policy is unknown …
+  // curated=unknown". That's a transient, not a failure — retry that SPECIFIC
+  // error with backoff (the devnet mines ~1 block/s), so the global-setup VM
+  // seed (and every other publish caller) waits for the policy instead of
+  // flaking. Any other non-ok status still throws immediately.
+  const POLICY_CONFIRM_BUDGET_MS = 45_000;
+  const policyDeadline = Date.now() + POLICY_CONFIRM_BUDGET_MS;
+  let res: Response;
+  for (;;) {
+    res = await devnetApiFetch('/api/shared-memory/publish', {
+      method: 'POST',
+      nodeNum: opts.nodeNum ?? 1,
+      body: JSON.stringify({
+        contextGraphId: opts.contextGraphId,
+        assertionName: opts.assertionName,
+        clearAfter: opts.clearAfter ?? false,
+      }),
+    });
+    if (res.ok) break;
+    const errText = await res.text();
+    const policyNotConfirmed =
+      res.status === 500 &&
+      /publish access-policy is unknown|curated=unknown/i.test(errText);
+    if (policyNotConfirmed && Date.now() < policyDeadline) {
+      await new Promise((r) => setTimeout(r, 3_000));
+      continue;
+    }
+    throw new Error(`publish failed: ${res.status} ${errText}`);
   }
   const body = (await res.json()) as { status?: string; kaId?: string; txHash?: string; contextGraphError?: string };
   // `res.ok` is true for 207 too. The daemon returns 207 when the SWM/VM publish

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-ui-cycle.devnet.spec.ts
@@ -32,6 +32,7 @@ import {
   waitForDevnetStatus,
   requireDevnetPrecondition,
   requireDevnetNode,
+  devnetApiFetch,
 } from '../../helpers/devnet.js';
 import { listContextGraphs } from '../../helpers/devnet-publish.js';
 import {
@@ -64,6 +65,20 @@ const run: {
 test.beforeAll(async () => {
   await requireDevnetNode(test, 1);
   await waitForDevnetStatus(1);
+
+  // HARD precondition (NOT a skip): this spec only reproduces #996 on a
+  // SPARQL-over-HTTP backend. If node 1 isn't on `oxigraph-server`, the
+  // blank-node DELETE-DATA path is never exercised and the spec would pass
+  // trivially — the exact silent-degradation trap that hid the bug in rc.16.
+  // Fail loudly so the devnet backend wiring (scripts/devnet.sh: node 1-2 →
+  // oxigraph-server) can never regress unnoticed.
+  const statusRes = await devnetApiFetch('/api/status', { nodeNum: 1 });
+  const status = (await statusRes.json()) as { storeBackend?: string };
+  expect(
+    status.storeBackend,
+    'node 1 must run the oxigraph-server backend for this spec to exercise #996 ' +
+      '(set in scripts/devnet.sh); got a non-SPARQL-over-HTTP backend instead',
+  ).toBe('oxigraph-server');
 
   // `/api/status` answering does NOT mean the seeded primary context graph has
   // finished registering — on a cold boot `listContextGraphs()` can briefly

--- a/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
@@ -241,7 +241,12 @@ export function ImportFilesModal({ open, onClose, contextGraphId, contextGraphNa
 
           {(status === 'done' || status === 'error') && (
             <>
-              <div className={`v10-import-result ${errorCount > 0 ? 'error' : 'success'}`}>
+              <div
+                className={`v10-import-result ${errorCount > 0 ? 'error' : 'success'}`}
+                data-testid="import-result"
+                data-import-status={errorCount > 0 ? 'error' : 'success'}
+                data-import-triples={totalTriples}
+              >
                 {errorCount === 0 ? (
                   <>
                     Successfully imported {successCount} file{successCount !== 1 ? 's' : ''}.

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -793,6 +793,27 @@ cmd_start() {
   # Stop any already-running devnet nodes so they pick up the config we are about to write
   stop_devnet_nodes_only
 
+  # The chain was just freshly deployed (start_hardhat wiped the deployment
+  # artifacts + marker above), so ANY persisted per-node store state is STALE —
+  # it references the OLD chain. The critical case: a node's store still holds
+  # the `dkg:contextGraphOnChainId` triple from a previous run, so
+  # `registerContextGraph` below short-circuits on a stale "already registered"
+  # view and never creates the CG on the NEW chain. The CG then reads back
+  # `isContextGraphActive=false` / `publishPolicy=0`, the post-boot policy
+  # assertion fails, and every VM publish hits LU-5 ("publish access-policy is
+  # unknown"). Wipe each node's persisted state now that the nodes are stopped —
+  # but KEEP the cached Oxigraph binary (`oxigraph/`) so we don't re-download it.
+  # Nodes re-register identities + CGs and re-sync from scratch against the fresh
+  # chain, which is exactly the e2e seed-from-clean model.
+  if [ -d "$DEVNET_DIR" ]; then
+    local nd
+    for nd in "$DEVNET_DIR"/node*/; do
+      [ -d "$nd" ] || continue
+      find "$nd" -mindepth 1 -maxdepth 1 ! -name oxigraph -exec rm -rf {} + 2>/dev/null || true
+    done
+    log "Cleared stale per-node store state for the freshly-deployed chain (kept cached Oxigraph binaries)"
+  fi
+
   # Generate a shared auth token for all devnet nodes
   local shared_token
   shared_token=$(openssl rand -base64 32 | tr -d '=/+' | head -c 43)

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -428,7 +428,11 @@ create_node_config() {
   #             generic external-endpoint path; Docker-only, optional)
   local store_block=""
   if [ "$node_num" -ge 1 ] && [ "$node_num" -le 2 ]; then
-    store_block="\"store\": { \"backend\": \"oxigraph-server\" },"
+    # The managed oxigraph-server defaults to port 7878; multiple nodes on one
+    # host must pin DISTINCT ports or the second collides ("Address already in
+    # use"). Give each node its own (7900 + node_num), clear of the Dockerized
+    # external Oxigraph on 7878/7879 (nodes 5-6) and a real node's 7878.
+    store_block="\"store\": { \"backend\": \"oxigraph-server\", \"options\": { \"port\": $((7900 + node_num)) } },"
   elif [ "$node_num" -ge 3 ] && [ "$node_num" -le 4 ]; then
     if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then
       store_block="\"store\": { \"backend\": \"blazegraph\", \"options\": { \"url\": \"http://127.0.0.1:${BLAZEGRAPH_PORT}/bigdata/namespace/node${node_num}/sparql\" } },"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -414,12 +414,22 @@ create_node_config() {
   # start_node() to point at node 1's local multiaddr.
   local relay_value='"relay": "none",'
 
-  # Backend assignment:
-  #   Node 1-2: oxigraph-worker  (worker thread, file-persisted — production default)
-  #   Node 3-4: oxigraph          (in-process, no worker thread — comparison baseline)
-  #   Node 5-6: blazegraph        (remote SPARQL, if Docker available — else oxigraph-worker)
+  # Backend assignment (production parity + hermetic — no Docker required for the
+  # primary coverage):
+  #   Node 1-2: oxigraph-server  (DAEMON-MANAGED local server — the actual
+  #             fresh-install production default since rc.12. The daemon
+  #             auto-downloads + SHA-256-verifies + caches the Oxigraph binary
+  #             and spawns it on its own port — NO Docker. Node 1 is the node the
+  #             UI/e2e suite drives, so the suite now exercises the REAL default
+  #             backend and deterministically reproduces SPARQL-over-HTTP-only
+  #             bugs such as #996 — which the old `oxigraph-worker` default hid.)
+  #   Node 3-4: blazegraph (if Docker) else oxigraph  (in-process baseline)
+  #   Node 5-6: sparql-http → external Dockerized Oxigraph  (EXTRA coverage of the
+  #             generic external-endpoint path; Docker-only, optional)
   local store_block=""
-  if [ "$node_num" -ge 3 ] && [ "$node_num" -le 4 ]; then
+  if [ "$node_num" -ge 1 ] && [ "$node_num" -le 2 ]; then
+    store_block="\"store\": { \"backend\": \"oxigraph-server\" },"
+  elif [ "$node_num" -ge 3 ] && [ "$node_num" -le 4 ]; then
     if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then
       store_block="\"store\": { \"backend\": \"blazegraph\", \"options\": { \"url\": \"http://127.0.0.1:${BLAZEGRAPH_PORT}/bigdata/namespace/node${node_num}/sparql\" } },"
     else
@@ -756,22 +766,24 @@ cmd_start() {
   start_oxigraph_servers
 
   # ── backend coverage summary + optional strict gate ───────────────────────
-  # The devnet runs a store-backend matrix (nodes 1-2 oxigraph-worker, 3-4
-  # blazegraph, 5-6 sparql-http/oxigraph-server). When Docker is unavailable
-  # the SPARQL-over-HTTP backends SILENTLY fall back to the embedded store —
-  # which is exactly how the rc.16 blank-node DELETE-DATA bug slipped past
-  # devnet (no node actually ran sparql-http). Make the degradation loud, and
-  # let CI demand the full matrix via DEVNET_REQUIRE_ALL_BACKENDS=1.
-  local bg_state ox_state
-  if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then bg_state="blazegraph"; else bg_state="DEGRADED → oxigraph in-process (blazegraph unavailable)"; fi
-  if [ "$OXIGRAPH_SERVER_AVAILABLE" = true ]; then ox_state="sparql-http / oxigraph-server"; else ox_state="DEGRADED → oxigraph-worker (oxigraph-server unavailable)"; fi
-  log "Store-backend matrix:  nodes 1-2: oxigraph-worker  |  nodes 3-4: $bg_state  |  nodes 5-6: $ox_state"
+  # Nodes 1-2 run the daemon-managed `oxigraph-server` (the production default)
+  # with NO Docker — the binary is auto-downloaded/cached by the daemon — so the
+  # SPARQL-over-HTTP path, AND the node the UI/e2e suite drives, is ALWAYS
+  # exercised. That closes the rc.16 gap where the matrix silently fell back to
+  # the embedded store and the blank-node DELETE-DATA bug slipped past devnet.
+  # The Docker-gated entries below (blazegraph on 3-4, an EXTERNAL Oxigraph
+  # server on 5-6) are EXTRA matrix coverage; DEVNET_REQUIRE_ALL_BACKENDS=1 makes
+  # their absence a hard failure for full-matrix CI.
+  local bg_state ox_extra
+  if [ "$BLAZEGRAPH_AVAILABLE" = true ]; then bg_state="blazegraph"; else bg_state="oxigraph in-process (blazegraph Docker unavailable)"; fi
+  if [ "$OXIGRAPH_SERVER_AVAILABLE" = true ]; then ox_extra="sparql-http → external Oxigraph"; else ox_extra="(skipped — external Oxigraph Docker unavailable)"; fi
+  log "Store-backend matrix:  nodes 1-2: oxigraph-server (managed, no Docker)  |  nodes 3-4: $bg_state  |  nodes 5-6: $ox_extra"
   if [ "$BLAZEGRAPH_AVAILABLE" != true ] || [ "$OXIGRAPH_SERVER_AVAILABLE" != true ]; then
     if [ "${DEVNET_REQUIRE_ALL_BACKENDS:-0}" = "1" ]; then
-      log "ERROR: DEVNET_REQUIRE_ALL_BACKENDS=1 but a SPARQL-over-HTTP backend could not be provisioned (needs Docker + the oxigraph/oxigraph and blazegraph images). Aborting rather than silently shrinking the backend matrix."
+      log "ERROR: DEVNET_REQUIRE_ALL_BACKENDS=1 but an EXTRA Docker backend (blazegraph and/or external Oxigraph) is missing. The core oxigraph-server path IS covered on nodes 1-2, but full-matrix CI also requires the Docker images. Aborting."
       exit 1
     fi
-    log "WARNING: SPARQL-over-HTTP backend coverage is REDUCED for this devnet run. The hermetic storage conformance matrix still exercises sparql-http on every test run; set DEVNET_REQUIRE_ALL_BACKENDS=1 to make this a hard failure in CI."
+    log "NOTE: EXTRA Docker backends (blazegraph / external Oxigraph) are not provisioned this run. The production-default oxigraph-server path IS covered on nodes 1-2; set DEVNET_REQUIRE_ALL_BACKENDS=1 to require the Docker extras too."
   fi
 
   # Stop any already-running devnet nodes so they pick up the config we are about to write


### PR DESCRIPTION
**Stacked on #996** (base = `fix/sparql-http-blank-node-delete`; retarget to `main` once #996 merges). Builds on #996's `wm-swm-vm-ui-cycle.devnet.spec.ts` + devnet backend gate.

## What this does

Makes the real-browser WM→SWM→VM lifecycle spec actually exercise (and pass on) the backend real users run — closing the rc.16 gap where the UI e2e silently ran the wrong store and the blank-node bug couldn't reproduce.

- **Devnet UI node → daemon-managed `oxigraph-server` (no Docker).** Nodes 1-2 now run the production-default backend; the daemon auto-downloads + SHA-256-verifies + caches the Oxigraph binary (cross-platform, CI fetches from GitHub releases). The Dockerized external Oxigraph stays as optional extra coverage. A **hard precondition** asserts node 1's `/api/status` `storeBackend === 'oxigraph-server'` and fails loudly (not skip) — the bug-reproducing backend can never silently regress.

## Result

```
✓ imports a Markdown file into Working Memory
✓ promotes WM → SWM and the triples actually migrate   ← #996 blank-node fix, end-to-end through the UI
- publishes SWM → VM  (author-intentional test.fixme — covered by the API-driven sibling spec)
2 passed, 1 skipped
```

## 3 real bugs surfaced + fixed by running it end-to-end

| # | Bug | Fix |
|---|-----|-----|
| 1 | Managed oxigraph-server defaults to port 7878 → **collides on multi-node hosts** (`Address already in use`) | Pin per-node ports (`7900+n`) |
| 2 | `devnet.sh start` redeploys a **fresh chain** but kept persisted per-node store state, so a stale `dkg:contextGraphOnChainId` made `registerContextGraph` short-circuit → CG never created on the new chain → `isContextGraphActive=false` → every VM publish hit **LU-5 "publish access-policy is unknown"** | Wipe per-node store state on fresh-chain boot (keep cached binary); nodes re-register against the new chain. (Masked in CI, which always starts clean; bit local repeated boots.) |
| 3 | `import-result` exposed `className` but **no `data-testid`/`data-import-*`** hooks the spec asserts on | Add them to `ImportFilesModal.tsx` |

Plus a defensive `publishToVm` retry for the genuine few-blocks registration→confirmation lag (distinct from #2), centralized so the global-setup seed + all publish callers benefit.

## Notes
- Switching node 1 to oxigraph-server means the **whole** node-ui e2e suite now runs on the production-default backend (intended — production parity).
- Bug #1 (port collision) is a real product-relevant defect for any multi-oxigraph-server-per-host deployment, not just the devnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)