### PR TITLE
fix(ka-routes): #1053 review — promote alias + resolve kaId on wm/quads GET

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -493,9 +493,15 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       authorAgentAddress,
       preSignedAuthorAttestation,
       schemeVersion,
-      alsoShareSwm,
       alsoPublishVm,
     } = parsed;
+    // OT-RFC-43 migration alias: the legacy one-shot publish shape posts
+    // `promote: true` (ApiClient.publishAssertion, MCP publishQuads, OpenClaw
+    // publish, and network-sim still send { quads, finalize: true, promote: true }).
+    // Honor it as `alsoShareSwm` so those calls still promote WM→SWM — otherwise
+    // they seal WM but never promote, and a follow-up VM publish runs against an
+    // empty SWM and fails. An explicit `alsoShareSwm` wins when both are supplied.
+    const alsoShareSwm = parsed.alsoShareSwm ?? parsed.promote;
     if (!name) {
       return jsonResponse(res, 400, { error: 'Missing "name"' });
     }
@@ -674,8 +680,19 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   if (method === "GET" && layer === "wm" && verb === "quads") {
     const p = readGetParams();
     if (!p) return;
+    // B3: ONLY a did:dkg / 0x<agent>:<number> kaId alias needs resolving to the
+    // lifecycle name before querying — otherwise the raw alias is passed as the
+    // assertion name and misses the real WM graph (parity with the sibling GETs).
+    // A plain name is queried directly (unchanged), so reads of a name-keyed WM
+    // draft still work even when no lifecycle descriptor exists yet.
+    let resolvedName = name;
+    if (classifyKaIdentifier(name).kind === "kaId") {
+      const hist = await resolveDescriptor(p.cg, p.subGraphName, p.agentAddress);
+      if (!hist) return jsonResponse(res, 404, { error: `No knowledge asset "${name}" in context graph "${p.cg}"` });
+      if (typeof hist.name === "string") resolvedName = hist.name;
+    }
     try {
-      const quads = await agent.assertion.query(p.cg, name, p.subGraphName ? { subGraphName: p.subGraphName } : undefined);
+      const quads = await agent.assertion.query(p.cg, resolvedName, p.subGraphName ? { subGraphName: p.subGraphName } : undefined);
       const sorted = [...quads].sort((l, r) => JSON.stringify(l).localeCompare(JSON.stringify(r)));
       return jsonResponse(res, 200, { quads: sorted, count: sorted.length });
     } catch (e: any) {

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -356,6 +356,32 @@ describe('GitHub-shaped /api/knowledge-assets routes (OT-RFC-43 §10.5)', () => 
     expect((b.errors as any[])[0]).toMatchObject({ phase: 'swm-share' });
   });
 
+  it('POST /api/knowledge-assets honors the legacy `promote: true` shape as an `alsoShareSwm` alias', async () => {
+    // First-party one-shot publishers (ApiClient.publishAssertion, MCP publishQuads,
+    // OpenClaw publish, network-sim) still post { quads, finalize: true, promote: true }.
+    // Without the alias they'd seal WM but never promote to SWM, then a follow-up VM
+    // publish would run against an empty SWM and fail.
+    const agent = makeAssertionAgent();
+    const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];
+    const ctx = ctxFor('POST', '/api/knowledge-assets', { contextGraphId: 'cg', name: 'legacy', quads, finalize: true, promote: true }, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(agent.assertion.promote).toHaveBeenCalledOnce();
+    expect(body(ctx)).toMatchObject({ swmShared: true, promotedCount: 3 });
+  });
+
+  it('GET .../:identifier/wm/quads resolves a did:dkg kaId alias to the lifecycle name before querying', async () => {
+    // The raw alias must NOT be passed straight to assertion.query as the name —
+    // that misses the real WM graph. Resolve it via resolveDescriptor first (parity
+    // with the sibling :identifier and :identifier/{wm,swm,vm} GETs).
+    const resolveByKaId = vi.fn(async () => ({ name: 'real-name', state: 'created' }));
+    const query = vi.fn(async () => [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }]);
+    const agent = makeAssertionAgent({ assertion: { resolveByKaId, query } });
+    const ctx = ctxFor('GET', '/api/knowledge-assets/did%3Adkg%3Aevm%3A31337%2F0xabc%2F7/wm/quads?contextGraphId=cg', undefined, agent);
+    await handleKnowledgeAssetsRoutes(ctx);
+    expect(query).toHaveBeenCalledWith('cg', 'real-name', undefined);
+    expect(body(ctx)).toMatchObject({ count: 1 });
+  });
+
   it('POST .../:name/wm/write appends quads', async () => {
     const agent = makeAssertionAgent();
     const quads = [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"', graph: '' }];


### PR DESCRIPTION
Addresses the two 🔴 bugs flagged on the rc.17 release PR (**#1053**), both in the `/api/knowledge-assets` route unification.

## 1. Collection POST: honor the legacy `promote: true` shape

The collection route honored only `alsoShareSwm`, but first-party one-shot publishers — `ApiClient.publishAssertion`, MCP `publishQuads`, OpenClaw `publish`, and `network-sim` — still post `{ quads, finalize: true, promote: true }`. Those calls **sealed WM but never promoted to SWM**, then a follow-up VM publish ran against an empty SWM and failed.

Fix: accept `promote` as a migration alias for `alsoShareSwm` (`const alsoShareSwm = parsed.alsoShareSwm ?? parsed.promote`); an explicit `alsoShareSwm` wins when both are supplied.

## 2. `GET …/:identifier/wm/quads`: resolve the kaId alias before querying

Unlike the sibling GETs (`:identifier`, `:identifier/{wm,swm,vm}`), this route passed the raw `:identifier` straight to `assertion.query` as the assertion name. A caller using a B3 `did:dkg…` / `0x<agent>:<number>` alias missed the real WM graph.

Fix: resolve via `resolveDescriptor()` and query the resolved lifecycle `name` (parity with the sibling GETs).

## Tests

+2 (promote alias → SWM share; `wm/quads` kaId alias → resolved name). cli typechecks clean; `knowledge-assets-route` **76/76**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
