### PR TITLE
docs(evm-module): correct stale "V9" labels to V10

### DIFF
--- a/packages/evm-module/README.md
+++ b/packages/evm-module/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-evm-module
 
-DKG V9 smart contracts and deployment scripts. Forked from the V8 `dkg-evm-module` and adapted for the V9 architecture. This is a Hardhat project — it compiles Solidity, runs tests, and deploys to EVM chains.
+DKG V10 smart contracts and deployment scripts. Forked from the V8 `dkg-evm-module` and adapted for the V10 architecture. This is a Hardhat project — it compiles Solidity, runs tests, and deploys to EVM chains.
 
 ## Features
 

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
   "version": "10.0.0-rc.17",
-  "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
+  "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,
   "exports": {


### PR DESCRIPTION
## What

The `@origintrail-official/dkg-evm-module` package is at `10.0.0-rc.17`, but its `package.json` `description` and `README.md` still describe it as **"DKG V9 smart contracts … adapted for the V9 architecture."** This updates both to **V10**.

## Why

The stale label is misleading — it implies a different protocol version than the one actually shipped in this package, and (combined with the unscoped legacy `dkg-evm-module` v8.1.0 package) makes it easy to point at the wrong module. Two-line, docs-only change.

## Notes

- Kept the historically-accurate "forked from V8 `dkg-evm-module`" provenance note intact.
- No code, ABI, or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)