### PR TITLE
feat(node-ui): on-chain provenance card for Verifiable Memory graph

### DIFF
--- a/packages/node-ui/src/ui/components/OnChainProvenanceCard.tsx
+++ b/packages/node-ui/src/ui/components/OnChainProvenanceCard.tsx
@@ -1,0 +1,186 @@
+/**
+ * OnChainProvenanceCard — a pinned corner card that surfaces the REAL
+ * blockchain identity of whichever graph node is currently selected.
+ *
+ * Mounted as a CHILD of `<RdfGraph>` (the dkg-graph-viz React wrapper), so it
+ * reads the clicked node straight from the viz context via `useRdfGraph()` —
+ * no screen-coordinate plumbing required. It floats in the graph's bottom-right
+ * corner (next to / above the library's `NodePanel`) and shows:
+ *
+ *   • UAL (did:dkg:…), transaction hash (+ block-explorer link), block number,
+ *     packed KA id, and author — for entities anchored in Verifiable Memory.
+ *   • an honest "not yet on-chain" state for Working / Shared-memory entities.
+ *
+ * Data comes from `useEntityOnChainReceipt`, which reads the publish receipt
+ * the daemon persists at publish time (read-only over /api/query).
+ */
+import React, { useState } from 'react';
+import { useRdfGraph } from '@origintrail-official/dkg-graph-viz/react';
+import { useEntityOnChainReceipt } from '../hooks/useEntityOnChainReceipt.js';
+import { truncateId } from '../hooks/useVerifiedEntityIdentity.js';
+
+export interface OnChainProvenanceCardProps {
+  contextGraphId: string;
+  /** Active memory layer — tunes the "off-chain" copy. */
+  layer?: 'wm' | 'swm' | 'vm';
+  /** Block-explorer base URL (from /api/status); links are omitted when absent. */
+  explorerUrl?: string;
+}
+
+const LAYER_OFFCHAIN_COPY: Record<'wm' | 'swm' | 'vm', string> = {
+  wm: 'This entity lives in Working Memory — a private local draft. It gets an on-chain anchor only after it is promoted and published to Verifiable Memory.',
+  swm: 'This entity lives in Shared Working Memory. It is not anchored on-chain until it is published to Verifiable Memory.',
+  vm: 'No on-chain receipt found for this entity yet. It may still be settling, or it was read back from a pre-cutover graph.',
+};
+
+export const OnChainProvenanceCard: React.FC<OnChainProvenanceCardProps> = ({
+  contextGraphId,
+  layer,
+  explorerUrl,
+}) => {
+  const { selectedNode } = useRdfGraph();
+  // Local dismissal keyed by node id: the × hides the card until a *different*
+  // node is clicked (the viz owns `selectedNode`; clicking empty space clears
+  // it). Re-selecting the same node after dismissing re-opens it.
+  const [dismissedId, setDismissedId] = useState<string | null>(null);
+
+  const nodeId = selectedNode?.id ?? null;
+  const open = Boolean(nodeId) && nodeId !== dismissedId;
+  const receipt = useEntityOnChainReceipt(contextGraphId, nodeId, open);
+
+  if (!open || !selectedNode) return null;
+
+  const copy = (value: string) => {
+    navigator.clipboard?.writeText(value).catch(() => {});
+  };
+
+  const title = selectedNode.label || selectedNode.id;
+  const verified = receipt.status === 'verified';
+
+  return (
+    <div
+      className={`v10-graph-prov-card${verified ? ' verified' : ''}`}
+      role="dialog"
+      aria-label="On-chain provenance"
+    >
+      <div className="v10-graph-prov-head">
+        <span className="v10-graph-prov-glyph">{verified ? '◉' : '◌'}</span>
+        <span className="v10-graph-prov-title">On-chain provenance</span>
+        {verified && <span className="v10-graph-prov-badge">VERIFIED</span>}
+        <button
+          type="button"
+          className="v10-graph-prov-close"
+          onClick={() => setDismissedId(nodeId)}
+          aria-label="Dismiss"
+          title="Dismiss"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="v10-graph-prov-entity" title={selectedNode.id}>{title}</div>
+
+      {receipt.status === 'loading' && (
+        <div className="v10-graph-prov-muted">Resolving on-chain identity…</div>
+      )}
+
+      {receipt.status === 'error' && (
+        <div className="v10-graph-prov-muted">Couldn’t load on-chain identity.</div>
+      )}
+
+      {(receipt.status === 'offchain') && (
+        <div className="v10-graph-prov-offchain">
+          <span className="v10-graph-prov-offchain-tag">Off-chain</span>
+          <p>{LAYER_OFFCHAIN_COPY[layer ?? 'vm']}</p>
+        </div>
+      )}
+
+      {verified && (
+        <div className="v10-vm-identity" style={{ margin: 0, background: 'none', border: 'none', padding: 0 }}>
+          {receipt.ual && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">UAL</span>
+              <span className="v10-vm-identity-val mono" title={receipt.ual}>{receipt.ual}</span>
+              <button type="button" className="v10-vm-identity-copy" onClick={() => copy(receipt.ual!)} title="Copy UAL">⎘</button>
+            </div>
+          )}
+
+          {receipt.txHash && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">Tx</span>
+              {explorerUrl ? (
+                <a
+                  className="v10-vm-identity-val mono v10-graph-prov-link"
+                  href={`${explorerUrl}/tx/${receipt.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={receipt.txHash}
+                >
+                  {truncateId(receipt.txHash, 10, 8)} ↗
+                </a>
+              ) : (
+                <span className="v10-vm-identity-val mono" title={receipt.txHash}>{truncateId(receipt.txHash, 10, 8)}</span>
+              )}
+              <button type="button" className="v10-vm-identity-copy" onClick={() => copy(receipt.txHash!)} title="Copy transaction hash">⎘</button>
+            </div>
+          )}
+
+          {receipt.blockNumber && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">Block</span>
+              <span className="v10-vm-identity-val mono">{formatBlock(receipt.blockNumber)}</span>
+            </div>
+          )}
+
+          {receipt.kaId && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">KA id</span>
+              <span className="v10-vm-identity-val mono" title={receipt.kaId}>{truncateId(receipt.kaId, 8, 8)}</span>
+              <button type="button" className="v10-vm-identity-copy" onClick={() => copy(receipt.kaId!)} title="Copy KA id">⎘</button>
+            </div>
+          )}
+
+          {receipt.author && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">Author</span>
+              {explorerUrl ? (
+                <a
+                  className="v10-vm-identity-val mono v10-graph-prov-link"
+                  href={`${explorerUrl}/address/${receipt.author}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={receipt.author}
+                >
+                  {truncateId(receipt.author, 6, 4)} ↗
+                </a>
+              ) : (
+                <span className="v10-vm-identity-val mono" title={receipt.author}>{truncateId(receipt.author, 6, 4)}</span>
+              )}
+              <button type="button" className="v10-vm-identity-copy" onClick={() => copy(receipt.author!)} title="Copy author address">⎘</button>
+            </div>
+          )}
+
+          {receipt.publishedAt && (
+            <div className="v10-vm-identity-row">
+              <span className="v10-vm-identity-lbl">Published</span>
+              <span className="v10-vm-identity-val">{formatWhen(receipt.publishedAt)}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function formatBlock(raw: string): string {
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n.toLocaleString() : raw;
+}
+
+function formatWhen(raw: string): string {
+  const d = new Date(raw.replace(/^"|"$/g, ''));
+  if (!Number.isFinite(d.getTime())) return raw;
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+}

--- a/packages/node-ui/src/ui/components/OnChainProvenanceCard.tsx
+++ b/packages/node-ui/src/ui/components/OnChainProvenanceCard.tsx
@@ -4,8 +4,8 @@
  *
  * Mounted as a CHILD of `<RdfGraph>` (the dkg-graph-viz React wrapper), so it
  * reads the clicked node straight from the viz context via `useRdfGraph()` —
- * no screen-coordinate plumbing required. It floats in the graph's bottom-right
- * corner (next to / above the library's `NodePanel`) and shows:
+ * no screen-coordinate plumbing required. It floats in the graph's bottom-left
+ * corner (clear of the library's `NodePanel`, which sits bottom-right) and shows:
  *
  *   • UAL (did:dkg:…), transaction hash (+ block-explorer link), block number,
  *     packed KA id, and author — for entities anchored in Verifiable Memory.
@@ -14,7 +14,7 @@
  * Data comes from `useEntityOnChainReceipt`, which reads the publish receipt
  * the daemon persists at publish time (read-only over /api/query).
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRdfGraph } from '@origintrail-official/dkg-graph-viz/react';
 import { useEntityOnChainReceipt } from '../hooks/useEntityOnChainReceipt.js';
 import { truncateId } from '../hooks/useVerifiedEntityIdentity.js';
@@ -39,12 +39,16 @@ export const OnChainProvenanceCard: React.FC<OnChainProvenanceCardProps> = ({
   explorerUrl,
 }) => {
   const { selectedNode } = useRdfGraph();
-  // Local dismissal keyed by node id: the × hides the card until a *different*
-  // node is clicked (the viz owns `selectedNode`; clicking empty space clears
-  // it). Re-selecting the same node after dismissing re-opens it.
+  // Local dismissal: the × hides the card for the CURRENT selection only. Any
+  // change of selection (to another node, or cleared to null) resets it via the
+  // effect below, so selecting a node away and back always re-opens its card —
+  // the dismissal never sticks past the selection it was made for.
   const [dismissedId, setDismissedId] = useState<string | null>(null);
 
   const nodeId = selectedNode?.id ?? null;
+  useEffect(() => {
+    setDismissedId(null);
+  }, [nodeId]);
   const open = Boolean(nodeId) && nodeId !== dismissedId;
   const receipt = useEntityOnChainReceipt(contextGraphId, nodeId, open);
 
@@ -160,10 +164,10 @@ export const OnChainProvenanceCard: React.FC<OnChainProvenanceCardProps> = ({
             </div>
           )}
 
-          {receipt.publishedAt && (
+          {receipt.finalizedAt && (
             <div className="v10-vm-identity-row">
-              <span className="v10-vm-identity-lbl">Published</span>
-              <span className="v10-vm-identity-val">{formatWhen(receipt.publishedAt)}</span>
+              <span className="v10-vm-identity-lbl">Finalized</span>
+              <span className="v10-vm-identity-val">{formatWhen(receipt.finalizedAt)}</span>
             </div>
           )}
         </div>

--- a/packages/node-ui/src/ui/components/VerifiedIdentityBanner.tsx
+++ b/packages/node-ui/src/ui/components/VerifiedIdentityBanner.tsx
@@ -16,6 +16,9 @@ import {
   agentFromPeerId,
   truncateId,
 } from '../hooks/useVerifiedEntityIdentity.js';
+import { useEntityOnChainReceipt } from '../hooks/useEntityOnChainReceipt.js';
+import { useFetch } from '../hooks.js';
+import { fetchStatus } from '../api.js';
 import { AgentChip } from './AgentChip.js';
 
 export interface VerifiedIdentityBannerProps {
@@ -32,11 +35,20 @@ export const VerifiedIdentityBanner: React.FC<VerifiedIdentityBannerProps> = ({
 }) => {
   const agents = useAgentsContext();
   const identity = useVerifiedEntityIdentity(contextGraphId, entityUri, enabled);
+  // Real on-chain receipt (UAL / tx hash / block / KA id). Layers on top of the
+  // identity block above, which still supplies owner / publisher attribution.
+  const receipt = useEntityOnChainReceipt(contextGraphId, entityUri, enabled);
+  const { data: statusData } = useFetch(fetchStatus, [], 60_000);
+  const explorerUrl = (statusData as any)?.blockExplorerUrl as string | undefined;
+  // Prefer the genuine did:dkg UAL once we have it; the identity hook's `ual`
+  // is the synthetic WorkspaceOperation URI used as a stand-in.
+  const onChainUal = receipt.ual ?? identity.ual;
+  const onChain = receipt.status === 'verified';
 
   if (!enabled || identity.loading) return null;
   // If we don't have *anything* useful to show, bail — the Provenance
   // Trail still renders below.
-  if (!identity.ual && !identity.owner && !identity.publishedAt) return null;
+  if (!identity.ual && !identity.owner && !identity.publishedAt && !onChain) return null;
 
   const publishedAt = identity.publishedAt ? formatWhen(identity.publishedAt) : null;
   const publisherAgentUri = identity.publisherPeerId && agents
@@ -60,17 +72,62 @@ export const VerifiedIdentityBanner: React.FC<VerifiedIdentityBannerProps> = ({
         <span className="v10-vm-identity-badge">VERIFIED</span>
       </div>
 
-      {identity.ual && (
+      {onChainUal && (
         <div className="v10-vm-identity-row">
           <span className="v10-vm-identity-lbl">UAL</span>
-          <span className="v10-vm-identity-val mono" title={identity.ual}>
-            {identity.ual}
+          <span className="v10-vm-identity-val mono" title={onChainUal}>
+            {onChainUal}
           </span>
           <button
             type="button"
             className="v10-vm-identity-copy"
-            onClick={() => copy(identity.ual!)}
+            onClick={() => copy(onChainUal)}
             title="Copy UAL"
+          >⎘</button>
+        </div>
+      )}
+
+      {onChain && receipt.txHash && (
+        <div className="v10-vm-identity-row">
+          <span className="v10-vm-identity-lbl">Tx</span>
+          {explorerUrl ? (
+            <a
+              className="v10-vm-identity-val mono"
+              href={`${explorerUrl}/tx/${receipt.txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={receipt.txHash}
+            >
+              {truncateId(receipt.txHash, 10, 8)} ↗
+            </a>
+          ) : (
+            <span className="v10-vm-identity-val mono" title={receipt.txHash}>
+              {truncateId(receipt.txHash, 10, 8)}
+            </span>
+          )}
+          <button
+            type="button"
+            className="v10-vm-identity-copy"
+            onClick={() => copy(receipt.txHash!)}
+            title="Copy transaction hash"
+          >⎘</button>
+          {receipt.blockNumber && (
+            <span className="v10-vm-identity-opid mono">· block {receipt.blockNumber}</span>
+          )}
+        </div>
+      )}
+
+      {onChain && receipt.kaId && (
+        <div className="v10-vm-identity-row">
+          <span className="v10-vm-identity-lbl">KA id</span>
+          <span className="v10-vm-identity-val mono" title={receipt.kaId}>
+            {truncateId(receipt.kaId, 8, 8)}
+          </span>
+          <button
+            type="button"
+            className="v10-vm-identity-copy"
+            onClick={() => copy(receipt.kaId!)}
+            title="Copy KA id"
           >⎘</button>
         </div>
       )}

--- a/packages/node-ui/src/ui/hooks/useEntityOnChainReceipt.ts
+++ b/packages/node-ui/src/ui/hooks/useEntityOnChainReceipt.ts
@@ -1,0 +1,240 @@
+/**
+ * useEntityOnChainReceipt — resolves the REAL on-chain identity of a single
+ * graph entity (UAL, transaction hash, block number, packed KA id, author).
+ *
+ * Unlike `useVerifiedEntityIdentity` (which surfaces the *synthetic*
+ * WorkspaceOperation op-id as a UAL placeholder), this hook reads the genuine
+ * blockchain receipt the publisher persists at publish time:
+ *
+ *   • `buildAssertionPublishReceiptQuads` (packages/core/src/assertion-seal.ts)
+ *     writes, keyed by the assertion URI, into the context-graph `_meta` graph:
+ *        <assertion>  dkg:publishedAtTx     "0x…"            (real tx hash)
+ *        <assertion>  dkg:publishedAtBlock  "N"^^xsd:integer
+ *        <assertion>  dkg:publishedAtKaId   "<packed>"^^xsd:integer
+ *   • the lifecycle URN carries  dkg:reservedUal  "did:dkg:evm:<chain>/<addr>/<n>"
+ *     — the deterministic Option-1 UAL.
+ *
+ * The clicked node is an *entity*, but the receipt is keyed by the *KA*
+ * (assertion / {addr}/{name}). The bridge is the `ShareTransition` record in
+ * `_shared_memory_meta` (packages/publisher/src/metadata.ts), which links each
+ * member entity to its assertion source:
+ *
+ *     <urn:dkg:share:{opId}>  dkg:entities  <entity> ;
+ *                             dkg:source    "assertion/{addr}/{name}" ;
+ *                             dkg:agent     did:dkg:agent:{addr} ;
+ *                             dkg:timestamp "…"^^xsd:dateTime .
+ *
+ * So the resolution is two SPARQL hops:
+ *   1. entity → ShareTransition → (addr, name, agent, timestamp)
+ *   2. (addr, name) → `_meta` → (reservedUal, txHash, block, kaId)
+ *
+ * Status semantics:
+ *   • 'verified'  — a real on-chain receipt (tx hash) was found.
+ *   • 'offchain'  — the entity is known to WM/SWM but has no VM receipt yet.
+ *   • 'idle'      — no entity / disabled.
+ *
+ * Everything is read-only over `/api/query`; nothing is written.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { executeQuery } from '../api.js';
+
+const DKG = 'http://dkg.io/ontology/';
+
+export type OnChainReceiptStatus = 'idle' | 'loading' | 'verified' | 'offchain' | 'error';
+
+export interface EntityOnChainReceipt {
+  status: OnChainReceiptStatus;
+  /** Real deterministic UAL: did:dkg:evm:<chainId>/<addr>/<number>. */
+  ual: string | null;
+  /** Real blockchain transaction hash of the publish. */
+  txHash: string | null;
+  /** Block number the publish landed in. */
+  blockNumber: string | null;
+  /** Packed Option-1 KA id (author<<96 | number), as a decimal string. */
+  kaId: string | null;
+  /** 0x author address (parsed from the assertion source). */
+  author: string | null;
+  /** ISO publish timestamp. */
+  publishedAt: string | null;
+  /** did:dkg:agent:… that fired the publish. */
+  agent: string | null;
+  error?: string;
+}
+
+const EMPTY: EntityOnChainReceipt = {
+  status: 'idle',
+  ual: null,
+  txHash: null,
+  blockNumber: null,
+  kaId: null,
+  author: null,
+  publishedAt: null,
+  agent: null,
+};
+
+/** SPARQL binding → plain string (handles both bare strings and {value}). */
+function bv(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') {
+    // strip wrapping quotes + ^^<datatype> / @lang on literal lexical forms
+    return v.startsWith('"')
+      ? v.replace(/^"/, '').replace(/"(\^\^<[^>]*>|@[\w-]+)?$/, '')
+      : v;
+  }
+  if (typeof v === 'object' && 'value' in (v as Record<string, unknown>)) {
+    const raw = (v as { value?: unknown }).value;
+    return raw == null ? '' : String(raw);
+  }
+  return String(v);
+}
+
+/** Strip `< >` IRI wrapping. */
+function unwrapIri(s: string): string {
+  const t = s.trim();
+  return t.startsWith('<') && t.endsWith('>') ? t.slice(1, -1) : t;
+}
+
+/** Escape a value for safe embedding inside a SPARQL string literal. */
+function sparqlStr(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}
+
+/** Escape a value for safe embedding inside a `<…>` SPARQL IRI. */
+function sparqlIri(value: string): string {
+  // Disallow the characters that would break out of an IRI ref. If any are
+  // present we treat the resolution as impossible rather than build a
+  // malformed query.
+  return /[<>"{}|\\^`\s]/.test(value) ? '' : value;
+}
+
+/**
+ * Step 1: entity → ShareTransition → assertion source / agent / timestamp.
+ * Cross-subgraph `GRAPH ?g` over `_shared_memory_meta`, so we deliberately do
+ * NOT pass contextGraphId (mirrors `useVerifiedMemoryAnchors`: passing it
+ * constrains `GRAPH ?g` to CG-direct graphs and drops the share records).
+ */
+function buildShareQuery(cgId: string, entityIri: string): string {
+  return `PREFIX dkg: <${DKG}>
+SELECT ?source ?agent ?ts WHERE {
+  GRAPH ?g {
+    ?op a dkg:ShareTransition ;
+        dkg:entities <${entityIri}> ;
+        dkg:source ?source ;
+        dkg:agent ?agent ;
+        dkg:timestamp ?ts .
+  }
+  FILTER(
+    STRSTARTS(STR(?g), "did:dkg:context-graph:${sparqlStr(cgId)}/") &&
+    CONTAINS(STR(?g), "_shared_memory_meta")
+  )
+} ORDER BY DESC(?ts) LIMIT 1`;
+}
+
+/**
+ * Step 2: (addr, name) → `_meta` → reservedUal + on-chain receipt.
+ * Fixed `GRAPH <…/_meta>` so we DO pass contextGraphId (mirrors
+ * `fetchAssertionUals`). The receipt is keyed by the assertion URI; we match
+ * it by `STRENDS(… "/assertion/{addr}/{name}")` so a sub-graph-qualified
+ * assertion URI still resolves. reservedUal/kaId sit on the lifecycle URN.
+ */
+function buildReceiptQuery(cgId: string, addr: string, name: string): string {
+  const metaGraph = `did:dkg:context-graph:${cgId}/_meta`;
+  const lifecycleUri = `urn:dkg:assertion:${cgId}:${addr}:${name}`;
+  const suffix = `/assertion/${addr}/${name}`;
+  return `PREFIX dkg: <${DKG}>
+SELECT ?ual ?tx ?block ?kaId WHERE {
+  GRAPH <${metaGraph}> {
+    OPTIONAL { <${lifecycleUri}> dkg:reservedUal ?ual . }
+    OPTIONAL {
+      ?asrt dkg:publishedAtTx ?tx ;
+            dkg:publishedAtBlock ?block ;
+            dkg:publishedAtKaId ?kaId .
+      FILTER(STRENDS(STR(?asrt), "${sparqlStr(suffix)}"))
+    }
+  }
+} LIMIT 1`;
+}
+
+/** `assertion/{addr}/{name}` → { addr, name }. */
+function parseSource(source: string): { addr: string; name: string } | null {
+  const m = source.match(/^assertion\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  return { addr: m[1], name: m[2] };
+}
+
+export function useEntityOnChainReceipt(
+  contextGraphId: string | undefined,
+  entityUri: string | null | undefined,
+  enabled: boolean = true,
+): EntityOnChainReceipt {
+  const [state, setState] = useState<EntityOnChainReceipt>(() => ({ ...EMPTY }));
+  const versionRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled || !contextGraphId || !entityUri) {
+      setState({ ...EMPTY });
+      return;
+    }
+    const version = ++versionRef.current;
+    setState({ ...EMPTY, status: 'loading' });
+
+    (async () => {
+      try {
+        // ── Hop 1: find the entity's assertion via ShareTransition ──
+        const shareRes = await executeQuery(buildShareQuery(contextGraphId, entityUri)).catch(() => null);
+        if (version !== versionRef.current) return;
+
+        const shareRow = ((shareRes as any)?.result?.bindings ?? [])[0];
+        if (!shareRow) {
+          // No share record — entity lives only in Working Memory.
+          setState({ ...EMPTY, status: 'offchain' });
+          return;
+        }
+        const source = bv(shareRow.source);
+        const parsed = parseSource(source);
+        const agent = shareRow.agent ? unwrapIri(bv(shareRow.agent)) : null;
+        const publishedAt = shareRow.ts ? bv(shareRow.ts) : null;
+        const addr = parsed?.addr ?? null;
+
+        if (!parsed || !sparqlIri(parsed.addr) || !sparqlStr(parsed.name)) {
+          // Resolved a share but can't safely build the receipt query.
+          setState({ ...EMPTY, status: 'offchain', author: addr, agent, publishedAt });
+          return;
+        }
+
+        // ── Hop 2: pull the real on-chain receipt from `_meta` ──
+        const receiptRes = await executeQuery(
+          buildReceiptQuery(contextGraphId, parsed.addr, parsed.name),
+          contextGraphId,
+        ).catch(() => null);
+        if (version !== versionRef.current) return;
+
+        const receiptRow = ((receiptRes as any)?.result?.bindings ?? [])[0];
+        const ual = receiptRow?.ual ? bv(receiptRow.ual) : null;
+        const txHash = receiptRow?.tx ? bv(receiptRow.tx) : null;
+        const blockNumber = receiptRow?.block ? bv(receiptRow.block) : null;
+        const kaId = receiptRow?.kaId ? bv(receiptRow.kaId) : null;
+
+        setState({
+          status: txHash ? 'verified' : 'offchain',
+          ual: ual || null,
+          txHash: txHash || null,
+          blockNumber: blockNumber || null,
+          kaId: kaId || null,
+          author: addr,
+          publishedAt,
+          agent,
+        });
+      } catch (err: any) {
+        if (version !== versionRef.current) return;
+        setState({ ...EMPTY, status: 'error', error: err?.message ?? String(err) });
+      }
+    })();
+  }, [contextGraphId, entityUri, enabled]);
+
+  return state;
+}

--- a/packages/node-ui/src/ui/hooks/useEntityOnChainReceipt.ts
+++ b/packages/node-ui/src/ui/hooks/useEntityOnChainReceipt.ts
@@ -7,30 +7,41 @@
  * blockchain receipt the publisher persists at publish time:
  *
  *   • `buildAssertionPublishReceiptQuads` (packages/core/src/assertion-seal.ts)
- *     writes, keyed by the assertion URI, into the context-graph `_meta` graph:
- *        <assertion>  dkg:publishedAtTx     "0x…"            (real tx hash)
- *        <assertion>  dkg:publishedAtBlock  "N"^^xsd:integer
- *        <assertion>  dkg:publishedAtKaId   "<packed>"^^xsd:integer
- *   • the lifecycle URN carries  dkg:reservedUal  "did:dkg:evm:<chain>/<addr>/<n>"
- *     — the deterministic Option-1 UAL.
+ *     writes, keyed by the FULL assertion URI, into the context-graph `_meta`:
+ *        <assertionUri>  dkg:publishedAtTx        "0x…"            (real tx hash)
+ *        <assertionUri>  dkg:publishedAtBlock     "N"^^xsd:integer
+ *        <assertionUri>  dkg:publishedAtKaId      "<packed>"^^xsd:integer
+ *        <assertionUri>  dkg:assertionFinalizedAt "…"^^xsd:dateTime
+ *   • the assertion lifecycle URN, in the SAME `_meta` graph, carries:
+ *        <lifecycle>  dkg:rootEntity  <assertionUri> ;
+ *                     dkg:reservedUal "did:dkg:evm:<chain>/<addr>/<n>" .
  *
- * The clicked node is an *entity*, but the receipt is keyed by the *KA*
- * (assertion / {addr}/{name}). The bridge is the `ShareTransition` record in
- * `_shared_memory_meta` (packages/publisher/src/metadata.ts), which links each
- * member entity to its assertion source:
+ * The clicked node is an *entity*, not the KA. The bridge is the
+ * `ShareTransition` record in `_shared_memory_meta`
+ * (packages/publisher/src/metadata.ts), which links each member entity to its
+ * assertion source:
  *
  *     <urn:dkg:share:{opId}>  dkg:entities  <entity> ;
  *                             dkg:source    "assertion/{addr}/{name}" ;
  *                             dkg:agent     did:dkg:agent:{addr} ;
  *                             dkg:timestamp "…"^^xsd:dateTime .
  *
- * So the resolution is two SPARQL hops:
- *   1. entity → ShareTransition → (addr, name, agent, timestamp)
- *   2. (addr, name) → `_meta` → (reservedUal, txHash, block, kaId)
+ * Resolution (two SPARQL hops):
+ *   1. entity → ShareTransition → (addr, name, agent).
+ *   2. (addr, name) + the clicked entity → `_meta`. Because the same
+ *      `(addr, name)` can exist in BOTH a root partition and a sub-graph
+ *      partition, we do not trust `(addr, name)` alone: we additionally require
+ *      the receipt's assertion URI to be a PREFIX of the clicked entity (every
+ *      member entity — the root and its skolem/genid descendants — is
+ *      namespaced under its assertion URI), preferring prefix / longest
+ *      matches, so the EXACT assertion the entity belongs to wins rather than
+ *      an arbitrary same-named one. reservedUal is read by joining the
+ *      lifecycle URN on `dkg:rootEntity = <assertionUri>` (no URN guessing).
  *
  * Status semantics:
  *   • 'verified'  — a real on-chain receipt (tx hash) was found.
  *   • 'offchain'  — the entity is known to WM/SWM but has no VM receipt yet.
+ *   • 'error'     — a query failed (kept DISTINCT from 'offchain').
  *   • 'idle'      — no entity / disabled.
  *
  * Everything is read-only over `/api/query`; nothing is written.
@@ -54,8 +65,13 @@ export interface EntityOnChainReceipt {
   kaId: string | null;
   /** 0x author address (parsed from the assertion source). */
   author: string | null;
-  /** ISO publish timestamp. */
-  publishedAt: string | null;
+  /**
+   * ISO assertion-finalize timestamp from the publish receipt
+   * (`dkg:assertionFinalizedAt`). This is the assertion's finalize time — NOT
+   * the WM→SWM promote time (the `ShareTransition` timestamp), which we
+   * deliberately do not surface as a publish/finalize time.
+   */
+  finalizedAt: string | null;
   /** did:dkg:agent:… that fired the publish. */
   agent: string | null;
   error?: string;
@@ -68,7 +84,7 @@ const EMPTY: EntityOnChainReceipt = {
   blockNumber: null,
   kaId: null,
   author: null,
-  publishedAt: null,
+  finalizedAt: null,
   agent: null,
 };
 
@@ -103,11 +119,13 @@ function sparqlStr(value: string): string {
     .replace(/\r/g, '\\r');
 }
 
-/** Escape a value for safe embedding inside a `<…>` SPARQL IRI. */
+/**
+ * Validate a value for embedding inside a `<…>` SPARQL IRI ref. Returns the
+ * value unchanged when safe, or '' when it contains characters that would
+ * break out of the IRI ref — in which case the caller treats resolution as
+ * impossible rather than building a malformed (or injectable) query.
+ */
 function sparqlIri(value: string): string {
-  // Disallow the characters that would break out of an IRI ref. If any are
-  // present we treat the resolution as impossible rather than build a
-  // malformed query.
   return /[<>"{}|\\^`\s]/.test(value) ? '' : value;
 }
 
@@ -116,6 +134,7 @@ function sparqlIri(value: string): string {
  * Cross-subgraph `GRAPH ?g` over `_shared_memory_meta`, so we deliberately do
  * NOT pass contextGraphId (mirrors `useVerifiedMemoryAnchors`: passing it
  * constrains `GRAPH ?g` to CG-direct graphs and drops the share records).
+ * `entityIri` MUST already be validated via `sparqlIri`.
  */
 function buildShareQuery(cgId: string, entityIri: string): string {
   return `PREFIX dkg: <${DKG}>
@@ -135,28 +154,32 @@ SELECT ?source ?agent ?ts WHERE {
 }
 
 /**
- * Step 2: (addr, name) → `_meta` → reservedUal + on-chain receipt.
- * Fixed `GRAPH <…/_meta>` so we DO pass contextGraphId (mirrors
- * `fetchAssertionUals`). The receipt is keyed by the assertion URI; we match
- * it by `STRENDS(… "/assertion/{addr}/{name}")` so a sub-graph-qualified
- * assertion URI still resolves. reservedUal/kaId sit on the lifecycle URN.
+ * Step 2: resolve the EXACT on-chain receipt for the assertion the clicked
+ * entity belongs to.
+ *
+ * The receipt is keyed by the full assertion URI. Since `(addr, name)` is NOT
+ * unique across partitions, we constrain the match three ways: the assertion
+ * URI must (a) end with `/assertion/{addr}/{name}` and (b) be a prefix of the
+ * clicked entity URI, and we (c) order prefix-matches first then longest-first
+ * so the most specific (correct) assertion wins under `LIMIT 1`. reservedUal is
+ * joined off the lifecycle URN via `dkg:rootEntity`, avoiding any reconstructed
+ * `urn:dkg:assertion:…` key.
  */
-function buildReceiptQuery(cgId: string, addr: string, name: string): string {
+function buildReceiptQuery(cgId: string, entityIri: string, addr: string, name: string): string {
   const metaGraph = `did:dkg:context-graph:${cgId}/_meta`;
-  const lifecycleUri = `urn:dkg:assertion:${cgId}:${addr}:${name}`;
   const suffix = `/assertion/${addr}/${name}`;
+  const entityLit = sparqlStr(entityIri);
   return `PREFIX dkg: <${DKG}>
-SELECT ?ual ?tx ?block ?kaId WHERE {
+SELECT ?ual ?tx ?block ?kaId ?finalizedAt WHERE {
   GRAPH <${metaGraph}> {
-    OPTIONAL { <${lifecycleUri}> dkg:reservedUal ?ual . }
-    OPTIONAL {
-      ?asrt dkg:publishedAtTx ?tx ;
-            dkg:publishedAtBlock ?block ;
-            dkg:publishedAtKaId ?kaId .
-      FILTER(STRENDS(STR(?asrt), "${sparqlStr(suffix)}"))
-    }
+    ?asrt dkg:publishedAtTx ?tx ;
+          dkg:publishedAtBlock ?block ;
+          dkg:publishedAtKaId ?kaId .
+    FILTER(STRENDS(STR(?asrt), "${sparqlStr(suffix)}"))
+    OPTIONAL { ?asrt dkg:assertionFinalizedAt ?finalizedAt . }
+    OPTIONAL { ?lc dkg:rootEntity ?asrt ; dkg:reservedUal ?ual . }
   }
-} LIMIT 1`;
+} ORDER BY DESC(STRSTARTS("${entityLit}", STR(?asrt))) DESC(STRLEN(STR(?asrt))) LIMIT 1`;
 }
 
 /** `assertion/{addr}/{name}` → { addr, name }. */
@@ -184,8 +207,17 @@ export function useEntityOnChainReceipt(
 
     (async () => {
       try {
+        const safeEntity = sparqlIri(entityUri);
+        if (!safeEntity) {
+          // Entity id is not embeddable as a SPARQL IRI ref — can't resolve.
+          setState({ ...EMPTY, status: 'offchain' });
+          return;
+        }
+
         // ── Hop 1: find the entity's assertion via ShareTransition ──
-        const shareRes = await executeQuery(buildShareQuery(contextGraphId, entityUri)).catch(() => null);
+        // NOTE: query rejections propagate to the outer catch → 'error' state,
+        // kept distinct from a clean "no rows" → 'offchain'.
+        const shareRes = await executeQuery(buildShareQuery(contextGraphId, safeEntity));
         if (version !== versionRef.current) return;
 
         const shareRow = ((shareRes as any)?.result?.bindings ?? [])[0];
@@ -197,20 +229,19 @@ export function useEntityOnChainReceipt(
         const source = bv(shareRow.source);
         const parsed = parseSource(source);
         const agent = shareRow.agent ? unwrapIri(bv(shareRow.agent)) : null;
-        const publishedAt = shareRow.ts ? bv(shareRow.ts) : null;
         const addr = parsed?.addr ?? null;
 
         if (!parsed || !sparqlIri(parsed.addr) || !sparqlStr(parsed.name)) {
           // Resolved a share but can't safely build the receipt query.
-          setState({ ...EMPTY, status: 'offchain', author: addr, agent, publishedAt });
+          setState({ ...EMPTY, status: 'offchain', author: addr, agent });
           return;
         }
 
-        // ── Hop 2: pull the real on-chain receipt from `_meta` ──
+        // ── Hop 2: pull the EXACT on-chain receipt from `_meta` ──
         const receiptRes = await executeQuery(
-          buildReceiptQuery(contextGraphId, parsed.addr, parsed.name),
+          buildReceiptQuery(contextGraphId, safeEntity, parsed.addr, parsed.name),
           contextGraphId,
-        ).catch(() => null);
+        );
         if (version !== versionRef.current) return;
 
         const receiptRow = ((receiptRes as any)?.result?.bindings ?? [])[0];
@@ -218,6 +249,7 @@ export function useEntityOnChainReceipt(
         const txHash = receiptRow?.tx ? bv(receiptRow.tx) : null;
         const blockNumber = receiptRow?.block ? bv(receiptRow.block) : null;
         const kaId = receiptRow?.kaId ? bv(receiptRow.kaId) : null;
+        const finalizedAt = receiptRow?.finalizedAt ? bv(receiptRow.finalizedAt) : null;
 
         setState({
           status: txHash ? 'verified' : 'offchain',
@@ -226,7 +258,7 @@ export function useEntityOnChainReceipt(
           blockNumber: blockNumber || null,
           kaId: kaId || null,
           author: addr,
-          publishedAt,
+          finalizedAt: finalizedAt || null,
           agent,
         });
       } catch (err: any) {

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -24,3 +24,4 @@
 @import './styles/22-subgraph-explorer-cta.css';
 @import './styles/23-agent-activity-profile.css';
 @import './styles/24-memory-stack-identity-primer.css';
+@import './styles/25-graph-provenance-card.css';

--- a/packages/node-ui/src/ui/styles/25-graph-provenance-card.css
+++ b/packages/node-ui/src/ui/styles/25-graph-provenance-card.css
@@ -1,0 +1,127 @@
+/* ── On-chain provenance card (graph corner popup) ──────────────────────────
+ * Pinned in the graph's bottom-LEFT corner so it never collides with the
+ * dkg-graph-viz NodePanel (bottom-right). Shows the real blockchain identity
+ * of the selected node: UAL, tx hash, block, KA id, author. Mirrors the
+ * .v10-mlv-node-panel surface + the .v10-vm-identity row vocabulary.
+ */
+.v10-graph-prov-card {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  width: 300px;
+  max-width: calc(100% - 24px);
+  max-height: 340px;
+  overflow-y: auto;
+  z-index: 21;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(6px);
+  font-size: 12px;
+  color: var(--text-primary);
+  pointer-events: auto;
+}
+.v10-graph-prov-card.verified {
+  border-color: rgba(34, 197, 94, 0.45);
+  background:
+    linear-gradient(135deg, rgba(34, 197, 94, 0.08) 0%, rgba(245, 158, 11, 0.04) 100%),
+    var(--bg-elevated);
+}
+
+.v10-graph-prov-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v10-graph-prov-glyph {
+  font-size: 14px;
+  line-height: 1;
+  color: #22c55e;
+}
+.v10-graph-prov-card:not(.verified) .v10-graph-prov-glyph {
+  color: var(--text-tertiary);
+}
+.v10-graph-prov-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+}
+.v10-graph-prov-badge {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  color: var(--text-success);
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+.v10-graph-prov-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  transition: color 0.15s;
+}
+.v10-graph-prov-close:hover {
+  color: var(--text-primary);
+}
+
+.v10-graph-prov-entity {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  word-break: break-word;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 6px;
+}
+
+.v10-graph-prov-muted {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  padding: 4px 0 2px;
+}
+
+.v10-graph-prov-offchain {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v10-graph-prov-offchain-tag {
+  align-self: flex-start;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  color: var(--text-tertiary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+}
+.v10-graph-prov-offchain p {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+/* explorer link affordance reusing the identity-value type */
+.v10-graph-prov-link {
+  color: var(--accent-blue, #3b82f6);
+  text-decoration: none;
+}
+.v10-graph-prov-link:hover {
+  text-decoration: underline;
+}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
-import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, describePromoteResult, describePromoteError, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
+import { executeQuery, fetchStatus, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, describePromoteResult, describePromoteError, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { memoryGraphLabels } from '../lib/memoryLabels.js';
@@ -11,6 +11,11 @@ const RdfGraph = lazy(() =>
 );
 const NodePanel = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.NodePanel }))
+);
+// Lazy — the card imports `useRdfGraph` from the viz package; deferring it
+// keeps the graph renderer out of the main bundle (matches RdfGraph/NodePanel).
+const OnChainProvenanceCard = lazy(() =>
+  import('../components/OnChainProvenanceCard.js').then(m => ({ default: m.OnChainProvenanceCard }))
 );
 
 type MemoryLayer = 'wm' | 'swm' | 'vm';
@@ -169,6 +174,11 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
     0
   );
   useMemoryGraphEvents(contextGraphId, refresh, { layers: [layer] });
+
+  // Block-explorer base URL for the on-chain provenance card's tx/address
+  // links. Polled slowly; absent in no-chain / mock mode (links degrade out).
+  const { data: statusData } = useFetch(fetchStatus, [], 30_000);
+  const explorerUrl = (statusData as any)?.blockExplorerUrl as string | undefined;
 
   const runQuery = useCallback(() => {
     const next = draftQuery.trim();
@@ -406,6 +416,11 @@ export function MemoryLayerView({ layer, contextGraphId, externalQuery, external
                 showProperties
                 showMetadata={false}
                 maxValueLength={150}
+              />
+              <OnChainProvenanceCard
+                contextGraphId={contextGraphId}
+                layer={layer}
+                explorerUrl={explorerUrl}
               />
             </RdfGraph>
           </Suspense>


### PR DESCRIPTION
## What & why

The Verifiable Memory UI never showed the on-chain identity of a published KA — the graph view rendered entities with **no UAL, transaction hash, or blockchain info**, and the KA-detail banner displayed a *synthetic* WorkspaceOperation op-id as a UAL stand-in. This surfaces the **real** blockchain receipt the publisher already persists.

Built on top of #1053 (`rc17-vm-wip`).

## Key finding: the data already exists

At publish time, `buildAssertionPublishReceiptQuads` (`packages/core/src/assertion-seal.ts`, called from `packages/agent/src/dkg-agent-publish.ts`) writes, into the context-graph `_meta` graph keyed by the assertion:

- `dkg:publishedAtTx` — the real transaction hash
- `dkg:publishedAtBlock` — block number
- `dkg:publishedAtKaId` — packed Option-1 KA id

…and `dkg:reservedUal` (`did:dkg:evm:<chain>/<addr>/<number>`) on the lifecycle URN. **All of it is reachable from the browser via `/api/query`** — so this is a pure node-ui change, no backend plumbing.

## What's in it

- **`useEntityOnChainReceipt`** (new hook) — resolves a clicked entity → its KA → on-chain receipt in two SPARQL hops: entity → `ShareTransition` (`dkg:entities` / `dkg:source`) → `_meta` publish receipt + `reservedUal`. Read-only.
- **`OnChainProvenanceCard`** (new) — a **pinned corner card** on the `MemoryLayerView` graph (VM / WM / SWM). Reads the selected node straight from the graph-viz `useRdfGraph()` context (no screen-coord plumbing). UAL / tx (with explorer link) / block / KA id / author, copy buttons, and an honest **"off-chain"** state for WM/SWM / not-yet-published entities. Pinned bottom-left so it never collides with the existing `NodePanel`.
- **`VerifiedIdentityBanner`** (KA detail) — enriched: prefers the genuine `did:dkg` UAL over the op-id placeholder, and adds tx hash, block, and KA id rows with block-explorer links.
- CSS: `25-graph-provenance-card.css` (reuses the `.v10-vm-identity` row vocabulary; lazy-loaded so the graph renderer stays out of the main bundle).

Explorer links come from `blockExplorerUrl` on `/api/status` (degrade out in no-chain / mock mode).

## Validation

- **Typecheck:** baseline-diffed `tsc` on the UI project — **net-zero new type errors** vs the `rc17-vm-wip` baseline.
- **⚠️ Not yet runtime-verified** against a live devnet publish (the card only populates for genuinely on-chain KAs). Draft until that's done.

## Known limitations / follow-ups

- Entity→KA bridge uses the `ShareTransition` record (written on the WM→SWM→VM promote path). A KA created via the *atomic* `create + alsoPublishVm` route may lack it — the receipt still exists in `_meta`, but this hook won't find the bridge. Candidate fix: stamp an entity-membership predicate on the receipt, or read `dkg:entity` membership directly.
- Sub-graph-scoped KAs use a `STRENDS` assertion-URI match (robust to the sub-graph segment) — not yet validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)