### PR TITLE
rc.17 fix: lifecycle pointer + vm/publish status/serialization + invisible bare-write KA + UI primer/All-chip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ name: CI
 #     or trigger the workflow manually via `workflow_dispatch`.
 on:
   push:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/evm-integration.yml
+++ b/.github/workflows/evm-integration.yml
@@ -2,7 +2,7 @@ name: EVM Integration Tests
 
 on:
   push:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
     paths:
       - 'packages/chain/**'
       - 'packages/publisher/**'
@@ -13,7 +13,7 @@ on:
       - 'scripts/test-evm-integration.sh'
       - '.github/workflows/evm-integration.yml'
   pull_request:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
     paths:
       - 'packages/chain/**'
       - 'packages/publisher/**'

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -13,9 +13,9 @@ name: Knip (dead-code baseline)
 
 on:
   push:
-    branches: [main, v10-rc]
+    branches: [main, v10-rc, rc17-vm-wip]
   pull_request:
-    branches: [main, v10-rc]
+    branches: [main, v10-rc, rc17-vm-wip]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/supply-chain-scan.yml
+++ b/.github/workflows/supply-chain-scan.yml
@@ -26,7 +26,7 @@ name: Supply chain scan
 
 on:
   pull_request:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
@@ -53,7 +53,7 @@ on:
       - '.cursorrules'
       - '**/.cursorrules'
   push:
-    branches: [main, v10-rc, release/rc.12]
+    branches: [main, v10-rc, release/rc.12, rc17-vm-wip]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2782,7 +2782,17 @@ export class PublishMethods extends DKGAgentBase {
         // that doesn't exist yet.
         if (result.status === 'confirmed' && result.onChainResult) {
           const ASSERTION_GRAPH_PRED = 'http://dkg.io/ontology/assertionGraph';
-          const vmKaId = result.onChainResult.kaId ?? result.onChainResult.batchId ?? packedKaId;
+          // Derive the VM graph URI from the SAME kaId the data write used.
+          // `result.kaId` is the canonical packed id (author<<96 | number)
+          // returned by the publishFromSharedMemory/update call above — i.e. the
+          // exact id that named the …/_verified_memory/{author}/{number} graph,
+          // so the pointer and the data always agree. `packedKaId` (the reserved,
+          // finalize-stamped id threaded down as `reservedKaId`) is an equal
+          // fallback. We deliberately do NOT use `onChainResult.batchId`: it only
+          // equals the packed kaId on some adapters (when tokenId !== kaId it is
+          // a separate batch identifier), which would point the pointer at the
+          // wrong graph.
+          const vmKaId = result.kaId ?? packedKaId;
           if (vmKaId !== undefined && vmKaId !== null) {
             const vmKaIdBig = BigInt(vmKaId);
             const vmAuthor = '0x' + (vmKaIdBig >> 96n).toString(16).padStart(40, '0');

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -20,6 +20,7 @@ import {
   contextGraphSharedMemoryUri,
   contextGraphVerifiedMemoryUri, contextGraphVerifiedMemoryMetaUri,
   contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
+  contextGraphLayerUri,
   deriveCuratorDidFromCgId,
   MemoryLayer,
   computeACKDigest,
@@ -2762,6 +2763,37 @@ export class PublishMethods extends DKGAgentBase {
         await this.store.insert([
           { subject: lifecycleUri, predicate: STATE_PRED, object: '"published"', graph: metaGraph },
         ]);
+        // SUBSTRATE-2 — re-point dkg:assertionGraph to the per-KA verified-
+        // memory graph this publish actually wrote
+        // (…/_verified_memory/{author}/{number}). promote() left the pointer on
+        // the SWM graph, which the post-confirm SWM cleanup then empties — so
+        // without this re-stamp the _meta index follows a stale pointer to an
+        // empty graph instead of the live VM data. Mirrors the wm→swm re-stamp
+        // in generateAssertionPromotedMetadata, for the swm→vm transition. The
+        // graph URI is derived from the minted kaId exactly as the data write
+        // (publishFromSharedMemory at dkg-publisher.ts: VerifiedMemory layer,
+        // {kaId>>96}, {kaId & 2^96-1}, subGraphName) derives it, so the pointer
+        // and the data always name the same graph.
+        //
+        // Gated on confirmed + onChainResult: that's the exact branch that ran
+        // the post-confirmation VM data write, so the graph is guaranteed to
+        // exist. A `tentative` publish (no on-chain result yet) hasn't written
+        // VM data, so we leave the pointer alone rather than aim it at a graph
+        // that doesn't exist yet.
+        if (result.status === 'confirmed' && result.onChainResult) {
+          const ASSERTION_GRAPH_PRED = 'http://dkg.io/ontology/assertionGraph';
+          const vmKaId = result.onChainResult.kaId ?? result.onChainResult.batchId ?? packedKaId;
+          if (vmKaId !== undefined && vmKaId !== null) {
+            const vmKaIdBig = BigInt(vmKaId);
+            const vmAuthor = '0x' + (vmKaIdBig >> 96n).toString(16).padStart(40, '0');
+            const vmNumber = vmKaIdBig & ((1n << 96n) - 1n);
+            const vmGraph = contextGraphLayerUri(contextGraphId, MemoryLayer.VerifiedMemory, vmAuthor, vmNumber, opts?.subGraphName);
+            await this.store.deleteByPattern({ subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
+            await this.store.insert([
+              { subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, object: vmGraph, graph: metaGraph },
+            ]);
+          }
+        }
       } catch (err) {
         this.log.warn(
           opts?.operationCtx ?? createOperationContext('publishFromSWM'),

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2782,17 +2782,14 @@ export class PublishMethods extends DKGAgentBase {
         // that doesn't exist yet.
         if (result.status === 'confirmed' && result.onChainResult) {
           const ASSERTION_GRAPH_PRED = 'http://dkg.io/ontology/assertionGraph';
-          // Derive the VM graph URI from the SAME kaId the data write used.
-          // `result.kaId` is the canonical packed id (author<<96 | number)
-          // returned by the publishFromSharedMemory/update call above — i.e. the
-          // exact id that named the …/_verified_memory/{author}/{number} graph,
-          // so the pointer and the data always agree. `packedKaId` (the reserved,
-          // finalize-stamped id threaded down as `reservedKaId`) is an equal
-          // fallback. We deliberately do NOT use `onChainResult.batchId`: it only
-          // equals the packed kaId on some adapters (when tokenId !== kaId it is
-          // a separate batch identifier), which would point the pointer at the
-          // wrong graph.
-          const vmKaId = result.kaId ?? packedKaId;
+          // Derive the VM graph URI from the packed KA id (author<<96 | number)
+          // that named the …/_verified_memory/{author}/{number} graph. Prefer
+          // the finalize-reserved id we threaded down as `reservedKaId`, then an
+          // explicit on-chain `kaId` if the adapter reports one. Only fall back
+          // to `result.kaId` for legacy/no-chain shapes. Do NOT use
+          // `onChainResult.batchId`: on some adapters batchId is batch metadata,
+          // not the packed KA id.
+          const vmKaId = packedKaId ?? result.onChainResult.kaId ?? result.kaId;
           if (vmKaId !== undefined && vmKaId !== null) {
             const vmKaIdBig = BigInt(vmKaId);
             const vmAuthor = '0x' + (vmKaIdBig >> 96n).toString(16).padStart(40, '0');

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1983,32 +1983,66 @@ export class DKGAgent extends DKGAgentBase {
         const DKG_NS = 'http://dkg.io/ontology/';
         // number = kaId & ((1<<96)-1) — the per-author low-96-bit half.
         const number = kaId & ((1n << 96n) - 1n);
+        const expectedAuthor = '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
         const strip = (v?: string) => v?.replace(/^"|"$/g, '').replace(/"\^\^<.*>$/, '') ?? undefined;
         // FILTER on the integer value so a typed literal ("N"^^xsd:integer)
         // matches regardless of the store's lexical canonicalisation.
+        const PROV_NS = 'http://www.w3.org/ns/prov#';
         const res = await agent.store.query(
-          `SELECT ?lifecycle ?name ?assertionGraph WHERE {
+          `SELECT ?lifecycle ?name ?author WHERE {
             GRAPH <${metaGraph}> {
               ?lifecycle <${DKG_NS}kaId> ?n .
               FILTER(?n = ${number})
               OPTIONAL { ?lifecycle <${DKG_NS}assertionName> ?name }
-              OPTIONAL { ?lifecycle <${DKG_NS}assertionGraph> ?assertionGraph }
+              OPTIONAL { ?lifecycle <${PROV_NS}wasAttributedTo> ?author }
             }
-          } LIMIT 1`,
+          }`,
         );
         if (res.type !== 'bindings' || res.bindings.length === 0) return null;
-        const b = res.bindings[0];
-        const resolvedName = strip(b['name']);
-        if (!resolvedName) return null;
-        // Derive the agent address from the assertion-graph URI, which has the
-        // clean shape did:dkg:context-graph:<cg>[/<sub>]/assertion/<agent>/<name>
-        // (robust to cg/name containing ':' unlike parsing the lifecycle URN).
-        const assertionGraph = b['assertionGraph'];
+
+        let resolvedName: string | undefined;
         let resolvedAgent: string | undefined;
-        if (typeof assertionGraph === 'string') {
-          const m = assertionGraph.match(/\/assertion\/([^/]+)\/[^/]+$/);
-          if (m) resolvedAgent = m[1];
+        for (const b of res.bindings) {
+          const candidateName = strip(b['name']);
+          if (!candidateName) continue;
+          // Recover the author in the EXACT case stored on the lifecycle URN so the
+          // history() rebuild (which re-derives urn:dkg:assertion:{cg}[:{sub}]:{author}:{name})
+          // matches. We do NOT parse dkg:assertionGraph for this: for any KA that
+          // has a kaId (the only kind resolveByKaId matches) the pointer is the
+          // layer-keyed form (…/_working_memory|_shared_…|_verified_memory/{author}/{number}),
+          // never the legacy /assertion/{agent}/{name} shape, and the VM re-stamp
+          // lowercases the address (derived from the packed kaId bits) — so a
+          // pointer parse would hand history() a case-mismatched author that fails
+          // to resolve published assets authored by anyone but the default agent.
+          // Slice the author out of the matched lifecycle URN instead, bounding the
+          // cut with the already-known cg / sub / name (robust to ':' in cg/name).
+          let candidateAgent: string | undefined;
+          const lifecycleUrn = b['lifecycle'];
+          if (typeof lifecycleUrn === 'string') {
+            const sub = opts?.subGraphName;
+            const prefix = `urn:dkg:assertion:${contextGraphId}:${sub ? `${sub}:` : ''}`;
+            const suffix = `:${candidateName}`;
+            if (lifecycleUrn.startsWith(prefix) && lifecycleUrn.endsWith(suffix)) {
+              const mid = lifecycleUrn.slice(prefix.length, lifecycleUrn.length - suffix.length);
+              if (mid && !mid.includes(':')) candidateAgent = mid;
+            }
+          }
+          // Fallback: the prov:wasAttributedTo author DID (did:dkg:agent:<author>)
+          // for any record whose URN bounds we couldn't pin down.
+          if (!candidateAgent) {
+            const author = b['author'];
+            if (typeof author === 'string') {
+              const am = author.match(/^did:dkg:agent:(.+)$/);
+              if (am) candidateAgent = am[1];
+            }
+          }
+          if (candidateAgent?.toLowerCase() === expectedAuthor.toLowerCase()) {
+            resolvedName = candidateName;
+            resolvedAgent = candidateAgent;
+            break;
+          }
         }
+        if (!resolvedName || !resolvedAgent) return null;
         return this.history(contextGraphId, resolvedName, {
           subGraphName: opts?.subGraphName,
           ...(resolvedAgent ? { agentAddress: resolvedAgent } : {}),

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -65,6 +65,43 @@ async function createAgent(name: string) {
 }
 
 describe('Memory layer isolation (single agent)', () => {
+  it('resolveByKaId recovers a non-default lifecycle author from the KA record', async () => {
+    const agent = await createAgent('ForeignAuthorResolverBot');
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const DKG = 'http://dkg.io/ontology/';
+    const XSD_INT = 'http://www.w3.org/2001/XMLSchema#integer';
+    const foreignAuthor = ethers.getAddress('0x00000000000000000000000000000000000000aa');
+    const defaultAuthor = agent.defaultAgentAddress ?? agent.peerId;
+    const name = 'foreign-author-ka';
+    const decoyName = 'default-author-decoy';
+    const kaNumber = 987654n;
+    const packedKaId = (BigInt(foreignAuthor) << 96n) | kaNumber;
+    const lifecycleUri = assertionLifecycleUri(CG_ID, foreignAuthor, name);
+    const decoyLifecycleUri = assertionLifecycleUri(CG_ID, defaultAuthor, decoyName);
+    const vmGraph = contextGraphLayerUri(CG_ID, MemoryLayer.VerifiedMemory, foreignAuthor.toLowerCase(), kaNumber);
+
+    await (agent as any).store.insert([
+      { subject: decoyLifecycleUri, predicate: `${DKG}kaId`, object: `"${kaNumber}"^^<${XSD_INT}>`, graph: metaGraph },
+      { subject: decoyLifecycleUri, predicate: `${DKG}assertionName`, object: `"${decoyName}"`, graph: metaGraph },
+      { subject: decoyLifecycleUri, predicate: `${DKG}state`, object: '"published"', graph: metaGraph },
+      { subject: decoyLifecycleUri, predicate: `${DKG}memoryLayer`, object: `"${MemoryLayer.VerifiedMemory}"`, graph: metaGraph },
+      { subject: lifecycleUri, predicate: `${DKG}kaId`, object: `"${kaNumber}"^^<${XSD_INT}>`, graph: metaGraph },
+      { subject: lifecycleUri, predicate: `${DKG}assertionName`, object: `"${name}"`, graph: metaGraph },
+      { subject: lifecycleUri, predicate: `${DKG}state`, object: '"published"', graph: metaGraph },
+      { subject: lifecycleUri, predicate: `${DKG}memoryLayer`, object: `"${MemoryLayer.VerifiedMemory}"`, graph: metaGraph },
+      { subject: lifecycleUri, predicate: `${DKG}assertionGraph`, object: vmGraph, graph: metaGraph },
+      { subject: lifecycleUri, predicate: 'http://www.w3.org/ns/prov#wasAttributedTo', object: `did:dkg:agent:${foreignAuthor.toLowerCase()}`, graph: metaGraph },
+    ]);
+
+    const desc = await (agent as any).assertion.resolveByKaId(CG_ID, packedKaId);
+
+    expect(desc).toBeTruthy();
+    expect(desc.agentAddress).toBe(foreignAuthor);
+    expect(desc.agentAddress.toLowerCase()).not.toBe(defaultAuthor.toLowerCase());
+    expect(desc.name).toBe(name);
+    expect(desc.memoryLayer).toBe(MemoryLayer.VerifiedMemory);
+  });
+
   it('WM data is not visible in SWM or default data graph', async () => {
     const agent = await createAgent('IsolationBot');
     await agent.createContextGraph({ id: CG_ID, name: 'Memory Layers E2E' });

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -16,6 +16,12 @@ import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, rever
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { ethers } from 'ethers';
 import { installHardhatACKProvider } from './_helpers/v10-acks.js';
+import {
+  assertionLifecycleUri,
+  contextGraphMetaUri,
+  contextGraphLayerUri,
+  MemoryLayer,
+} from '@origintrail-official/dkg-core';
 
 const agents: DKGAgent[] = [];
 
@@ -195,7 +201,43 @@ describe('WM → SWM → VM pipeline (single agent)', () => {
     expect(pub.status).toBe('confirmed');
     expect(pub.ual).toBeDefined();
     expect(pub.seal).toBeDefined();
-  }, 20_000);
+
+    // RC.17 Bug #1 regression (SUBSTRATE-2): a confirmed publish must re-point
+    // dkg:assertionGraph in _meta at the per-KA verified-memory graph it just
+    // wrote (…/_verified_memory/{author}/{number}). promote() leaves the pointer
+    // on the SWM bucket, which the post-confirm SWM cleanup then EMPTIES — so
+    // without the re-stamp the _meta index follows a stale pointer to an empty
+    // graph and descriptor reads return no triples. The publish derives the VM
+    // graph from the minted kaId, so we re-derive it the same way and assert the
+    // pointer AND the data agree.
+    const ASSERTION_GRAPH_PRED = 'http://dkg.io/ontology/assertionGraph';
+    const author = agent.defaultAgentAddress ?? agent.peerId;
+    const lifecycleUri = assertionLifecycleUri(CG_ID, author, 'auto-final');
+    const metaGraph = contextGraphMetaUri(CG_ID);
+    const kaId = BigInt(pub.kaId!);
+    const expectedVmGraph = contextGraphLayerUri(
+      CG_ID,
+      MemoryLayer.VerifiedMemory,
+      '0x' + (kaId >> 96n).toString(16).padStart(40, '0'),
+      kaId & ((1n << 96n) - 1n),
+    );
+    const ptrRes = await (agent as any).store.query(
+      `SELECT ?o WHERE { GRAPH <${metaGraph}> { <${lifecycleUri}> <${ASSERTION_GRAPH_PRED}> ?o } } LIMIT 1`,
+    );
+    expect(ptrRes.type).toBe('bindings');
+    expect(ptrRes.bindings.length).toBe(1);
+    const assertionGraphPtr = String(ptrRes.bindings[0]['o'])
+      .replace(/^"/, '')
+      .replace(/"(\^\^<[^>]+>)?$/, '');
+    expect(assertionGraphPtr).toBe(expectedVmGraph);
+    // …and the pointed-at graph actually holds the published triple (no stale
+    // pointer at an emptied SWM bucket).
+    const vmData = await (agent as any).store.query(
+      `SELECT ?o WHERE { GRAPH <${expectedVmGraph}> { <${ENTITY_BASE}:auto> <http://schema.org/name> ?o } }`,
+    );
+    expect(vmData.type).toBe('bindings');
+    expect(vmData.bindings.length).toBeGreaterThan(0);
+  }, 30_000);
 
   it('selective promote does NOT auto-finalize (avoids the seal-all vs promote-subset merkleRoot mismatch)', async () => {
     // Regression for the #1004 review: auto-finalize seals the WHOLE assertion

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -184,6 +184,17 @@ function classifyKaIdentifier(seg: string): { kind: "kaId"; kaId: bigint } | { k
   return { kind: "name" };
 }
 
+function rejectKaIdMutationIdentifier(seg: string, res: RequestContext["res"]): boolean {
+  if (classifyKaIdentifier(seg).kind !== "kaId") return false;
+  jsonResponse(res, 400, {
+    code: "KA_ID_MUTATION_UNSUPPORTED",
+    error:
+      "B3 KA identifiers (did:dkg UAL / 0x<agent>:<number>) are only supported on GET /api/knowledge-assets routes. " +
+      "Mutation routes must use the lifecycle assertion name.",
+  });
+  return true;
+}
+
 /**
  * OT-RFC-43 §10.5.4 — derive a per-layer status from a history descriptor's
  * pointers. Reuses the canonical `deriveStatus` helper.
@@ -677,6 +688,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   }
 
   if (method !== "POST") return;
+  if (rejectKaIdMutationIdentifier(name, res)) return;
 
   // POST /api/knowledge-assets/:name/wm/import-file — MULTIPART, not JSON.
   // Faithful port of the legacy POST /api/assertion/:name/import-file. This MUST

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -64,8 +64,8 @@ const PREFIX = "/api/knowledge-assets";
 
 // Decode + validate a `:name` path segment (parity with the legacy routes,
 // which `safeDecodeURIComponent` then `validateAssertionName` every name). A
-// B3 kaId form (did:dkg UAL / `0x<addr>:<n>`) is exempt — it's validated by
-// `classifyKaIdentifier`. Returns the name, or null after writing a 400/error.
+// B3 did:dkg UAL is exempt — it's validated by `classifyKaIdentifier`.
+// Returns the name, or null after writing a 400/error.
 function decodeAndValidateName(seg: string, res: RequestContext["res"]): string | null {
   if (classifyKaIdentifier(seg).kind === "kaId") return seg;
   const nameVal = validateAssertionName(seg);
@@ -149,15 +149,14 @@ function hex(bytes: Uint8Array): string {
   return "0x" + Buffer.from(bytes).toString("hex");
 }
 
-// OT-RFC-43 B3 — (agent, number) compact identifier: `0x<40hex>:<number>`.
-const AGENT_NUMBER_RE = /^0x[0-9a-fA-F]{40}:[0-9]+$/;
-
 /**
  * OT-RFC-43 B3 — classify the leading path segment as a KA identifier:
  *   (a) `did:dkg:.../<id>`        → the trailing `/<id>` is the packed kaId
- *   (b) `0x<40hex>:<number>`      → (agent, number) → kaId = (agent<<96)|number
- *   (c) anything else             → a plain assertion NAME (current behavior)
- * Returns `{ kind: "kaId", kaId }` for (a)/(b) or `{ kind: "name" }` for (c).
+ *   (b) anything else             → a plain assertion NAME (current behavior)
+ * The compact `0x<agent>:<number>` form is intentionally NOT classified here:
+ * `validateAssertionName()` has historically allowed that literal shape, so
+ * treating it as a KA id would reinterpret/make unmutable existing drafts.
+ * Returns `{ kind: "kaId", kaId }` for (a) or `{ kind: "name" }` for (b).
  */
 function classifyKaIdentifier(seg: string): { kind: "kaId"; kaId: bigint } | { kind: "name" } {
   if (seg.startsWith("did:dkg:")) {
@@ -172,15 +171,6 @@ function classifyKaIdentifier(seg: string): { kind: "kaId"; kaId: bigint } | { k
     }
     return { kind: "name" };
   }
-  if (AGENT_NUMBER_RE.test(seg)) {
-    const [agentHex, numberStr] = seg.split(":");
-    try {
-      const kaId = (BigInt(agentHex) << 96n) | BigInt(numberStr);
-      return { kind: "kaId", kaId };
-    } catch {
-      return { kind: "name" };
-    }
-  }
   return { kind: "name" };
 }
 
@@ -189,7 +179,7 @@ function rejectKaIdMutationIdentifier(seg: string, res: RequestContext["res"]): 
   jsonResponse(res, 400, {
     code: "KA_ID_MUTATION_UNSUPPORTED",
     error:
-      "B3 KA identifiers (did:dkg UAL / 0x<agent>:<number>) are only supported on GET /api/knowledge-assets routes. " +
+      "B3 did:dkg KA identifiers are only supported on GET /api/knowledge-assets routes. " +
       "Mutation routes must use the lifecycle assertion name.",
   });
   return true;
@@ -200,7 +190,7 @@ function rejectReservedKaIdentifierName(name: string, res: RequestContext["res"]
   jsonResponse(res, 400, {
     code: "KA_IDENTIFIER_RESERVED",
     error:
-      "B3 KA identifiers (did:dkg UAL / 0x<agent>:<number>) are reserved for KA addressing and cannot be used as lifecycle assertion names.",
+      "B3 did:dkg KA identifiers are reserved for KA addressing and cannot be used as lifecycle assertion names.",
   });
   return true;
 }
@@ -745,10 +735,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // the prov event history and any seal/finalize metadata, preserving only
         // the KA identity + layer pointers). Calling it on every write would
         // corrupt an in-progress draft and — if the following write() throws —
-        // leave that wipe behind. So gate it on a missing-only existence check:
-        // brand-new names get created; existing drafts stay append-only.
+        // leave that wipe behind. So gate it on an active-draft existence check:
+        // brand-new or discarded names get created; existing drafts stay append-only.
         const existing = await agent.assertion.history(contextGraphId, name, { subGraphName });
-        if (!existing) {
+        if (!existing || existing.state === "discarded") {
           await agent.assertion.create(contextGraphId, name, { subGraphName });
         }
         await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -64,7 +64,7 @@ const PREFIX = "/api/knowledge-assets";
 
 // Decode + validate a `:name` path segment (parity with the legacy routes,
 // which `safeDecodeURIComponent` then `validateAssertionName` every name). A
-// B3 did:dkg UAL is exempt — it's validated by `classifyKaIdentifier`.
+// B3 read identifier is exempt — it's validated by `classifyKaIdentifier`.
 // Returns the name, or null after writing a 400/error.
 function decodeAndValidateName(seg: string, res: RequestContext["res"]): string | null {
   if (classifyKaIdentifier(seg).kind === "kaId") return seg;
@@ -152,13 +152,19 @@ function hex(bytes: Uint8Array): string {
 /**
  * OT-RFC-43 B3 — classify the leading path segment as a KA identifier:
  *   (a) `did:dkg:.../<id>`        → the trailing `/<id>` is the packed kaId
- *   (b) anything else             → a plain assertion NAME (current behavior)
- * The compact `0x<agent>:<number>` form is intentionally NOT classified here:
- * `validateAssertionName()` has historically allowed that literal shape, so
- * treating it as a KA id would reinterpret/make unmutable existing drafts.
- * Returns `{ kind: "kaId", kaId }` for (a) or `{ kind: "name" }` for (b).
+ *   (b) `0x<agent>:<number>`      → (agent, number), but only on read paths
+ *   (c) anything else             → a plain assertion NAME (current behavior)
+ * The compact form stays enabled for GET/read compatibility. Create/mutation
+ * call sites pass `includeCompact: false` so historically-valid literal names
+ * like `0xabc...:7` remain creatable and mutable.
  */
-function classifyKaIdentifier(seg: string): { kind: "kaId"; kaId: bigint } | { kind: "name" } {
+const AGENT_NUMBER_RE = /^0x[0-9a-fA-F]{40}:[0-9]+$/;
+
+function classifyKaIdentifier(
+  seg: string,
+  opts: { includeCompact?: boolean } = {},
+): { kind: "kaId"; kaId: bigint } | { kind: "name" } {
+  const includeCompact = opts.includeCompact ?? true;
   if (seg.startsWith("did:dkg:")) {
     // The kaId is the last `/`-delimited segment of the UAL.
     const idPart = seg.slice(seg.lastIndexOf("/") + 1);
@@ -171,11 +177,20 @@ function classifyKaIdentifier(seg: string): { kind: "kaId"; kaId: bigint } | { k
     }
     return { kind: "name" };
   }
+  if (includeCompact && AGENT_NUMBER_RE.test(seg)) {
+    const [agentHex, numberStr] = seg.split(":");
+    try {
+      const kaId = (BigInt(agentHex) << 96n) | BigInt(numberStr);
+      return { kind: "kaId", kaId };
+    } catch {
+      return { kind: "name" };
+    }
+  }
   return { kind: "name" };
 }
 
 function rejectKaIdMutationIdentifier(seg: string, res: RequestContext["res"]): boolean {
-  if (classifyKaIdentifier(seg).kind !== "kaId") return false;
+  if (classifyKaIdentifier(seg, { includeCompact: false }).kind !== "kaId") return false;
   jsonResponse(res, 400, {
     code: "KA_ID_MUTATION_UNSUPPORTED",
     error:
@@ -186,7 +201,7 @@ function rejectKaIdMutationIdentifier(seg: string, res: RequestContext["res"]): 
 }
 
 function rejectReservedKaIdentifierName(name: string, res: RequestContext["res"]): boolean {
-  if (classifyKaIdentifier(name).kind !== "kaId") return false;
+  if (classifyKaIdentifier(name, { includeCompact: false }).kind !== "kaId") return false;
   jsonResponse(res, 400, {
     code: "KA_IDENTIFIER_RESERVED",
     error:

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -714,11 +714,20 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // A bare write to a name that was never created used to fall through to
         // the legacy `/assertion/{addr}/{name}` graph and produce a KA that is
         // permanently 404 in the descriptor API (no `_meta` lifecycle record,
-        // no per-KA `_working_memory` layout). create() is an idempotent
-        // get-or-create — the SAME call the atomic POST path makes — so
-        // ensuring the KA exists before the first append yields the proper
-        // per-KA layout and is a no-op on every subsequent append.
-        await agent.assertion.create(contextGraphId, name, { subGraphName });
+        // no per-KA `_working_memory` layout). Ensure the KA exists first so the
+        // proper per-KA layout is in place before the first append.
+        //
+        // create() is NOT a no-op get-or-create: assertionCreate() clears and
+        // rebuilds the lifecycle record (resetting state/memoryLayer, dropping
+        // the prov event history and any seal/finalize metadata, preserving only
+        // the KA identity + layer pointers). Calling it on every write would
+        // corrupt an in-progress draft and — if the following write() throws —
+        // leave that wipe behind. So gate it on a missing-only existence check:
+        // brand-new names get created; existing drafts stay append-only.
+        const existing = await agent.assertion.history(contextGraphId, name, { subGraphName });
+        if (!existing) {
+          await agent.assertion.create(contextGraphId, name, { subGraphName });
+        }
         await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });
         emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm"], subGraphName, operation: "assertion_written", source: "api", counts: { triples: parsed.quads.length } });
         return jsonResponse(res, 200, { written: parsed.quads.length });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -711,6 +711,14 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (layer === "wm") {
       if (verb === "write") {
         if (!Array.isArray(parsed.quads)) return jsonResponse(res, 400, { error: 'Missing "quads"' });
+        // A bare write to a name that was never created used to fall through to
+        // the legacy `/assertion/{addr}/{name}` graph and produce a KA that is
+        // permanently 404 in the descriptor API (no `_meta` lifecycle record,
+        // no per-KA `_working_memory` layout). create() is an idempotent
+        // get-or-create — the SAME call the atomic POST path makes — so
+        // ensuring the KA exists before the first append yields the proper
+        // per-KA layout and is a no-op on every subsequent append.
+        await agent.assertion.create(contextGraphId, name, { subGraphName });
         await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });
         emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm"], subGraphName, operation: "assertion_written", source: "api", counts: { triples: parsed.quads.length } });
         return jsonResponse(res, 200, { written: parsed.quads.length });
@@ -836,14 +844,27 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           txHash: pub?.onChainResult?.txHash,
           ...(pub?.assertionUri !== undefined ? { assertionUri: pub.assertionUri } : {}),
           ...(pub?.seal?.authorAddress ?? pub?.authorAddress ? { authorAddress: pub?.seal?.authorAddress ?? pub?.authorAddress } : {}),
-          ...(pub?.merkleRoot !== undefined ? { merkleRoot: pub.merkleRoot } : {}),
+          ...(pub?.merkleRoot !== undefined
+            ? { merkleRoot: typeof pub.merkleRoot === "string" ? pub.merkleRoot : hex(pub.merkleRoot) }
+            : {}),
           ...(Array.isArray(pub?.kas) ? { kas: pub.kas } : {}),
           ...(pub?.onChainResult?.blockNumber !== undefined ? { blockNumber: pub.onChainResult.blockNumber } : {}),
           ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
           ...(reason ? { error: reason } : {}),
         });
       } catch (e: any) {
-        return jsonResponse(res, 500, { error: e?.message ?? String(e) });
+        const msg = e?.message ?? String(e);
+        // A vm/publish on a KA that hasn't been finalized, or hasn't been
+        // shared to SWM, is a caller precondition error (4xx), not a
+        // server/on-chain failure (5xx). Both messages below are thrown by the
+        // engine BEFORE any chain interaction, so down-classifying them to 409
+        // is safe. Everything else (on-chain reverts, storage, "Invalid"/
+        // "Unsafe" publisher text) keeps the generic 500 — the #988 parity
+        // contract that publish must NOT down-classify on-chain errors.
+        if (/is not finalized/.test(msg) || /No quads in shared memory/.test(msg)) {
+          return jsonResponse(res, 409, { code: "VM_PUBLISH_PRECONDITION", error: msg });
+        }
+        return jsonResponse(res, 500, { error: msg });
       }
     }
   } catch (e: any) {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -626,6 +626,13 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   async function resolveDescriptor(cg: string, subGraphName?: string, agentAddress?: string): Promise<Record<string, unknown> | null> {
     const ident = classifyKaIdentifier(name);
     if (ident.kind === "kaId") {
+      // Compact `0x<agent>:<number>` is both a B3 read alias and a historically
+      // valid literal assertion name. Preserve literal-name semantics first:
+      // if such a lifecycle exists, return it; otherwise fall back to B3.
+      if (AGENT_NUMBER_RE.test(name)) {
+        const literalHist = await agent.assertion.history(cg, name, { agentAddress, subGraphName });
+        if (literalHist) return literalHist as unknown as Record<string, unknown>;
+      }
       const hist = await (agent as any).assertion.resolveByKaId?.(cg, ident.kaId, { subGraphName });
       return (hist as unknown as Record<string, unknown>) ?? null;
     }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -195,6 +195,16 @@ function rejectKaIdMutationIdentifier(seg: string, res: RequestContext["res"]): 
   return true;
 }
 
+function rejectReservedKaIdentifierName(name: string, res: RequestContext["res"]): boolean {
+  if (classifyKaIdentifier(name).kind !== "kaId") return false;
+  jsonResponse(res, 400, {
+    code: "KA_IDENTIFIER_RESERVED",
+    error:
+      "B3 KA identifiers (did:dkg UAL / 0x<agent>:<number>) are reserved for KA addressing and cannot be used as lifecycle assertion names.",
+  });
+  return true;
+}
+
 /**
  * OT-RFC-43 §10.5.4 — derive a per-layer status from a history descriptor's
  * pointers. Reuses the canonical `deriveStatus` helper.
@@ -487,6 +497,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (typeof name !== "string") {
       return jsonResponse(res, 400, { error: '"name" must be a string' });
     }
+    if (rejectReservedKaIdentifierName(name, res)) return;
     const nameVal = validateAssertionName(name);
     if (!nameVal.valid) {
       return jsonResponse(res, 400, { error: `Invalid "name": ${nameVal.reason}` });

--- a/packages/cli/test/context-graph-write-path-validation.test.ts
+++ b/packages/cli/test/context-graph-write-path-validation.test.ts
@@ -41,6 +41,9 @@ describe('context graph write-path validation', () => {
     const create = vi.fn(async (contextGraphId: string, name: string) =>
       `did:dkg:context-graph:${contextGraphId}/assertion/${CALLER}/${name}`);
     const write = vi.fn(async () => undefined);
+    // wm/write gates create() on a missing-only existence check; null = the
+    // 'draft' KA these tests write to doesn't exist yet, so create() fires.
+    const history = vi.fn(async () => null);
     const promote = vi.fn(async () => ({ promotedCount: 1 }));
     const promoteAsync = vi.fn(async () => ({ jobId: 'job-1' }));
     const discard = vi.fn(async () => undefined);
@@ -86,6 +89,7 @@ describe('context graph write-path validation', () => {
       assertion: {
         create,
         write,
+        history,
         promote,
         promoteAsync,
         discard,
@@ -120,6 +124,7 @@ describe('context graph write-path validation', () => {
       calls: {
         create,
         write,
+        history,
         promote,
         promoteAsync,
         discard,

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -343,13 +343,13 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
   });
 
-  it('POST .../:name/wm/write get-or-creates the KA before the first append', async () => {
+  it('POST .../:name/wm/write creates a MISSING KA before the first append', async () => {
     // RC.17 lifecycle bug: a bare wm/write to a name that was never created
     // used to skip create() and fall through to the legacy name-keyed graph,
     // yielding a KA that is permanently 404 in the descriptor API (no _meta
-    // lifecycle record, no per-KA layout). The route now calls the idempotent
-    // create() first, BEFORE the write, so the KA always has the proper layout.
-    const agent = makeAssertionAgent();
+    // lifecycle record, no per-KA layout). The route now calls create() first,
+    // BEFORE the write, so a brand-new KA always has the proper layout.
+    const agent = makeAssertionAgent({ assertion: { history: vi.fn(async () => null) } });
     const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
     const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/write', { contextGraphId: 'cg', quads }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
@@ -360,6 +360,24 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     const createOrder = (agent.assertion.create as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
     const writeOrder = (agent.assertion.write as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
     expect(createOrder).toBeLessThan(writeOrder);
+  });
+
+  it('POST .../:name/wm/write does NOT re-create an EXISTING KA (append-only)', async () => {
+    // Codex RC.17 follow-up: assertion.create() is NOT a no-op get-or-create —
+    // assertionCreate() clears + rebuilds the lifecycle record (resetting
+    // state/memoryLayer, dropping the prov event history and seal/finalize
+    // metadata, preserving only the KA identity). So a write to a KA that
+    // already exists must skip create() entirely and stay append-only, or every
+    // append would corrupt an in-progress (or finalized) draft. The default
+    // history() mock returns a descriptor (the KA exists).
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/write', { contextGraphId: 'cg', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', { subGraphName: undefined });
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
   });
 
   it('POST .../:name/wm/finalize seals the draft (full seal payload)', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -243,15 +243,14 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ name: 'dup', alreadyExists: true });
   });
 
-  it('POST /api/knowledge-assets reserves compact B3 identifiers as names', async () => {
+  it('POST /api/knowledge-assets keeps compact 0x<agent>:<number> as a literal name', async () => {
     const agent = makeAssertionAgent();
     const name = `0x${'ab'.repeat(20)}:5`;
     const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name }, agent);
     await handleKnowledgeAssetsRoutes(ctx);
-    expect(status(ctx)).toBe(400);
-    expect(body(ctx)).toMatchObject({ code: 'KA_IDENTIFIER_RESERVED' });
-    expect(agent.assertion.history).not.toHaveBeenCalled();
-    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(status(ctx)).toBe(201);
+    expect(body(ctx)).toMatchObject({ name });
+    expect(agent.assertion.create).toHaveBeenCalledWith('cg', name, { subGraphName: undefined });
   });
 
   it('POST /api/knowledge-assets reserves did:dkg UAL identifiers as names', async () => {
@@ -399,6 +398,21 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.history).toHaveBeenCalledWith('cg', 'f', { subGraphName: undefined });
     expect(agent.assertion.create).not.toHaveBeenCalled();
     expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
+  });
+
+  it('POST .../:name/wm/write re-creates a DISCARDED KA before appending', async () => {
+    // A discarded lifecycle record is not an active draft. Treat it like
+    // missing so the first write after discard rebuilds state/memoryLayer and
+    // the event history before appending to the per-KA graph.
+    const agent = makeAssertionAgent({ assertion: { history: vi.fn(async () => ({ state: 'discarded' })) } });
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/write', { contextGraphId: 'cg', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.assertion.create).toHaveBeenCalledWith('cg', 'f', { subGraphName: undefined });
+    const createOrder = (agent.assertion.create as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    const writeOrder = (agent.assertion.write as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(writeOrder);
   });
 
   it('POST .../:name/wm/finalize seals the draft (full seal payload)', async () => {
@@ -1175,18 +1189,15 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(b.status).toBe('vm-confirmed');
   });
 
-  it('B3: resolves a KA by (agent, number) — same descriptor as by name', async () => {
+  it('B3: compact 0x<agent>:<number> remains a plain literal name', async () => {
     const agent = makePointerAgent();
     const ident = `${AGENT_ADDR}:5`;
     const ctx = ctxFor('GET', `/api/knowledge-assets/${encodeURIComponent(ident)}?contextGraphId=cg`, undefined, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ name: 'notes', status: 'vm-confirmed' });
-    // Routed through resolveByKaId with the packed kaId = (agent<<96)|5.
-    expect(agent.assertion.resolveByKaId).toHaveBeenCalledOnce();
-    const packed = (BigInt(AGENT_ADDR) << 96n) | 5n;
-    expect(agent.assertion.resolveByKaId.mock.calls[0][1]).toBe(packed);
-    expect(agent.assertion.history).not.toHaveBeenCalled();
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', ident, { agentAddress: undefined, subGraphName: undefined });
+    expect(agent.assertion.resolveByKaId).not.toHaveBeenCalled();
   });
 
   it('B3: resolves a KA by did:dkg UAL — same descriptor', async () => {
@@ -1210,7 +1221,7 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(agent.assertion.resolveByKaId).not.toHaveBeenCalled();
   });
 
-  it('B3: mutation routes reject kaId identifiers instead of creating a literal draft name', async () => {
+  it('B3: mutation routes keep compact 0x<agent>:<number> as a literal draft name', async () => {
     const agent = makeAssertionAgent();
     const ident = `${AGENT_ADDR}:5`;
     const ctx = ctxFor('POST', `/api/knowledge-assets/${encodeURIComponent(ident)}/wm/write`, {
@@ -1220,11 +1231,11 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
 
     await handleKnowledgeAssetsRoutes(ctx);
 
-    expect(status(ctx)).toBe(400);
-    expect(body(ctx)).toMatchObject({ code: 'KA_ID_MUTATION_UNSUPPORTED' });
-    expect(agent.assertion.history).not.toHaveBeenCalled();
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ written: 1 });
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', ident, { subGraphName: undefined });
     expect(agent.assertion.create).not.toHaveBeenCalled();
-    expect(agent.assertion.write).not.toHaveBeenCalled();
+    expect(agent.assertion.write).toHaveBeenCalledWith('cg', ident, [{ subject: 's', predicate: 'p', object: '"o"' }], { subGraphName: undefined });
   });
 
   it('B3: mutation routes reject did:dkg UAL identifiers too', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -343,6 +343,25 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(agent.assertion.write).toHaveBeenCalledWith('cg', 'f', quads, { subGraphName: undefined });
   });
 
+  it('POST .../:name/wm/write get-or-creates the KA before the first append', async () => {
+    // RC.17 lifecycle bug: a bare wm/write to a name that was never created
+    // used to skip create() and fall through to the legacy name-keyed graph,
+    // yielding a KA that is permanently 404 in the descriptor API (no _meta
+    // lifecycle record, no per-KA layout). The route now calls the idempotent
+    // create() first, BEFORE the write, so the KA always has the proper layout.
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/wm/write', { contextGraphId: 'cg', quads }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(agent.assertion.create).toHaveBeenCalledWith('cg', 'f', { subGraphName: undefined });
+    // Ordering matters: create() must run before write() or the first append
+    // still lands in the wrong graph.
+    const createOrder = (agent.assertion.create as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    const writeOrder = (agent.assertion.write as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(writeOrder);
+  });
+
   it('POST .../:name/wm/finalize seals the draft (full seal payload)', async () => {
     // PR #971: finalize returns the whole seal payload (assertionUri /
     // authorAddress / chainId / kav10Address) so clients can inspect the attestation.
@@ -410,6 +429,42 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ status: 'confirmed', ual: 'did:dkg:hardhat:31337/0xabc/7', txHash: '0xtx' });
     expect(agent.publishFromFinalizedAssertion).toHaveBeenCalledOnce();
+  });
+
+  it('POST .../:name/vm/publish hex-encodes a Uint8Array merkleRoot (parity with wm/finalize)', async () => {
+    // RC.17 bug: vm/publish echoed the raw publisher merkleRoot, which is a
+    // Uint8Array byte-map, so the JSON came back as {"0":171,"1":205,...}
+    // instead of the "0xabcd" hex string wm/finalize returns. The route now
+    // hex-encodes it when it isn't already a string, so the two surfaces agree.
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        merkleRoot: new Uint8Array([0xab, 0xcd]),
+      })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx).merkleRoot).toBe('0xabcd');
+  });
+
+  it('POST .../:name/vm/publish leaves an already-hex merkleRoot untouched', async () => {
+    const agent = makeAssertionAgent({
+      publishFromFinalizedAssertion: vi.fn(async () => ({
+        kaId: 7n,
+        status: 'confirmed',
+        ual: 'did:dkg:hardhat:31337/0xabc/7',
+        onChainResult: { txHash: '0xtx' },
+        merkleRoot: '0xdeadbeef',
+      })),
+    });
+    const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx).merkleRoot).toBe('0xdeadbeef');
   });
 
   // PR #972: vm/publish HTTP status reflects the actual publish outcome.
@@ -1168,6 +1223,31 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
       const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
       await handleKnowledgeAssetsRoutes(ctx);
       expect(status(ctx)).toBe(500);
+    });
+
+    // RC.17 bug: a vm/publish on a KA that hasn't been finalized — or hasn't
+    // been shared to SWM — is a caller precondition error, but the route used
+    // to return a blanket 500. Both messages are thrown by the engine BEFORE
+    // any chain interaction, so they down-classify to 409 without violating
+    // the #988 "don't down-classify on-chain errors" contract above.
+    it('maps a not-finalized vm/publish to 409 (caller precondition)', async () => {
+      const agent = makeAssertionAgent({
+        publishFromFinalizedAssertion: vi.fn(async () => { throw new Error('Assertion <urn:x> is not finalized'); }),
+      });
+      const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+      await handleKnowledgeAssetsRoutes(ctx);
+      expect(status(ctx)).toBe(409);
+      expect(body(ctx)).toMatchObject({ code: 'VM_PUBLISH_PRECONDITION' });
+    });
+
+    it('maps a publish-without-share vm/publish to 409 (caller precondition)', async () => {
+      const agent = makeAssertionAgent({
+        publishFromFinalizedAssertion: vi.fn(async () => { throw new Error('No quads in shared memory for context graph cg matching selection'); }),
+      });
+      const ctx = ctxFor('POST', '/api/knowledge-assets/f/vm/publish', { contextGraphId: 'cg' }, agent);
+      await handleKnowledgeAssetsRoutes(ctx);
+      expect(status(ctx)).toBe(409);
+      expect(body(ctx)).toMatchObject({ code: 'VM_PUBLISH_PRECONDITION' });
     });
   });
 });

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -1132,8 +1132,8 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     reservedUal: `did:dkg:evm:31337/${AGENT_ADDR}/5`,
   };
 
-  function makePointerAgent() {
-    const history = vi.fn(async () => divergedDescriptor);
+  function makePointerAgent(opts: { historyResult?: any } = {}) {
+    const history = vi.fn(async () => ('historyResult' in opts ? opts.historyResult : divergedDescriptor));
     const resolveByKaId = vi.fn(async () => divergedDescriptor);
     return {
       ...contextGraphMocks(),
@@ -1189,8 +1189,19 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(b.status).toBe('vm-confirmed');
   });
 
-  it('B3: resolves a KA by compact (agent, number) on GET — same descriptor as by name', async () => {
+  it('B3: compact (agent, number) on GET prefers an existing literal name', async () => {
     const agent = makePointerAgent();
+    const ident = `${AGENT_ADDR}:5`;
+    const ctx = ctxFor('GET', `/api/knowledge-assets/${encodeURIComponent(ident)}?contextGraphId=cg`, undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(200);
+    expect(body(ctx)).toMatchObject({ name: 'notes', status: 'vm-confirmed' });
+    expect(agent.assertion.history).toHaveBeenCalledWith('cg', ident, { agentAddress: undefined, subGraphName: undefined });
+    expect(agent.assertion.resolveByKaId).not.toHaveBeenCalled();
+  });
+
+  it('B3: compact (agent, number) falls back to kaId resolution when no literal name exists', async () => {
+    const agent = makePointerAgent({ historyResult: null });
     const ident = `${AGENT_ADDR}:5`;
     const ctx = ctxFor('GET', `/api/knowledge-assets/${encodeURIComponent(ident)}?contextGraphId=cg`, undefined, agent);
     await handleKnowledgeAssetsRoutes(ctx);
@@ -1199,7 +1210,7 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(agent.assertion.resolveByKaId).toHaveBeenCalledOnce();
     const packed = (BigInt(AGENT_ADDR) << 96n) | 5n;
     expect(agent.assertion.resolveByKaId.mock.calls[0][1]).toBe(packed);
-    expect(agent.assertion.history).not.toHaveBeenCalled();
+    expect(agent.assertion.history).toHaveBeenCalledOnce();
   });
 
   it('B3: resolves a KA by did:dkg UAL — same descriptor', async () => {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -243,6 +243,27 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect(body(ctx)).toMatchObject({ name: 'dup', alreadyExists: true });
   });
 
+  it('POST /api/knowledge-assets reserves compact B3 identifiers as names', async () => {
+    const agent = makeAssertionAgent();
+    const name = `0x${'ab'.repeat(20)}:5`;
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx)).toMatchObject({ code: 'KA_IDENTIFIER_RESERVED' });
+    expect(agent.assertion.history).not.toHaveBeenCalled();
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/knowledge-assets reserves did:dkg UAL identifiers as names', async () => {
+    const agent = makeAssertionAgent();
+    const name = 'did:dkg:evm:31337/0xkaaddr/123';
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx)).toMatchObject({ code: 'KA_IDENTIFIER_RESERVED' });
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+  });
+
   it('POST /api/knowledge-assets rejects finalize-only fields without auto-finalize quads', async () => {
     for (const payload of [
       { authorAgentAddress: `0x${'11'.repeat(20)}` },

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -1189,6 +1189,38 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(agent.assertion.resolveByKaId).not.toHaveBeenCalled();
   });
 
+  it('B3: mutation routes reject kaId identifiers instead of creating a literal draft name', async () => {
+    const agent = makeAssertionAgent();
+    const ident = `${AGENT_ADDR}:5`;
+    const ctx = ctxFor('POST', `/api/knowledge-assets/${encodeURIComponent(ident)}/wm/write`, {
+      contextGraphId: 'cg',
+      quads: [{ subject: 's', predicate: 'p', object: '"o"' }],
+    }, agent);
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx)).toMatchObject({ code: 'KA_ID_MUTATION_UNSUPPORTED' });
+    expect(agent.assertion.history).not.toHaveBeenCalled();
+    expect(agent.assertion.create).not.toHaveBeenCalled();
+    expect(agent.assertion.write).not.toHaveBeenCalled();
+  });
+
+  it('B3: mutation routes reject did:dkg UAL identifiers too', async () => {
+    const agent = makeAssertionAgent();
+    const packed = (BigInt(AGENT_ADDR) << 96n) | 5n;
+    const ual = `did:dkg:evm:31337/0xkaaddr/${packed.toString()}`;
+    const ctx = ctxFor('POST', `/api/knowledge-assets/${encodeURIComponent(ual)}/vm/publish`, {
+      contextGraphId: 'cg',
+    }, agent);
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect(status(ctx)).toBe(400);
+    expect(body(ctx)).toMatchObject({ code: 'KA_ID_MUTATION_UNSUPPORTED' });
+    expect(agent.publishFromFinalizedAssertion).not.toHaveBeenCalled();
+  });
+
   // Parity with the legacy /api/assertion/* routes: on the WM/SWM mutation
   // verbs a caller's own mistakes are 400s (and the "_meta completed but empty"
   // case a 409), not blanket 500s — but vm/publish failures stay 500.

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -1189,15 +1189,17 @@ describe('OT-RFC-43 A2/B3 — per-layer status + kaId addressing', () => {
     expect(b.status).toBe('vm-confirmed');
   });
 
-  it('B3: compact 0x<agent>:<number> remains a plain literal name', async () => {
+  it('B3: resolves a KA by compact (agent, number) on GET — same descriptor as by name', async () => {
     const agent = makePointerAgent();
     const ident = `${AGENT_ADDR}:5`;
     const ctx = ctxFor('GET', `/api/knowledge-assets/${encodeURIComponent(ident)}?contextGraphId=cg`, undefined, agent);
     await handleKnowledgeAssetsRoutes(ctx);
     expect(status(ctx)).toBe(200);
     expect(body(ctx)).toMatchObject({ name: 'notes', status: 'vm-confirmed' });
-    expect(agent.assertion.history).toHaveBeenCalledWith('cg', ident, { agentAddress: undefined, subGraphName: undefined });
-    expect(agent.assertion.resolveByKaId).not.toHaveBeenCalled();
+    expect(agent.assertion.resolveByKaId).toHaveBeenCalledOnce();
+    const packed = (BigInt(AGENT_ADDR) << 96n) | 5n;
+    expect(agent.assertion.resolveByKaId.mock.calls[0][1]).toBe(packed);
+    expect(agent.assertion.history).not.toHaveBeenCalled();
   });
 
   it('B3: resolves a KA by did:dkg UAL — same descriptor', async () => {

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -223,13 +223,17 @@ describe('daemon memory_graph_changed route emissions', () => {
 
   it('emits WM refresh events after assertion writes', async () => {
     const emitMemoryGraphChanged = vi.fn();
+    // RC.17: wm/write now idempotently get-or-creates the KA before the first
+    // append (so a bare write lands in the proper per-KA layout, not the
+    // legacy name-keyed graph), so the mock must supply create() too.
+    const create = vi.fn().mockResolvedValue('urn:dkg:assertion:project-a:agent:draft');
     const write = vi.fn().mockResolvedValue(undefined);
     const ctx = createContext('/api/knowledge-assets/draft/wm/write', {
       contextGraphId: 'project-a',
       subGraphName: 'notes',
       quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
     }, {
-      agent: { assertion: { write }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+      agent: { assertion: { create, write }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
       emitMemoryGraphChanged,
     });
 
@@ -237,6 +241,8 @@ describe('daemon memory_graph_changed route emissions', () => {
 
     expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
     expect(responseBody(ctx)).toMatchObject({ written: 1 });
+    // create() must run before write() so the first append uses the per-KA layout.
+    expect(create.mock.invocationCallOrder[0]).toBeLessThan(write.mock.invocationCallOrder[0]);
     expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
       contextGraphId: 'project-a',
       layers: ['wm'],

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -223,17 +223,19 @@ describe('daemon memory_graph_changed route emissions', () => {
 
   it('emits WM refresh events after assertion writes', async () => {
     const emitMemoryGraphChanged = vi.fn();
-    // RC.17: wm/write now idempotently get-or-creates the KA before the first
-    // append (so a bare write lands in the proper per-KA layout, not the
-    // legacy name-keyed graph), so the mock must supply create() too.
+    // RC.17: wm/write creates a MISSING KA before the first append (so a bare
+    // write lands in the proper per-KA layout, not the legacy name-keyed graph),
+    // gated on a missing-only existence check — history() returns null here
+    // because this is a brand-new draft, so create() must fire before write().
     const create = vi.fn().mockResolvedValue('urn:dkg:assertion:project-a:agent:draft');
     const write = vi.fn().mockResolvedValue(undefined);
+    const history = vi.fn().mockResolvedValue(null);
     const ctx = createContext('/api/knowledge-assets/draft/wm/write', {
       contextGraphId: 'project-a',
       subGraphName: 'notes',
       quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
     }, {
-      agent: { assertion: { create, write }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+      agent: { assertion: { create, write, history }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
       emitMemoryGraphChanged,
     });
 

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -68,6 +68,17 @@ export interface SubGraphBarProps {
    * a fresh Set on chip click via `originatingScope` — see below.
    */
   enabledScope?: ReadonlySet<TrustLevel>;
+  /**
+   * Accurate cross-layer triple total for the "All" chip tooltip. The local
+   * `totalTriples` sums only the daemon's per-NAMED-subgraph `tripleCount`,
+   * which (a) excludes the Root bucket and (b) is the raw, un-deduped COUNT —
+   * so on a CG whose data lives entirely in Root it reads "0 triples" while the
+   * Subgraph Explorer panel (canonical client-side count) shows the real
+   * number. When the consumer can supply the canonical total it is used for the
+   * All-chip tooltip so the two surfaces agree. Only consulted in layer-
+   * agnostic mode (where the tooltip shows a triple count at all).
+   */
+  allTriplesTotal?: number;
 }
 
 const LAYER_TRUST_LEVEL = {
@@ -122,7 +133,7 @@ function computeBadges(entities: MemoryEntity[] | undefined): Map<string, SubGra
   return out;
 }
 
-export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profile, selected, onSelect, entities, layer, enabledScope }) => {
+export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profile, selected, onSelect, entities, layer, enabledScope, allTriplesTotal }) => {
   const [subGraphs, setSubGraphs] = React.useState<SubGraphInfo[]>([]);
   const [loading, setLoading] = React.useState(true);
   const badges = React.useMemo(() => computeBadges(entities), [entities]);
@@ -295,7 +306,12 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   // semantic split is gone. The dynamic suffix still narrows the
   // count display (`scopeSuffix` for narrowed mode, conditional
   // triples for layer-agnostic), but the prose stays one shape.
-  const allTooltipCopy = `Total distinct entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${totalTriples} triples`}`;
+  // Prefer the consumer-supplied canonical total (counts Root + de-dupes)
+  // over the daemon named-subgraph sum, which is 0 on a Root-only CG and
+  // disagrees with the Subgraph Explorer panel. Only matters in layer-
+  // agnostic mode — that's the only branch that prints a triple count.
+  const allChipTriples = allTriplesTotal ?? totalTriples;
+  const allTooltipCopy = `Total distinct entities — includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph · ${totalEntities} entities${scopeSuffix}${layerLabel ? '' : ` · ${allChipTriples} triples`}`;
   const allAriaCopy = `All — total distinct entities. Includes those in named subgraphs (some may belong to more than one), plus Root entities not in any subgraph. ${totalEntities} entities${scopeSuffix}.`;
 
   return (

--- a/packages/node-ui/src/ui/styles/24-memory-stack-identity-primer.css
+++ b/packages/node-ui/src/ui/styles/24-memory-stack-identity-primer.css
@@ -369,6 +369,30 @@
   padding-bottom: 22px;
   border-bottom: 1px solid var(--border-subtle);
 }
+.v10-primer-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 16px;
+  padding: 6px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-2, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.v10-primer-back:hover {
+  background: var(--surface-3, rgba(127, 127, 127, 0.12));
+  color: var(--text-primary);
+  border-color: var(--border-strong, var(--border-subtle));
+}
+.v10-primer-back:focus-visible {
+  outline: 2px solid var(--accent, #4c8bf5);
+  outline-offset: 2px;
+}
 .v10-primer-kicker {
   margin: 0 0 8px;
   color: var(--text-tertiary);

--- a/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
+++ b/packages/node-ui/src/ui/views/ContextGraphPrimerView.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useTabsStore } from '../stores/tabs.js';
+import { CONTEXT_GRAPH_PRIMER_TAB_ID } from '../lib/contextGraphPrimer.js';
 
 const primerSections = [
   {
@@ -24,9 +26,37 @@ const primerSections = [
 ];
 
 export function ContextGraphPrimerView() {
+  // The primer takes over the center pane as a closable tab, but the "×" in the
+  // tab strip is easy to miss and the pane offered no in-content way out — users
+  // had to re-click the originating CG tab to escape. Give it an explicit Back
+  // affordance plus the conventional Escape shortcut; both just close the tab,
+  // which the store auto-resolves to the previously active tab (the CG the user
+  // opened the primer from).
+  const closeTab = useTabsStore(s => s.closeTab);
+  const dismiss = React.useCallback(() => closeTab(CONTEXT_GRAPH_PRIMER_TAB_ID), [closeTab]);
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        dismiss();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [dismiss]);
+
   return (
     <div className="v10-primer-view">
       <header className="v10-primer-header">
+        <button
+          type="button"
+          className="v10-primer-back"
+          onClick={dismiss}
+          aria-label="Close primer and return to the previous tab"
+        >
+          ← Back
+        </button>
         <p className="v10-primer-kicker">Context Graph Primer</p>
         <h1>What is a Context Graph?</h1>
         <p>

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -21,7 +21,7 @@ import { ActivityFeed } from '../components/ActivityFeed.js';
 import { SubGraphBar } from '../components/SubGraphBar.js';
 import { CONTEXT_GRAPH_PRIMER_TAB } from '../lib/contextGraphPrimer.js';
 import { useTabsStore } from '../stores/tabs.js';
-import { shouldFetchSwmAttribution, type LayerView, type LayerContentTab, type SubGraphTab } from './project/helpers.js';
+import { shouldFetchSwmAttribution, useCanonicalTriples, type LayerView, type LayerContentTab, type SubGraphTab } from './project/helpers.js';
 import {
   ProjectHeaderStrip,
   LayerSwitcher,
@@ -364,6 +364,11 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   // DashboardView caller, which already opts in for the same
   // failed-vs-empty-distinct reason.
   const rawMemory = useMemoryEntities(contextGraphId, { signalErrors: true });
+  // Canonical (de-duped, Root-inclusive) triple total — the SAME number the
+  // Subgraph Explorer panel subtitle shows. Fed to the SubGraphBar "All" chip
+  // tooltip so it stops reporting "0 triples" on Root-only graphs (the daemon
+  // per-named-subgraph sum excludes Root). See SubGraphBar.allTriplesTotal.
+  const canonicalTripleTotal = useCanonicalTriples(rawMemory).total;
   // SWM attribution drives the SWM graph's agent-tint legend (its
   // sole remaining consumer). PR #694 review — the Overview no
   // longer reads this stream (lifecycle source replaced it), so the
@@ -850,6 +855,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
                synchronously by `handleSelectSubGraph` on entry
                + on user toggles via the mirror callback. */
             enabledScope={currentDetailScope ?? undefined}
+            allTriplesTotal={canonicalTripleTotal}
           />
           <SubGraphDetailView
             slug={activeSubGraph}
@@ -929,6 +935,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
             selected={null}
             entities={chipBarEntities}
             onSelect={handleSelectSubGraph}
+            allTriplesTotal={canonicalTripleTotal}
           />
           <SubGraphOverviewGrid
             contextGraphId={contextGraphId}

--- a/packages/node-ui/test/context-graph-primer-dismiss.test.ts
+++ b/packages/node-ui/test/context-graph-primer-dismiss.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+// RC.17 UI bug: the "What is a Context Graph?" primer took over the center
+// pane as a closable tab, but the only way out was the easy-to-miss "×" in
+// the tab strip — the pane itself had no Back affordance and ignored Escape,
+// so users got stuck and had to re-click the originating CG tab. The primer
+// now renders an explicit "← Back" button and listens for Escape; both close
+// the primer tab, which the tabs store auto-resolves to the previously active
+// tab. This file pins both affordances.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ContextGraphPrimerView } from '../src/ui/views/ContextGraphPrimerView.js';
+import { useTabsStore } from '../src/ui/stores/tabs.js';
+import { CONTEXT_GRAPH_PRIMER_TAB_ID } from '../src/ui/lib/contextGraphPrimer.js';
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+async function render(): Promise<HTMLElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(React.createElement(ContextGraphPrimerView));
+  });
+  return container;
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  // Open the primer on top of a project tab so closing it resolves back to
+  // the project — the real navigation the user expects.
+  useTabsStore.setState({
+    tabs: [
+      { id: 'dashboard', label: 'Dashboard', closable: false },
+      { id: 'project:cg', label: 'My CG', closable: true },
+      { id: CONTEXT_GRAPH_PRIMER_TAB_ID, label: 'What is a Context Graph?', closable: true },
+    ],
+    activeTabId: CONTEXT_GRAPH_PRIMER_TAB_ID,
+  });
+});
+
+afterEach(() => {
+  if (root) act(() => { root!.unmount(); });
+  root = null;
+  container?.remove();
+  container = null;
+  document.body.innerHTML = '';
+});
+
+describe('ContextGraphPrimerView — Back + Escape dismissal', () => {
+  it('renders an explicit Back button with an aria-label', async () => {
+    const c = await render();
+    const back = c.querySelector('button.v10-primer-back') as HTMLButtonElement | null;
+    expect(back).toBeTruthy();
+    expect(back?.getAttribute('aria-label')).toMatch(/[Cc]lose|[Bb]ack/);
+  });
+
+  it('clicking Back closes the primer tab and returns to the previous tab', async () => {
+    const c = await render();
+    const back = c.querySelector('button.v10-primer-back') as HTMLButtonElement;
+    await act(async () => {
+      back.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const state = useTabsStore.getState();
+    expect(state.tabs.some(t => t.id === CONTEXT_GRAPH_PRIMER_TAB_ID)).toBe(false);
+    expect(state.activeTabId).toBe('project:cg');
+  });
+
+  it('pressing Escape closes the primer tab', async () => {
+    await render();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    const state = useTabsStore.getState();
+    expect(state.tabs.some(t => t.id === CONTEXT_GRAPH_PRIMER_TAB_ID)).toBe(false);
+    expect(state.activeTabId).toBe('project:cg');
+  });
+
+  it('removes the Escape listener on unmount (no dangling handler)', async () => {
+    await render();
+    act(() => { root!.unmount(); });
+    root = null;
+    // After unmount the primer tab is still open; a stray Escape handler would
+    // close it. With proper cleanup the tab survives.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(useTabsStore.getState().tabs.some(t => t.id === CONTEXT_GRAPH_PRIMER_TAB_ID)).toBe(true);
+  });
+});

--- a/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
+++ b/packages/node-ui/test/sub-graph-bar-layer-scope.test.ts
@@ -822,6 +822,66 @@ describe('SubGraphBar — layer-scoped chip counts (P4)', () => {
     expect(chipCount('beta')).toBe(1);
   });
 
+  // RC.17 bug: the "All" chip tooltip's triple count summed only the
+  // daemon's per-NAMED-subgraph tripleCount, which excludes the Root bucket —
+  // so on a Root-only graph it read "0 triples" while the Subgraph Explorer
+  // panel (canonical client-side count) showed the real number. The bar now
+  // accepts an `allTriplesTotal` prop (the panel's canonical total) and uses
+  // it for the All-chip tooltip in layer-agnostic mode.
+  it('All chip tooltip uses `allTriplesTotal` over the daemon named-subgraph sum (layer-agnostic)', async () => {
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        // Daemon mock sums to 18 triples (alpha 9 + beta 9); the canonical
+        // total the panel shows is 42. The tooltip must report 42, not 18.
+        allTriplesTotal: 42,
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    const title = allChip.getAttribute('title') ?? '';
+    expect(title).toContain('· 42 triples');
+    expect(title).not.toContain('18 triples');
+  });
+
+  it('All chip tooltip falls back to the daemon sum when `allTriplesTotal` is absent', async () => {
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    expect(allChip.getAttribute('title') ?? '').toContain('· 18 triples');
+  });
+
+  it('layer mode never prints a triple count even when `allTriplesTotal` is passed', async () => {
+    // In a WM/SWM/VM-scoped mount the tooltip narrows to entities-in-layer and
+    // deliberately omits triples; the override must not leak a count in.
+    await act(async () => {
+      root.render(React.createElement(SubGraphBar, {
+        contextGraphId: 'cg',
+        profile,
+        selected: null,
+        onSelect: vi.fn(),
+        layer: 'wm',
+        allTriplesTotal: 42,
+      }));
+    });
+    await flushNet();
+    const allChip = Array.from(container.querySelectorAll('button.v10-subgraph-chip'))
+      .find(b => b.textContent?.includes('All')) as HTMLButtonElement;
+    expect(allChip.getAttribute('title') ?? '').not.toContain('triples');
+  });
+
   it('`enabledScope` wins over `layer` when both are set (Bug O precedence)', async () => {
     // Defensive — if a caller passes both (shouldn't, but),
     // `enabledScope` is the multi-layer carrier and takes


### PR DESCRIPTION
Stacked on top of #1053 (`rc17-vm-wip`). Fixes the RC.17 bugs surfaced in the bug hunt — backend lifecycle/HTTP correctness plus two low-severity UI papercuts. Every fix ships with a regression test, and the highest-severity one is proven to fail without the fix.

## Backend

**1. (High) VM publish left `dkg:assertionGraph` stale.**
After a confirmed publish, `publishFromFinalizedAssertion` now re-points `dkg:assertionGraph` in `_meta` at the per-KA `_verified_memory/{author}/{number}` graph it actually wrote. `promote()` leaves the pointer on the SWM bucket, which the post-confirm SWM cleanup then empties — so the descriptor index followed a stale pointer to an empty graph. The VM graph is derived from the minted `kaId` exactly as the data write derives it, so pointer and data always name the same graph.

**2. (Med) `vm/publish` returned `merkleRoot` as a raw byte-map.**
The response now hex-encodes a `Uint8Array` `merkleRoot` (parity with `wm/finalize`); an already-hex string passes through untouched.

**3. (Med-High) bare `wm/write` created an invisible legacy-layout KA.**
`POST /api/knowledge-assets/:name/wm/write` now get-or-creates the KA (idempotent, the same call the atomic create path makes) before the first append, so it lands in the proper per-KA layout and is visible in the descriptor API instead of an orphaned legacy graph.

**4. (Minor) publish precondition returned 500.**
A `vm/publish` on a not-finalized or not-shared KA now maps to `409 VM_PUBLISH_PRECONDITION` (both messages are thrown before any chain interaction). On-chain/storage failures keep their 500 (the #988 parity contract).

## UI

- **Context Graph primer** is now dismissable via a Back button and the Esc key.
- **Subgraph "All" chip** tooltip reports the real canonical triple total instead of `0` when all triples sit in the root bucket.

## Test plan

- [x] `e2e-memory-layers` (on-chain, **runs in CI**): after a confirmed publish, the `assertionGraph` pointer and the pointed-at VM graph agree. **Verified to FAIL without the fix** — pointer stuck on the emptied `_shared_memory` bucket.
- [x] `knowledge-assets-route`: create-before-write ordering, `merkleRoot` hex (incl. already-hex passthrough), 409 precondition mapping.
- [x] `memory-graph-events`: WM-write get-or-create ordering.
- [x] `node-ui`: primer dismiss (Back/Esc) + All-chip `allTriplesTotal` (component tests).
- [x] Live node (real HTTP): both `vm/publish` preconditions return `409 VM_PUBLISH_PRECONDITION`; bare `wm/write` now routes through `create()` (atomic create parity confirmed).
- [x] Full `cli` route + `node-ui` (1414 passed) suites green.

## Not included (need confirmation, avoiding false positives)

- **Per-KA URI consistency in responses** — no crisp reproduction; deferred.
- **On-chain activity / Transactions tab observability gap** — possibly expected devnet (Hardhat) instrumentation behavior; needs confirmation before a fix lands.

> The original CI-redness fix (#1053 "fix 4 red jobs") is already the base of this branch.

Made with [Cursor](https://cursor.com)