### PR TITLE
fix(rc.17): random-sampling §F2 fixture (unblocks #1053 CI) + core-mesh devnet default

### DIFF
--- a/packages/random-sampling/test/e2e-hardhat-chain.test.ts
+++ b/packages/random-sampling/test/e2e-hardhat-chain.test.ts
@@ -175,24 +175,28 @@ describe('Random Sampling E2E (Hardhat)', () => {
         };
       }),
     );
+    // OT-RFC-43 Option 1 (variant 1a): the real adapter requires a packed
+    // reservedKaId = (uint160(author) << 96) | number. Mirror the publisher's
+    // allocator cold-start (DKGPublisher.ensureReservedKaId): read the author's
+    // highest minted number from chain (-1n on a fresh deploy) and reserve the
+    // next one. CORE_OP has minted nothing in this snapshot, so this is number 0.
+    // §F2 — the AuthorAttestation digest binds reservedKaId as its 5th field, so it
+    // must be reserved BEFORE the typed data is built and signed (otherwise the
+    // EIP-712 message's reservedKaId is null and ethers throws at encodeData).
+    const authorChainMax = await publisherAdapter.getMaxKaNumberForAuthor!(coreOpWallet.address);
+    const reservedKaId =
+      (BigInt(ethers.getAddress(coreOpWallet.address)) << 96n) | (authorChainMax + 1n);
     const authorTyped = buildAuthorAttestationTypedData({
       chainId: TEST_CHAIN_ID,
       kav10Address,
       contextGraphId: cgId,
       merkleRoot,
       authorAddress: coreOpWallet.address,
+      reservedKaId,
     });
     const authorSig = ethers.Signature.from(
       await coreOpWallet.signTypedData(authorTyped.domain, authorTyped.types, authorTyped.message),
     );
-    // OT-RFC-43 Option 1 (variant 1a): the real adapter requires a packed
-    // reservedKaId = (uint160(author) << 96) | number. Mirror the publisher's
-    // allocator cold-start (DKGPublisher.ensureReservedKaId): read the author's
-    // highest minted number from chain (-1n on a fresh deploy) and reserve the
-    // next one. CORE_OP has minted nothing in this snapshot, so this is number 0.
-    const authorChainMax = await publisherAdapter.getMaxKaNumberForAuthor!(coreOpWallet.address);
-    const reservedKaId =
-      (BigInt(ethers.getAddress(coreOpWallet.address)) << 96n) | (authorChainMax + 1n);
     const publishResult = await publisherAdapter.createKnowledgeAssets!({
       publishOperationId: 'rs-e2e-publish',
       contextGraphId: cgId,

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -593,11 +593,18 @@ start_node() {
     const cfgPath = process.env.NODE_DIR + '/config.json';
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
     if (process.env.RELAY_ARG) cfg.relay = process.env.RELAY_ARG;
-    const n = Number(process.env.NODE_NUM), cores = Number(process.env.NUM_CORE_NODES);
-    // core: earlier cores (mesh forms bidirectionally); edge: all cores (spoke).
-    const hi = (n <= cores) ? (n - 1) : cores;
+    const n = Number(process.env.NODE_NUM);
+    // Bootstrap targets are the CORE nodes among 1..n-1, read from each node's
+    // authoritative nodeRole — NOT the ordinal 'first NUM_CORE_NODES are cores',
+    // since cmd_addnode can spawn a core beyond NUM_CORE_NODES (via
+    // DEVNET_NODE_ROLE_OVERRIDE). A core thus meshes with every earlier core; an
+    // edge spokes to every earlier core. Connections are bidirectional, so a
+    // later-added core dials the earlier cores and joins the mesh.
     const peers = [];
-    for (let c = 1; c <= hi; c++) {
+    for (let c = 1; c < n; c++) {
+      let cRole = 'edge';
+      try { cRole = JSON.parse(fs.readFileSync(dir + '/node' + c + '/config.json', 'utf8')).nodeRole || 'edge'; } catch {}
+      if (cRole !== 'core') continue;
       try { const m = fs.readFileSync(dir + '/node' + c + '/multiaddr', 'utf8').trim(); if (m) peers.push(m); } catch {}
     }
     if (peers.length) cfg.bootstrapPeers = peers;
@@ -671,9 +678,19 @@ start_node() {
     local libp2p_port=$((LIBP2P_PORT_BASE + node_num - 1))
     echo "/ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}" > "$DEVNET_DIR/node${node_num}/multiaddr"
     log "Node $node_num multiaddr saved: /ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}"
-  elif [ "$node_num" -eq 1 ]; then
-    log "ERROR: Could not extract relay multiaddr for node 1 — aborting devnet start"
-    return 1
+  else
+    # A CORE that fails to publish its multiaddr is silently dropped from every
+    # later core's bootstrapPeers, degrading the mesh back to the gossip-only
+    # quorum path this topology exists to avoid — so abort on ANY core (not just
+    # node 1). Edges stay best-effort: a missing edge multiaddr just means it
+    # isn't a direct-dial target, and it still works via the relay + gossip.
+    local node_role="edge"
+    node_role=$(node -e "try{process.stdout.write(JSON.parse(require('fs').readFileSync('$node_dir/config.json','utf8')).nodeRole||'edge')}catch{process.stdout.write('edge')}" 2>/dev/null || echo edge)
+    if [ "$node_role" = "core" ]; then
+      log "ERROR: Could not extract multiaddr for CORE node $node_num — later cores would silently omit it from the direct mesh (gossip-only quorum). Aborting devnet start."
+      return 1
+    fi
+    log "WARNING: Could not extract multiaddr for edge node $node_num — not a direct-dial target (still reachable via gossip)."
   fi
 }
 

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -575,15 +575,34 @@ start_node() {
     relay_arg=$(cat "$DEVNET_DIR/node1/multiaddr")
   fi
 
-  # Update config with relay address if available
-  if [ -n "$relay_arg" ]; then
-    node -e "
-      const fs = require('fs');
-      const cfg = JSON.parse(fs.readFileSync('$node_dir/config.json','utf8'));
-      cfg.relay = '$relay_arg';
-      fs.writeFileSync('$node_dir/config.json', JSON.stringify(cfg, null, 2));
-    "
-  fi
+  # Core mesh (default topology): a CORE node directly dials every EARLIER core
+  # via `bootstrapPeers`, instead of every node hubbing through node 1. libp2p
+  # connections are bidirectional and `identify` exchanges listen addresses, so
+  # "dial all earlier cores" yields an all-core direct mesh once the last core is
+  # up. That keeps every core directly DIALABLE for SWM substrate fan-out (the
+  # StorageACK responders), so VM-publish quorum is delivered reliably point-to-
+  # point instead of riding best-effort gossip (which raced and dropped quorum on
+  # the all-hub-through-node-1 topology). EDGE nodes dial ALL cores — a scalable
+  # hub-and-spoke spoke (O(cores) connections per edge, never edge<->edge) — so
+  # an edge can still publish and reach quorum; edges never mesh with each other.
+  # Node 1 (first core) dials no one and meshes via inbound dials from the rest.
+  DEVNET_DIR="$DEVNET_DIR" NODE_DIR="$node_dir" NODE_NUM="$node_num" \
+  NUM_CORE_NODES="$NUM_CORE_NODES" RELAY_ARG="$relay_arg" node -e "
+    const fs = require('fs');
+    const dir = process.env.DEVNET_DIR;
+    const cfgPath = process.env.NODE_DIR + '/config.json';
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    if (process.env.RELAY_ARG) cfg.relay = process.env.RELAY_ARG;
+    const n = Number(process.env.NODE_NUM), cores = Number(process.env.NUM_CORE_NODES);
+    // core: earlier cores (mesh forms bidirectionally); edge: all cores (spoke).
+    const hi = (n <= cores) ? (n - 1) : cores;
+    const peers = [];
+    for (let c = 1; c <= hi; c++) {
+      try { const m = fs.readFileSync(dir + '/node' + c + '/multiaddr', 'utf8').trim(); if (m) peers.push(m); } catch {}
+    }
+    if (peers.length) cfg.bootstrapPeers = peers;
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+  "
 
   # Remove any stale daemon.pid so the CLI doesn't think it's already running
   rm -f "$node_dir/daemon.pid"
@@ -628,31 +647,33 @@ start_node() {
     log "WARNING: Node $node_num not ready after ${max_wait}s (check $node_dir/daemon.log)"
   fi
 
-  # For node 1 (relay), save its multiaddr so other nodes can connect.
-  # Retry a few times even if initial wait timed out — node may still be booting.
-  if [ "$node_num" -eq 1 ]; then
-    local peer_id=""
-    for attempt in $(seq 1 10); do
-      local peer_info
-      peer_info=$(curl -sf "${auth_args[@]}" "http://127.0.0.1:$api_port/api/status" 2>/dev/null || echo "{}")
-      peer_id=$(echo "$peer_info" | node -e "
-        let d=''; process.stdin.on('data',c=>d+=c);
-        process.stdin.on('end',()=>{
-          try{const j=JSON.parse(d);console.log(j.peerId||'')}catch{console.log('')}
-        })
-      " 2>/dev/null || echo "")
-      [ -n "$peer_id" ] && break
-      sleep 3
-    done
+  # Save THIS node's multiaddr so (a) node 1 serves as the universal relay and
+  # (b) later cores/edges can directly dial it to form the core mesh + spokes
+  # (see the bootstrapPeers block above). Node 1's multiaddr is REQUIRED (every
+  # node bootstraps off it; failure aborts); the rest are best-effort — a missing
+  # one only means that node isn't a direct-dial target, it still works via the
+  # relay + gossip. Retry a few times even if the initial wait timed out.
+  local peer_id=""
+  for attempt in $(seq 1 10); do
+    local peer_info
+    peer_info=$(curl -sf "${auth_args[@]}" "http://127.0.0.1:$api_port/api/status" 2>/dev/null || echo "{}")
+    peer_id=$(echo "$peer_info" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c);
+      process.stdin.on('end',()=>{
+        try{const j=JSON.parse(d);console.log(j.peerId||'')}catch{console.log('')}
+      })
+    " 2>/dev/null || echo "")
+    [ -n "$peer_id" ] && break
+    sleep 3
+  done
 
-    if [ -n "$peer_id" ]; then
-      local libp2p_port=$((LIBP2P_PORT_BASE))
-      echo "/ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}" > "$DEVNET_DIR/node1/multiaddr"
-      log "Relay multiaddr saved: /ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}"
-    else
-      log "ERROR: Could not extract relay multiaddr for node 1 — aborting devnet start"
-      return 1
-    fi
+  if [ -n "$peer_id" ]; then
+    local libp2p_port=$((LIBP2P_PORT_BASE + node_num - 1))
+    echo "/ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}" > "$DEVNET_DIR/node${node_num}/multiaddr"
+    log "Node $node_num multiaddr saved: /ip4/127.0.0.1/tcp/${libp2p_port}/p2p/${peer_id}"
+  elif [ "$node_num" -eq 1 ]; then
+    log "ERROR: Could not extract relay multiaddr for node 1 — aborting devnet start"
+    return 1
   fi
 }
 


### PR DESCRIPTION
Two small CI / dev-tooling fixes for the rc.17 release branch.

## 1. `random-sampling`: §F2 AuthorAttestation fixture — **unblocks #1053 CI**

The only red check on the rc.17 release PR (**#1053**) is *"Kosava: random-sampling + kafka-plugin (real Hardhat)"*. Root cause: the `e2e-hardhat-chain` test was **half-migrated** for OT-RFC-43 §F2 — it reserved a packed `reservedKaId` and passed it to the *mint* (`createKnowledgeAssets`), but built and **signed the AuthorAttestation EIP-712 digest *before* computing it**, so the message's 5th field was null:

```
TypeError: invalid BigNumberish value (value=null) at TypedDataEncoder.encodeData
```

→ the whole suite throws at setup. Fix: reserve the id **before** building/signing the typed data.

This is **not** the deferred async/Kafka work — just a stale fixture the §F2 sweep (which fixed core/publisher/agent/chain/cli) didn't reach.

Verified locally:
- `random-sampling`: **1 passed** (was the failing suite)
- `kafka-plugin`: **169 passed** (the other half of the combined check)

## 2. `devnet.sh`: core-node mesh default (reliability)

Previously every node bootstrapped through node 1, so cores weren't directly dial-peered and SWM share propagation rode best-effort gossip alone — which can race ahead of VM-publish ACK collection (issue **#1064**). Now cores form a full direct mesh (each dials earlier cores via `bootstrapPeers`) and edges spoke to all cores — scalable hub-and-spoke (O(cores) per edge, never edge↔edge).

Impact on the node-ui e2e on a freshly-built `rc17-vm-wip`:
- **before** (hub topology): 310/312, 2 quorum-race failures
- **after** (core mesh): **311/312, 0 failures**

Dev/CI tooling only — touches `scripts/devnet.sh`, not the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
