### PR TITLE
fix(evm): require curated ciphertext commitments

### DIFF
--- a/packages/chain/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/chain/abi/KnowledgeAssetsLifecycle.json
@@ -43,6 +43,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      }
+    ],
+    "name": "CuratedCGRequiresCiphertextCommitment",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "IncompleteCiphertextCommitment",
     "type": "error"

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -135,7 +135,13 @@ const PINNED_DIGESTS: Record<string, string> = {
   // rotates the commitment.
 
   // Greenfield rename (rc.12): logic + storage pair replaces the legacy names.
-  KnowledgeAssetsLifecycle:     '45957310345c8cc8dd027ccf006bd0730e47510d72f8d14857de251788b10a52',
+  // Updated PR #1072 (RFC-39): the chain-local ABI now declares the new
+  // `CuratedCGRequiresCiphertextCommitment(uint256)` error. evm-adapter-abi
+  // resolves this contract from packages/chain/abi/ first (the evm-module copy
+  // is only a fallback), so the error had to be added here for chain-side revert
+  // decoding to name it instead of "unknown custom error". Digest now matches
+  // the evm-module ABI surface.
+  KnowledgeAssetsLifecycle:     'e9c457c5208f0a2da42ec9ced785e1241da4c1a1c6e4ef05d28828b9022ad5d1',
 
   // Re-pinned for OT-RFC-43 Option-1 (variant 1a, PR #975): deterministic
   // author-namespaced KA identity. `createKnowledgeAsset` now takes an explicit

--- a/packages/chain/test/chain-lifecycle-extra.test.ts
+++ b/packages/chain/test/chain-lifecycle-extra.test.ts
@@ -103,7 +103,11 @@ async function publishOneKCV10(opts: {
     ethers.parseEther('500000'),
   );
 
-  const contextGraphId = await createTestContextGraph(adapter);
+  // Public CG (accessPolicy 0): publishOneKCV10 exercises §F2 mint / replay /
+  // byte-size lifecycle mechanics with PLAINTEXT, not curated ciphertext. A
+  // curated CG would (correctly) require a ciphertext commitment the plaintext
+  // path never carries, reverting with CuratedCGRequiresCiphertextCommitment.
+  const contextGraphId = await createTestContextGraph(adapter, undefined, 0);
 
   const kaCount = opts.kaCount ?? 1;
   const byteSize = opts.byteSize ?? 256n;

--- a/packages/chain/test/evm-test-context.ts
+++ b/packages/chain/test/evm-test-context.ts
@@ -88,16 +88,19 @@ export async function createTestContextGraph(
   chain?: EVMChainAdapter,
   _identityId?: bigint,
   accessPolicy: number = 1,
+  publishPolicy: number = accessPolicy === 0 ? 1 : 0,
 ): Promise<bigint> {
   const adapter = chain ?? createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-  // Default stays curated (accessPolicy 1 / publishPolicy 0) so existing
-  // curated call-sites are unchanged. Callers exercising plaintext lifecycle
-  // mechanics pass accessPolicy 0 to get the fully-public pairing
-  // (accessPolicy 0 / publishPolicy 1) — otherwise a plaintext publish to a
-  // curated CG now reverts with CuratedCGRequiresCiphertextCommitment.
+  // accessPolicy and publishPolicy are independent on-chain. Defaults keep
+  // curated (accessPolicy 1 / publishPolicy 0) so existing curated call-sites
+  // are unchanged; accessPolicy 0 defaults to the fully-public pairing
+  // (publishPolicy 1) so a plaintext publish doesn't hit
+  // CuratedCGRequiresCiphertextCommitment. publishPolicy is an explicit
+  // override so other valid modes (e.g. accessPolicy 0 / publishPolicy 0)
+  // remain reachable through this shared helper.
   const result = await adapter.createOnChainContextGraph({
     accessPolicy,
-    publishPolicy: accessPolicy === 0 ? 1 : 0,
+    publishPolicy,
   });
   if (!result.success || result.contextGraphId === 0n) {
     throw new Error(`Failed to create on-chain context graph: ${JSON.stringify(result)}`);

--- a/packages/chain/test/evm-test-context.ts
+++ b/packages/chain/test/evm-test-context.ts
@@ -87,11 +87,17 @@ export async function revertToBase(): Promise<void> {
 export async function createTestContextGraph(
   chain?: EVMChainAdapter,
   _identityId?: bigint,
+  accessPolicy: number = 1,
 ): Promise<bigint> {
   const adapter = chain ?? createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+  // Default stays curated (accessPolicy 1 / publishPolicy 0) so existing
+  // curated call-sites are unchanged. Callers exercising plaintext lifecycle
+  // mechanics pass accessPolicy 0 to get the fully-public pairing
+  // (accessPolicy 0 / publishPolicy 1) — otherwise a plaintext publish to a
+  // curated CG now reverts with CuratedCGRequiresCiphertextCommitment.
   const result = await adapter.createOnChainContextGraph({
-    accessPolicy: 1,
-    publishPolicy: 0,
+    accessPolicy,
+    publishPolicy: accessPolicy === 0 ? 1 : 0,
   });
   if (!result.success || result.contextGraphId === 0n) {
     throw new Error(`Failed to create on-chain context graph: ${JSON.stringify(result)}`);

--- a/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
+++ b/packages/evm-module/abi/KnowledgeAssetsLifecycle.json
@@ -43,6 +43,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      }
+    ],
+    "name": "CuratedCGRequiresCiphertextCommitment",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "IncompleteCiphertextCommitment",
     "type": "error"

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -102,12 +102,15 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     // storage slot at the end of the inheritance chain; KAV10 owns its
     // slots below the inherited chain and V10 deploys are redeploy +
     // reinit, so no storage-layout migration is required.
+    // 10.0.3 → 10.0.4: curated publishes and paid legacy curated updates
+    // must carry a ciphertext commitment before entering value-weighted
+    // random-sampling state.
     // 2.0.0 → 2.0.1 (PATCH): protocol treasury fee skimmed inside
     // `_addTokens` (publisher pays the same gross amount; the fee is taken
     // out of the staker-bound net). Patch-level on purpose — the EIP-712
     // author-attestation domain version (`_EIP712_VERSION_HASH`) MUST stay
     // pinned at "2.0.0" so previously signed attestations keep verifying.
-    string private constant _VERSION = "10.0.3";
+    string private constant _VERSION = "10.0.4";
 
     // --- V10 publish input (grouped to bypass the 16-arg stack limit) ---
 
@@ -138,17 +141,16 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         /// @notice V10 flat-KC Merkle leaf count (sorted + deduped), must match
         ///         off-chain `V10MerkleTree` built from the same publish payload.
         uint32 merkleLeafCount;
-        // ── RFC-39 Phase A.5: curated-CG ciphertext commitment (OPTIONAL) ──
+        // ── RFC-39 Phase A.5: curated-CG ciphertext commitment ──
         /// @notice RFC-39: Merkle root over `[keccak256(ct_i)]` in
         ///         `swmMessageIndex` order for this publish batch's ciphertext
         ///         chunks (one chunk per SWM message — LU-11 Option B).
         ///         MUST be `bytes32(0)` for public CGs (rejected with
         ///         `PublicCGCannotHaveCiphertextCommitment`). For curated CGs,
-        ///         MAY be `bytes32(0)` (legacy/transitional path — picker
-        ///         skips that KC in the curated draw) OR non-zero AND paired
-        ///         with a non-zero `ciphertextChunkCount` (full commitment —
-        ///         KC participates in the curated draw). Partial commitments
-        ///         (one zero, one non-zero) revert with
+        ///         MUST be non-zero AND paired with a non-zero
+        ///         `ciphertextChunkCount`; otherwise the publish reverts with
+        ///         `CuratedCGRequiresCiphertextCommitment`. Partial
+        ///         commitments (one zero, one non-zero) revert with
         ///         `IncompleteCiphertextCommitment`.
         bytes32 ciphertextChunksRoot;
         /// @notice RFC-39: number of ciphertext chunks in this batch (==
@@ -219,9 +221,10 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         // left their commitment frozen to the initial publish and the
         // random-sampling challenge surface would point at stale
         // ciphertext after the first update. Same zero-or-paired
-        // contract as `PublishParams` (zero on metadata-only or
-        // public-CG updates; both non-zero on curated commitment
-        // rotation). Appended at the END of the struct so the
+        // contract as `PublishParams`: zero for public-CG updates or
+        // metadata-only legacy curated KCs without prior commitment;
+        // both non-zero for curated commitment rotation or paid
+        // legacy-curated growth. Appended at the END of the struct so the
         // positional ABI for pre-existing 12-field callers stays
         // intact — they encode the same prefix and ABI decoder
         // zero-fills the trailing pair (Codex PR #630 R1 #1 on
@@ -271,6 +274,12 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     ///      leaking into a public publish would silently bloat storage and
     ///      mislead off-chain indexers about which KCs are sampleable).
     error PublicCGCannotHaveCiphertextCommitment(uint256 contextGraphId);
+
+    /// @dev A curated-CG publish or paid update attempted to introduce
+    ///      sampling value without a full ciphertext commitment. Curated KCs
+    ///      without commitments are unchallengeable by design, so KAV10 must
+    ///      not let them enter the value-weighted challenge surface.
+    error CuratedCGRequiresCiphertextCommitment(uint256 contextGraphId);
 
     /// @dev RFC-39 Phase A.5: a curated-CG publish carried a partial ciphertext
     ///      commitment (root without count, or vice versa). The two are
@@ -606,31 +615,32 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         // KC.
         //
         // Semantics:
-        //   - Public CG  + any non-zero ciphertext field → revert
+        //   - Public CG + any non-zero ciphertext field → revert
         //     (catches client bugs; curated-only payload leaking to public).
-        //   - Curated CG + both fields zero                → no commitment
-        //     persisted; picker treats the KC as "skip in curated draw"
-        //     (legacy / pre-LU-11 publishes — forward-only adoption per
-        //     RFC-39 §6.4, Q4).
-        //   - Curated CG + both fields non-zero            → commitment
+        //   - Curated CG + both fields non-zero → commitment
         //     persisted; KC participates in curated draw.
-        //   - Curated CG + exactly one field zero          → revert
+        //   - Curated CG + both fields zero → revert
+        //     (unchallengeable encrypted KC must not enter value-weighted
+        //     sampling state).
+        //   - Curated CG + exactly one field zero → revert
         //     (partial commitment would zero-divide the picker or verify
         //     against the empty-tree zero).
         //
         // The cached `_hasCiphertextCommitment` carries the populate decision
         // forward to the post-create persistence call below — avoids a
-        // second `getIsCurated` read and the two zero-checks that already
-        // gated this branch.
+        // second pair of zero-checks that already gated this branch.
+        bool _isCurated = contextGraphStorage.getIsCurated(p.contextGraphId);
         bool _hasCiphertextCommitment =
             p.ciphertextChunksRoot != bytes32(0) || p.ciphertextChunkCount != 0;
-        if (_hasCiphertextCommitment) {
-            if (!contextGraphStorage.getIsCurated(p.contextGraphId)) {
-                revert PublicCGCannotHaveCiphertextCommitment(p.contextGraphId);
+        if (_isCurated) {
+            if (!_hasCiphertextCommitment) {
+                revert CuratedCGRequiresCiphertextCommitment(p.contextGraphId);
             }
             if (p.ciphertextChunksRoot == bytes32(0) || p.ciphertextChunkCount == 0) {
                 revert IncompleteCiphertextCommitment();
             }
+        } else if (_hasCiphertextCommitment) {
+            revert PublicCGCannotHaveCiphertextCommitment(p.contextGraphId);
         }
 
         // H7: SafeCast guards the uint96 cast in _validateTokenAmount.
@@ -1456,9 +1466,13 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         //     unprovable. Once a KC has been committed, every
         //     subsequent update MUST rotate the commitment in lockstep
         //     with the plaintext one.
-        //   - Curated CG + KC has no prior commitment + zero pair → no-op
-        //     (legacy / pre-LU-11 path; picker still skips this KC in
-        //     the curated draw until the first commitment lands).
+        //   - Curated CG + KC has no prior commitment + zero pair + delta 0
+        //     → no-op (legacy / pre-LU-11 metadata maintenance; picker still
+        //     skips this KC in the curated draw until the first commitment
+        //     lands).
+        //   - Curated CG + KC has no prior commitment + zero pair + delta > 0
+        //     → revert. Value growth would otherwise add weight for a KC that
+        //     cannot satisfy a ciphertext proof when sampled.
         //   - Curated CG + both fields non-zero → commitment rotated
         //     (or set for the first time).
         //   - Curated CG + exactly one field zero → revert
@@ -1479,10 +1493,11 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                 // KC was previously committed; a zero-pair update would
                 // strand the stale commitment.
                 revert IncompleteCiphertextCommitment();
+            } else if (deltaTokenAmount > 0) {
+                revert CuratedCGRequiresCiphertextCommitment(contextGraphId);
             }
             // else: legacy / pre-LU-11 curated KC, no commitment yet —
-            // zero-pair update is permitted (mirrors the publish
-            // legacy-path behaviour).
+            // zero-pair metadata-only update is permitted.
         } else if (_hasNewCiphertextCommitment) {
             revert PublicCGCannotHaveCiphertextCommitment(contextGraphId);
         }

--- a/packages/evm-module/test/helpers/v10-kc-helpers.ts
+++ b/packages/evm-module/test/helpers/v10-kc-helpers.ts
@@ -355,13 +355,13 @@ export async function buildPublishParams(args: {
    */
   reservedKaId?: bigint;
   /**
-   * RFC-39 Phase A.5 curated-CG ciphertext commitment (optional).
-   * Defaults to `bytes32(0)` + `0` — the explicit "no commitment" sentinel
-   * the contract treats as: legal on public CGs (default behavior); legal
-   * on curated CGs (legacy / pre-LU-11 path — KC won't be sampleable in
-   * the curated draw). Curated-CG tests that exercise the sampleable path
-   * MUST set both to non-zero values; the contract enforces the
-   * paired-or-zero invariant via `IncompleteCiphertextCommitment`.
+   * RFC-39 Phase A.5 curated-CG ciphertext commitment.
+   * Defaults to `bytes32(0)` + `0`, which is legal only on public CGs.
+   * Curated-CG publishes MUST set both fields to non-zero values; otherwise
+   * KAV10 reverts before the KA can enter value-weighted sampling.
+   * The contract enforces both the required-curated and paired-or-zero
+   * invariants via `CuratedCGRequiresCiphertextCommitment` and
+   * `IncompleteCiphertextCommitment`.
    *
    * Note: the on-chain ACK digest DOES include these fields plus `isImmutable`
    * (`KnowledgeAssetsLifecycle._executePublishCore` packs
@@ -529,7 +529,10 @@ export async function buildUpdateParams(args: {
   newMerkleLeafCount?: number;
   /**
    * RFC-39 curated-CG ciphertext commitment for the update (optional).
-   * Defaults to `bytes32(0)` + `0`. The on-chain ACK digest binds BOTH fields
+   * Defaults to `bytes32(0)` + `0`, which is legal on public-CG updates and
+   * metadata-only updates for legacy curated KAs that do not yet have a
+   * commitment. Curated paid updates MUST set both fields to non-zero values.
+   * The on-chain ACK digest binds BOTH fields
    * (`KnowledgeAssetsLifecycle._executeUpdateCore`), so they MUST be passed
    * here — not spread onto the returned struct after signing — or the receiver
    * quorum signatures fail recovery with `SignerIsNotNodeOperator`.

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -680,6 +680,140 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       .withArgs(curatedCgId);
   });
 
+  it('update: paid legacy curated top-up succeeds when it supplies the first ciphertext commitment', async () => {
+    const setup = await setupRegisteredAgentPublish();
+    const curatedCgId = await createCuratedContextGraphFor(setup.creator);
+    const storageOperator = accounts[19];
+    await HubContract.setContractAddress(
+      'TestStorageOperator',
+      storageOperator.address,
+    );
+
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const endEpoch = currentEpoch + BigInt(setup.epochs);
+    const initialTokenAmount = ethers.parseEther('1000');
+    const kaId = packReservedKaId(setup.creator.address, 778);
+    await DKGKnowledgeAssets.connect(storageOperator).createKnowledgeAsset(
+      storageOperator.address,
+      setup.creator.address,
+      kaId,
+      'legacy-curated-first-commit-op',
+      ethers.keccak256(ethers.toUtf8Bytes('legacy-curated-first-commit')),
+      1,
+      1000,
+      currentEpoch,
+      endEpoch,
+      initialTokenAmount,
+      false,
+      1,
+    );
+    await CGS.connect(storageOperator).registerKnowledgeAssetToContextGraph(
+      curatedCgId,
+      kaId,
+    );
+    expect(await DKGKnowledgeAssets.getLatestCiphertextChunksRoot(kaId)).to
+      .equal(ethers.ZeroHash);
+
+    const firstCommitmentRoot = ethers.keccak256(
+      ethers.toUtf8Bytes('legacy-curated-first-commit-root'),
+    );
+    const firstCommitmentCount = 4n;
+    const up = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: setup.receivingNodes,
+      publisherIdentityId: setup.publisherIdentityId,
+      receiverIdentityIds: setup.receiverIdentityIds,
+      contextGraphId: curatedCgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: ethers.keccak256(
+        ethers.toUtf8Bytes('legacy-curated-paid-top-up-committed'),
+      ),
+      newByteSize: 1000n,
+      newTokenAmount: initialTokenAmount + ethers.parseEther('1'),
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'legacy-curated-first-commit-op',
+      author: setup.creator,
+      newCiphertextChunksRoot: firstCommitmentRoot,
+      newCiphertextChunkCount: firstCommitmentCount,
+    });
+
+    await (await KAV10.connect(setup.creator).update(up)).wait();
+
+    // The paid top-up supplied the first commitment, so the legacy KA can now
+    // enter value-weighted sampling — the commitment anchor is persisted.
+    expect(await DKGKnowledgeAssets.getLatestCiphertextChunksRoot(kaId)).to
+      .equal(firstCommitmentRoot);
+    expect(await DKGKnowledgeAssets.getCiphertextChunkCount(kaId)).to.equal(
+      firstCommitmentCount,
+    );
+  });
+
+  it('update: metadata-only maintenance of a legacy uncommitted curated KA stays allowed without a commitment', async () => {
+    const setup = await setupRegisteredAgentPublish();
+    const curatedCgId = await createCuratedContextGraphFor(setup.creator);
+    const storageOperator = accounts[19];
+    await HubContract.setContractAddress(
+      'TestStorageOperator',
+      storageOperator.address,
+    );
+
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const endEpoch = currentEpoch + BigInt(setup.epochs);
+    const initialTokenAmount = ethers.parseEther('1000');
+    const kaId = packReservedKaId(setup.creator.address, 779);
+    await DKGKnowledgeAssets.connect(storageOperator).createKnowledgeAsset(
+      storageOperator.address,
+      setup.creator.address,
+      kaId,
+      'legacy-curated-metadata-only-op',
+      ethers.keccak256(ethers.toUtf8Bytes('legacy-curated-metadata-only')),
+      1,
+      1000,
+      currentEpoch,
+      endEpoch,
+      initialTokenAmount,
+      false,
+      1,
+    );
+    await CGS.connect(storageOperator).registerKnowledgeAssetToContextGraph(
+      curatedCgId,
+      kaId,
+    );
+
+    // No paid top-up (newTokenAmount unchanged) and no ciphertext pair: this is
+    // metadata-only maintenance, which stays allowed for legacy uncommitted
+    // curated KAs — the commitment gate only guards value-adding (paid) updates.
+    const up = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: setup.receivingNodes,
+      publisherIdentityId: setup.publisherIdentityId,
+      receiverIdentityIds: setup.receiverIdentityIds,
+      contextGraphId: curatedCgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: ethers.keccak256(
+        ethers.toUtf8Bytes('legacy-curated-metadata-only-update'),
+      ),
+      newByteSize: 1000n,
+      newTokenAmount: initialTokenAmount,
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'legacy-curated-metadata-only-op',
+      author: setup.creator,
+    });
+
+    await (await KAV10.connect(setup.creator).update(up)).wait();
+
+    // Still uncommitted and that is fine — metadata maintenance does not force
+    // a commitment on a legacy curated KA.
+    expect(await DKGKnowledgeAssets.getLatestCiphertextChunksRoot(kaId)).to
+      .equal(ethers.ZeroHash);
+  });
+
   it('greenfield: a successful publish mints exactly one KA (the packed reservedKaId) to the author and binds it to the CG', async () => {
     const setup = await setupRegisteredAgentPublish();
     const p = await buildBasePublishParams(setup, 'greenfield-mint');

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -121,6 +121,7 @@ async function deployFixture(): Promise<Fixture> {
 describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function () {
   let accounts: SignerWithAddress[];
   let Token: Token;
+  let HubContract: Hub;
   let Chronos: Chronos;
   let ProfileContract: Profile;
   let ConvictionStakingStorage: ConvictionStakingStorage;
@@ -138,6 +139,7 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     hre.helpers.resetDeploymentsJson();
     ({
       accounts,
+      Hub: HubContract,
       Token,
       Chronos,
       Profile: ProfileContract,
@@ -314,6 +316,25 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       publisherIdentityId,
       receiverIdentityIds,
     };
+  };
+
+  const createCuratedContextGraphFor = async (
+    creator: SignerWithAddress,
+  ): Promise<bigint> => {
+    await CGFacade.connect(creator).createContextGraph(
+      [],
+      0,
+      1,
+      0,
+      creator.address,
+      0,
+      ethers.ZeroHash,
+    );
+    const cgId = await CGS.getLatestContextGraphId();
+    expect(await CGS.getIsCurated(cgId)).to.equal(true);
+    expect(await CGFacade.isAuthorizedPublisher(cgId, creator.address)).to.be
+      .true;
+    return cgId;
   };
 
   // --------------------------------------------------------------------------
@@ -549,6 +570,114 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       DKGKnowledgeAssets,
       'ERC721NonexistentToken',
     );
+  });
+
+  it('greenfield: curated publish requires a ciphertext commitment before value enters sampling', async () => {
+    const setup = await setupRegisteredAgentPublish();
+    const curatedCgId = await createCuratedContextGraphFor(setup.creator);
+    const p = await buildBasePublishParams(setup, 'curated-missing-ct', {
+      contextGraphId: curatedCgId,
+    });
+
+    await expect(KAV10.connect(setup.creator).publish(p))
+      .to.be.revertedWithCustomError(
+        KAV10,
+        'CuratedCGRequiresCiphertextCommitment',
+      )
+      .withArgs(curatedCgId);
+
+    await expect(
+      DKGKnowledgeAssets.ownerOf(p.reservedKaId),
+    ).to.be.revertedWithCustomError(
+      DKGKnowledgeAssets,
+      'ERC721NonexistentToken',
+    );
+  });
+
+  it('greenfield: curated publish with a full ciphertext commitment persists the sampling proof anchor', async () => {
+    const setup = await setupRegisteredAgentPublish();
+    const curatedCgId = await createCuratedContextGraphFor(setup.creator);
+    const ciphertextChunksRoot = ethers.keccak256(
+      ethers.toUtf8Bytes('curated-publish-ct-root'),
+    );
+    const ciphertextChunkCount = 3n;
+    const p = await buildBasePublishParams(setup, 'curated-with-ct', {
+      contextGraphId: curatedCgId,
+      ciphertextChunksRoot,
+      ciphertextChunkCount,
+    });
+
+    await (await KAV10.connect(setup.creator).publish(p)).wait();
+
+    const kaId = BigInt(p.reservedKaId);
+    expect(await CGS.kaToContextGraph(kaId)).to.equal(curatedCgId);
+    expect(await DKGKnowledgeAssets.getLatestCiphertextChunksRoot(kaId)).to
+      .equal(ciphertextChunksRoot);
+    expect(await DKGKnowledgeAssets.getCiphertextChunkCount(kaId)).to.equal(
+      ciphertextChunkCount,
+    );
+  });
+
+  it('update: paid legacy curated top-up requires the first ciphertext commitment', async () => {
+    const setup = await setupRegisteredAgentPublish();
+    const curatedCgId = await createCuratedContextGraphFor(setup.creator);
+    const storageOperator = accounts[19];
+    await HubContract.setContractAddress(
+      'TestStorageOperator',
+      storageOperator.address,
+    );
+
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const endEpoch = currentEpoch + BigInt(setup.epochs);
+    const initialTokenAmount = ethers.parseEther('1000');
+    const kaId = packReservedKaId(setup.creator.address, 777);
+    await DKGKnowledgeAssets.connect(storageOperator).createKnowledgeAsset(
+      storageOperator.address,
+      setup.creator.address,
+      kaId,
+      'legacy-curated-uncommitted-op',
+      ethers.keccak256(ethers.toUtf8Bytes('legacy-curated-uncommitted')),
+      1,
+      1000,
+      currentEpoch,
+      endEpoch,
+      initialTokenAmount,
+      false,
+      1,
+    );
+    await CGS.connect(storageOperator).registerKnowledgeAssetToContextGraph(
+      curatedCgId,
+      kaId,
+    );
+    expect(await DKGKnowledgeAssets.getLatestCiphertextChunksRoot(kaId)).to
+      .equal(ethers.ZeroHash);
+
+    const up = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: setup.receivingNodes,
+      publisherIdentityId: setup.publisherIdentityId,
+      receiverIdentityIds: setup.receiverIdentityIds,
+      contextGraphId: curatedCgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: ethers.keccak256(
+        ethers.toUtf8Bytes('legacy-curated-paid-top-up'),
+      ),
+      newByteSize: 1000n,
+      newTokenAmount: initialTokenAmount + ethers.parseEther('1'),
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'legacy-curated-paid-top-up-op',
+      author: setup.creator,
+    });
+
+    await expect(KAV10.connect(setup.creator).update(up))
+      .to.be.revertedWithCustomError(
+        KAV10,
+        'CuratedCGRequiresCiphertextCommitment',
+      )
+      .withArgs(curatedCgId);
   });
 
   it('greenfield: a successful publish mints exactly one KA (the packed reservedKaId) to the author and binds it to the CG', async () => {

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -40,7 +40,10 @@ describe('Access Protocol', () => {
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(_provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph();
+    // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise the
+    // off-chain access protocol + private-metadata mechanics, not curated-CG
+    // ciphertext semantics, so a curated CG would revert (CuratedCGRequiresCiphertextCommitment).
+    const cgId = await createTestContextGraph(undefined, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
     _kav10Address = await chain.getKnowledgeAssetsLifecycleAddress();

--- a/packages/publisher/test/agent-provenance-e2e.test.ts
+++ b/packages/publisher/test/agent-provenance-e2e.test.ts
@@ -87,7 +87,12 @@ beforeAll(async () => {
   // that the harness owns this.
 
   const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-  const cgId = await createTestContextGraph(chain);
+  // PUBLIC CG (accessPolicy 0): these walkthrough diagrams publish PLAINTEXT to
+  // exercise author-attestation / attribution / cost / update mechanics, not
+  // curated/ciphertext semantics. A curated CG would now require a ciphertext
+  // commitment (#1072 CuratedCGRequiresCiphertextCommitment) the bare publisher
+  // here never supplies.
+  const cgId = await createTestContextGraph(chain, undefined, 0);
   CONTEXT_GRAPH = String(cgId);
   GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
   coreId = BigInt(ctx.coreProfileId);

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -71,7 +71,10 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     const provider = createProvider();
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
-    const cgId = await createTestContextGraph();
+    // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise
+    // async-lift lifecycle/SWM/recovery/provenance mechanics, not curated
+    // ciphertext-commitment semantics, so they must not require a ciphertext commitment.
+    const cgId = await createTestContextGraph(undefined, undefined, 0);
     CONTEXT_GRAPH = cgId.toString();
     _provider = provider;
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -47,7 +47,9 @@ describe('subtractFinalizedExactQuads', () => {
     const provider = createProvider();
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
-    const cgId = await createTestContextGraph();
+    // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise async-lift
+    // subtraction mechanics, not curated/ciphertext semantics (#1072).
+    const cgId = await createTestContextGraph(undefined, undefined, 0);
     CONTEXT_GRAPH = cgId.toString();
     _provider = provider;
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -75,7 +75,11 @@ describe('DKGPublisher', () => {
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(_provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph(chain);
+    // PR #1072: these tests publish PLAINTEXT to exercise lifecycle/mint/update/
+    // event/UAL/reserved-namespace/share mechanics (no ciphertext commitment),
+    // so use a PUBLIC CG (accessPolicy 0) — a curated CG would now revert with
+    // CuratedCGRequiresCiphertextCommitment.
+    const cgId = await createTestContextGraph(chain, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
     _kav10Address = await chain.getKnowledgeAssetsLifecycleAddress();

--- a/packages/publisher/test/e2e.test.ts
+++ b/packages/publisher/test/e2e.test.ts
@@ -61,7 +61,9 @@ describe('End-to-end: Publish → Replicate → Query', () => {
     const { hubAddress } = getSharedContext();
     const provider = createProvider();
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, TEST_PUBLISHER_ADDRESS, ethers.parseEther('5000000'));
-    const cgId = await createTestContextGraph();
+    // Public CG (accessPolicy 0): these tests publish plaintext to exercise
+    // publish/replicate/query lifecycle, not curated/ciphertext semantics.
+    const cgId = await createTestContextGraph(undefined, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
     _provider = provider;

--- a/packages/publisher/test/ka-update.test.ts
+++ b/packages/publisher/test/ka-update.test.ts
@@ -170,7 +170,10 @@ describe('UpdateHandler', () => {
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph(chain);
+    // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise KA
+    // update lifecycle / gossip / ordering / replay mechanics, not curated /
+    // ciphertext semantics, so they must not require a ciphertext commitment.
+    const cgId = await createTestContextGraph(chain, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     DATA_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
     _provider = createProvider();

--- a/packages/publisher/test/phase-sequences.test.ts
+++ b/packages/publisher/test/phase-sequences.test.ts
@@ -84,7 +84,11 @@ describe('Phase-sequence contracts', () => {
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
 
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph(chain);
+    // PR #1072: these phase-sequence tests publish PLAINTEXT to pin phase
+    // ordering / ACK / WAL / workspace mechanics, not curated/ciphertext
+    // semantics. Use a PUBLIC CG (accessPolicy 0) so plaintext publishes
+    // don't revert with CuratedCGRequiresCiphertextCommitment.
+    const cgId = await createTestContextGraph(chain, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     _provider = provider;
     _kav10Address = await chain.getKnowledgeAssetsLifecycleAddress();

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -92,7 +92,11 @@ beforeAll(async () => {
   const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
   await mintTokens(_provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
   const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-  const cgId = await createTestContextGraph(chain);
+  // PR #1072: these lifecycle/merkle/update/tentative tests publish PLAINTEXT
+  // (no encrypt hook) to exercise publish mechanics — not curated/ciphertext
+  // semantics. A curated CG now reverts plaintext publishes
+  // (CuratedCGRequiresCiphertextCommitment), so use a PUBLIC CG (accessPolicy 0).
+  const cgId = await createTestContextGraph(chain, undefined, 0);
   CONTEXT_GRAPH = String(cgId);
   GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
   _kav10Address = await chain.getKnowledgeAssetsLifecycleAddress();

--- a/packages/publisher/test/publish-ordering-rpc-spy-extra.test.ts
+++ b/packages/publisher/test/publish-ordering-rpc-spy-extra.test.ts
@@ -110,7 +110,10 @@ describe('Publish ordering & RPC spy — P-1 / P-6 / P-7', () => {
     await mintTokens(_provider, hubAddress, HARDHAT_KEYS.DEPLOYER, wallet.address, ethers.parseEther('5000000'));
 
     const cgChain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgIdBn = await createTestContextGraph(cgChain);
+    // Public CG (accessPolicy 0): these tests publish plaintext to exercise
+    // SWM/chain ordering, write-ahead txHash, and nonce serialization — not
+    // curated/ciphertext semantics — so they must not require a ciphertext commitment.
+    const cgIdBn = await createTestContextGraph(cgChain, undefined, 0);
     cgId = String(cgIdBn);
     _kav10Address = await cgChain.getKnowledgeAssetsLifecycleAddress();
   }, 120_000);

--- a/packages/publisher/test/security-regressions.test.ts
+++ b/packages/publisher/test/security-regressions.test.ts
@@ -92,7 +92,11 @@ beforeAll(async () => {
   await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
 
   const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-  const cgId = await createTestContextGraph(chain);
+  // PR #1072: these regression tests publish PLAINTEXT to exercise lifecycle /
+  // update / ordering / SWM / provenance mechanics (not curated/ciphertext
+  // semantics), so use a PUBLIC CG (accessPolicy 0) that does not require a
+  // ciphertext commitment.
+  const cgId = await createTestContextGraph(chain, undefined, 0);
   CONTEXT_GRAPH = String(cgId);
   DATA_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
   WORKSPACE_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;

--- a/packages/publisher/test/signature-collection.test.ts
+++ b/packages/publisher/test/signature-collection.test.ts
@@ -311,7 +311,10 @@ describe('Reordered Publish Flow (replicate-then-publish)', () => {
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, publisherWallet.address, ethers.parseEther('5000000'));
 
     const cgChain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph(cgChain);
+    // PR1072: public CG (accessPolicy 0) — these tests publish plaintext to
+    // exercise publish ordering / V10 path / ACK quorum, not curated/ciphertext
+    // semantics, so they must not require a ciphertext commitment.
+    const cgId = await createTestContextGraph(cgChain, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     if (!_provider) _provider = provider;
     if (!_kav10Address) _kav10Address = await cgChain.getKnowledgeAssetsLifecycleAddress();
@@ -479,10 +482,20 @@ describe('Reordered Publish Flow (replicate-then-publish)', () => {
     // we'd be exercising the wrong branch and a future regression that
     // restores the catch-then-tentative behaviour on the chain branch
     // could slip past undetected.
+    // PR1072: publish to a CURATED CG (created by a funded CORE_OP adapter) so the
+    // bare publisher — which carries no ciphertext commitment — reverts AT the
+    // chain-submit branch with CuratedCGRequiresCiphertextCommitment. That is a
+    // genuine V10 chain failure (not the ACK pre-flight guard), so it exercises the
+    // PR2 no-silent-tentative-downgrade rethrow exactly as the EXTRA1-no-tokens path
+    // did pre-#1072. The describe's shared CONTEXT_GRAPH is public (for the
+    // plaintext-success tests), which would instead let this publish succeed.
+    const curatedFailCg = String(
+      await createTestContextGraph(createEVMAdapter(HARDHAT_KEYS.CORE_OP), undefined, 1),
+    );
     let err: unknown;
     try {
       await failPublisher.publish({
-        contextGraphId: CONTEXT_GRAPH,
+        contextGraphId: curatedFailCg,
         quads,
       });
     } catch (e) {
@@ -770,7 +783,10 @@ describe('Regression: complete publish result fields', () => {
     await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, pubAddr, ethers.parseEther('5000000'));
 
     const cgChain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph(cgChain);
+    // PR1072: public CG (accessPolicy 0) — this regression publishes plaintext to
+    // assert confirmed-result fields (txHash/batchId/...), not curated/ciphertext
+    // semantics, so it must not require a ciphertext commitment.
+    const cgId = await createTestContextGraph(cgChain, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
   });
 

--- a/packages/publisher/test/swm-subset-cleanup.test.ts
+++ b/packages/publisher/test/swm-subset-cleanup.test.ts
@@ -72,7 +72,10 @@ describe('SWM subset publish cleanup', () => {
     const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
     await mintTokens(_provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const cgId = await createTestContextGraph();
+    // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise SWM
+    // subset-cleanup mechanics, not curated/ciphertext semantics, so they must not
+    // trip CuratedCGRequiresCiphertextCommitment (PR #1072).
+    const cgId = await createTestContextGraph(undefined, undefined, 0);
     CONTEXT_GRAPH = String(cgId);
     WORKSPACE_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
     WORKSPACE_META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory_meta`;

--- a/packages/publisher/test/v10-publish-e2e.test.ts
+++ b/packages/publisher/test/v10-publish-e2e.test.ts
@@ -60,9 +60,13 @@ describe('V10 Publish E2E', () => {
     // double-spends the setup path and reverts before the skipped shard tests run.
 
     const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    // Public CG (accessPolicy 0 / publishPolicy 1): these E2E tests exercise ACK
+    // collection + createKnowledgeAssets round-trip mechanics with PLAINTEXT, not
+    // curated ciphertext, so a curated CG would revert with
+    // CuratedCGRequiresCiphertextCommitment (#1072).
     const cgResult = await adapter.createOnChainContextGraph({
-      accessPolicy: 1,
-      publishPolicy: 0,
+      accessPolicy: 0,
+      publishPolicy: 1,
     });
     if (!cgResult.success || cgResult.contextGraphId === 0n) {
       throw new Error(`Failed to create on-chain context graph: ${JSON.stringify(cgResult)}`);

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -122,7 +122,10 @@ async function encryptWorkspaceMessage(
 }
 
 beforeAll(async () => {
-  const cgId = await createTestContextGraph();
+  // Public CG (accessPolicy 0): these tests publish PLAINTEXT to exercise
+  // workspace/SWM/lifecycle mechanics, not curated/ciphertext semantics, so a
+  // curated CG would now revert (#1072 CuratedCGRequiresCiphertextCommitment).
+  const cgId = await createTestContextGraph(undefined, undefined, 0);
   CONTEXT_GRAPH = String(cgId);
   DATA_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
   WORKSPACE_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;


### PR DESCRIPTION
## Summary

- Require curated-CG publishes to provide a full ciphertext commitment before the KA can enter value-weighted sampling.
- Prevent paid updates on legacy uncommitted curated KAs unless the update supplies the first ciphertext commitment.
- Keep metadata-only maintenance of legacy uncommitted curated KAs allowed, and keep storage-level RandomSampling legacy handling intact.
- Update the tracked KAV10 ABI and helper docs for the stricter rule.

## Why

Curated KAs without ciphertext commitments are intentionally skipped by the proof path because they cannot satisfy a ciphertext proof. Allowing fresh curated publishes, or paid top-ups of legacy curated KAs, to add sampling value without a commitment lets an authorized curator steer weighted challenge selection toward unchallengeable IDs and DoS challenge finalization.

## Tests

- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "hardhat" not found
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "hardhat" not found

Full lifecycle file: 19 passing.