### PR TITLE
fix(ka): require finalize before SWM share

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -16,9 +16,10 @@
 //   POST /api/knowledge-assets/:name/vm/publish      mint/update on chain
 //
 // These delegate to the SAME agent lifecycle methods the legacy
-// `/api/assertion/*` + `/api/shared-memory/*` routes use, so behavior is
-// identical; only the URL shape changes. This module is purely ADDITIVE — the
-// legacy routes are untouched (308 redirects from them land in a follow-up).
+// `/api/assertion/*` + `/api/shared-memory/*` routes use, with V10 route-level
+// preconditions (for example: SWM share requires a finalized WM pointer).
+// This module is purely ADDITIVE — the legacy routes are untouched (308
+// redirects from them land in a follow-up).
 //
 // Identifier note (OT-RFC-43 §10.5.7): for the v10.0 floor the KA is addressed
 // by its lifecycle NAME (the file handle) + `contextGraphId`. Minter-namespaced
@@ -104,6 +105,21 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
   "preSignedAuthorAttestation",
   "schemeVersion",
 ] as const;
+const ASSERTION_NOT_FINALIZED = "ASSERTION_NOT_FINALIZED";
+
+function assertionNotFinalizedBody(
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+): Record<string, unknown> {
+  return {
+    code: ASSERTION_NOT_FINALIZED,
+    error: `Knowledge asset "${name}" must be finalized before it can be shared to SWM. Call POST /api/knowledge-assets/${encodeURIComponent(name)}/wm/finalize first.`,
+    contextGraphId,
+    name,
+    ...(subGraphName ? { subGraphName } : {}),
+  };
+}
 
 /**
  * Translate engine/publisher errors on the WM/SWM mutation verbs into the same
@@ -115,6 +131,10 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
  * publish path, which never down-classified them).
  */
 function respondAssertionError(res: RequestContext["res"], e: any): void {
+  if (e?.code === ASSERTION_NOT_FINALIZED) {
+    jsonResponse(res, 409, assertionNotFinalizedBody(e.contextGraphId, e.assertionName, e.subGraphName));
+    return;
+  }
   if (e?.name === "AssertionNotPersistedError" || e?.code === "ASSERTION_NOT_PERSISTED") {
     jsonResponse(res, 409, {
       error: e.message,
@@ -137,6 +157,22 @@ function respondAssertionError(res: RequestContext["res"], e: any): void {
     return;
   }
   jsonResponse(res, 500, { error: msg });
+}
+
+async function requireFinalizedBeforeSwmShare(
+  ctx: RequestContext,
+  contextGraphId: string,
+  name: string,
+  subGraphName?: string,
+): Promise<boolean> {
+  const { agent, res } = ctx;
+  const hist = await agent.assertion.history(contextGraphId, name, { subGraphName });
+  const wmCurrentAssertion = (hist as Record<string, unknown> | null | undefined)?.wmCurrentAssertion;
+  if (typeof wmCurrentAssertion === "string" && wmCurrentAssertion.length > 0) {
+    return true;
+  }
+  jsonResponse(res, 409, assertionNotFinalizedBody(contextGraphId, name, subGraphName));
+  return false;
 }
 
 function hex(bytes: Uint8Array): string {
@@ -755,6 +791,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
 
     // ── SWM verb: share (WM → SWM; OT-RFC-43 §10.6 renames promote → share) ──
     if (layer === "swm" && verb === "share") {
+      if (!(await requireFinalizedBeforeSwmShare(ctx, contextGraphId, name, subGraphName))) return;
       const share = await agent.assertion.promote(contextGraphId, name, { entities: parsed.entities, subGraphName });
       if (share.promotedCount !== 0) {
         emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm", "swm"], subGraphName, operation: "assertion_promoted", source: "api", counts: { triples: share.promotedCount } });
@@ -768,15 +805,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // preflight above already decoded/validated `name`, parsed the JSON body,
     // validated `subGraphName`, and resolved `contextGraphId` — so we reuse
     // those here (parity with how `swm/share` reuses them). The worker-
-    // availability 503 guard, `validateEntities` 400, and the conflict/error
-    // mapping match the legacy handler exactly. Self-contained try/catch (like
-    // `vm/publish`) so the legacy enqueue error mapping is preserved verbatim
-    // and unmatched errors rethrow rather than falling through to the outer
-    // `respondAssertionError` catch.
+    // availability 503 guard, `validateEntities` 400, finalized-WM preflight,
+    // and the conflict/error mapping match the V10 share semantics.
+    // Self-contained try/catch (like `vm/publish`) so the legacy enqueue error
+    // mapping is preserved verbatim and unmatched errors rethrow rather than
+    // falling through to the outer `respondAssertionError` catch.
     if (layer === "swm" && verb === "share-async") {
       if (asyncPromoteUnavailable(res)) return;
       const entities = parsed.entities;
       if (!validateEntities(entities, res)) return;
+      if (!(await requireFinalizedBeforeSwmShare(ctx, contextGraphId, name, subGraphName))) return;
       try {
         const result = await agent.assertion.promoteAsync(contextGraphId, name, {
           entities: entities ?? "all",

--- a/packages/cli/test/async-promote-queue-e2e.test.ts
+++ b/packages/cli/test/async-promote-queue-e2e.test.ts
@@ -115,6 +115,13 @@ describe('async-promote queue — end-to-end (routes + worker + queue)', () => {
       },
       resolveAgentByToken: () => undefined,
       assertion: {
+        async history() {
+          return {
+            state: 'created',
+            memoryLayer: 'WorkingMemory',
+            wmCurrentAssertion: 'abcd',
+          };
+        },
         async promote(
           contextGraphId: string,
           name: string,

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -131,6 +131,11 @@ function status(ctx: RequestContext): number {
 // argument, so we surface a writable row for every id the suite uses; the
 // `resolveRequiredWriteContextGraphId` `exact` match then keys off the request.
 const WRITABLE_CG_IDS = ['cg', 'cg-2', 'other'];
+const FINALIZED_DESCRIPTOR = {
+  state: 'created',
+  memoryLayer: 'WorkingMemory',
+  wmCurrentAssertion: 'abcd',
+};
 
 function contextGraphMocks() {
   return {
@@ -381,7 +386,9 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
   });
 
   it('POST .../:name/swm/share advances the SWM pointer (promote→share) + emits activity', async () => {
-    const agent = makeAssertionAgent();
+    const agent = makeAssertionAgent({
+      assertion: { history: vi.fn(async () => FINALIZED_DESCRIPTOR) },
+    });
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/swm/share', { contextGraphId: 'cg' }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
@@ -393,6 +400,22 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(ctx.emitNotification).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'assertion_activity' }),
     );
+  });
+
+  it('POST .../:name/swm/share rejects drafts that have not been finalized', async () => {
+    const agent = makeAssertionAgent({
+      assertion: { history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory' })) },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/swm/share', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(409);
+    expect(body(ctx)).toMatchObject({
+      code: 'ASSERTION_NOT_FINALIZED',
+      contextGraphId: 'cg',
+      name: 'f',
+    });
+    expect(agent.assertion.promote).not.toHaveBeenCalled();
+    expect(ctx.emitMemoryGraphChanged).not.toHaveBeenCalled();
   });
 
   it('POST .../:name/vm/publish mints/updates on chain', async () => {
@@ -894,13 +917,31 @@ describe('async SWM-share queue routes', () => {
 
   it('POST /:name/swm/share-async enqueues a job → { jobId, state: queued }', async () => {
     const agent = makeAssertionAgent({
-      assertion: { promoteAsync: vi.fn(async () => ({ jobId: 'job-xyz' })) },
+      assertion: {
+        history: vi.fn(async () => FINALIZED_DESCRIPTOR),
+        promoteAsync: vi.fn(async () => ({ jobId: 'job-xyz' })),
+      },
     });
     const ctx = ctxFor('POST', '/api/knowledge-assets/notes/swm/share-async', { contextGraphId: 'cg' }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ jobId: 'job-xyz', state: 'queued' });
     expect(agent.assertion.promoteAsync).toHaveBeenCalledWith('cg', 'notes', { entities: 'all', subGraphName: undefined });
+  });
+
+  it('POST /:name/swm/share-async rejects drafts that have not been finalized before enqueue', async () => {
+    const agent = makeAssertionAgent({
+      assertion: { history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory' })) },
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/notes/swm/share-async', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(409);
+    expect(body(ctx)).toMatchObject({
+      code: 'ASSERTION_NOT_FINALIZED',
+      contextGraphId: 'cg',
+      name: 'notes',
+    });
+    expect(agent.assertion.promoteAsync).not.toHaveBeenCalled();
   });
 
   it('POST /:name/swm/share-async returns 503 when the worker is unavailable (daemonState)', async () => {
@@ -1137,7 +1178,12 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
         assertionGraph: 'urn:g',
         expectedTripleCount: 4,
       });
-      const agent = makeAssertionAgent({ assertion: { promote: vi.fn(async () => { throw err; }) } });
+      const agent = makeAssertionAgent({
+        assertion: {
+          history: vi.fn(async () => FINALIZED_DESCRIPTOR),
+          promote: vi.fn(async () => { throw err; }),
+        },
+      });
       const ctx = ctxFor('POST', '/api/knowledge-assets/f/swm/share', { contextGraphId: 'cg' }, agent);
       await handleKnowledgeAssetsRoutes(ctx);
       expect(status(ctx)).toBe(409);

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -255,7 +255,13 @@ describe('daemon memory_graph_changed route emissions', () => {
       subGraphName: 'notes',
       entities: ['urn:root'],
     }, {
-      agent: { assertion: { promote }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+      agent: {
+        assertion: {
+          history: vi.fn(async () => ({ state: 'created', memoryLayer: 'WorkingMemory', wmCurrentAssertion: 'abcd' })),
+          promote,
+        },
+        resolveAgentByToken: () => undefined,
+      } as unknown as RequestContext['agent'],
       emitMemoryGraphChanged,
     });
 

--- a/packages/cli/test/promote-async-daemon-lifecycle.test.ts
+++ b/packages/cli/test/promote-async-daemon-lifecycle.test.ts
@@ -90,6 +90,13 @@ describe('promote-async daemon lifecycle wiring', () => {
       },
       resolveAgentByToken: () => undefined,
       assertion: {
+        async history() {
+          return {
+            state: 'created',
+            memoryLayer: 'WorkingMemory',
+            wmCurrentAssertion: 'abcd',
+          };
+        },
         async promoteAsync(
           contextGraphId: string,
           name: string,

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -86,6 +86,13 @@ describe('async SWM-share queue daemon routes', () => {
       },
       resolveAgentByToken: () => undefined,
       assertion: {
+        async history() {
+          return {
+            state: 'created',
+            memoryLayer: 'WorkingMemory',
+            wmCurrentAssertion: 'abcd',
+          };
+        },
         async promoteAsync(
           contextGraphId: string,
           name: string,

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -81,6 +81,13 @@ describe('POST /api/knowledge-assets/:name/swm/share — issue #864 not-persiste
       },
       resolveAgentByToken: () => undefined,
       assertion: {
+        async history() {
+          return {
+            state: 'created',
+            memoryLayer: 'WorkingMemory',
+            wmCurrentAssertion: 'abcd',
+          };
+        },
         promote,
       },
     };


### PR DESCRIPTION
## Summary
- require a finalized WM pointer before POST /api/knowledge-assets/:name/swm/share can promote to SWM
- apply the same finalized preflight before /swm/share-async enqueues a promote job
- add route coverage for unfinalized sync/async share rejection and update async fixtures to model finalized KAs

## Testing
- pnpm run build:runtime:packages
- pnpm --filter @origintrail-official/dkg exec vitest run test/knowledge-assets-route.test.ts test/promote-async-routes.test.ts test/async-promote-queue-e2e.test.ts test/promote-async-daemon-lifecycle.test.ts test/memory-graph-events.test.ts test/promote-route-not-persisted.test.ts