### PR TITLE
rc.17 fix: peerId-author create regression + by-name WM read-flip

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1670,8 +1670,15 @@ export class DKGAgent extends DKGAgentBase {
         // D1 (identity-at-create): mint the KA number/UAL at create so the UAL is the
         // KA's identity from the first write. assertionCreate only allocates when the
         // draft has no preserved kaId (the re-open guard lives there), so passing the
-        // callback unconditionally is safe — re-opens reuse the preserved identity.
-        const allocateKaNumber = agent.kaNumberAllocator
+        // callback is safe — re-opens reuse the preserved identity.
+        //
+        // Gate on a valid 0x EVM author: when no default agent is registered,
+        // `agentAddress` falls back to the libp2p peerId, which the allocator rejects
+        // (`ethers.getAddress` throws). A peerId-author draft falls back to the legacy
+        // name-keyed WM graph instead of hard-failing create. Mirrors the publisher's
+        // own self-allocation guard.
+        const isEvmAuthor = /^0x[a-fA-F0-9]{40}$/.test(agentAddress);
+        const allocateKaNumber = agent.kaNumberAllocator && isEvmAuthor
           ? () => reconcileAndAllocateKaNumber(agent.kaNumberAllocator!, agent.chain, agent.reconciledKaAuthors, agentAddress)
           : undefined;
         return agent.publisher.assertionCreate(contextGraphId, name, agentAddress, opts?.subGraphName, { allocateKaNumber });

--- a/packages/agent/test/d1-peerid-author-create.test.ts
+++ b/packages/agent/test/d1-peerid-author-create.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression (rc.17 D1 wiring): `agent.assertion.create` must not hard-fail on a
+ * node that has no `defaultAgentAddress`.
+ *
+ * When no default agent is registered (e.g. a `NoChainAdapter` node with no
+ * operational key), `agentAddress` falls back to the libp2p `peerId` — which is
+ * NOT a valid `0x…` EVM address. The D1 create wrapper builds an `allocateKaNumber`
+ * callback whenever a `kaNumberAllocator` is wired, and the allocator validates the
+ * author via `ethers.getAddress`. Passing the callback unconditionally therefore made
+ * `allocator.allocate(peerId)` throw, regressing `create()` from working to
+ * hard-failing on every default-agent node.
+ *
+ * The fix: only pass `allocateKaNumber` for a valid `0x…` author. Non-EVM (peerId)
+ * authors fall back to the legacy name-keyed WM graph (no number minted).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
+
+describe('rc.17 D1: default-agent (peerId author) create regression', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+    agent = undefined;
+  });
+
+  it('agent.assertion.create succeeds on a node with no defaultAgentAddress even when a kaNumberAllocator is wired', async () => {
+    agent = await DKGAgent.create({
+      name: 'PeerIdAuthorNode',
+      listenPort: 0,
+      listenHost: '127.0.0.1',
+      store: new OxigraphStore(),
+      chainAdapter: new NoChainAdapter(),
+      nodeRole: 'core',
+      skills: [],
+      // Wiring the allocator is what (pre-fix) makes the create wrapper build the
+      // allocateKaNumber callback — the trigger for the regression.
+      kaNumberAllocator: makeTestKaNumberAllocator(),
+    });
+    await agent.start();
+
+    // No operational key + NoChainAdapter ⇒ no default agent ⇒ agentAddress = peerId (non-EVM).
+    expect(agent.getDefaultAgentAddress()).toBeUndefined();
+
+    const cgId = 'peerid-author-cg';
+    await agent.createContextGraph({ id: cgId, name: 'PeerId Author CG' });
+
+    // Pre-fix this rejects with "invalid author address: <peerId>".
+    const uri = await agent.assertion.create(cgId, 'draft-1');
+    expect(uri).toContain(cgId);
+
+    // Round-trip: a peerId-author draft still writes + reads back (legacy name-keyed WM graph).
+    await agent.assertion.write(cgId, 'draft-1', [
+      { subject: 'urn:peerid:x', predicate: 'http://schema.org/name', object: '"X"' },
+    ]);
+    const quads = await agent.assertion.query(cgId, 'draft-1');
+    expect(quads.map((q) => q.object)).toContain('"X"');
+  });
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -3,7 +3,7 @@ import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { QueryResult, QueryOptions, QueryEngine } from './query-engine.js';
 import {
   contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiedMemoryUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer,
-  contextGraphSubGraphUri, contextGraphMetaUri, contextGraphSharedMemoryMetaUri,
+  contextGraphSubGraphUri, contextGraphMetaUri, contextGraphSharedMemoryMetaUri, assertionLifecycleUri,
   contextGraphSubGraphMetaUri, contextGraphPrivateUri, contextGraphSubGraphPrivateUri,
   assertSafeIri, escapeSparqlLiteral, validateSubGraphName,
   type GetView,
@@ -374,10 +374,25 @@ export class DKGQueryEngine implements QueryEngine {
     contextGraphId: string,
     options: QueryOptions,
   ): Promise<QueryResult> {
+    // Uniform layout (rc.17): a by-name working-memory read must target the per-KA
+    // graph `…/_working_memory/{addr}/{number}` the data was written to. Resolve the
+    // KA number from the `dkg:kaId` stamped on the lifecycle URN in `_meta` and pass
+    // it to resolveViewGraphs; without it the read falls back to the (empty) legacy
+    // name-keyed graph and returns nothing for newly created assertions.
+    let kaNumber: bigint | undefined;
+    if (view === 'working-memory' && options.assertionName && options.agentAddress) {
+      kaNumber = await this.resolveWorkingMemoryKaNumber(
+        contextGraphId,
+        options.agentAddress,
+        options.assertionName,
+      );
+    }
+
     const resolution = resolveViewGraphs(view, contextGraphId, {
       agentAddress: options.agentAddress,
       verifiedGraph: options.verifiedGraph,
       assertionName: options.assertionName,
+      kaNumber,
       // Back-compat: accept the legacy `_minTrust` underscore form for a
       // deprecation window. See QueryOptions._minTrust.
       minTrust: options.minTrust ?? options._minTrust,
@@ -526,6 +541,29 @@ export class DKGQueryEngine implements QueryEngine {
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );
+  }
+
+  /**
+   * Resolve a WM assertion's allocated KA number (`dkg:kaId`) off its lifecycle URN
+   * in `_meta`, for single-graph by-name reads under the uniform layout. Returns
+   * `undefined` for an unallocated draft (legacy name-keyed graph fallback). Mirrors
+   * the publisher's `resolveKaNumber`.
+   */
+  private async resolveWorkingMemoryKaNumber(
+    contextGraphId: string,
+    agentAddress: string,
+    assertionName: string,
+  ): Promise<bigint | undefined> {
+    const urn = assertionLifecycleUri(contextGraphId, agentAddress, assertionName);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const res = await this.store.query(
+      `SELECT ?n WHERE { GRAPH <${metaGraph}> { <${urn}> <http://dkg.io/ontology/kaId> ?n } } LIMIT 1`,
+    );
+    if (res.type === 'bindings' && res.bindings.length > 0) {
+      const m = res.bindings[0]['n']?.match(/(\d+)/);
+      if (m) return BigInt(m[1]);
+    }
+    return undefined;
   }
 
   private async resolveScopedGraphVariableAllowList(

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -52,6 +52,8 @@ import {
   contextGraphLayerUri,
   MemoryLayer,
   contextGraphSharedMemoryUri,
+  contextGraphMetaUri,
+  assertionLifecycleUri,
   TrustLevel,
 } from '@origintrail-official/dkg-core';
 import { DKGQueryEngine, resolveViewGraphs } from '../src/dkg-query-engine.js';
@@ -657,6 +659,35 @@ describe('[Q-3] resolveViewGraphs + DKGQueryEngine route working-memory', () => 
     );
     expect(result.bindings).toHaveLength(1);
     expect(result.bindings[0]['name']).toBe('"One"');
+  });
+
+  it('by-name WM read resolves name→number from _meta and reads the per-KA graph (rc.17 read-flip)', async () => {
+    // Regression: under the uniform layout, a created+written assertion's data lives in the
+    // number-keyed graph `…/_working_memory/{addr}/{number}`, and its number is stamped as
+    // `dkg:kaId` on the lifecycle URN in `_meta`. A by-name `view: 'working-memory'` query must
+    // resolve that number and read the per-KA graph. Before the fix, the engine passed no
+    // kaNumber to resolveViewGraphs, so it fell back to the (empty) legacy name-keyed graph and
+    // returned 0 bindings.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const name = 'numbered-draft';
+    const kaNumber = 7n;
+    const perKaGraph = contextGraphLayerUri(CG, MemoryLayer.WorkingMemory, AGENT, kaNumber);
+    const urn = assertionLifecycleUri(CG, AGENT, name);
+    const metaGraph = contextGraphMetaUri(CG);
+
+    await store.insert([
+      // data written by the new create/write path → number-keyed per-KA graph
+      quad('urn:numbered:1', 'http://schema.org/name', '"NumberedValue"', perKaGraph),
+      // identity-at-create (D1): the KA number stamped on the lifecycle URN in _meta
+      quad(urn, 'http://dkg.io/ontology/kaId', '"7"^^<http://www.w3.org/2001/XMLSchema#integer>', metaGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CG, view: 'working-memory', agentAddress: AGENT, assertionName: name },
+    );
+    expect(result.bindings.map((b) => b['name'])).toEqual(['"NumberedValue"']);
   });
 });
 


### PR DESCRIPTION
Stacked on #1047 (`rc17-flip`). Fixes the two `🔴` bot-flagged bugs in the rc.17 WM per-KA flip, each via TDD (failing test written first, then the fix).

## Bug 1 — default-agent (peerId) create regression
`packages/agent/src/dkg-agent.ts`. The D1 create wrapper built the `allocateKaNumber` callback whenever a `kaNumberAllocator` was wired, but `agentAddress` falls back to the libp2p peerId when no default agent is registered. The allocator validates the author via `ethers.getAddress`, so `allocate(peerId)` **threw** — regressing `agent.assertion.create()` from working to hard-failing on any node without a `defaultAgentAddress`.

**Fix:** gate the callback on a valid `0x…` EVM author (mirrors the publisher's own self-allocation guard). peerId-author drafts fall back to the legacy name-keyed WM graph. No-op for EVM authors, so the existing hardhat e2e suites are unaffected by construction.

**Test:** `packages/agent/test/d1-peerid-author-create.test.ts` — a `NoChainAdapter` node (peerId author) with a wired allocator; `create → write → query` round-trip. Confirmed red (`KaNumberAllocator: invalid author address: 12D3Koo…`) before the fix, green after.

## Bug 2 — by-name working-memory read goes empty for new assertions
`packages/query/src/dkg-query-engine.ts`. Writes land in the per-KA `…/_working_memory/{addr}/{number}` graph, but a `view: 'working-memory'` by-name read resolved to the legacy name-keyed graph unless `kaNumber` was supplied — and nothing on the query caller path populated it (the PR's own TODO).

**Fix:** in `queryWithView`, resolve name→number from the `dkg:kaId` stamped on the lifecycle URN in `_meta` (mirrors the publisher's `resolveKaNumber`) and pass it to `resolveViewGraphs`. Unallocated drafts keep the legacy fallback (the single-graph, no-sibling-leak guarantee is preserved).

**Test:** `packages/query/test/query-extra.test.ts` (Q-3) — seeds a numbered per-KA graph + the `_meta` `dkg:kaId` row, asserts the by-name WM read returns the data. Confirmed red (`[]`) before the fix, green after.

## Verification
- Full query suite: **261 passed**.
- Agent: `e2e-assertion-lifecycle` **7/7**, `e2e-sub-graphs` + `wm-multi-agent-isolation-extra` green.
- `tsc` clean for `query` + `agent`.

## Test plan
- [x] New regression tests fail on the base (`rc17-flip`) and pass with the fixes.
- [x] No regression in the PR-touched agent suites.
- [ ] CI green under the real harness.

Made with [Cursor](https://cursor.com)