### PR TITLE
demo(fibo-reasoner): eye-js reasoning across the Chorus memory layers

### DIFF
--- a/demo/fibo-reasoner/README.md
+++ b/demo/fibo-reasoner/README.md
@@ -1,0 +1,99 @@
+# FIBO Reasoner Demo — reasoning across the Chorus memory layers
+
+A small, end-to-end demo that puts a **reasoner** (eye-js — the EYE reasoner
+compiled to WebAssembly) inside the rc.17 **Working → Shared → Verifiable** memory
+pipeline, using a **FIBO** corporate-control example.
+
+## The story
+
+The rc.17 "Chorus" model gives every Knowledge Asset a three-layer memory:
+
+| Layer | Meaning |
+|-------|---------|
+| **Working Memory (WM)** | what an agent observed — local, unverified |
+| **Shared Working Memory (SWM)** | promoted for the swarm to see and challenge |
+| **Verifiable Memory (VM)** | anchored, provenance-backed, on chain |
+
+This demo adds the missing verb. Agents assert plain ownership facts into WM.
+eye-js applies a FIBO-style control ontology and **derives facts nobody
+asserted**. Each inference is written with provenance (`prov:wasDerivedFrom` the
+exact WM facts + the rule), promoted to SWM, and published to VM.
+
+The example is corporate control:
+
+```
+  Acme Capital ──60%──▶ Bridge Holdings ──55%──▶ SmallCo
+       │
+       ├──10%──▶ SmallCo            (a tiny direct stake)
+       └──30%──▶ Meridian Trading   (a minority stake)
+```
+
+No asserted fact says Acme controls SmallCo — on the cap table it owns 10%. The
+reasoner derives `Acme indirectlyControls SmallCo` through Bridge: **concealed,
+beneficial control**. Meanwhile the 30% Meridian stake produces nothing (below
+the 50% threshold) — the rule encodes the law, not a guess.
+
+## Why a reasoner (not an LLM) here
+
+The daemon already has a `semantic-enrichment/write` path that attaches
+`prov:wasDerivedFrom` / `generatedBy` provenance to *model-derived* triples. A
+reasoner is a better citizen of it than an LLM: the output is **deterministic**
+and the derivation is a **formal proof** you can replay and audit.
+
+## Run it
+
+```sh
+pnpm install                         # picks up eyereasoner + n3 (added to demo/package.json)
+
+node fibo-reasoner/run.mjs           # paced, narrated walkthrough (offline — always runs)
+node fibo-reasoner/run.mjs --no-pause
+node fibo-reasoner/run.mjs --json | jq .     # NDJSON, one line per step (agent-friendly)
+```
+
+Offline mode needs nothing but the install — eye-js runs in-process, no daemon,
+no devnet. That's deliberate: the reasoning + layer narration is the same with
+or without a live node, so it's safe to run on stage.
+
+### Live mode (optional)
+
+```sh
+dkg start                            # healthy daemon + devnet required
+node fibo-reasoner/run.mjs --live
+```
+
+`--live` additionally drives the real rc.17 lifecycle on a running node:
+
+| Step | Endpoint |
+|------|----------|
+| WM write (one KA per ownership fact) | `POST /api/knowledge-assets` (auto-finalize) |
+| SWM share (the inference + provenance) | `POST /api/knowledge-assets` `{alsoShareSwm:true}` |
+| VM publish | `POST /api/knowledge-assets/:name/vm/publish` |
+| read back | `dkg query <cg> --sparql … --include-shared-memory` |
+
+Every live call is best-effort — a flaky devnet degrades to a warning, never an
+abort. Set `FIBO_DEMO_CG=<cg-id>` to reuse an existing context graph, or
+`DKG_HOME` to point at a non-default daemon home.
+
+## Layout
+
+```
+fibo-reasoner/
+  run.mjs                 orchestrator: 5 phases, --json / --no-pause / --live
+  rules/control.n3        the entire reasoner — 2 N3 rules
+  fixtures/fibo-slice.ttl  curated FIBO fragment (LegalEntity vocab)
+  lib/
+    data.mjs              entities + ownership facts (single source of truth)
+    reasoner.mjs          eye-js wrapper + deterministic explain()
+    narrative.mjs         the spoken story, one beat per phase
+    live.mjs              best-effort WM→SWM→VM client
+    format.mjs            self-contained terminal formatting
+  test/reasoner.test.mjs  pins the inference (hidden control fires, minority doesn't)
+```
+
+Run the test: `pnpm --filter @origintrail-official/dkg-demo test:fibo`.
+
+## Swap the domain
+
+The reasoner is two rules in `rules/control.n3`. Replace them with supply-chain,
+compliance, or eligibility rules and the same WM → reason → SWM → VM pipeline
+applies — the memory model doesn't care what the inference is about.

--- a/demo/fibo-reasoner/fixtures/fibo-slice.ttl
+++ b/demo/fibo-reasoner/fixtures/fibo-slice.ttl
@@ -1,0 +1,21 @@
+# A hand-picked FIBO slice — NOT the full ontology.
+#
+# FIBO (the EDM Council's Financial Industry Business Ontology) is thousands of
+# classes across dozens of modules; loading it whole would bury the demo. This
+# file declares only what the reasoning needs: that each party is a FIBO
+# LegalEntity. The control vocabulary the rules PRODUCE
+# (demo:controls / demo:indirectlyControls) corresponds to FIBO's
+# BE/OwnershipAndControl/Control module and is kept in the demo namespace so the
+# inferred triples are easy to read on stage.
+#
+# Real FIBO module referenced:
+#   BE/LegalEntities/LegalPersons  →  LegalEntity
+
+@prefix rdfs:          <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fibo-be-le-lp: <https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/> .
+@prefix ex:            <https://example.org/entity/> .
+
+ex:AcmeCapital a fibo-be-le-lp:LegalEntity ; rdfs:label "Acme Capital Partners" .
+ex:BridgeHldgs a fibo-be-le-lp:LegalEntity ; rdfs:label "Bridge Holdings plc" .
+ex:SmallCo     a fibo-be-le-lp:LegalEntity ; rdfs:label "SmallCo Manufacturing Ltd" .
+ex:Meridian    a fibo-be-le-lp:LegalEntity ; rdfs:label "Meridian Trading SA" .

--- a/demo/fibo-reasoner/lib/data.mjs
+++ b/demo/fibo-reasoner/lib/data.mjs
@@ -1,0 +1,80 @@
+// Single source of truth for the demo's domain facts.
+//
+// Four legal entities and the voting-share stakes between them. The numbers
+// are picked to tell one specific story:
+//
+//   Acme ──60%──▶ Bridge ──55%──▶ SmallCo        (two majority links)
+//     │
+//     ├──10%──▶ SmallCo                           (a tiny DIRECT stake)
+//     └──30%──▶ Meridian                          (a minority stake)
+//
+// A naive "who owns what" view says Acme has no control of SmallCo (only 10%).
+// The reasoner derives the opposite: Acme *indirectly* controls SmallCo through
+// Bridge — concealed control that no single asserted fact states. Meridian stays
+// uncontrolled (30% < 50%), proving the rule isn't just "any stake = control".
+//
+// Turtle/quads for eye-js and for the --live path are GENERATED from these
+// arrays so the reasoning input, the on-graph KAs, and the provenance
+// justification can never drift apart.
+
+export const ENTITY_NS = 'https://example.org/entity/';
+export const DEMO_NS = 'https://example.org/fibo-demo#';
+
+export const ENTITIES = [
+  { id: 'AcmeCapital', label: 'Acme Capital Partners' },
+  { id: 'BridgeHldgs', label: 'Bridge Holdings plc' },
+  { id: 'SmallCo', label: 'SmallCo Manufacturing Ltd' },
+  { id: 'Meridian', label: 'Meridian Trading SA' },
+];
+
+// Each row is one Working-Memory fact: "<owner> holds <pct>% of the voting
+// shares of <company>". A real FIBO model reifies this as an OwnershipInterest
+// with hasPercentageValue; we flatten it to a list so the N3 rules stay legible.
+export const OWNERSHIP = [
+  { owner: 'AcmeCapital', company: 'BridgeHldgs', pct: 60 },
+  { owner: 'BridgeHldgs', company: 'SmallCo', pct: 55 },
+  { owner: 'AcmeCapital', company: 'SmallCo', pct: 10 },
+  { owner: 'AcmeCapital', company: 'Meridian', pct: 30 },
+];
+
+export const labelOf = (id) => ENTITIES.find((e) => e.id === id)?.label ?? id;
+
+// Stable per-fact KA name, used as the Working-Memory assertion name in --live
+// mode and as the prov:wasDerivedFrom target in the provenance chain.
+export const ownershipKaName = (o) =>
+  `ownership-${o.owner}-${o.company}`.toLowerCase();
+
+// Turtle for the ownership facts (consumed by eye-js and printable for the
+// human walkthrough). Voting percentage carried as an rdf:List `( company pct )`.
+export function ownershipTurtle() {
+  const lines = [
+    '@prefix demo: <https://example.org/fibo-demo#> .',
+    '@prefix ex: <https://example.org/entity/> .',
+    '',
+  ];
+  for (const o of OWNERSHIP) {
+    lines.push(`ex:${o.owner} demo:ownsVotingShares ( ex:${o.company} ${o.pct} ) .`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// Flat {subject,predicate,object} quads for ONE ownership fact, in the shape the
+// /api/knowledge-assets wm/write + create endpoints accept. The list node is
+// expanded to explicit rdf:first/rdf:rest so no blank-node list sugar is assumed.
+export function ownershipQuads(o) {
+  const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+  const ownerIri = `${ENTITY_NS}${o.owner}`;
+  const companyIri = `${ENTITY_NS}${o.company}`;
+  const list = `urn:dkg:list:${o.owner}-${o.company}`;
+  return [
+    { subject: ownerIri, predicate: `${DEMO_NS}ownsVotingShares`, object: list },
+    { subject: list, predicate: `${RDF}first`, object: companyIri },
+    { subject: list, predicate: `${RDF}rest`, object: `${list}-tail` },
+    {
+      subject: `${list}-tail`,
+      predicate: `${RDF}first`,
+      object: `"${o.pct}"^^http://www.w3.org/2001/XMLSchema#integer`,
+    },
+    { subject: `${list}-tail`, predicate: `${RDF}rest`, object: `${RDF}nil` },
+  ];
+}

--- a/demo/fibo-reasoner/lib/format.mjs
+++ b/demo/fibo-reasoner/lib/format.mjs
@@ -1,0 +1,37 @@
+// Small, self-contained terminal formatting. No deps — a demo dir should stand
+// on its own. Honours NO_COLOR and non-TTY stdout (so `| jq` / piped output is
+// clean).
+
+const useColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+const wrap = (code) => (s) => (useColor ? `\x1b[${code}m${s}\x1b[0m` : String(s));
+
+export const bold = wrap('1');
+export const dim = wrap('2');
+export const red = wrap('31');
+export const green = wrap('32');
+export const yellow = wrap('33');
+export const blue = wrap('34');
+export const magenta = wrap('35');
+export const cyan = wrap('36');
+
+export const divider = (ch = '─', w = 74) => dim(ch.repeat(w));
+export const header = (t) => `\n${bold(t)}\n${divider()}`;
+export const step = (id, t) => `${cyan('▶')} ${bold(id)}  ${t}`;
+export const note = (t) => `${dim('·')} ${dim(t)}`;
+export const success = (t) => `${green('✓')} ${t}`;
+export const warn = (t) => `${yellow('!')} ${t}`;
+export const fail = (t) => `${red('✗')} ${t}`;
+export const kv = (k, v) => `  ${dim(String(k).padEnd(18))}${v}`;
+export const bullet = (t) => `    ${dim('•')} ${t}`;
+
+// A labelled box marking which memory layer a write lands in — the visual spine
+// of the demo. layer ∈ { WM, SWM, VM }.
+const LAYER_COLOR = { WM: yellow, SWM: cyan, VM: green };
+export function layerTag(layer, text) {
+  const paint = LAYER_COLOR[layer] ?? bold;
+  return `${paint(`[${layer}]`)} ${text}`;
+}
+
+export function paragraphs(lines) {
+  return lines.map((l) => l).join('\n\n');
+}

--- a/demo/fibo-reasoner/lib/live.mjs
+++ b/demo/fibo-reasoner/lib/live.mjs
@@ -1,0 +1,104 @@
+// --live path: drive the real rc.17 /api/knowledge-assets lifecycle against a
+// running daemon. Best-effort by design — every call is wrapped so a flaky
+// devnet degrades to a warning, never an abort. The offline narrative is the
+// star; this proves the same story lands on a real node when one is healthy.
+//
+// Lifecycle used (all confirmed in packages/cli/src/daemon/routes/knowledge-assets.ts):
+//   POST /api/knowledge-assets                      create + auto-finalize (→ WM)
+//   POST /api/knowledge-assets  {alsoShareSwm:true} create + promote      (→ SWM)
+//   POST /api/knowledge-assets/:name/vm/publish     mint on chain         (→ VM)
+//   dkg query <cg> -q <sparql> --include-shared-memory   read it back
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SELF_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SELF_DIR, '..', '..', '..');
+const LOCAL_CLI = join(REPO_ROOT, 'packages/cli/dist/cli.js');
+
+export async function resolveAuth() {
+  const dkgHome = process.env.DKG_HOME || join(homedir(), '.dkg');
+  let port;
+  try {
+    port = parseInt((await readFile(join(dkgHome, 'api.port'), 'utf8')).trim(), 10);
+  } catch {
+    throw new Error(`No daemon reachable: cannot read ${join(dkgHome, 'api.port')} (is \`dkg start\` running?)`);
+  }
+  if (!Number.isFinite(port)) throw new Error(`Bad port in ${join(dkgHome, 'api.port')}`);
+
+  let token = process.env.DKG_API_TOKEN || null;
+  if (!token) {
+    for (const p of [join(dkgHome, 'auth.token'), join(dkgHome, 'auth', 'token')]) {
+      try {
+        const t = (await readFile(p, 'utf8')).trim();
+        if (t) { token = t; break; }
+      } catch { /* auth may be disabled — fine */ }
+    }
+  }
+  return { baseUrl: `http://127.0.0.1:${port}`, token, dkgHome };
+}
+
+function runCli(args) {
+  const useLocal = existsSync(LOCAL_CLI);
+  const cmd = useLocal ? 'node' : 'dkg';
+  const full = useLocal ? [LOCAL_CLI, ...args] : args;
+  const proc = spawnSync(cmd, full, { encoding: 'utf8' });
+  return { exit: proc.status ?? 1, stdout: proc.stdout || '', stderr: proc.stderr || '' };
+}
+
+async function apiPost(auth, path, body) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  const res = await fetch(`${auth.baseUrl}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { raw: text.slice(0, 400) }; }
+  return { ok: res.ok, status: res.status, body: json };
+}
+
+// Create (or reuse) the context graph that holds the demo's KAs. Honours
+// FIBO_DEMO_CG when set, otherwise creates one and best-effort parses the
+// daemon-resolved, author-namespaced id from the CLI output.
+export async function ensureContextGraph(nameInput) {
+  if (process.env.FIBO_DEMO_CG) return { contextGraphId: process.env.FIBO_DEMO_CG, created: false };
+  const create = runCli(['context-graph', 'create', nameInput]);
+  if (create.exit !== 0) {
+    throw new Error(`\`context-graph create\` failed (exit ${create.exit}): ${create.stderr.trim() || create.stdout.trim()}`);
+  }
+  const m = create.stdout.match(/(0x[0-9a-fA-F]{6,}\/[\w.-]+)/) || create.stdout.match(/did:dkg:context-graph:([\w.\/-]+)/);
+  const contextGraphId = m ? (m[1] ?? m[0]) : nameInput;
+  runCli(['context-graph', 'register', contextGraphId]); // idempotent; ignore result
+  return { contextGraphId, created: true };
+}
+
+// One Working-Memory KA per ownership fact (create with quads auto-finalizes).
+export function writeWorkingMemory(auth, contextGraphId, name, quads) {
+  return apiPost(auth, '/api/knowledge-assets', { contextGraphId, name, quads });
+}
+
+// The inference KA: derived control triples + provenance, promoted to SWM in
+// one atomic create (alsoShareSwm).
+export function shareToSwm(auth, contextGraphId, name, quads) {
+  return apiPost(auth, '/api/knowledge-assets', { contextGraphId, name, quads, alsoShareSwm: true });
+}
+
+// Anchor the inference to Verifiable Memory.
+export function publishToVm(auth, contextGraphId, name) {
+  return apiPost(auth, `/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, { contextGraphId });
+}
+
+// Read the verified inference back, including the shared-memory layer.
+export function querySparql(contextGraphId, sparql) {
+  const res = runCli(['query', contextGraphId, '-q', sparql, '--include-shared-memory']);
+  let parsed = null;
+  try { parsed = JSON.parse(res.stdout); } catch { /* leave raw */ }
+  return { exit: res.exit, parsed, raw: res.stdout, stderr: res.stderr };
+}

--- a/demo/fibo-reasoner/lib/narrative.mjs
+++ b/demo/fibo-reasoner/lib/narrative.mjs
@@ -1,0 +1,58 @@
+// Story content for the paced human walkthrough. One short beat per phase.
+// --json mode skips all of this — that channel is for agents.
+
+export const OPENING = {
+  title: 'Reasoning across the memory layers — a FIBO control example',
+  body: [
+    'The rc.17 "Chorus" model gives every Knowledge Asset a three-layer memory: Working Memory (what an agent observed, locally), Shared Working Memory (promoted for the swarm to see and challenge), and Verifiable Memory (anchored, provenance-backed, on-chain). The layers are a pipeline for turning raw observation into trusted knowledge.',
+    'This demo puts a reasoner in that pipeline. Agents assert plain ownership facts into Working Memory. eye-js — the EYE reasoner running in-process — applies a FIBO-style control ontology and DERIVES facts nobody asserted. Those derived facts, each carrying provenance back to the evidence and the rule, are promoted to Shared Working Memory and finally published to Verifiable Memory.',
+    'The example is corporate control. Four legal entities, a handful of voting-share stakes. On the surface, Acme Capital barely touches SmallCo — a 10% sliver. The reasoner shows otherwise.',
+  ],
+};
+
+export const OWNERSHIP_DIAGRAM = `
+  What the agents asserted (Working Memory) — voting-share stakes:
+
+      Acme Capital ──60%──▶ Bridge Holdings ──55%──▶ SmallCo
+           │
+           ├──10%──▶ SmallCo            (a tiny direct stake)
+           └──30%──▶ Meridian Trading   (a minority stake)
+
+  No asserted fact says Acme controls SmallCo. Read literally, it owns 10%.
+`;
+
+export const PHASES = {
+  setup: {
+    id: 'Phase 0',
+    title: 'Load the FIBO slice & the facts',
+    body: 'We load a tiny curated FIBO fragment (every party is a fibo:LegalEntity) and the asserted ownership stakes. In --live mode this also creates the context graph that will hold the KAs.',
+  },
+  wm: {
+    id: 'Phase 1',
+    title: 'Working Memory — assert the raw facts',
+    body: 'Each ownership stake is a Working-Memory fact: agent-local, unverified, exactly as observed. Nothing is inferred yet. This is the bottom of the Chorus pipeline.',
+  },
+  reason: {
+    id: 'Phase 2',
+    title: 'Reason — run eye-js over the facts',
+    body: 'eye-js applies the FIBO control rules to Working Memory. Two rules: majority voting interest ⇒ control, and control is transitive. Watch what comes out that nobody put in.',
+  },
+  provenance: {
+    id: 'Phase 3',
+    title: 'Provenance & Shared Working Memory',
+    body: 'A derived fact is only as good as its justification. Each inference is written with prov:wasDerivedFrom pointing at the exact Working-Memory facts and the rule that fired — then promoted to Shared Working Memory so the swarm can see and challenge it. Unlike an LLM enrichment, the derivation is a formal proof.',
+  },
+  vm: {
+    id: 'Phase 4',
+    title: 'Verifiable Memory — publish the inference',
+    body: 'The inference is anchored to Verifiable Memory. Querying it back returns not just "Acme indirectlyControls SmallCo" but the whole provenance chain — the two facts and the rule behind it. A verified, explainable claim on the DKG.',
+  },
+};
+
+export const CLOSING = {
+  title: 'What just happened',
+  body: [
+    'A fact that no agent asserted — Acme Capital indirectly controls SmallCo — was derived by rule, justified by provenance, and promoted Working → Shared → Verified. Meanwhile the 30% Meridian stake correctly produced nothing: the reasoner encodes the law, not a guess.',
+    'The reasoner is the missing verb in the memory model. Working Memory is what was seen; Verifiable Memory is what the swarm reasoned and confirmed; eye-js is the inference in between. Swap the FIBO control rules for supply-chain, compliance, or eligibility rules and the same pipeline applies.',
+  ],
+};

--- a/demo/fibo-reasoner/lib/reasoner.mjs
+++ b/demo/fibo-reasoner/lib/reasoner.mjs
@@ -1,0 +1,111 @@
+// Thin wrapper around eye-js (the `eyereasoner` package — EYE compiled to WASM).
+// Loads the FIBO slice + ownership facts + N3 rules, runs forward inference
+// in-process, and returns the derived control relations as structured triples.
+//
+// explain() reconstructs WHY each derived triple holds — the supporting facts
+// and the rule — straight from the source data. That justification is what the
+// provenance phase writes onto the graph (prov:wasDerivedFrom + the rule), and
+// it's deterministic: same facts, same proof, every run.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { n3reasoner } from 'eyereasoner';
+import N3 from 'n3';
+
+import { DEMO_NS, ENTITY_NS, OWNERSHIP, labelOf, ownershipTurtle, ownershipKaName } from './data.mjs';
+
+const SELF_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SELF_DIR, '..');
+
+const CONTROLS = `${DEMO_NS}controls`;
+const INDIRECT = `${DEMO_NS}indirectlyControls`;
+
+export function shorten(iri) {
+  if (typeof iri !== 'string') return String(iri);
+  if (iri.startsWith(DEMO_NS)) return `demo:${iri.slice(DEMO_NS.length)}`;
+  if (iri.startsWith(ENTITY_NS)) return `ex:${iri.slice(ENTITY_NS.length)}`;
+  return iri;
+}
+
+const localName = (iri) => (typeof iri === 'string' ? iri.slice(iri.lastIndexOf('/') + 1) : iri);
+
+export async function loadSources() {
+  const [fibo, rules] = await Promise.all([
+    readFile(join(ROOT, 'fixtures/fibo-slice.ttl'), 'utf8'),
+    readFile(join(ROOT, 'rules/control.n3'), 'utf8'),
+  ]);
+  return { fibo, ownership: ownershipTurtle(), rules };
+}
+
+// Run eye-js. `data` = FIBO slice + ownership facts; `rules` = the N3 rules.
+// With no query, the reasoner returns its derivations; we keep the two control
+// predicates and drop anything echoed from the input graph.
+export async function reason({ fibo, ownership, rules }) {
+  const data = `${fibo}\n${ownership}`;
+  const n3Text = await n3reasoner([data, rules], null);
+  const triples = parseTurtle(n3Text)
+    .filter((t) => t.p === CONTROLS || t.p === INDIRECT)
+    .sort((a, b) => (a.p === b.p ? 0 : a.p === CONTROLS ? -1 : 1));
+  return { n3Text, triples };
+}
+
+function parseTurtle(ttl) {
+  // No-callback form parses synchronously and returns the quad array — the
+  // callback form populates on later ticks, which would race reason()'s return.
+  return new N3.Parser()
+    .parse(ttl)
+    .map((q) => ({ s: q.subject.value, p: q.predicate.value, o: q.object.value }));
+}
+
+export const isIndirect = (t) => t.p === INDIRECT;
+
+// Why does this derived triple hold? Returns the rule, a one-line gloss, the
+// supporting facts in plain English, and the Working-Memory KAs they came from
+// (used as prov:wasDerivedFrom targets).
+export function explain(triple) {
+  const a = localName(triple.s);
+  const z = localName(triple.o);
+
+  if (triple.p === CONTROLS) {
+    const o = OWNERSHIP.find((x) => x.owner === a && x.company === z && x.pct > 50);
+    return {
+      rule: 'R1 · majority-voting-control',
+      gloss: 'owns > 50% of voting shares ⇒ controls',
+      because: o ? [`${labelOf(a)} holds ${o.pct}% of ${labelOf(z)} — a majority stake`] : [],
+      derivedFrom: o ? [ownershipKaName(o)] : [],
+    };
+  }
+
+  if (triple.p === INDIRECT) {
+    let chain = null;
+    for (const o1 of OWNERSHIP.filter((x) => x.owner === a && x.pct > 50)) {
+      const o2 = OWNERSHIP.find((x) => x.owner === o1.company && x.company === z && x.pct > 50);
+      if (o2) {
+        chain = [o1, o2];
+        break;
+      }
+    }
+    const direct = OWNERSHIP.find((x) => x.owner === a && x.company === z);
+    const because = [];
+    if (chain) {
+      because.push(`${labelOf(a)} controls ${labelOf(chain[0].company)} (${chain[0].pct}%)`);
+      because.push(`${labelOf(chain[1].owner)} controls ${labelOf(z)} (${chain[1].pct}%)`);
+      if (direct) {
+        because.push(
+          `direct stake is only ${direct.pct}% — control here is BENEFICIAL, through the chain, not on the cap table`,
+        );
+      } else {
+        because.push(`no direct stake at all — this control is entirely indirect`);
+      }
+    }
+    return {
+      rule: 'R2 · transitive-control (beneficial ownership)',
+      gloss: 'controls(a,b) ∧ controls(b,c) ⇒ indirectlyControls(a,c)',
+      because,
+      derivedFrom: chain ? [ownershipKaName(chain[0]), ownershipKaName(chain[1])] : [],
+    };
+  }
+
+  return { rule: 'unknown', gloss: '', because: [], derivedFrom: [] };
+}

--- a/demo/fibo-reasoner/rules/control.n3
+++ b/demo/fibo-reasoner/rules/control.n3
@@ -1,0 +1,22 @@
+# FIBO-style corporate-control rules, in Notation3, run by eye-js (the EYE
+# reasoner compiled to WebAssembly). These are the entire "reasoner" — two
+# rules, no code. Change a threshold here and the whole derivation shifts.
+#
+# Mirrors FIBO BE/OwnershipAndControl/Control: a majority voting interest
+# constitutes control, and control passes down a chain of holdings.
+
+@prefix demo: <https://example.org/fibo-demo#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+
+# R1 — majority voting interest ⇒ control
+#      "If A holds more than 50% of B's voting shares, A controls B."
+{ ?a demo:ownsVotingShares ( ?b ?pct ) . ?pct math:greaterThan 50 . }
+  =>
+{ ?a demo:controls ?b } .
+
+# R2 — control is transitive ⇒ indirect (beneficial) control
+#      "If A controls B and B controls C, then A indirectly controls C —
+#       even when A's *direct* stake in C is small or zero."
+{ ?a demo:controls ?b . ?b demo:controls ?c . }
+  =>
+{ ?a demo:indirectlyControls ?c } .

--- a/demo/fibo-reasoner/run.mjs
+++ b/demo/fibo-reasoner/run.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// FIBO reasoner on the Chorus memory layers.
+//
+//   node run.mjs              Paced, narrated walkthrough (offline — always runs)
+//   node run.mjs --no-pause   Same, no Enter prompts
+//   node run.mjs --json       NDJSON, one line per step (agent-friendly)
+//   node run.mjs --live       Also drive a real daemon's WM→SWM→VM KA lifecycle
+//
+// Offline mode needs nothing but `pnpm install` (eye-js runs in-process).
+// --live additionally needs a healthy daemon (`dkg start`) and devnet.
+
+import { createInterface } from 'node:readline';
+
+import * as fmt from './lib/format.mjs';
+import { OPENING, OWNERSHIP_DIAGRAM, PHASES, CLOSING } from './lib/narrative.mjs';
+import { DEMO_NS, ENTITY_NS, ENTITIES, OWNERSHIP, labelOf, ownershipKaName, ownershipQuads } from './lib/data.mjs';
+import { loadSources, reason, explain, shorten, isIndirect } from './lib/reasoner.mjs';
+import * as live from './lib/live.mjs';
+
+const JSON_MODE = process.argv.includes('--json');
+const NO_PAUSE = process.argv.includes('--no-pause') || JSON_MODE;
+const LIVE = process.argv.includes('--live');
+
+const PROV = 'http://www.w3.org/ns/prov#';
+const DKG_ONT = 'https://ontology.origintrail.io/dkg/1.0#';
+const REASONER_AGENT = 'urn:dkg:agent:eye-js-reasoner';
+const NOW = '2026-06-08T00:00:00Z'; // fixed for deterministic, replayable output
+
+const say = (...lines) => { if (!JSON_MODE) console.log(lines.join('\n')); };
+const emit = (obj) => { if (JSON_MODE) process.stdout.write(JSON.stringify(obj) + '\n'); };
+
+async function pause() {
+  if (NO_PAUSE) return;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  await new Promise((r) => rl.question(fmt.dim('\n  ⏎  Enter to continue…  '), () => r()));
+  rl.close();
+}
+
+const fact = (t) => `${shorten(t.s)} ${fmt.bold(shorten(t.p))} ${shorten(t.o)}`;
+const prettyJson = (o) => fmt.dim(JSON.stringify(o, null, 2).split('\n').slice(0, 24).join('\n'));
+
+// Build the inference KA content: the derived triples + PROV provenance, in the
+// same spirit as the daemon's buildSemanticEnrichmentProvenanceQuads.
+function inferenceQuads(triples) {
+  const enrich = 'urn:dkg:semantic-enrichment:fibo-control';
+  const quads = [];
+  const sources = new Set();
+  for (const t of triples) {
+    quads.push({ subject: t.s, predicate: t.p, object: t.o });
+    quads.push({ subject: t.s, predicate: `${PROV}wasAttributedTo`, object: REASONER_AGENT });
+    for (const d of explain(t).derivedFrom) sources.add(d);
+  }
+  for (const s of sources) {
+    quads.push({ subject: enrich, predicate: `${PROV}wasDerivedFrom`, object: `urn:dkg:ka:${s}` });
+  }
+  quads.push({ subject: enrich, predicate: `${DKG_ONT}generatedBy`, object: REASONER_AGENT });
+  quads.push({
+    subject: enrich,
+    predicate: `${DKG_ONT}generatedAt`,
+    object: `"${NOW}"^^http://www.w3.org/2001/XMLSchema#dateTime`,
+  });
+  return quads;
+}
+
+async function main() {
+  let auth = null;
+  let cgId = null;
+  if (LIVE) {
+    try {
+      auth = await live.resolveAuth();
+    } catch (e) {
+      say(fmt.fail(`--live unavailable: ${e.message}`));
+      say(fmt.note('Continuing offline — the narrative is identical.\n'));
+    }
+  }
+
+  // ── Opening ───────────────────────────────────────────────────────────
+  say(fmt.header(OPENING.title));
+  for (const p of OPENING.body) say('\n' + p);
+  say('\n' + OWNERSHIP_DIAGRAM);
+  emit({ phase: 'opening', live: Boolean(auth) });
+  await pause();
+
+  // ── Phase 0 — Setup ───────────────────────────────────────────────────
+  const { fibo, ownership, rules } = await loadSources();
+  say(fmt.header(`${PHASES.setup.id} — ${PHASES.setup.title}`));
+  say('\n' + PHASES.setup.body + '\n');
+  say(fmt.kv('FIBO slice', `${ENTITIES.length} entities, all fibo:LegalEntity`));
+  say(fmt.kv('Rules', 'rules/control.n3 — 2 N3 rules (majority control, transitivity)'));
+  say(fmt.kv('Facts', `${OWNERSHIP.length} voting-share stakes`));
+  if (auth) {
+    try {
+      const r = await live.ensureContextGraph(`fibo-reasoner-${Date.now().toString(36)}`);
+      cgId = r.contextGraphId;
+      say(fmt.success(`context graph: ${cgId}${r.created ? ' (created)' : ' (reused)'}`));
+    } catch (e) {
+      say(fmt.warn(`context-graph create failed — falling back to offline: ${e.message}`));
+      auth = null;
+    }
+  }
+  emit({ phase: 'setup', entities: ENTITIES.length, rules: 2, facts: OWNERSHIP.length, contextGraphId: cgId });
+  await pause();
+
+  // ── Phase 1 — Working Memory ──────────────────────────────────────────
+  say(fmt.header(`${PHASES.wm.id} — ${PHASES.wm.title}`));
+  say('\n' + PHASES.wm.body + '\n');
+  for (const o of OWNERSHIP) {
+    const name = ownershipKaName(o);
+    const line = `${labelOf(o.owner)} owns ${o.pct}% of ${labelOf(o.company)}`;
+    let status = fmt.dim('(offline)');
+    if (auth) {
+      const res = await live.writeWorkingMemory(auth, cgId, name, ownershipQuads(o));
+      status = res.ok ? fmt.green(`→ KA ${name}`) : fmt.red(`HTTP ${res.status}`);
+    }
+    say('  ' + fmt.layerTag('WM', `${line}  ${status}`));
+    emit({ phase: 'wm', ka: name, owner: o.owner, company: o.company, pct: o.pct });
+  }
+  say('\n' + fmt.note('All four facts are now Working Memory: asserted, local, nothing inferred.'));
+  await pause();
+
+  // ── Phase 2 — Reason ──────────────────────────────────────────────────
+  say(fmt.header(`${PHASES.reason.id} — ${PHASES.reason.title}`));
+  say('\n' + PHASES.reason.body + '\n');
+  const { triples } = await reason({ fibo, ownership, rules });
+  for (const t of triples) {
+    const tag = isIndirect(t) ? fmt.magenta('  ◀ derived, not asserted') : '';
+    say('  ' + fact(t) + tag);
+    emit({ phase: 'reason', subject: shorten(t.s), predicate: shorten(t.p), object: shorten(t.o), indirect: isIndirect(t) });
+  }
+  const hidden = triples.find(isIndirect);
+  if (hidden) {
+    say('');
+    say(fmt.success(
+      `${fmt.bold(labelOf(hidden.s.slice(ENTITY_NS.length)))} controls ` +
+      `${fmt.bold(labelOf(hidden.o.slice(ENTITY_NS.length)))} — through the chain, not the cap table.`,
+    ));
+  }
+  say(fmt.note('Meridian (30%) produced nothing: below the 50% control threshold. The rule encodes the law, not a guess.'));
+  await pause();
+
+  // ── Phase 3 — Provenance & SWM ────────────────────────────────────────
+  say(fmt.header(`${PHASES.provenance.id} — ${PHASES.provenance.title}`));
+  say('\n' + PHASES.provenance.body + '\n');
+  for (const t of triples) {
+    const why = explain(t);
+    say('  ' + fmt.layerTag('SWM', fact(t)));
+    say(fmt.kv('  rule', why.rule));
+    say(fmt.kv('  ' + fmt.dim(why.gloss), ''));
+    for (const b of why.because) say(fmt.bullet(b));
+    say(fmt.kv('  wasDerivedFrom', why.derivedFrom.map((d) => `urn:dkg:ka:${d}`).join('  ') || fmt.dim('—')));
+    say(fmt.kv('  generatedBy', REASONER_AGENT));
+    say('');
+    emit({ phase: 'provenance', triple: fact(t), rule: why.rule, derivedFrom: why.derivedFrom });
+  }
+  const infQuads = inferenceQuads(triples);
+  if (auth) {
+    const res = await live.shareToSwm(auth, cgId, 'fibo-control-inference', infQuads);
+    say(res.ok
+      ? fmt.success('inference KA created & promoted to Shared Working Memory (alsoShareSwm)')
+      : fmt.red(`SWM share failed: HTTP ${res.status} ${JSON.stringify(res.body).slice(0, 160)}`));
+  } else {
+    say(fmt.note(`Would write ${infQuads.length} quads (inference + provenance) and swm/share them.`));
+  }
+  await pause();
+
+  // ── Phase 4 — Verifiable Memory ─────────────────────────────────────────
+  say(fmt.header(`${PHASES.vm.id} — ${PHASES.vm.title}`));
+  say('\n' + PHASES.vm.body + '\n');
+  if (auth) {
+    const pub = await live.publishToVm(auth, cgId, 'fibo-control-inference');
+    say(pub.ok ? fmt.success('published to Verifiable Memory (vm/publish)') : fmt.red(`vm/publish failed: HTTP ${pub.status}`));
+    const sparql = `PREFIX demo: <${DEMO_NS}>
+SELECT ?a ?c WHERE { ?a demo:indirectlyControls ?c }`;
+    const q = live.querySparql(cgId, sparql);
+    say(fmt.kv('SPARQL', 'SELECT ?a ?c WHERE { ?a demo:indirectlyControls ?c }'));
+    say(q.parsed ? prettyJson(q.parsed) : fmt.dim((q.raw || q.stderr || '').trim().slice(0, 400)));
+    emit({ phase: 'vm', published: pub.ok, query: q.parsed ?? null });
+  } else {
+    if (hidden) {
+      say('  ' + fmt.layerTag('VM', fmt.bold(fact(hidden))));
+      const why = explain(hidden);
+      say(fmt.dim('     provenance chain on the verified fact:'));
+      for (const b of why.because) say(fmt.bullet(b));
+      say(fmt.bullet(`rule: ${why.rule}`));
+      say(fmt.bullet(`generatedBy: ${REASONER_AGENT}`));
+    }
+    say('\n' + fmt.note('Run with --live against a healthy daemon to publish and SPARQL it back for real.'));
+    emit({ phase: 'vm', published: false, offline: true });
+  }
+  await pause();
+
+  // ── Closing ───────────────────────────────────────────────────────────
+  say(fmt.header(CLOSING.title));
+  for (const p of CLOSING.body) say('\n' + p);
+  say('');
+  emit({ phase: 'closing' });
+}
+
+main().catch((e) => {
+  if (JSON_MODE) emit({ phase: 'error', error: String(e?.message ?? e) });
+  else console.error(fmt.fail(String(e?.stack ?? e)));
+  process.exit(1);
+});

--- a/demo/fibo-reasoner/test/reasoner.test.mjs
+++ b/demo/fibo-reasoner/test/reasoner.test.mjs
@@ -1,0 +1,39 @@
+// Pins the inference so the demo can't silently rot: the hidden-control beat
+// must keep firing and minority stakes must keep producing nothing.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadSources, reason, explain } from '../lib/reasoner.mjs';
+import { DEMO_NS, ENTITY_NS } from '../lib/data.mjs';
+
+const has = (triples, s, p, o) =>
+  triples.some((t) => t.s === `${ENTITY_NS}${s}` && t.p === `${DEMO_NS}${p}` && t.o === `${ENTITY_NS}${o}`);
+
+test('derives direct control from a majority stake', async () => {
+  const { triples } = await reason(await loadSources());
+  assert.ok(has(triples, 'AcmeCapital', 'controls', 'BridgeHldgs'), 'Acme controls Bridge (60%)');
+  assert.ok(has(triples, 'BridgeHldgs', 'controls', 'SmallCo'), 'Bridge controls SmallCo (55%)');
+});
+
+test('surfaces hidden transitive control', async () => {
+  const { triples } = await reason(await loadSources());
+  assert.ok(
+    has(triples, 'AcmeCapital', 'indirectlyControls', 'SmallCo'),
+    'Acme indirectly controls SmallCo through Bridge',
+  );
+});
+
+test('minority stakes never confer control', async () => {
+  const { triples } = await reason(await loadSources());
+  assert.ok(!has(triples, 'AcmeCapital', 'controls', 'SmallCo'), '10% direct is not control');
+  assert.ok(!has(triples, 'AcmeCapital', 'controls', 'Meridian'), '30% is not control');
+  assert.ok(!triples.some((t) => t.o === `${ENTITY_NS}Meridian`), 'Meridian stays uncontrolled');
+});
+
+test('explanation cites the right rule and evidence', async () => {
+  const { triples } = await reason(await loadSources());
+  const indirect = triples.find((t) => t.p === `${DEMO_NS}indirectlyControls`);
+  const why = explain(indirect);
+  assert.match(why.rule, /transitive/);
+  assert.equal(why.derivedFrom.length, 2, 'indirect control derives from two WM facts');
+});

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,10 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test kafka-streams/test/*.mjs"
+    "test": "node --test kafka-streams/test/*.mjs",
+    "test:fibo": "node --test fibo-reasoner/test/*.mjs",
+    "demo:fibo": "node fibo-reasoner/run.mjs"
   },
   "dependencies": {
     "@multiformats/multiaddr": "^13.0.3",
+    "eyereasoner": "^21.1.10",
+    "n3": "^1.22.3",
     "@origintrail-official/dkg-agent": "workspace:*",
     "@origintrail-official/dkg-chain": "workspace:*",
     "@origintrail-official/dkg-core": "workspace:*",


### PR DESCRIPTION
## What

A self-contained demo (`demo/fibo-reasoner/`) that puts a **reasoner** — [eye-js](https://github.com/eyereasoner/eye-js), the EYE reasoner compiled to WASM — **inside the rc.17 Chorus memory pipeline**, using a **FIBO** corporate-control example. It's not bolted on: the reasoner is the inference step that turns Working Memory into Verifiable Memory.

## Why it's meaningful

The Chorus model (this PR's parent work) progresses each KA **Working Memory → Shared Working Memory → Verifiable Memory**. Today that's about *sharing and verifying asserted facts*. A reasoner gives each transition semantic weight:

| Layer | With the reasoner |
|---|---|
| **WM** | agents assert raw FIBO facts: voting-share stakes |
| **reason** | eye-js applies the FIBO control ontology + N3 rules → derives facts nobody asserted |
| **SWM** | derived facts promoted (with provenance) for the swarm to see and challenge |
| **VM** | the inference becomes a verified, provenance-backed claim |

It also gives the existing `semantic-enrichment/write` provenance path (`prov:wasDerivedFrom` / `generatedBy`) a **deterministic, formally-provable** producer instead of an LLM.

## The example — hidden corporate control

```
  Acme Capital ──60%──▶ Bridge Holdings ──55%──▶ SmallCo
       │
       ├──10%──▶ SmallCo            (a tiny direct stake)
       └──30%──▶ Meridian Trading   (a minority stake)
```

No asserted fact says Acme controls SmallCo — on the cap table it owns 10%. eye-js derives **`Acme indirectlyControls SmallCo`** through Bridge (concealed beneficial control), while the 30% Meridian stake correctly yields nothing. The rule encodes the law, not a guess.

## Run it

```sh
pnpm install
node demo/fibo-reasoner/run.mjs            # paced, narrated (offline — always runs)
node demo/fibo-reasoner/run.mjs --json     # NDJSON, agent-friendly
node demo/fibo-reasoner/run.mjs --live     # drives real WM→SWM→VM endpoints (needs healthy daemon)
pnpm --filter @origintrail-official/dkg-demo test:fibo
```

**Offline by default** — eye-js runs in-process, no daemon or devnet required, so the reasoning + layer narration are demo-safe. `--live` additionally drives `POST /api/knowledge-assets` (WM), `{alsoShareSwm:true}` (SWM), and `:name/vm/publish` (VM), then SPARQLs the result back.

## Notes for reviewers

- New dependency: `eyereasoner` (+ `n3`), added to `demo/package.json`. WASM, no native build.
- `node --test` pins the inference so the hidden-control beat can't silently rot.
- **Terminology:** this demo uses **"Verifiable Memory"**, aligned with the in-flight `Verified → Verifiable` rename. The rest of `rc17-vm-wip` still says "Verified Memory" pending that rename — happy to switch the demo's wording to match the base if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)