### PR TITLE
fix(node-ui): read SWM/VM attribution across all sub-graph partitions (B2)

### DIFF
--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -184,6 +184,15 @@ export function buildAttributionsQuery(cgId: string): string {
   // `did:dkg:context-graph:<cg>/[<sg>/]_shared_memory_meta`, so "<cgUri>/"
   // matches all of this CG's partitions while excluding sibling CGs whose id
   // merely shares the prefix (cg-1 must not capture cg-10 / cg-1-foo).
+  //
+  // Known limitation: CG ids may themselves contain "/" (validateContextGraphId
+  // allows it; convention is <addr>/<name>), so a hypothetical path-extending
+  // child CG `<cg>/<x>` would still prefix-match. That URI is structurally
+  // identical to a real sub-graph `<sg>=<x>`, so only the sub-graph registry
+  // can disambiguate — i.e. the deferred server-side sub-graph SWM routing
+  // (rc.17 A2/A4). The raw-prefix read is the deliberate client bridge and is
+  // preferred over a client-built registry allow-list, which would re-drop
+  // partitions whose `_meta` registration is missing — a condition seen live.
   const cgPrefix = `did:dkg:context-graph:${cgId}/`;
   return `PREFIX dkg: <http://dkg.io/ontology/>
 PREFIX prov: <http://www.w3.org/ns/prov#>

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -251,8 +251,14 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
             headers: { 'Content-Type': 'application/json', ...authHeaders() },
             signal: controller.signal,
             body: JSON.stringify({
+              // Do NOT send contextGraphId here. The query already scopes to the
+              // CG via its STRSTARTS(?g, "<cgUri>") filter and must read EVERY
+              // sub-graph's <cg>/<sg>/_shared_memory_meta partition. Passing
+              // contextGraphId makes the engine constrain GRAPH ?g to CG-direct
+              // graphs only, dropping per-sub-graph attribution so the legend
+              // under-counts agents (B2). See dkg-query-engine.ts graph-variable
+              // allow-list.
               sparql: buildAttributionsQuery(contextGraphId),
-              contextGraphId,
             }),
           });
           if (!res.ok) throw new Error(`SPARQL query failed: ${res.status}`);

--- a/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
+++ b/packages/node-ui/src/ui/hooks/useSwmAttributions.ts
@@ -180,7 +180,11 @@ function subGraphFromMetaGraphUri(gUri: string, cgId: string): string | undefine
 }
 
 export function buildAttributionsQuery(cgId: string): string {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
+  // Trailing slash makes this an EXACT CG prefix: every partition graph is
+  // `did:dkg:context-graph:<cg>/[<sg>/]_shared_memory_meta`, so "<cgUri>/"
+  // matches all of this CG's partitions while excluding sibling CGs whose id
+  // merely shares the prefix (cg-1 must not capture cg-10 / cg-1-foo).
+  const cgPrefix = `did:dkg:context-graph:${cgId}/`;
   return `PREFIX dkg: <http://dkg.io/ontology/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 SELECT ?op ?root ?agent ?publishedAt ?g WHERE {
@@ -191,7 +195,7 @@ SELECT ?op ?root ?agent ?publishedAt ?g WHERE {
         prov:wasAttributedTo ?agent .
   }
   FILTER(
-    STRSTARTS(STR(?g), "${cgUri}") &&
+    STRSTARTS(STR(?g), "${cgPrefix}") &&
     CONTAINS(STR(?g), "_shared_memory_meta")
   )
 } ORDER BY DESC(?publishedAt) LIMIT 5000`;
@@ -252,7 +256,7 @@ export function useSwmAttributions(contextGraphId: string | undefined): SwmAttri
             signal: controller.signal,
             body: JSON.stringify({
               // Do NOT send contextGraphId here. The query already scopes to the
-              // CG via its STRSTARTS(?g, "<cgUri>") filter and must read EVERY
+              // CG via its exact STRSTARTS(?g, "<cgUri>/") filter and must read EVERY
               // sub-graph's <cg>/<sg>/_shared_memory_meta partition. Passing
               // contextGraphId makes the engine constrain GRAPH ?g to CG-direct
               // graphs only, dropping per-sub-graph attribution so the legend

--- a/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
+++ b/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
@@ -234,8 +234,13 @@ export function useVerifiedMemoryAnchors(
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body: JSON.stringify({
+            // Do NOT send contextGraphId here. buildAnchorsQuery already scopes to
+            // the CG via STRSTARTS(?g, "<cgUri>") and enumerates EVERY sub-graph's
+            // <cg>/<sg>/_shared_memory_meta partition. Passing contextGraphId makes
+            // the engine constrain GRAPH ?g to CG-direct graphs only, dropping
+            // per-sub-graph anchors/attribution (same bug class as B2). See
+            // dkg-query-engine.ts graph-variable allow-list.
             sparql: buildAnchorsQuery(contextGraphId),
-            contextGraphId,
           }),
         });
         if (!res.ok) throw new Error(`SPARQL query failed: ${res.status}`);

--- a/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
+++ b/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
@@ -114,7 +114,11 @@ function buildAnchorsQuery(cgId: string): string {
   // Trailing slash makes this an EXACT CG prefix: every partition graph is
   // `did:dkg:context-graph:<cg>/[<sg>/]_shared_memory_meta`, so "<cgUri>/"
   // matches all of this CG's partitions while excluding sibling CGs whose id
-  // merely shares the prefix (cg-1 must not capture cg-10 / cg-1-foo).
+  // merely shares the prefix (cg-1 must not capture cg-10 / cg-1-foo). Same
+  // known limitation as useSwmAttributions.buildAttributionsQuery: a
+  // path-extending child CG `<cg>/<x>` (CG ids may contain "/") would still
+  // prefix-match; the authoritative fix is the deferred server-side sub-graph
+  // SWM routing (A2/A4).
   const cgPrefix = `did:dkg:context-graph:${cgId}/`;
   return `PREFIX dkg: <http://dkg.io/ontology/>
 PREFIX prov: <http://www.w3.org/ns/prov#>

--- a/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
+++ b/packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts
@@ -111,7 +111,11 @@ function agentLabel(agentId: string): string {
 /** Build the SPARQL that enumerates every publish-batch WorkspaceOperation
  *  across every sub-graph's `_shared_memory_meta`. */
 function buildAnchorsQuery(cgId: string): string {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
+  // Trailing slash makes this an EXACT CG prefix: every partition graph is
+  // `did:dkg:context-graph:<cg>/[<sg>/]_shared_memory_meta`, so "<cgUri>/"
+  // matches all of this CG's partitions while excluding sibling CGs whose id
+  // merely shares the prefix (cg-1 must not capture cg-10 / cg-1-foo).
+  const cgPrefix = `did:dkg:context-graph:${cgId}/`;
   return `PREFIX dkg: <http://dkg.io/ontology/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 SELECT ?op ?root ?agent ?publishedAt ?g WHERE {
@@ -122,7 +126,7 @@ SELECT ?op ?root ?agent ?publishedAt ?g WHERE {
         prov:wasAttributedTo ?agent .
   }
   FILTER(
-    STRSTARTS(STR(?g), "${cgUri}") &&
+    STRSTARTS(STR(?g), "${cgPrefix}") &&
     CONTAINS(STR(?g), "_shared_memory_meta")
   )
 } ORDER BY ?publishedAt LIMIT 2000`;
@@ -235,7 +239,7 @@ export function useVerifiedMemoryAnchors(
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body: JSON.stringify({
             // Do NOT send contextGraphId here. buildAnchorsQuery already scopes to
-            // the CG via STRSTARTS(?g, "<cgUri>") and enumerates EVERY sub-graph's
+            // the CG via its exact STRSTARTS(?g, "<cgUri>/") and enumerates EVERY sub-graph's
             // <cg>/<sg>/_shared_memory_meta partition. Passing contextGraphId makes
             // the engine constrain GRAPH ?g to CG-direct graphs only, dropping
             // per-sub-graph anchors/attribution (same bug class as B2). See

--- a/packages/node-ui/test/use-swm-attributions.test.ts
+++ b/packages/node-ui/test/use-swm-attributions.test.ts
@@ -25,6 +25,18 @@ describe('useSwmAttributions — SPARQL query shape', () => {
     // the new DESC and the old `ORDER BY ?publishedAt` both present.
     expect(q).not.toMatch(/ORDER BY \?publishedAt\s+LIMIT/);
   });
+
+  // Codex review (PR #1055) — with contextGraphId removed from the request
+  // (B2), scoping rests entirely on this STRSTARTS prefix, so it MUST end in
+  // "/" to be exact. A bare "did:dkg:context-graph:cg-1" prefix would also
+  // match a sibling CG like cg-10 / cg-1-foo and merge its _shared_memory_meta
+  // attribution rows into the legend.
+  it('scopes via an exact "<cgUri>/" STRSTARTS prefix so sibling CGs do not leak in', () => {
+    const q = buildAttributionsQuery('cg-1');
+    expect(q).toContain('STRSTARTS(STR(?g), "did:dkg:context-graph:cg-1/")');
+    // The slash-less prefix would over-match cg-10 / cg-1-foo.
+    expect(q).not.toMatch(/STRSTARTS\(STR\(\?g\), "did:dkg:context-graph:cg-1"\)/);
+  });
 });
 
 // Codex Code7 (PR #656) — the hook returns its previous-graph result

--- a/packages/node-ui/test/use-swm-attributions.test.ts
+++ b/packages/node-ui/test/use-swm-attributions.test.ts
@@ -63,9 +63,12 @@ describe('useSwmAttributions — stale-on-switch protection', () => {
       const body = init?.body ? JSON.parse(String(init.body)) : {};
       // B2: the POST body no longer carries contextGraphId (it scoped the
       // engine to CG-direct graphs and dropped per-sub-graph attribution).
-      // Recover the cgId from the SPARQL's STRSTARTS filter to route the
-      // deferred promise, matching how the daemon now scopes the query.
-      const cgId: string = String(body.sparql).match(/context-graph:([^"/]+)/)?.[1] ?? '';
+      // Recover the cgId from the SPARQL's exact STRSTARTS prefix
+      // ("did:dkg:context-graph:<cgId>/") to route the deferred promise.
+      // Capture up to the trailing `/"` (non-greedy) rather than `[^"/]+`, so
+      // canonical slash-containing ids like `<wallet>/project` route under the
+      // full key instead of being truncated at the first `/`.
+      const cgId: string = String(body.sparql).match(/context-graph:(.+?)\/"/)?.[1] ?? '';
       const p = new Promise<any[]>((resolve) => {
         pending.set(cgId, { resolve });
       });
@@ -105,40 +108,40 @@ describe('useSwmAttributions — stale-on-switch protection', () => {
       return null;
     }
 
-    // Initial render for cg-A.
+    // Initial render for acme/alpha.
     await act(async () => {
-      root.render(React.createElement(Probe, { id: 'cg-A' }));
+      root.render(React.createElement(Probe, { id: 'acme/alpha' }));
     });
     await flushMicrotasks();
     expect(latest!.resultContextGraphId).toBeUndefined();
     expect(latest!.events).toHaveLength(0);
 
-    // Resolve cg-A's fetch.
-    pending.get('cg-A')!.resolve(rowsFor('cg-A'));
+    // Resolve acme/alpha's fetch.
+    pending.get('acme/alpha')!.resolve(rowsFor('acme/alpha'));
     await flushMicrotasks();
-    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.resultContextGraphId).toBe('acme/alpha');
     expect(latest!.events).toHaveLength(1);
-    expect(latest!.events[0].rootUri).toBe('urn:e:cg-A');
+    expect(latest!.events[0].rootUri).toBe('urn:e:acme/alpha');
 
-    // Switch to cg-B. The hook still holds cg-A's events until the
+    // Switch to acme/beta. The hook still holds acme/alpha's events until the
     // new SPARQL lands — that's the pre-existing behaviour. The fix
     // is the discriminator: callers can detect the mismatch and
     // suppress downstream rendering until it clears.
     await act(async () => {
-      root.render(React.createElement(Probe, { id: 'cg-B' }));
+      root.render(React.createElement(Probe, { id: 'acme/beta' }));
     });
     await flushMicrotasks();
-    // Before cg-B's fetch resolves, the result still describes cg-A.
+    // Before acme/beta's fetch resolves, the result still describes acme/alpha.
     // A consumer that gates on `resultContextGraphId === currentId`
     // would now suppress these events (they're for the wrong graph).
-    expect(latest!.resultContextGraphId).toBe('cg-A');
+    expect(latest!.resultContextGraphId).toBe('acme/alpha');
 
-    // Resolve cg-B; the discriminator catches up.
-    pending.get('cg-B')!.resolve(rowsFor('cg-B'));
+    // Resolve acme/beta; the discriminator catches up.
+    pending.get('acme/beta')!.resolve(rowsFor('acme/beta'));
     await flushMicrotasks();
-    expect(latest!.resultContextGraphId).toBe('cg-B');
+    expect(latest!.resultContextGraphId).toBe('acme/beta');
     expect(latest!.events).toHaveLength(1);
-    expect(latest!.events[0].rootUri).toBe('urn:e:cg-B');
+    expect(latest!.events[0].rootUri).toBe('urn:e:acme/beta');
   });
 });
 

--- a/packages/node-ui/test/use-swm-attributions.test.ts
+++ b/packages/node-ui/test/use-swm-attributions.test.ts
@@ -49,7 +49,11 @@ describe('useSwmAttributions — stale-on-switch protection', () => {
     originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(async (_url: any, init?: any) => {
       const body = init?.body ? JSON.parse(String(init.body)) : {};
-      const cgId: string = body.contextGraphId;
+      // B2: the POST body no longer carries contextGraphId (it scoped the
+      // engine to CG-direct graphs and dropped per-sub-graph attribution).
+      // Recover the cgId from the SPARQL's STRSTARTS filter to route the
+      // deferred promise, matching how the daemon now scopes the query.
+      const cgId: string = String(body.sparql).match(/context-graph:([^"/]+)/)?.[1] ?? '';
       const p = new Promise<any[]>((resolve) => {
         pending.set(cgId, { resolve });
       });
@@ -123,5 +127,51 @@ describe('useSwmAttributions — stale-on-switch protection', () => {
     expect(latest!.resultContextGraphId).toBe('cg-B');
     expect(latest!.events).toHaveLength(1);
     expect(latest!.events[0].rootUri).toBe('urn:e:cg-B');
+  });
+});
+
+// B2 (DKG-NODE-ISSUES-FOR-RC17) — the attribution fetch MUST NOT send
+// contextGraphId. The SPARQL scopes itself to the CG via STRSTARTS(?g, …)
+// and must read every sub-graph's <cg>/<sg>/_shared_memory_meta partition;
+// sending contextGraphId makes the daemon constrain GRAPH ?g to CG-direct
+// graphs only, so the legend under-counted agents (showed 1 of 5 agents live).
+describe('useSwmAttributions — B2 POST body scoping', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: { bindings: [] } }),
+    } as any)) as any;
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it('omits contextGraphId from the /api/query POST body so all sub-graph partitions are reached', async () => {
+    function Probe({ id }: { id: string }) {
+      useSwmAttributions(id);
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-1' }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const body = JSON.parse(String((calls[0][1] as any)?.body ?? '{}'));
+    expect(body.sparql).toContain('_shared_memory_meta');
+    expect(body).not.toHaveProperty('contextGraphId');
   });
 });

--- a/packages/node-ui/test/use-verified-memory-anchors.test.ts
+++ b/packages/node-ui/test/use-verified-memory-anchors.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { useVerifiedMemoryAnchors } from '../src/ui/hooks/useVerifiedMemoryAnchors.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Same bug class as B2 (DKG-NODE-ISSUES-FOR-RC17): buildAnchorsQuery already
+// scopes to the CG via STRSTARTS(?g, …) and enumerates EVERY sub-graph's
+// <cg>/<sg>/_shared_memory_meta partition, so the fetch MUST NOT also send
+// contextGraphId — that makes the daemon constrain GRAPH ?g to CG-direct
+// graphs only, dropping per-sub-graph anchors/attribution.
+describe('useVerifiedMemoryAnchors — POST body scoping', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: { bindings: [] } }),
+    } as any)) as any;
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it('omits contextGraphId from the /api/query POST body so all sub-graph partitions are reached', async () => {
+    function Probe({ id }: { id: string }) {
+      useVerifiedMemoryAnchors(id);
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Probe, { id: 'cg-1' }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const body = JSON.parse(String((calls[0][1] as any)?.body ?? '{}'));
+    expect(body.sparql).toContain('_shared_memory_meta');
+    expect(body).not.toHaveProperty('contextGraphId');
+  });
+});

--- a/packages/node-ui/test/use-verified-memory-anchors.test.ts
+++ b/packages/node-ui/test/use-verified-memory-anchors.test.ts
@@ -50,5 +50,8 @@ describe('useVerifiedMemoryAnchors — POST body scoping', () => {
     const body = JSON.parse(String((calls[0][1] as any)?.body ?? '{}'));
     expect(body.sparql).toContain('_shared_memory_meta');
     expect(body).not.toHaveProperty('contextGraphId');
+    // Codex review (PR #1055) — exact "<cgUri>/" prefix so a sibling CG
+    // (cg-10 / cg-1-foo) can't leak its anchors in once contextGraphId is gone.
+    expect(body.sparql).toContain('STRSTARTS(STR(?g), "did:dkg:context-graph:cg-1/")');
   });
 });


### PR DESCRIPTION
## Summary

- **Fixes B2** (`DKG-NODE-ISSUES-FOR-RC17`): the node-UI **SWM Attribution** legend under-counted contributing agents in one-agent-per-sub-graph deployments — it showed **1 agent** when **5** had attributed (live on-disk: Curator 1, Literature 11, Trials 4, Mechanism 4, Synthesis 1).
- **Root cause:** `useSwmAttributions` already scopes its query to the context graph (CG) *inside the SPARQL* via `FILTER(STRSTARTS(STR(?g), "did:dkg:context-graph:<cg>") && CONTAINS(STR(?g), "_shared_memory_meta"))`, so it intends to read **every** sub-graph's `…/<sg>/_shared_memory_meta` partition. But it *also* sent `contextGraphId` in the `/api/query` body. With `contextGraphId` set and no `view`, the query engine constrains the `GRAPH ?g` variable to a CG-direct allow-list (`dkg-query-engine.ts` graph-variable allow-list) that **excludes** per-sub-graph `_shared_memory_meta` partitions, so the `STRSTARTS` filter can never bind them. Only the CG-direct partition's agents were counted.
- **Fix:** omit `contextGraphId` from the POST body. The SPARQL's own `STRSTARTS` filter already scopes to the CG and reaches all partitions — the same raw-query pattern the integration's `swm-scan` runbook uses. Note: `includeContextGraphPartitions:true` would *not* fix this (per A4 the partition-discovery allow-list skips `_shared_memory_meta` entirely); omitting `contextGraphId` is the proven path.
- **Also fixes the identical bug in `useVerifiedMemoryAnchors`** (VM on-chain anchor decorations) — same `STRSTARTS + _shared_memory_meta` query whose own docstring says it enumerates "every sub-graph's `_shared_memory_meta`", silently scoped to the CG-direct partition by the same `contextGraphId`. Directly relevant to this VM-focused base branch.
- **Safe by construction (B2a):** the per-entity detail view ("Proposed by" / provenance trail) reads the entity's *own* `prov:wasAttributedTo` (data-graph scoped, a separate path) and is unchanged. `useAssertionLifecycleEvents` is intentionally left alone — it targets a hardcoded CG-level `GRAPH <…/_meta>` (no sub-graph partitions), where `contextGraphId` is legitimately required.

## Related

- Fixes **B2** in `DKG-NODE-ISSUES-FOR-RC17.md` (medical-research showcase feedback).
- Regression origin: `4935dafc1` (*"feat(node-ui): dkg-v9 subgraphs PoC"*) added `contextGraphId` to the attribution fetch — harmless before sub-graphs existed (all SWM attribution lived in CG-direct graphs), but it began dropping per-sub-graph partitions once data moved into them.
- Related deferred query-engine items (not addressed here): **A1/A2/A4** — declarative `view` / `includeContextGraphPartitions` routing for sub-graph SWM. This PR is the client-side one-line workaround that makes the UI correct today.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useSwmAttributions.ts` | Drop `contextGraphId` from the `/api/query` body so the attribution query reaches every sub-graph `_shared_memory_meta`; comment explaining why it must not be re-added. |
| `packages/node-ui/src/ui/hooks/useVerifiedMemoryAnchors.ts` | Same fix for the VM anchor query (same bug class). |
| `packages/node-ui/test/use-swm-attributions.test.ts` | New regression test asserting the POST body omits `contextGraphId`; update the stale-on-switch mock to route by the cgId embedded in the SPARQL (body no longer carries it). |
| `packages/node-ui/test/use-verified-memory-anchors.test.ts` | New test asserting the VM anchor POST body omits `contextGraphId`. |

## Test plan

- [x] `vitest run test/use-swm-attributions.test.ts test/use-verified-memory-anchors.test.ts` → **4 passed** (3 SWM incl. the new B2 guard + the existing Code5/Code7 cases; 1 VM anchors).
- [x] Full node-ui suite (`pnpm --filter @origintrail-official/dkg-node-ui test`): **0 test-assertion failures**, **+2 passing** vs the clean base. The branch has ~10 pre-existing **flaky file-level** failures in stateful suites (`db` / `notifications` / `messenger-stores` / `chat-memory` / etc.) — reproduced on the clean base with these changes stashed, and the failing set shifts run-to-run; **none relate to SWM/VM attribution**.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui build` (tsc) → clean.
- [x] Live-verified on the showcase node (rc.16): with `contextGraphId` the daemon returns **1** agent (~16s); without it, **5** agents / 2,084 rows (~0.23s). The legend now renders all five contributing agents.

## Known limitations (accepted)

- The query scopes to the CG via an **exact** `STRSTARTS(?g, "<cgUri>/")` prefix, which correctly excludes siblings like `cg-10`/`cg-1-foo`. However, `validateContextGraphId` permits `/` inside CG ids (convention `<addr>/<name>`), so a **path-extending child CG** `<cg>/<x>` produces a graph URI byte-identical to a real sub-graph `<sg>=<x>` of `<cg>`. Only the sub-graph **registry** can disambiguate the two; doing so authoritatively is the **deferred server-side sub-graph SWM routing (A2/A4)**.
- A client-built registry allow-list (`/api/sub-graph/list`) was considered and rejected: it re-introduces a B2-class **under-count** whenever a present sub-graph's `_meta` registration is missing — a condition this showcase hit live (`deriveCuratorDidFromCgId` and the runbook's "missing sub-graph registration step" exist for exactly that). The raw-prefix read surfaces whatever partitions physically exist, which is more robust under those gaps.
- Net: this is the deliberate **client-side bridge** until A2/A4 lands; the residual child-CG case requires a non-conventional multi-slash CG id with a prefix collision co-resident on the node. Documented in code (`e2466174a`). Maintainer-accepted.
- **Authoritative fix tracked in #1056** (CG-wide sub-graph SWM + attribution view routing, A2/A4) — builds on `discoverKnownChildContextGraphUris` from #184/#1037; once it lands, these hooks can drop the raw-prefix read.
