### PR TITLE
rc.17 D1 — mint the KA number/UAL at create (identity-at-create)

### DIFF
--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -43,6 +43,48 @@ export interface KaAllocation {
   number: bigint;
 }
 
+/** Minimal chain surface the allocate helper needs (avoids a ChainAdapter import). */
+export interface KaAllocatorChain {
+  readonly chainId: string;
+  getMaxKaNumberForAuthor?: (author: string) => Promise<bigint>;
+}
+
+/**
+ * Reconcile the per-author KA-number floor against the chain (ONCE per author,
+ * cached in `reconciled`) then allocate the next number and derive its reserved
+ * UAL `did:dkg:{chainId}/{author}/{number}`.
+ *
+ * Shared by create (OT-RFC-46 D1 — identity-at-create) and finalize. Moving the
+ * call to create means the first KA per author pays the chain reconcile at create
+ * instead of finalize; every later create is a local counter bump.
+ */
+export async function reconcileAndAllocateKaNumber(
+  allocator: KaNumberAllocator,
+  chain: KaAllocatorChain,
+  reconciled: Set<string>,
+  author: string,
+): Promise<{ number: bigint; reservedUal: string }> {
+  const key = author.toLowerCase();
+  if (!reconciled.has(key)) {
+    let chainMax = -1n;
+    if (typeof chain.getMaxKaNumberForAuthor === 'function') {
+      try {
+        chainMax = await chain.getMaxKaNumberForAuthor(author);
+      } catch (err) {
+        throw new Error(
+          `OT-RFC-43 A2: failed to reconcile KA-number floor for author ${author}: ` +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      }
+    }
+    if (chainMax >= 0n) allocator.reconcile(author, chainMax);
+    allocator.markReconciled();
+    reconciled.add(key);
+  }
+  const { number } = allocator.allocate(author);
+  return { number, reservedUal: `did:dkg:${chain.chainId}/${key}/${number}` };
+}
+
 export class KaNumberAllocator {
   private readonly store: KaNumberStore;
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -371,6 +371,7 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import { reconcileAndAllocateKaNumber } from './allocator.js';
 import { applyMixins } from './dkg-agent-apply-mixins.js';
 import { OwnershipMethods } from './dkg-agent-ownership.js';
 import { ContextGraphResolveMethods } from './dkg-agent-cg-resolve.js';
@@ -1666,7 +1667,14 @@ export class DKGAgent extends DKGAgentBase {
     const agentAddress = this.defaultAgentAddress ?? this.peerId;
     return {
       async create(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<string> {
-        return agent.publisher.assertionCreate(contextGraphId, name, agentAddress, opts?.subGraphName);
+        // D1 (identity-at-create): mint the KA number/UAL at create so the UAL is the
+        // KA's identity from the first write. assertionCreate only allocates when the
+        // draft has no preserved kaId (the re-open guard lives there), so passing the
+        // callback unconditionally is safe — re-opens reuse the preserved identity.
+        const allocateKaNumber = agent.kaNumberAllocator
+          ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, agentAddress)
+          : undefined;
+        return agent.publisher.assertionCreate(contextGraphId, name, agentAddress, opts?.subGraphName, { allocateKaNumber });
       },
 
       /**

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4065,7 +4065,13 @@ export class DKGPublisher implements Publisher {
     this.privateStore.clearCache(ownershipKey);
   }
 
-  async assertionCreate(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<string> {
+  async assertionCreate(
+    contextGraphId: string,
+    name: string,
+    agentAddress: string,
+    subGraphName?: string,
+    opts?: { allocateKaNumber?: () => Promise<{ number: bigint; reservedUal: string }> },
+  ): Promise<string> {
     await this.ensureSubGraphRegistered(contextGraphId, subGraphName);
     const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     await this.store.createGraph(graphUri);
@@ -4120,12 +4126,25 @@ export class DKGPublisher implements Publisher {
       await this.store.insert(preserved);
     }
 
+    // D1 (identity-at-create): mint the KA number now, UNLESS the draft already
+    // carries a persistent identity. The A2 preserve step above re-inserts a prior
+    // kaId on discard+recreate / pull-from, so reuse it and never double-allocate
+    // (this is the re-open guard the create-time allocation needs).
+    const hasPreservedKaId = preserved.some((q) => q.predicate === `${A2_DKG}kaId`);
+    let kaNumber: bigint | undefined;
+    let reservedUal: string | undefined;
+    if (!hasPreservedKaId && opts?.allocateKaNumber) {
+      ({ number: kaNumber, reservedUal } = await opts.allocateKaNumber());
+    }
+
     const lifecycleQuads = generateAssertionCreatedMetadata({
       contextGraphId,
       agentAddress,
       assertionName: name,
       subGraphName,
       timestamp: new Date(),
+      kaNumber,
+      reservedUal,
     });
     await this.store.insert(lifecycleQuads);
 

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -71,6 +71,49 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(uri).toBe(contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME));
   });
 
+  it('D1: create stamps kaId + reservedUal on the URN when given an allocate callback', async () => {
+    const name = 'd1-mint';
+    const ual = `did:dkg:31337/${AGENT.toLowerCase()}/42`;
+    await publisher.assertionCreate(CG_ID, name, AGENT, undefined, {
+      allocateKaNumber: async () => ({ number: 42n, reservedUal: ual }),
+    });
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const urn = assertionLifecycleUri(CG_ID, AGENT, name);
+    const kaId = await store.query(`SELECT ?n WHERE { GRAPH <${metaGraph}> { <${urn}> <http://dkg.io/ontology/kaId> ?n } }`);
+    expect(kaId.type).toBe('bindings');
+    if (kaId.type === 'bindings') {
+      expect(kaId.bindings.map((r) => r['n'])).toEqual(['"42"^^<http://www.w3.org/2001/XMLSchema#integer>']);
+    }
+    const ru = await store.query(`SELECT ?u WHERE { GRAPH <${metaGraph}> { <${urn}> <http://dkg.io/ontology/reservedUal> ?u } }`);
+    if (ru.type === 'bindings') {
+      expect(ru.bindings.map((r) => r['u'])).toEqual([`"${ual}"`]);
+    }
+  });
+
+  it('D1: re-create does NOT re-allocate — the preserved kaId is reused (re-open guard)', async () => {
+    const name = 'd1-reopen';
+    const ual42 = `did:dkg:31337/${AGENT.toLowerCase()}/42`;
+    await publisher.assertionCreate(CG_ID, name, AGENT, undefined, {
+      allocateKaNumber: async () => ({ number: 42n, reservedUal: ual42 }),
+    });
+    // Re-create with a callback that WOULD allocate a different number — it must NOT be invoked,
+    // because the draft already carries a preserved kaId (the re-open guard lives in assertionCreate).
+    let called = false;
+    await publisher.assertionCreate(CG_ID, name, AGENT, undefined, {
+      allocateKaNumber: async () => {
+        called = true;
+        return { number: 99n, reservedUal: `did:dkg:31337/${AGENT.toLowerCase()}/99` };
+      },
+    });
+    expect(called).toBe(false);
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const urn = assertionLifecycleUri(CG_ID, AGENT, name);
+    const kaId = await store.query(`SELECT ?n WHERE { GRAPH <${metaGraph}> { <${urn}> <http://dkg.io/ontology/kaId> ?n } }`);
+    if (kaId.type === 'bindings') {
+      expect(kaId.bindings.map((r) => r['n'])).toEqual(['"42"^^<http://www.w3.org/2001/XMLSchema#integer>']);
+    }
+  });
+
   it('write inserts triples into the assertion graph', async () => {
     await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
     await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);


### PR DESCRIPTION
Stacked on #1045. Moves KA-number allocation from **finalize → create**, so the UAL is the KA's identity from the first write (the per-KA graph name `{addr}/{number}` and the `_meta` row key derive from it) — the prerequisite for the uniform-layer caller flip.

- **`allocator.ts`** — extract `reconcileAndAllocateKaNumber(allocator, chain, reconciled, author)`: the once-per-author chain-floor reconcile + allocate + `reservedUal` derivation. Shared by create and finalize.
- **`assertionCreate`** — accepts an `allocateKaNumber` callback, invoked **only when the draft has no preserved `kaId`**. The existing A2 preserve step (which re-inserts a prior `kaId` on discard+recreate / pull-from) **is** the re-open guard, so identity is minted once and reused — never double-allocated.
- **agent create wrapper** — passes the callback bound to the agent's allocator/chain. The first KA per author now pays the chain reconcile at create instead of finalize (cached thereafter); finalize's `hasExistingKaId` guard then skips re-allocation.

**Consensus-neutral** — `kaId` is not in the seal (`merkle.ts:9,57`).

**Verified:** publisher + agent `tsc` clean; publisher suite **1153** + standard agent suite (12 e2e files) green; +2 `draft-lifecycle` tests (create-allocate + re-open guard).

> Note: the first create per author now needs a chain read for the floor reconcile (then cached). Mild availability shift from finalize→create; acceptable since the node is online to publish anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)