### PR TITLE
feat(evm): bind reservedKaId into AuthorAttestation EIP-712 digest (OT-RFC-43 §F2) [protocol core]

### DIFF
--- a/packages/core/src/crypto/ack.ts
+++ b/packages/core/src/crypto/ack.ts
@@ -382,7 +382,14 @@ export const AUTHOR_SCHEME_VERSION_V1 = 1;
  * `KnowledgeAssetsV10.sol`:
  *
  *   AuthorAttestation(uint256 contextGraphId, bytes32 merkleRoot,
- *                     address authorAddress, uint8 schemeVersion)
+ *                     address authorAddress, uint8 schemeVersion,
+ *                     uint256 reservedKaId)
+ *
+ * OT-RFC-43 Option-1 (variant 1a): `reservedKaId` — the packed
+ * `(uint160(author) << 96) | uint96(number)` slot this publish claims — is
+ * bound into the attestation so the author signs the *slot*, not just the
+ * content. This MUST stay byte-for-byte aligned with the on-chain
+ * `abi.encode(...)` order; the field is appended LAST.
  */
 export const AUTHOR_ATTESTATION_PRIMARY_TYPE = 'AuthorAttestation';
 
@@ -402,6 +409,7 @@ export interface AuthorAttestationTypedData {
     merkleRoot: string;
     authorAddress: string;
     schemeVersion: number;
+    reservedKaId: bigint;
   };
 }
 
@@ -411,8 +419,13 @@ export interface AuthorAttestationTypedData {
  * Domain pins `(chainId, verifyingContract)` to defeat cross-chain and
  * cross-deployment replay. Struct hash binds the publication's
  * `(contextGraphId, merkleRoot)` to a specific
- * `(authorAddress, schemeVersion)` — leaked signatures cannot be
- * redirected to a different CG, root, or author.
+ * `(authorAddress, schemeVersion, reservedKaId)` — leaked signatures cannot
+ * be redirected to a different CG, root, author, or KA id/slot.
+ *
+ * `reservedKaId` is the packed `(uint160(author) << 96) | uint96(number)`
+ * the publish will mint; it is REQUIRED under OT-RFC-43 Option-1 variant 1a
+ * and must equal the `reservedKaId` placed in `PublishParams`, or on-chain
+ * recovery will revert with `InvalidAuthorSignature`.
  *
  * Pass directly to `ethers.Signer.signTypedData(domain, types, message)`
  * or to a wallet-of-record (EIP-1271 contract).
@@ -423,6 +436,7 @@ export function buildAuthorAttestationTypedData(args: {
   contextGraphId: bigint;
   merkleRoot: Uint8Array;
   authorAddress: string;
+  reservedKaId: bigint;
   schemeVersion?: number;
 }): AuthorAttestationTypedData {
   if (args.merkleRoot.length !== 32) {
@@ -449,6 +463,7 @@ export function buildAuthorAttestationTypedData(args: {
         { name: 'merkleRoot', type: 'bytes32' },
         { name: 'authorAddress', type: 'address' },
         { name: 'schemeVersion', type: 'uint8' },
+        { name: 'reservedKaId', type: 'uint256' },
       ],
     },
     primaryType: AUTHOR_ATTESTATION_PRIMARY_TYPE,
@@ -457,6 +472,7 @@ export function buildAuthorAttestationTypedData(args: {
       merkleRoot: merkleRootHex,
       authorAddress: args.authorAddress,
       schemeVersion,
+      reservedKaId: args.reservedKaId,
     },
   };
 }

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -303,10 +303,18 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     error InvalidAuthorSignature1271();
 
     /// @dev RFC-001 §3.2 — EIP-712 type hash for `AuthorAttestation`.
-    /// `keccak256("AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion)")`.
+    /// `keccak256("AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion,uint256 reservedKaId)")`.
+    /// @dev OT-RFC-43 Option-1 (variant 1a): `reservedKaId` is bound into the
+    ///      author attestation so the author signs the *slot* (the packed
+    ///      `(author << 96) | number`) as well as the content. Without it a
+    ///      delegated publisher/relay could mint the author's content at a
+    ///      different number inside the author's own namespace — the on-chain
+    ///      guard only enforces `(reservedKaId >> 96) == author` (the
+    ///      namespace), not the number. Mirrors `UpdateAuthorAttestation`,
+    ///      which already binds `kaId`.
     bytes32 private constant _AUTHOR_ATTESTATION_TYPEHASH =
         keccak256(
-            "AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion)"
+            "AuthorAttestation(uint256 contextGraphId,bytes32 merkleRoot,address authorAddress,uint8 schemeVersion,uint256 reservedKaId)"
         );
 
     bytes32 private constant _UPDATE_AUTHOR_ATTESTATION_TYPEHASH =
@@ -865,7 +873,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         uint256 _contextGraphId,
         bytes32 _merkleRoot,
         address _authorAddress,
-        uint8 _schemeVersion
+        uint8 _schemeVersion,
+        uint256 _reservedKaId
     ) internal view returns (bytes32) {
         bytes32 domainSeparator = keccak256(
             abi.encode(
@@ -882,7 +891,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                 _contextGraphId,
                 _merkleRoot,
                 _authorAddress,
-                _schemeVersion
+                _schemeVersion,
+                _reservedKaId
             )
         );
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -975,7 +985,8 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
             p.contextGraphId,
             p.merkleRoot,
             p.authorAddress,
-            p.authorSchemeVersion
+            p.authorSchemeVersion,
+            p.reservedKaId
         );
 
         if (p.authorAddress.code.length == 0) {

--- a/packages/evm-module/test/helpers/v10-kc-helpers.ts
+++ b/packages/evm-module/test/helpers/v10-kc-helpers.ts
@@ -102,6 +102,7 @@ export type AuthorAttestationPayload = {
     merkleRoot: string;
     authorAddress: string;
     schemeVersion: number;
+    reservedKaId: bigint;
   };
 };
 
@@ -112,8 +113,8 @@ export type AuthorAttestationPayload = {
  *   name="KnowledgeAssetsLifecycle", version="2.0.0", chainId, verifyingContract.
  *
  * The struct hash binds (contextGraphId, merkleRoot, authorAddress,
- * schemeVersion). Drift between this builder and the contract will surface
- * as `InvalidAuthorSignature` at publish time.
+ * schemeVersion, reservedKaId). Drift between this builder and the contract
+ * will surface as `InvalidAuthorSignature` at publish time.
  */
 export function buildAuthorAttestationPayload(args: {
   chainId: bigint;
@@ -121,6 +122,7 @@ export function buildAuthorAttestationPayload(args: {
   contextGraphId: bigint;
   merkleRoot: string;
   authorAddress: string;
+  reservedKaId: bigint;
   schemeVersion?: number;
 }): AuthorAttestationPayload {
   const schemeVersion = args.schemeVersion ?? AUTHOR_SCHEME_VERSION_V1;
@@ -137,6 +139,7 @@ export function buildAuthorAttestationPayload(args: {
         { name: 'merkleRoot', type: 'bytes32' },
         { name: 'authorAddress', type: 'address' },
         { name: 'schemeVersion', type: 'uint8' },
+        { name: 'reservedKaId', type: 'uint256' },
       ],
     },
     value: {
@@ -144,6 +147,7 @@ export function buildAuthorAttestationPayload(args: {
       merkleRoot: args.merkleRoot,
       authorAddress: ethers.getAddress(args.authorAddress),
       schemeVersion,
+      reservedKaId: args.reservedKaId,
     },
   };
 }
@@ -392,6 +396,12 @@ export async function buildPublishParams(args: {
   );
 
   const schemeVersion = args.authorSchemeVersion ?? AUTHOR_SCHEME_VERSION_V1;
+  // OT-RFC-43 Option 1 (1a): author-namespaced packed id. Defaults to a
+  // fresh, unused number in the author's namespace; pinned/reused values
+  // come through `args.reservedKaId` for collision / negative tests. Resolved
+  // BEFORE the author attestation so the author signs the exact slot that the
+  // publish mints (OT-RFC-43 §F2 — `reservedKaId` is bound into the digest).
+  const reservedKaId = args.reservedKaId ?? nextReservedKaId(args.author.address);
   const authorSig =
     args.authorSigOverride ??
     (await signAuthorAttestation(
@@ -402,6 +412,7 @@ export async function buildPublishParams(args: {
         contextGraphId: args.contextGraphId,
         merkleRoot: args.merkleRoot,
         authorAddress: args.author.address,
+        reservedKaId,
         schemeVersion,
       }),
     ));
@@ -423,10 +434,7 @@ export async function buildPublishParams(args: {
     authorR: authorSig.authorR,
     authorVS: authorSig.authorVS,
     authorSchemeVersion: schemeVersion,
-    // OT-RFC-43 Option 1 (1a): author-namespaced packed id. Defaults to a
-    // fresh, unused number in the author's namespace; pinned/reused values
-    // come through `args.reservedKaId` for collision / negative tests.
-    reservedKaId: args.reservedKaId ?? nextReservedKaId(args.author.address),
+    reservedKaId,
     identityIds: args.receiverIdentityIds,
     r: sig.receiverRs,
     vs: sig.receiverVSs,

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -875,6 +875,39 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     );
   });
 
+  it('B5(f): a delegated publisher cannot swap the author-signed reservedKaId to another number in the same namespace (OT-RFC-43 §F2 digest binding)', async () => {
+    const setup = await setupRegisteredAgentPublish();
+
+    // The author (setup.creator) signs an attestation that binds slot #7.
+    const signedKaId = packReservedKaId(setup.creator.address, 7);
+    const p = await buildBasePublishParams(setup, 'b5-f-signed-slot-7', {
+      reservedKaId: signedKaId,
+    });
+
+    // A relay/publisher tampers the publish to mint at slot #99 instead —
+    // still inside the author's OWN namespace, so the `(kaId >> 96) == author`
+    // guard would pass. Pre-F2 the author signature covered only the content,
+    // so this substitution succeeded. With `reservedKaId` bound into the
+    // EIP-712 digest, the recomputed digest no longer recovers to the author.
+    const substitutedKaId = packReservedKaId(setup.creator.address, 99);
+    expect(substitutedKaId >> 96n).to.equal(BigInt(setup.creator.address));
+    const tampered = { ...p, reservedKaId: substitutedKaId };
+
+    await expect(
+      KAV10.connect(setup.creator).publish(tampered),
+    ).to.be.revertedWithCustomError(KAV10, 'InvalidAuthorSignature');
+
+    // Neither the signed nor the substituted slot was minted.
+    for (const id of [signedKaId, substitutedKaId]) {
+      await expect(
+        DKGKnowledgeAssets.ownerOf(id),
+      ).to.be.revertedWithCustomError(
+        DKGKnowledgeAssets,
+        'ERC721NonexistentToken',
+      );
+    }
+  });
+
   it('B5(c): reusing the same (author, number) reverts KaIdAlreadyMinted on the second publish (no silent clobber)', async () => {
     const setup = await setupRegisteredAgentPublish();
 


### PR DESCRIPTION
## OT-RFC-43 Option-1 §F2 — bind `reservedKaId` into the `AuthorAttestation` EIP-712 digest

Closes the within-namespace **slot-substitution** gap deferred from #975. Today the author attestation signs only the *content* — `(contextGraphId, merkleRoot, authorAddress, schemeVersion)` — not the *slot*. The on-chain mint guard enforces only `(reservedKaId >> 96) == author` (the namespace), so a **delegated publisher / PCA relay** can mint the author's content at a different `number` inside the author's **own** namespace.

> **Example.** Alice reserves slot `7` and signs her attestation. A relay submits `publish()` with `reservedKaId = (Alice << 96) | 99`. Pre-fix: the 4-field digest still recovers to Alice and `(99 >> 96) == Alice` passes → her content mints at `/Alice/99`, her announced `/Alice/7` dangles, and the relay can squat `/Alice/7`. Post-fix: the digest includes `99`, recovery no longer yields Alice → `InvalidAuthorSignature`.

This mirrors `UpdateAuthorAttestation`, which **already** binds `kaId`. Audit-greenlit; pre-mainnet (needs a coordinated testnet redeploy — bytecode changes, but see "no ABI change" below).

## ✅ In this PR — protocol core (landed + verified)

**On-chain** — `KnowledgeAssetsLifecycle.sol`
- `_AUTHOR_ATTESTATION_TYPEHASH` → 5 fields, appending `uint256 reservedKaId`.
- `_hashAuthorAttestation` takes/encodes `_reservedKaId`; `_verifyAuthorAttestation` passes `p.reservedKaId`.

**Off-chain** — `core/src/crypto/ack.ts`
- `buildAuthorAttestationTypedData` requires + binds `reservedKaId` as the 5th typed-data field, byte-aligned with the contract.

**Tests** — `evm-module`
- Helper signs the same `reservedKaId` it mints.
- **New `B5(f)`**: a delegated publisher swapping the author-signed slot 7 → in-namespace slot 99 reverts `InvalidAuthorSignature`. **16/16 PCA-lifecycle tests pass.**

**Verified:** contracts compile (97 files); **no external ABI change** (`_AUTHOR_ATTESTATION_TYPEHASH`/`_hashAuthorAttestation` are internal, and `reservedKaId` is already a `PublishParams` field shipped in rc.16) → no ABI regen / tuple-layout churn. New bytecode → redeploy required.

**Scoped out:** the F1 field-reorder from #975's `11b480acf`. rc.16 already shipped `reservedKaId` mid-struct, so reordering now would be a *second* breaking ABI change for marginal ergonomics.

## 🚧 Remaining coordinated work (tracked — NOT yet wired; CI TS build will be red until done)

Because `buildAuthorAttestationTypedData` now **requires** `reservedKaId` (so the gap can't be silently reintroduced), the off-chain callers must be threaded. This is the "coordinated off-chain change" the #975 deferral described — it includes a **flow reorder and an external API change**, so it's intentionally staged behind the verified protocol core:

- [ ] **`dkg-agent-publish.ts` — allocate-before-sign.** The author seal is signed in `assertionFinalize` *before* the KA number is allocated (the "ALLOCATE-AT-FINALIZE" block). Hoist allocation (or the existing-`kaId` read, for updates) above the 4 `buildAuthorAttestationTypedData` sites and sign over the packed id.
- [ ] **Persist `reservedKaId` on the seal** (`AssertionSeal` / `LiftRequestAuthorSeal`) so the idempotent existing-seal rebuild and the async-lift pre-seal recover the same value.
- [ ] **External API:** extend `preSignedAuthorAttestation` (`PreSignedAuthorAttestation`) to carry `reservedKaId`, so self-sovereign authors sign over their reserved slot. ⚠️ public-surface change.
- [ ] **`dkg-publisher.ts`** (2 sites) — thread `reservedKaId`.
- [ ] **`evm-adapter-context-graph.ts`** — the V9→V10 mirror `publishToContextGraph` builds an attestation with no `reservedKaId` and already throws under Option-1 (`createKnowledgeAssets` requires it); mark explicitly unsupported.
- [ ] **~12 test sites** (publisher/agent/chain/cli/random-sampling) + golden vectors in `core/test/v10-author-attestation-digest.test.ts`.
- [ ] **Validate** the full finalize→publish→mint roundtrip on a hardhat chain (agent + publisher e2e).
- [ ] **Redeploy** to Base Sepolia + record addresses (à la #995), gated on audit sign-off.

Refs #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
