### PR TITLE
rc.17 Chorus foundation — uniform per-KA layer primitives (D6 + _meta substrate + layer URI builder + D1 create-stamping)

### DIFF
--- a/docs/rc17-chorus-implementation.md
+++ b/docs/rc17-chorus-implementation.md
@@ -1,0 +1,105 @@
+# rc.17 — Chorus 3-layer equivalence: implementation & devnet-test plan
+
+> Status: **planning + safe foundation started.** D6 (advisory ownership) is implemented on this
+> branch (`rc17a-chorus-foundation`, sender-side, pending CI). Everything else below is spec'd
+> for execution. This is a **multi-PR effort gated on #1041 landing on `main`**; it cannot be one
+> commit. Consensus is invariant throughout — the merkle leaf is `(s,p,o)` only and the seal
+> commits content+author, never the name or graph IRI (`packages/publisher/src/merkle.ts:9,57`;
+> `packages/core/src/assertion-seal.ts:10-15`), so nothing here is chain-gated.
+
+## The two sub-trains (cut at the layout boundary)
+
+- **rc.17a** — substrate + identity + atomic + exclusivity. **Keeps the old graph layout** → each item independently shippable & revertable.
+- **rc.17b** — uniform naming + query model + SWM per-KA + migration. **One coherent unit behind a `chorusLayout` feature flag + dual-read window** (mutually dependent: read-flip ↔ write re-home ↔ enumerator re-point).
+
+## Hard requirements (non-negotiable)
+
+1. **`chorusLayout` feature flag + dual-read window** gates the entire rc.17b train. The cutover flips physical graph IRIs; without dual-read it is irreversible mid-flight. Safe because old/new layouts can't diverge a merkle root.
+2. **D1 re-allocation guard** — moving `allocate()` to create destroys the `hasExistingKaId` dedup signal (`dkg-agent-publish.ts:1801-1802`). Port an explicit "already-reserved?" check to create-time (keyed on the `reservedUal`/`kaId` carry-over in `A2_PRESERVE_PREDS`, `dkg-publisher.ts` create path) BEFORE allocating, or a draft re-open double-allocates and breaks the stable-UAL invariant.
+3. **Sealed-quad invariance** — D1 may change identity labels and *where* triples live, but MUST NOT alter the reserved-subject-filtered, `skolemizeByEntity` input quad set the seal hashes (`assertion-seal.ts:47-58`). Byte-identical sealed quad set ⇒ identical root.
+4. **CI grep-guard** for `'/assertion/'` and `'/_shared_memory'` string literals before flipping the URI builders — ~15 parsers fail OPEN (empty/wrong, not loud).
+
+---
+
+## Wave 1 — route anchor (existing plan, unchanged)
+- Unblock **#1041** (fix the 2 Kosava jobs: `adapters+epcis+graph-viz+mcp-server+network-sim`, `node-ui`) → merge `feat/ka-routes-main` → `main`; close **#1039** (integration twin); rebase+land **#1042** (base must move to `main`).
+- **D6** rides here (this branch): drop the `workspaceOwner` first-writer-wins **throw**, keep advisory.
+  - ✅ **Sender** (`dkg-publisher.ts` ~4481): throw → warn+skip (done on this branch).
+  - ☐ **Receiver** (`workspace-handler.ts` ~995-1014 validate/ownership gate, ~1018-1033 CAS): demote the reject to the same advisory warn+skip; keep the `workspaceOwner` quad write (~1104).
+  - **Tests:** `shared-memory-publish-boundary.test.ts`, `workspace.test.ts` — flip the "throws on foreign co-claim" assertions to "skips & warns"; keep the `workspaceOwner` quad assertions.
+
+## Wave 2 — rc.17a (substrate + identity; OLD layout preserved)
+
+### SUBSTRATE-1 — `dkg:entity` on the lifecycle URN  *(M)*
+- `metadata.ts` `generateAssertionCreatedMetadata` (~1313-1345): also emit `mq(subject /*URN*/, ${DKG}entity, <member-entity>, metaGraph)` per member entity (today entity rows hang off per-root label rows + the event subject via `entityMemberQuads`, ~204/227/856 — **not** the URN). Dual-write alongside the existing `dkg:rootEntity` per OT-RFC-43 §10.1.
+- **Not** a prerequisite of the read-flip (corrected): the read-flip enumerates by `contextGraph`/`memoryLayer`/`assertionGraph`/`wasAttributedTo`, all already on the URN at create. SUBSTRATE-1 is for **entity-membership** queries + the SWM backfill CONSTRUCT.
+- **Tests:** new `_meta`-membership unit test asserting the created-row carries `dkg:entity` on the URN.
+
+### SUBSTRATE-2 — re-stamp `dkg:assertionGraph` on promote + publish  *(M)*  ← the read-flip's true hard gate
+- Today `dkg:assertionGraph` is stamped **once at create** (`metadata.ts:1328`, → the WM graph) and never re-stamped: `generateAssertionPromotedMetadata` (1365-1403) flips only state+memoryLayer; `generateAssertionPublishedMetadata` (1420-1451) flips to VM + `vmCurrentAssertion` but no `assertionGraph`.
+- **Promote:** in `generateAssertionPromotedMetadata`, `delete` the old `assertionGraph` (WM) quad and `insert` the layer-correct SWM graph (`contextGraphSharedMemoryUri(cg, sub)` in rc.17a; the per-KA SWM URI in rc.17b).
+- **Publish:** in `generateAssertionPublishedMetadata`, same — `insert` the VM graph. **Caveat:** the VM graph is `_verified_memory/{vmId}` and `vmId` is **not** in `AssertionPublishedMeta` (it's a separate on-chain counter, `dkg-agent-endorse.ts:644`). Thread the VM graph URI (or `vmId`) into `AssertionPublishedMeta`, computed at the endorse call site.
+- Backfill the **missing VM `assertionGraph` pointer** for existing VM KAs (one-shot migration step).
+- **Tests:** lifecycle unit test asserting `assertionGraph` re-points WM→SWM→VM across promote/publish; the explicit seam regression — promote that flips `memoryLayer` MUST also re-stamp `assertionGraph` (the #1 silent-bug surface).
+
+### SUBSTRATE-3 — index-driven discovery read (kill `listGraphs`)  *(L)*  — `dependsOn: SUBSTRATE-2`
+- Replace `discoverGraphsByPrefix`/`listGraphs` scan (`dkg-query-engine.ts:517,576`) and the `graphPrefixes` prefix-FILTER routing (`:82` WM, `:158` VM) with a bounded `_meta` query (bind `dkg:contextGraph`,`dkg:memoryLayer`,`prov:wasAttributedTo`,`dkg:subGraphName`; follow `dkg:assertionGraph`) returning the EXACT graph list, fed into the existing `wrapWithGraph` bound path (`:439/:448`).
+- Retire the other two `listGraphs` scans: `dkg-publisher.ts:3432/3666`, `dkg-agent-cg-registry.ts:904`.
+- **Keep the per-agent ACL constraint** (`constrainGraphVariablesToAllowedSet`, `:1050`, invoked `:291/:397`): the `_meta` discovery query MUST include the `wasAttributedTo` constraint, else other agents' WM leaks into the bound set.
+- **Tests:** `_meta`-index discovery unit tests (returns exact graph list, no `listGraphs` call — spy it to assert 0 calls); ACL test (agent B can't enumerate agent A's WM graphs).
+
+### D1 — identity-at-create (one UAL)  *(M)*  — `dependsOn: SUBSTRATE-1` (parallel to substrate)
+- Move `kaNumberAllocator.allocate(author)` + the per-author reconcile gate from finalize (`dkg-agent-publish.ts:1808-1830`) to `assertionCreate` (`dkg-publisher.ts:4068`, which already carries `kaId`/`reservedUal` via `A2_PRESERVE_PREDS`).
+- Collapse the seal-subject (`assertionUri`, `dkg-agent-publish.ts:2550-2554`) and the lifecycle-subject onto the **one UAL**; demote `{addr}/{name}` + the lifecycle URN from identities; keep `assertionName` as a `dkg:assertionName` label only.
+- **HARD AC:** port the re-allocation guard (req. #2). **HARD AC:** sealed-quad invariance (req. #3).
+- **Tests:** "create mints a stable reservedUal"; "draft re-open does NOT re-allocate" (the guard); "sealed quad set byte-identical before/after D1" (merkle invariance).
+
+### D2 — atomic create+finalize  *(M)*  — `dependsOn: D1`
+- Add one create-and-seal orchestration method (create→write→finalize reusing the seal/merkle compute, `dkg-agent-publish.ts:1480-1510`) + one route. Add the `>10MB` body-cap constant to gate normal create-and-seal vs the existing chunked path (`knowledge-assets-import.ts:836,1373`, left unchanged).
+- **Tests:** "one-shot create-and-seal yields a sealed KA + UAL"; "oversized payload routes to the chunked path."
+
+### Land in Wave 2 once SUBSTRATE-3 is green
+- Independent mergeables **#1021 #1029 #1032 #1033 #1034 #1038**; **#1037** (now reading the index — **and add it to the D3b parser checklist**, req: it introduces NEW `/assertion/`-shape `assertionName`→WM routing); rebase **#1020**.
+
+## Wave 3 — rc.17b (uniform naming + query model + SWM per-KA; ONE flagged unit)
+
+### D3a — flip the 3 URI builders  *(L)*
+`constants.ts`: → `did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}`, `{_layer} ∈ _working_memory|_shared_memory|_verified_memory`.
+- `contextGraphAssertionUri` (WM, 235-238): `assertion/{addr}/{name}` → `_working_memory/{addr}/{number}`.
+- `contextGraphVerifiedMemoryUri` (VM, 227-229): `_verified_memory/{vmId}` → `_verified_memory/{addr}/{number}` + **gain `subGraphName` arg**.
+- `contextGraphSharedMemoryUri` (SWM, 217-220): bucket → `_shared_memory/{addr}/{number}`.
+- Thread `{addr,number}` through `graph-manager.ts` (38-56) facade + **~25 direct callers** (publisher/query/agent/import/memory).
+
+### D3b — replace ~15 hardcoded `/assertion/`-shape parsers  *(M)*
+`dkg-agent.ts:1936` regex; node-ui `sub-graph-uri.ts:40-46`, `useMemoryEntities.ts:243/291`; `sync-handler.ts:290/389` boundary filters; `openclaw.ts:1204/1226`; `shared-assertion-helpers.ts:286-291`; `dkg-agent-cg-registry.ts:903`; node-ui e2e helpers; **+ #1037's `assertionName`→WM resolver (16th site)**. Switch each to an `_meta`-index read or a layer-token-agnostic parse.
+
+### D3c — SWM per-KA conversion (the single sync-breaking seam)  *(L)*  — `dependsOn: D3a, SUBSTRATE-3`
+Re-point the SWM responder enumeration (`sync-handler.ts:131-194` + `registeredSubGraphSwmFilter` 141-161) and the boot re-arm `reconstructSharedMemoryOwnership` (`dkg-publisher.ts:3424-3450`) from bucket-URI-suffix shape (`/_shared_memory`) to the `_meta` index (`memoryLayer=SWM` + `assertionGraph`), extending the lifecycle-driven path at `sync-handler.ts:392`.
+
+### D4 — query model (land WITH D3a/D3b)  *(L)*  — `dependsOn: SUBSTRATE-3, D3a`
+CG content reads use `VALUES ?g {…} GRAPH ?g {}` (the existing `wrapWithGraph` bound path) sourced from the SUBSTRATE-3 index — **never a prefix-FILTER**. Replace the textual N-way `wrapWithGraphUnion` fan-out (`:452`) with the variable-graph+`VALUES` pattern. Denormalize hot aggregates into `_meta`; wire the per-subgraph Canon escape (§16.10/§17.6) for the analytics/traversal-heavy subgraph. (See `docs/rfcs/OT-RFC-46` query-model section.)
+
+### D3d — off-chain data migration (consensus-safe)  *(L)*  — `dependsOn: D1, SUBSTRATE-3, D3a`
+WM `…/assertion/{addr}/{name}` → `…/_working_memory/{addr}/{number}` (needs `name→number` from D1); VM `…/_verified_memory/{vmId}` → `…/_verified_memory/{addr}/{number}` (**`vmId` is a separate on-chain counter — non-trivial remap + `assertionGraph` backfill; highest-stakes row**); SWM bucket-split into N per-KA graphs keyed by owning KA. **Dual-read window** during cutover (req. #1).
+
+## Wave 4 — rc.18 (unchanged)
+Option-1 contracts **#975 #1019** (DRAFT, chain-gated); the per-subgraph Canon bucket for the traversal-heavy subgraph (§17.6) if needed.
+
+---
+
+## Devnet / test changes (the "update devnet tests in detail" ask)
+
+Per the regression item (~63–120 test files reference old URI shapes / allocator-at-finalize):
+
+| Area | Change |
+|---|---|
+| **Unit — URI shape** | every `toEqual([contextGraphSharedMemoryUri(CG)])`-style assertion (e.g. `get-views.test.ts:39-44`) → the new `{_layer}/{addr}/{number}` shape; `swm-subset-cleanup.test.ts`, `workspace.test.ts`, `shared-memory-publish-boundary.test.ts`. |
+| **Unit — allocator** | move the "allocate at finalize" expectation to "allocate at create"; add the **re-allocation guard** test (draft re-open ≠ double-allocate). |
+| **Unit — substrate** | new: `dkg:entity` on the URN (S-1); `assertionGraph` re-stamp WM→SWM→VM (S-2); `_meta`-index discovery returns exact list with **0 `listGraphs` calls** (S-3, spy); ACL leak test. |
+| **Unit — query model** | bound `VALUES ?g {…}` content read; whole-CG aggregate over N graphs returns correct (and the prefix-FILTER path is gone). |
+| **Devnet (`./scripts/devnet.sh`) — multi-node** | (1) **SWM per-KA sync round-trip**: peer A shares a KA, peer B (late-joiner) receives exactly that KA's per-KA graph via the `_meta`-index responder (the fail-silent seam — assert the received set, not just "no error"). (2) **WM→SWM→VM lifecycle** over the new uniform graph names, asserting `assertionGraph` re-points each hop. (3) **overlap**: two peers assert differing facts about one entity-as-subject in SWM → both coexist (D6 + per-KA), attributed. (4) **migration idempotency**: run the dual-read backfill twice → identical end state; assert **merkle roots unchanged** pre/post migration (consensus invariance). (5) **#184**: `{view, subGraphName}` returns the subgraph's KAs (via #1037 + the index). |
+| **CI guard** | grep-fail on new `'/assertion/'` / `'/_shared_memory'` string literals (req. #4). |
+
+> These devnet tests must be written **alongside** their implementation wave (they assert behavior that
+> doesn't exist until the layout flips), and run under the real `pnpm`/`turbo`/`devnet.sh` harness — not
+> in this throwaway clone.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,5 @@
+import { MemoryLayer, memoryLayerSlug } from './memory-model.js';
+
 // ── V10 Protocol Stream IDs ─────────────────────────────────────────────
 
 export const PROTOCOL_PUBLISH = '/dkg/10.0.0/publish';
@@ -235,6 +237,30 @@ export function contextGraphVerifiedMemoryMetaUri(contextGraphId: string, verifi
 export function contextGraphAssertionUri(contextGraphId: string, agentAddress: string, name: string, subGraphName?: string): string {
   if (subGraphName) return `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/${agentAddress}/${name}`;
   return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
+}
+
+/**
+ * Uniform per-KA graph URI for ANY memory layer (OT-RFC-46 Chorus).
+ *
+ *   did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}
+ *
+ * The layer is just a parameter — WM, SWM, and VM share ONE structure, ONE
+ * builder, and (downstream) ONE read path. `kaNumber` is the per-author KA
+ * number (the identifying half of the UAL `did:dkg:{chain}/{addr}/{number}`),
+ * minted at create. A KA moves between layers by swapping only the `{_layer}`
+ * segment; the `{addr}/{number}` suffix is stable for its whole lifecycle.
+ */
+export function contextGraphLayerUri(
+  contextGraphId: string,
+  layer: MemoryLayer,
+  agentAddress: string,
+  kaNumber: string | number | bigint,
+  subGraphName?: string,
+): string {
+  const base = subGraphName
+    ? `did:dkg:context-graph:${contextGraphId}/${subGraphName}`
+    : `did:dkg:context-graph:${contextGraphId}`;
+  return `${base}/${memoryLayerSlug(layer)}/${agentAddress}/${kaNumber}`;
 }
 
 export function contextGraphRulesUri(contextGraphId: string): string {

--- a/packages/core/src/memory-model.ts
+++ b/packages/core/src/memory-model.ts
@@ -17,6 +17,22 @@ export enum MemoryLayer {
 }
 
 /**
+ * The named-graph slug for each memory layer (OT-RFC-46 uniform Chorus layout).
+ * Every layer's per-KA graph is `…/{slug}/{addr}/{number}` — the layer is just a
+ * parameter, so one builder / one read path serves WM, SWM, and VM alike.
+ */
+export function memoryLayerSlug(layer: MemoryLayer): string {
+  switch (layer) {
+    case MemoryLayer.WorkingMemory:
+      return '_working_memory';
+    case MemoryLayer.SharedWorkingMemory:
+      return '_shared_memory';
+    case MemoryLayer.VerifiedMemory:
+      return '_verified_memory';
+  }
+}
+
+/**
  * Trust levels for Verified Memory triples, ordered by ascending trust.
  * Used with `minTrust` on verified-memory queries to filter results.
  */

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -31,6 +31,7 @@ import {
   contextGraphVerifiedMemoryUri,
   contextGraphVerifiedMemoryMetaUri,
   contextGraphAssertionUri,
+  contextGraphLayerUri,
   contextGraphRulesUri,
   contextGraphSubGraphUri,
   // Deprecated aliases
@@ -47,6 +48,7 @@ import {
   contextGraphSessionsTopic,
   contextGraphSessionTopic,
 } from '../src/constants.js';
+import { MemoryLayer } from '../src/memory-model.js';
 
 describe('V10 protocol stream IDs', () => {
   // rc.9 plan: protocols on /dkg/10.0.1/* are migrated onto the
@@ -155,6 +157,30 @@ describe('V10 named graph URIs', () => {
 
   it('assertion URI', () => {
     expect(contextGraphAssertionUri(id, '0xAbc', 'my-assertion')).toBe('did:dkg:context-graph:42/assertion/0xAbc/my-assertion');
+  });
+
+  it('uniform per-KA layer URI: every layer differs ONLY by the {_layer} token', () => {
+    expect(contextGraphLayerUri(id, MemoryLayer.WorkingMemory, '0xAbc', 7))
+      .toBe('did:dkg:context-graph:42/_working_memory/0xAbc/7');
+    expect(contextGraphLayerUri(id, MemoryLayer.SharedWorkingMemory, '0xAbc', 7))
+      .toBe('did:dkg:context-graph:42/_shared_memory/0xAbc/7');
+    expect(contextGraphLayerUri(id, MemoryLayer.VerifiedMemory, '0xAbc', 7))
+      .toBe('did:dkg:context-graph:42/_verified_memory/0xAbc/7');
+  });
+
+  it('uniform per-KA layer URI: same {addr}/{number} suffix across the lifecycle', () => {
+    const wm = contextGraphLayerUri(id, MemoryLayer.WorkingMemory, '0xAbc', 7);
+    const swm = contextGraphLayerUri(id, MemoryLayer.SharedWorkingMemory, '0xAbc', 7);
+    const vm = contextGraphLayerUri(id, MemoryLayer.VerifiedMemory, '0xAbc', 7);
+    const suffix = (u: string) => u.split('/').slice(-2).join('/');
+    expect(suffix(wm)).toBe('0xAbc/7');
+    expect(suffix(swm)).toBe('0xAbc/7');
+    expect(suffix(vm)).toBe('0xAbc/7');
+  });
+
+  it('uniform per-KA layer URI: sub-graph scoping is uniform across layers', () => {
+    expect(contextGraphLayerUri(id, MemoryLayer.VerifiedMemory, '0xAbc', 7, 'game-state'))
+      .toBe('did:dkg:context-graph:42/game-state/_verified_memory/0xAbc/7');
   });
 
   it('rules URI', () => {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4478,21 +4478,22 @@ export class DKGPublisher implements Publisher {
       gossipMessage = wrapped;
     }
 
-    // Rule 4: reject roots owned by a different peer before any mutations.
+    // OT-RFC-46 §17.4 / rc.17 D6 — workspaceOwner is now an ADVISORY hint, not a
+    // hard exclusivity gate: a foreign co-claim is no longer REJECTED (the Rule-4
+    // throw is removed). While SWM is still a shared bucket (pre rc.17b per-KA
+    // conversion) we SKIP foreign-owned roots so a co-claim cannot clobber the
+    // owner's quads in the shared graph; once SWM is per-KA (each peer owns its own
+    // graph) this skip is dropped entirely and overlap is fully allowed.
     const skippedRoots = new Set<string>();
     for (const root of rootEntities) {
       const owner = swmOwners.get(root);
       if (!owner) continue;
-      if (opts?.publisherPeerId) {
-        if (owner !== opts.publisherPeerId) {
-          throw new Error(
-            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
-          );
-        }
-      } else {
-        this.log.warn(createOperationContext('share'), `Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
-        skippedRoots.add(root);
-      }
+      if (opts?.publisherPeerId && owner === opts.publisherPeerId) continue; // self-owned — proceed
+      this.log.warn(
+        createOperationContext('share'),
+        `Skipping entity <${root}>: owned by peer ${owner} in SWM (advisory ownership; co-claim not rejected). caller=${opts?.publisherPeerId ?? '(none)'}`,
+      );
+      skippedRoots.add(root);
     }
 
     // Filter out skipped roots so subsequent mutations don't touch foreign-owned data.

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1309,6 +1309,10 @@ export interface AssertionCreatedMeta {
   assertionName: string;
   subGraphName?: string;
   timestamp: Date;
+  /** D1 (identity-at-create) — per-author KA number minted at create. */
+  kaNumber?: string | number | bigint;
+  /** D1 (identity-at-create) — reserved UAL `did:dkg:{chain}/{addr}/{number}`. */
+  reservedUal?: string;
 }
 
 export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Quad[] {
@@ -1338,6 +1342,18 @@ export function generateAssertionCreatedMetadata(meta: AssertionCreatedMeta): Qu
     mq(eventUri, `${DKG}fromLayer`, lit('none'), metaGraph),
     mq(eventUri, `${DKG}toLayer`, lit(MemoryLayer.WorkingMemory), metaGraph),
   ];
+
+  // D1 (identity-at-create): stamp the KA number + reserved UAL on the lifecycle URN
+  // so the UAL is the KA's identity from the first write — the per-KA graph name
+  // {addr}/{number} and the _meta row key both derive from it. Finalize's
+  // hasExistingKaId guard then finds this stamp and skips re-allocation. Consensus-
+  // neutral: the seal commits content+author, never the kaId.
+  if (meta.kaNumber !== undefined) {
+    quads.push(mq(subject, KA_ID_PRED, intLit(BigInt(meta.kaNumber)), metaGraph));
+  }
+  if (meta.reservedUal) {
+    quads.push(mq(subject, RESERVED_UAL_PRED, lit(meta.reservedUal), metaGraph));
+  }
 
   if (meta.subGraphName) {
     quads.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -5,6 +5,7 @@ import {
   isSafeIri,
   assertionLifecycleUri,
   contextGraphAssertionUri,
+  contextGraphSharedMemoryUri,
   contextGraphDataUri,
   contextGraphMetaUri,
   MemoryLayer,
@@ -1367,15 +1368,24 @@ export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): 
   const subject = assertionLifecycleUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
   const agentUri = agentDid(meta.agentAddress);
   const eventUri = `${subject}/event/${nextEventId()}`;
+  // SUBSTRATE-2: the layer-aware assertionGraph re-stamp. At create the pointer names
+  // the WM graph (metadata.ts generateAssertionCreatedMetadata); on promote it must
+  // re-point to the SWM-layer graph so the _meta index locates SWM data correctly.
+  // rc.17a: the shared bucket (contextGraphSharedMemoryUri); rc.17b flips this target
+  // to the per-KA SWM graph. Without this re-stamp the index follows a stale WM pointer.
+  const wmGraphUri = contextGraphAssertionUri(meta.contextGraphId, meta.agentAddress, meta.assertionName, meta.subGraphName);
+  const swmGraphUri = contextGraphSharedMemoryUri(meta.contextGraphId, meta.subGraphName);
 
   const del = [
     assertionStateQuad(subject, 'created', metaGraph),
     assertionLayerQuad(subject, MemoryLayer.WorkingMemory, metaGraph),
+    mq(subject, `${DKG}assertionGraph`, wmGraphUri, metaGraph),
   ];
   const ins: Quad[] = [
     // Update assertion entity (mutable fields)
     mq(subject, `${DKG}state`, lit('promoted'), metaGraph),
     mq(subject, `${DKG}memoryLayer`, lit(MemoryLayer.SharedWorkingMemory), metaGraph),
+    mq(subject, `${DKG}assertionGraph`, swmGraphUri, metaGraph),
     // Event entity (prov:Activity + DKG layer transition)
     mq(eventUri, `${RDF}type`, `${PROV}Activity`, metaGraph),
     mq(eventUri, `${RDF}type`, `${DKG}AssertionPromoted`, metaGraph),

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1404,7 +1404,14 @@ export function generateAssertionPromotedMetadata(meta: AssertionPromotedMeta): 
     ins.push(assertionLayerPointerQuad(subject, SWM_CURRENT_ASSERTION_PRED, meta.merkleHex, metaGraph));
   }
   for (const entity of meta.rootEntities) {
+    // membership on the event node (provenance of this promote)
     ins.push(...entityMemberQuads(eventUri, entity, metaGraph));
+    // SUBSTRATE-1: membership on the STABLE lifecycle URN, so the _meta index can
+    // resolve "which KAs contain member-entity X" by binding dkg:entity on the URN
+    // instead of walking per-event nodes. (Member entities are first known once the
+    // KA is sealed; promote is the first lifecycle event that carries them. The
+    // create-and-seal path (D2) should stamp the same rows on the URN.)
+    ins.push(...entityMemberQuads(subject, entity, metaGraph));
   }
   if (meta.subGraphName) {
     ins.push(mq(subject, `${DKG}subGraphName`, lit(meta.subGraphName), metaGraph));

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -249,7 +249,7 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(result.promotedCount).toBe(0);
   });
 
-  it('durable SWM ownership blocks cross-author promote after publisher restart with empty map', async () => {
+  it('durable SWM ownership skips (advisory) cross-author promote after publisher restart with empty map', async () => {
     const root = 'urn:test:entity:restart-owned';
     const firstAssertion = 'restart-owner-a';
     const secondAssertion = 'restart-owner-b';
@@ -285,11 +285,18 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: root, predicate: 'http://schema.org/name', object: '"Overwritten"' },
     ]);
 
-    await expect(
-      restartedPublisher.assertionPromote(CG_ID, secondAssertion, AGENT_B, { publisherPeerId: PEER_B }),
-    ).rejects.toThrow(
-      `Cannot promote entity <${root}>: owned by peer ${PEER}, not by caller ${PEER_B}.`,
+    // OT-RFC-46 §17.4 / rc.17 D6: a cross-author promote is no longer REJECTED — the
+    // foreign-owned root is skipped (workspaceOwner is now advisory, not a hard gate).
+    // Under the still-bucket SWM the skip preserves the owner's data (no clobber); the
+    // assertions below confirm SWM content and ownership are unchanged. Once SWM is
+    // per-KA (rc.17b) the co-claim coexists in its own graph instead of being skipped.
+    const promoteResult = await restartedPublisher.assertionPromote(
+      CG_ID,
+      secondAssertion,
+      AGENT_B,
+      { publisherPeerId: PEER_B },
     );
+    expect(promoteResult.promotedCount).toBe(0);
 
     const remaining = await restartedPublisher.assertionQuery(CG_ID, secondAssertion, AGENT_B);
     expect(remaining).toHaveLength(1);

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -683,6 +683,21 @@ describe('generateAssertionCreatedMetadata', () => {
     expect(graphQuad!.object).toBe(ASSERTION_GRAPH);
   });
 
+  it('D1: stamps kaId + reservedUal on the URN when the number is minted at create', () => {
+    const ual = `did:dkg:31337/${AGENT_ADDR}/7`;
+    const quads = generateAssertionCreatedMetadata({ ...meta, kaNumber: 7, reservedUal: ual });
+    const kaId = quads.find(q => q.subject === LIFECYCLE_URI && q.predicate === `${DKG}kaId`);
+    expect(kaId!.object).toBe('"7"^^<http://www.w3.org/2001/XMLSchema#integer>');
+    const ru = quads.find(q => q.subject === LIFECYCLE_URI && q.predicate === `${DKG}reservedUal`);
+    expect(ru!.object).toBe(`"${ual}"`);
+  });
+
+  it('D1: omits kaId/reservedUal when not minted (no-op for callers that have not adopted create-time allocation)', () => {
+    const quads = generateAssertionCreatedMetadata(meta);
+    expect(quads.find(q => q.predicate === `${DKG}kaId`)).toBeUndefined();
+    expect(quads.find(q => q.predicate === `${DKG}reservedUal`)).toBeUndefined();
+  });
+
   it('event entity is dual-typed prov:Activity + dkg:AssertionCreated', () => {
     const quads = generateAssertionCreatedMetadata(meta);
     const eventUri = findEventUri(quads);

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -34,7 +34,7 @@ import {
   type AssertionPublishedMeta,
   type AssertionDiscardedMeta,
 } from '../src/metadata.js';
-import { assertionLifecycleUri, contextGraphAssertionUri, MemoryLayer } from '@origintrail-official/dkg-core';
+import { assertionLifecycleUri, contextGraphAssertionUri, contextGraphSharedMemoryUri, MemoryLayer } from '@origintrail-official/dkg-core';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const DKG = 'http://dkg.io/ontology/';
@@ -750,6 +750,28 @@ describe('generateAssertionPromotedMetadata', () => {
     expect(del.find(q => q.predicate === `${DKG}state`)!.object).toBe('"created"');
     expect(insert.find(q => q.subject === LIFECYCLE_URI && q.predicate === `${DKG}memoryLayer`)!.object).toBe(`"${MemoryLayer.SharedWorkingMemory}"`);
     expect(del.find(q => q.predicate === `${DKG}memoryLayer`)!.object).toBe(`"${MemoryLayer.WorkingMemory}"`);
+  });
+
+  it('SUBSTRATE-2: re-stamps dkg:assertionGraph from the WM graph to the SWM graph on promote', () => {
+    const { insert, delete: del } = generateAssertionPromotedMetadata(meta);
+    const wmGraph = contextGraphAssertionUri(CONTEXT_GRAPH, AGENT_ADDR, ASSERTION);
+    const swmGraph = contextGraphSharedMemoryUri(CONTEXT_GRAPH);
+    // the stale WM-layer pointer is deleted
+    expect(del).toContainEqual(expect.objectContaining({
+      subject: LIFECYCLE_URI, predicate: `${DKG}assertionGraph`, object: wmGraph, graph: META_GRAPH,
+    }));
+    // the layer-correct SWM pointer is inserted
+    expect(insert).toContainEqual(expect.objectContaining({
+      subject: LIFECYCLE_URI, predicate: `${DKG}assertionGraph`, object: swmGraph, graph: META_GRAPH,
+    }));
+    // exactly one assertionGraph value is written (no duplicate/stale pointer)
+    expect(insert.filter(q => q.predicate === `${DKG}assertionGraph`)).toHaveLength(1);
+  });
+
+  it('SUBSTRATE-2: re-stamps to the sub-graph-scoped SWM graph when scoped', () => {
+    const swmScoped = contextGraphSharedMemoryUri(CONTEXT_GRAPH, 'players');
+    const { insert } = generateAssertionPromotedMetadata({ ...meta, subGraphName: 'players' });
+    expect(insert.find(q => q.predicate === `${DKG}assertionGraph`)!.object).toBe(swmScoped);
   });
 
   it('event is prov:Activity + dkg:AssertionPromoted with prov:used', () => {

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -774,6 +774,20 @@ describe('generateAssertionPromotedMetadata', () => {
     expect(insert.find(q => q.predicate === `${DKG}assertionGraph`)!.object).toBe(swmScoped);
   });
 
+  it('SUBSTRATE-1: stamps member-entity membership (dkg:entity + legacy dkg:rootEntity) on the lifecycle URN', () => {
+    const { insert } = generateAssertionPromotedMetadata(meta);
+    for (const entity of meta.rootEntities) {
+      // the new membership predicate on the stable URN (what the _meta index binds)
+      expect(insert).toContainEqual(expect.objectContaining({
+        subject: LIFECYCLE_URI, predicate: `${DKG}entity`, object: entity, graph: META_GRAPH,
+      }));
+      // dual-write: the legacy predicate is also on the URN (OT-RFC-43 §10.1)
+      expect(insert).toContainEqual(expect.objectContaining({
+        subject: LIFECYCLE_URI, predicate: `${DKG}rootEntity`, object: entity, graph: META_GRAPH,
+      }));
+    }
+  });
+
   it('event is prov:Activity + dkg:AssertionPromoted with prov:used', () => {
     const { insert } = generateAssertionPromotedMetadata(meta);
     const eventUri = findEventUriFromInsert(insert);


### PR DESCRIPTION
## rc.17 Chorus foundation — uniform per-KA layer primitives

The reviewable foundation for **OT-RFC-46 Chorus** (one named graph per KA; the layer is just a parameter; WM/SWM/VM share one structure, one builder, one read path). Pure additive primitives — **no behavior change to existing flows yet** — so this is safe to land and review independently of the wiring that follows.

### What's here (5 commits, each verified)

| Commit | Item | Change |
|---|---|---|
| `0b9e4a62` | **D6** | `workspaceOwner` first-writer-wins **throw → advisory warn+skip** (OT-RFC-46 §17.4). Co-claims are no longer rejected; under the still-bucket SWM the foreign root is skipped (no clobber); the skip is dropped once SWM is per-KA. + impl/test plan doc. |
| `7055c348` | **SUBSTRATE-2** (promote) | `generateAssertionPromotedMetadata` re-stamps `dkg:assertionGraph` WM→SWM — the seam today's promote omitted, so the `_meta` index locates promoted data at the right graph. |
| `db3eff82` | **SUBSTRATE-1** | member-entity membership (`dkg:entity` + legacy `dkg:rootEntity`) on the **stable lifecycle URN** at promote, so the index resolves "which KAs contain entity X" without walking event nodes. |
| `7a010b49` | **D3 builder** | `contextGraphLayerUri(cg, layer, addr, number, sub?)` + `memoryLayerSlug` → `did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}`. **The cornerstone: layer is a parameter** — one builder for WM/SWM/VM; a KA moves layers by swapping only the `{_layer}` segment. |
| `20c9ba80` | **D1 (core)** | `generateAssertionCreatedMetadata` stamps `dkg:kaId` + `dkg:reservedUal` on the URN at **create** (optional, gated). Makes the UAL the KA's identity from the first write. No-op until the agent create wrapper mints the number (next PR). |

### Consensus
Untouched throughout. The merkle leaf is `(s,p,o)` only and the seal commits content+author, never the name or graph IRI (`merkle.ts:9,57`, `assertion-seal.ts:10-15`) — so re-homing graphs, stamping identity, and dropping the ownership throw are all consensus-neutral and chain-independent.

### Verification
- `dkg-core`: tsc clean · **1038 tests pass** (incl. 3 new for the unified builder).
- `dkg-publisher`: tsc clean · **1153 tests pass** (incl. SUBSTRATE-1/2 + D1 stamping; the one D6 test flipped from "throws" to "skips & preserves owner data").

### What follows (the wiring — separate PRs)
1. **D1 wiring** — allocate in the agent create wrapper + the re-open guard (create does the once-per-author chain reconcile finalize does today).
2. **Caller flip** — swap the 3 old URI builders for `contextGraphLayerUri` across ~25 sites; convert SWM + the published layer to per-KA.
3. **Read-path unification** — one layer-parameterized, `_meta`-index reader; retire the `listGraphs` scans.
4. **D2** (atomic create+finalize), then the comprehensive devnet pass.

Design context: uniform per-KA across all three layers, no backwards-compat (testnet) so no migration/dual-read. See `docs/rc17-chorus-implementation.md` (in this PR) and OT-RFC-46.

> Base is `feat/unify-knowledge-assets-routes` for a clean foundation-only diff; re-target to `main`/integration per the rc.17 merge order once #1041 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
