### PR TITLE
chore(release): align demo package to 10.0.0-rc.17

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-demo",
-  "version": "10.0.0-rc.10",
+  "version": "10.0.0-rc.17",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Bumps `demo/package.json` (`@origintrail-official/dkg-demo`) from **`10.0.0-rc.10`** → **`10.0.0-rc.17`**.

## Why

After the rc.17 → `main` merge (#1053), I audited every tracked `package.json`. The root and **all publishable workspace packages** (`cli`, `core`, `agent`, `node-ui`, `evm-module`, `publisher`, `query`, `storage`, `chain`, `graph-viz`, `epcis`, `random-sampling`, `mcp-dkg`, `network-sim`, `kafka-plugin`, `adapter-*`) are already at `10.0.0-rc.17`.

The lone straggler is `demo`: it was version-synced with the monorepo through `v10.0.0-rc.10` (the `release:`/`chore(release): align all monorepo packages` commits bumped it in lockstep) but was missed by every release bump from rc.11 onward, leaving it at `10.0.0-rc.10`. This re-aligns it.

## Scope

- Version field only. `demo`'s internal deps already use the `workspace:*` protocol, so no dependency pins needed updating.
- `demo` is `private: true` (not published), so this is purely monorepo-version hygiene.
- The `devnet/*` scenario packages and `test-fixtures` remain at `0.0.0` by design (intentionally unversioned, never part of the rc scheme) — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)