### PR TITLE
fix(epoch-storage): preserve tokens credited to an already-finalized epoch

### DIFF
--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -152,28 +152,27 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         uint256 endEpoch,
         uint96 tokenAmount
     ) external onlyContracts {
-        uint256 currentEpoch = chronos.getCurrentEpoch();
-        // SECURITY FIX: a credit whose startEpoch is already finalized is
+        // SECURITY FIX: a credit whose startEpoch is already FINALIZED is
         // otherwise lost forever. `_finalizeEpochsUpTo` only folds `diff` for
         // `(lastFinalizedEpoch, currentEpoch-1]` and never revisits a finalized
         // epoch, so `diff[startEpoch] += p` at `startEpoch <= lastFinalizedEpoch`
         // is never folded into `cumulative` (the tokens vanish — stranded in the
         // contract with no payable pool entry) and the paired
         // `diff[endEpoch+1] -= p` later under-credits an unrelated future epoch.
-        // Clamp the range forward to the first still-OPEN epoch so the tokens are
-        // preserved and land in a payable epoch. The first open epoch is
-        // max(lastFinalizedEpoch + 1, currentEpoch): `lastFinalizedEpoch + 1`
-        // excludes epochs already folded into `cumulative`, and `currentEpoch`
-        // excludes past-but-not-yet-finalized epochs that an IDLE shard has not
-        // closed yet (where `lastFinalizedEpoch` lags wall clock) — without it a
-        // delayed settlement would back-date tokens into an already-elapsed,
-        // claimable epoch. Callers like PublishingConviction settle elapsed
-        // billing windows lazily, so a past startEpoch is normal — clamp,
-        // don't revert.
+        //
+        // Clamp the range up to `lastFinalizedEpoch + 1` — the first epoch NOT
+        // yet folded into `cumulative`, and therefore still payable (epochs above
+        // `lastFinalizedEpoch` are read via on-the-fly simulation in
+        // `getEpochPool`). This is the minimal correction: it rescues only the
+        // credits that were genuinely lost (finalized epochs) and lands them in
+        // the CLOSEST still-creditable epoch, preserving the caller's intended
+        // attribution as much as possible — PublishingConviction deliberately
+        // attributes a closed billing window to the chain epochs it overlapped,
+        // so forcing `currentEpoch` here would misattribute/delay those rewards
+        // on an idle shard. Any stricter "settle into the current epoch" policy
+        // belongs at the specific caller, not in this shared primitive. Clamp,
+        // don't revert: lazy past-window settlement is an intended pattern.
         uint256 firstOpenEpoch = lastFinalizedEpoch[shardId] + 1;
-        if (firstOpenEpoch < currentEpoch) {
-            firstOpenEpoch = currentEpoch;
-        }
         if (startEpoch < firstOpenEpoch) {
             startEpoch = firstOpenEpoch;
             if (endEpoch < startEpoch) {
@@ -194,6 +193,7 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         diff[shardId][startEpoch] += tokensPerEpoch;
         diff[shardId][endEpoch + 1] -= tokensPerEpoch;
 
+        uint256 currentEpoch = chronos.getCurrentEpoch();
         if (currentEpoch > 1) {
             _finalizeEpochsUpTo(shardId, currentEpoch - 1);
         }

--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -152,6 +152,25 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         uint256 endEpoch,
         uint96 tokenAmount
     ) external onlyContracts {
+        // SECURITY FIX: a credit whose startEpoch is already finalized is
+        // otherwise lost forever. `_finalizeEpochsUpTo` only folds `diff` for
+        // `(lastFinalizedEpoch, currentEpoch-1]` and never revisits a finalized
+        // epoch, so `diff[startEpoch] += p` at `startEpoch <= lastFinalizedEpoch`
+        // is never folded into `cumulative` (the tokens vanish — stranded in the
+        // contract with no payable pool entry) and the paired
+        // `diff[endEpoch+1] -= p` later under-credits an unrelated future epoch.
+        // Clamp the range forward to the first still-open epoch so the tokens are
+        // preserved and land in a payable epoch instead of being dropped. (Callers
+        // such as PublishingConviction settle elapsed billing windows lazily, so a
+        // past startEpoch is normal — clamp, don't revert.)
+        uint256 firstOpenEpoch = lastFinalizedEpoch[shardId] + 1;
+        if (startEpoch < firstOpenEpoch) {
+            startEpoch = firstOpenEpoch;
+            if (endEpoch < startEpoch) {
+                endEpoch = startEpoch;
+            }
+        }
+
         uint256 numEpochs = endEpoch - startEpoch + 1;
 
         uint96 totalTokens = tokenAmount + accumulatedRemainder[shardId];

--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -152,6 +152,7 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         uint256 endEpoch,
         uint96 tokenAmount
     ) external onlyContracts {
+        uint256 currentEpoch = chronos.getCurrentEpoch();
         // SECURITY FIX: a credit whose startEpoch is already finalized is
         // otherwise lost forever. `_finalizeEpochsUpTo` only folds `diff` for
         // `(lastFinalizedEpoch, currentEpoch-1]` and never revisits a finalized
@@ -159,11 +160,20 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         // is never folded into `cumulative` (the tokens vanish — stranded in the
         // contract with no payable pool entry) and the paired
         // `diff[endEpoch+1] -= p` later under-credits an unrelated future epoch.
-        // Clamp the range forward to the first still-open epoch so the tokens are
-        // preserved and land in a payable epoch instead of being dropped. (Callers
-        // such as PublishingConviction settle elapsed billing windows lazily, so a
-        // past startEpoch is normal — clamp, don't revert.)
+        // Clamp the range forward to the first still-OPEN epoch so the tokens are
+        // preserved and land in a payable epoch. The first open epoch is
+        // max(lastFinalizedEpoch + 1, currentEpoch): `lastFinalizedEpoch + 1`
+        // excludes epochs already folded into `cumulative`, and `currentEpoch`
+        // excludes past-but-not-yet-finalized epochs that an IDLE shard has not
+        // closed yet (where `lastFinalizedEpoch` lags wall clock) — without it a
+        // delayed settlement would back-date tokens into an already-elapsed,
+        // claimable epoch. Callers like PublishingConviction settle elapsed
+        // billing windows lazily, so a past startEpoch is normal — clamp,
+        // don't revert.
         uint256 firstOpenEpoch = lastFinalizedEpoch[shardId] + 1;
+        if (firstOpenEpoch < currentEpoch) {
+            firstOpenEpoch = currentEpoch;
+        }
         if (startEpoch < firstOpenEpoch) {
             startEpoch = firstOpenEpoch;
             if (endEpoch < startEpoch) {
@@ -184,7 +194,6 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         diff[shardId][startEpoch] += tokensPerEpoch;
         diff[shardId][endEpoch + 1] -= tokensPerEpoch;
 
-        uint256 currentEpoch = chronos.getCurrentEpoch();
         if (currentEpoch > 1) {
             _finalizeEpochsUpTo(shardId, currentEpoch - 1);
         }

--- a/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
@@ -57,6 +57,34 @@ describe('@unit EpochStorage credit to a finalized epoch is preserved (not dropp
     expect(await EpochStorage.getEpochPool(shardId, cur - 2)).to.equal(0n);
   });
 
+  it('on an idle shard (lastFinalizedEpoch lags wall clock), a past credit lands in the CURRENT epoch, not a back-dated one', async () => {
+    const shardId = 7003;
+    await time.increase(epochSeconds * 3);
+    const e1 = Number(await Chronos.getCurrentEpoch());
+
+    // Touch the shard once → lastFinalizedEpoch = e1-1, then leave it IDLE.
+    await EpochStorage.addTokensToEpochRange(shardId, e1, e1, 1);
+    const laggedFinalized = Number(await EpochStorage.lastFinalizedEpoch(shardId)); // e1-1
+    expect(laggedFinalized).to.equal(e1 - 1);
+
+    // Wall clock advances well past lastFinalizedEpoch without any shard activity.
+    await time.increase(epochSeconds * 5);
+    const cur = Number(await Chronos.getCurrentEpoch());
+    expect(cur).to.be.greaterThan(laggedFinalized + 1); // the shard is "idle"
+
+    const staleTarget = laggedFinalized + 1; // where a naive clamp would back-date to (a past epoch)
+    const curBefore = await EpochStorage.getEpochPool(shardId, cur);
+    const staleBefore = await EpochStorage.getEpochPool(shardId, staleTarget);
+
+    // Backfill a credit aimed at a long-past epoch.
+    await EpochStorage.addTokensToEpochRange(shardId, laggedFinalized - 1, laggedFinalized - 1, 1000);
+
+    // It lands in the genuinely-open CURRENT epoch — not back-dated into the
+    // already-elapsed (and possibly already-claimable) `lastFinalizedEpoch + 1`.
+    expect((await EpochStorage.getEpochPool(shardId, cur)) - curBefore).to.equal(1000n);
+    expect(await EpochStorage.getEpochPool(shardId, staleTarget)).to.equal(staleBefore);
+  });
+
   it('a settlement range does not corrupt the pool of an epoch outside it', async () => {
     const shardId = 7002;
     await time.increase(epochSeconds * 5);

--- a/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
@@ -1,0 +1,78 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import { Chronos, EpochStorage } from '../../typechain';
+
+/**
+ * Regression: `addTokensToEpochRange` must never lose tokens credited to an
+ * already-finalized epoch, and a credit range must not affect epochs outside
+ * it. Finalized epochs can't be paid retroactively, so the credit is clamped
+ * forward to the first still-open epoch (funds preserved, distribution bounded).
+ */
+describe('@unit EpochStorage credit to a finalized epoch is preserved (not dropped)', () => {
+  let accounts: SignerWithAddress[];
+  let EpochStorage: EpochStorage;
+  let Chronos: Chronos;
+  let epochSeconds: number;
+
+  async function deployFixture() {
+    await hre.deployments.fixture(['EpochStorage', 'Chronos']);
+    EpochStorage = await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+    Chronos = await hre.ethers.getContract<Chronos>('Chronos');
+    epochSeconds = Number(await Chronos.epochLength());
+    accounts = await hre.ethers.getSigners();
+    return { accounts, EpochStorage, Chronos };
+  }
+
+  beforeEach(async () => {
+    hre.helpers.resetDeploymentsJson();
+    ({ accounts, EpochStorage, Chronos } = await loadFixture(deployFixture));
+  });
+
+  async function sumPools(shardId: number, from: number, to: number): Promise<bigint> {
+    let total = 0n;
+    for (let e = from; e <= to; e++) total += await EpochStorage.getEpochPool(shardId, e);
+    return total;
+  }
+
+  it('preserves a credit aimed at an already-finalized epoch (clamped forward, not lost)', async () => {
+    const shardId = 7001;
+    await time.increase(epochSeconds * 5);
+    const cur = Number(await Chronos.getCurrentEpoch());
+
+    // Establish finalized history: lastFinalizedEpoch = cur-1.
+    await EpochStorage.addTokensToEpochRange(shardId, cur, cur, 1000);
+    expect(await EpochStorage.lastFinalizedEpoch(shardId)).to.equal(cur - 1);
+
+    const totalBefore = await sumPools(shardId, cur, cur + 12);
+    // Credit aimed at a finalized epoch (cur-2): pre-fix this vanished.
+    await EpochStorage.addTokensToEpochRange(shardId, cur - 2, cur - 2, 1000);
+    const totalAfter = await sumPools(shardId, cur, cur + 12);
+
+    // The 1000 is preserved in the open range, not dropped.
+    expect(totalAfter - totalBefore).to.equal(1000n);
+    // A finalized epoch is never retroactively credited.
+    expect(await EpochStorage.getEpochPool(shardId, cur - 2)).to.equal(0n);
+  });
+
+  it('a settlement range does not corrupt the pool of an epoch outside it', async () => {
+    const shardId = 7002;
+    await time.increase(epochSeconds * 5);
+    const cur = Number(await Chronos.getCurrentEpoch());
+    await EpochStorage.addTokensToEpochRange(shardId, cur, cur, 1);
+
+    // Legitimate forward distribution.
+    await EpochStorage.addTokensToEpochRange(shardId, cur, cur + 10, 11000);
+    const outOfRangeEpoch = cur + 8;
+    const legit = await EpochStorage.getEpochPool(shardId, outOfRangeEpoch);
+    expect(legit).to.be.greaterThan(0n);
+
+    // A lazy/past-anchored settlement whose intended range ends at cur+5.
+    await EpochStorage.addTokensToEpochRange(shardId, cur - 3, cur + 5, 4500);
+
+    // Epoch cur+8 is outside [.., cur+5] → its legitimate pool is untouched.
+    expect(await EpochStorage.getEpochPool(shardId, outOfRangeEpoch)).to.equal(legit);
+  });
+});

--- a/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.finalized-credit.test.ts
@@ -57,7 +57,7 @@ describe('@unit EpochStorage credit to a finalized epoch is preserved (not dropp
     expect(await EpochStorage.getEpochPool(shardId, cur - 2)).to.equal(0n);
   });
 
-  it('on an idle shard (lastFinalizedEpoch lags wall clock), a past credit lands in the CURRENT epoch, not a back-dated one', async () => {
+  it('on an idle shard (lastFinalizedEpoch lags wall clock), a finalized-epoch credit is preserved in the first unfolded epoch', async () => {
     const shardId = 7003;
     await time.increase(epochSeconds * 3);
     const e1 = Number(await Chronos.getCurrentEpoch());
@@ -72,17 +72,18 @@ describe('@unit EpochStorage credit to a finalized epoch is preserved (not dropp
     const cur = Number(await Chronos.getCurrentEpoch());
     expect(cur).to.be.greaterThan(laggedFinalized + 1); // the shard is "idle"
 
-    const staleTarget = laggedFinalized + 1; // where a naive clamp would back-date to (a past epoch)
-    const curBefore = await EpochStorage.getEpochPool(shardId, cur);
-    const staleBefore = await EpochStorage.getEpochPool(shardId, staleTarget);
+    // The first epoch NOT yet folded into `cumulative` = lastFinalizedEpoch + 1.
+    // It is still payable (read via simulation), so the rescued credit lands here
+    // — closest to the epochs the (late) settlement actually overlapped, rather
+    // than being lost in a finalized epoch.
+    const firstUnfolded = laggedFinalized + 1;
+    const before = await EpochStorage.getEpochPool(shardId, firstUnfolded);
 
-    // Backfill a credit aimed at a long-past epoch.
+    // Backfill a credit aimed at a long-past (finalized) epoch.
     await EpochStorage.addTokensToEpochRange(shardId, laggedFinalized - 1, laggedFinalized - 1, 1000);
 
-    // It lands in the genuinely-open CURRENT epoch — not back-dated into the
-    // already-elapsed (and possibly already-claimable) `lastFinalizedEpoch + 1`.
-    expect((await EpochStorage.getEpochPool(shardId, cur)) - curBefore).to.equal(1000n);
-    expect(await EpochStorage.getEpochPool(shardId, staleTarget)).to.equal(staleBefore);
+    // Preserved (not lost), in the first still-creditable epoch.
+    expect((await EpochStorage.getEpochPool(shardId, firstUnfolded)) - before).to.equal(1000n);
   });
 
   it('a settlement range does not corrupt the pool of an epoch outside it', async () => {


### PR DESCRIPTION
## Summary

`EpochStorage.addTokensToEpochRange` silently **loses** tokens credited to an already-finalized epoch, and corrupts an unrelated future epoch's pool.

`addTokensToEpochRange` writes `diff[startEpoch] += p; diff[endEpoch+1] -= p`, then `_finalizeEpochsUpTo(currentEpoch-1)`. `_finalizeEpochsUpTo` only folds `diff` for `(lastFinalizedEpoch, currentEpoch-1]` and **never revisits a finalized epoch**; `getEpochPool` returns the frozen `cumulative[epoch]` for finalized epochs. So:

- a credit with `startEpoch <= lastFinalizedEpoch` is **never folded** → the tokens vanish (stranded in the contract balance, no payable pool entry), and
- the paired `diff[endEpoch+1] -= p` at a future epoch is folded later → it **under-credits an unrelated future epoch's** reward pool.

**Reachable in normal operation:** `PublishingConviction` settles elapsed billing windows lazily into **past** chain epochs on shard 1 (the staker pool). `lastFinalizedEpoch` is bumped by every protocol op, so by the time a window is swept its epochs are usually already finalized — making the lossy/corrupting case the default, not an edge.

## Fix

Clamp the credit range forward to the first still-open epoch (`lastFinalizedEpoch + 1`). Finalized epochs can't be paid retroactively, so the tokens are distributed over the still-open part of the intended range instead of vanishing, and the `diff` stays bracketed inside the open range (no leakage to out-of-range epochs). Clamp rather than revert, because lazy past-window settlement is an intended caller pattern.

## Tests

- New regression test (`EpochStorage.finalized-credit.test.ts`): a credit aimed at a finalized epoch is **preserved** in the open range (not dropped); a settlement range does **not** alter an epoch outside it.
- No regression: existing `EpochStorage` unit suite (26 ✓) and the conviction/settlement e2e suites `v10-conviction` / `v10-e2e-conviction` / `v10-migration-conviction-credit` (19 ✓) stay green.

> Security note: identified during a pre-mainnet review of the rc.17 contracts; severity ~High (permanent staker-reward loss + cross-account pool corruption, conservative direction — no theft/over-mint).
