### PR TITLE
fix(sharding-table): enforce shardingTableSizeLimit on insert

### DIFF
--- a/packages/evm-module/abi/ShardingTable.json
+++ b/packages/evm-module/abi/ShardingTable.json
@@ -77,6 +77,22 @@
   {
     "inputs": [
       {
+        "internalType": "uint72",
+        "name": "nodesCount",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint16",
+        "name": "sizeLimit",
+        "type": "uint16"
+      }
+    ],
+    "name": "ShardingTableIsFull",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "msg",
         "type": "string"

--- a/packages/evm-module/contracts/ShardingTable.sol
+++ b/packages/evm-module/contracts/ShardingTable.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 import {ProfileStorage} from "./storage/ProfileStorage.sol";
 import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
 import {ConvictionStakingStorage} from "./storage/ConvictionStakingStorage.sol";
+import {ParametersStorage} from "./storage/ParametersStorage.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {INamed} from "./interfaces/INamed.sol";
@@ -31,6 +32,12 @@ contract ShardingTable is INamed, IVersioned, ContractStatus, IInitializable {
     ///         `stakingStorage` reference; the V8 archive is unmaintained
     ///         post-migration so its `getNodeStake` is not a faithful read.
     ConvictionStakingStorage public convictionStakingStorage;
+
+    /// @notice The sharding table is full: `nodesCount` has reached the
+    ///         governance-configured `shardingTableSizeLimit`. The cap bounds
+    ///         the O(n) re-index loops in `insertNode`/`removeNode` so they
+    ///         cannot exceed the block gas limit.
+    error ShardingTableIsFull(uint72 nodesCount, uint16 sizeLimit);
 
     // solhint-disable-next-line no-empty-blocks
     constructor(address hubAddress) ContractStatus(hubAddress) {}
@@ -135,6 +142,20 @@ contract ShardingTable is INamed, IVersioned, ContractStatus, IInitializable {
     function _insertNode(uint72 index, uint72 identityId, uint256 newNodeHashRingPosition) internal virtual {
         ShardingTableStorage sts = shardingTableStorage;
         ProfileStorage ps = profileStorage;
+
+        // SECURITY FIX: enforce the configured size cap. `shardingTableSizeLimit`
+        // (default 500) had a setter but was checked at NO insert site, so the
+        // table could grow without bound — making the O(n) re-index loops in
+        // insertNode/removeNode (both walk every node after the touched index)
+        // exceed the block gas limit, which freezes unstake/redelegate/leave
+        // and any other op that re-indexes the table. ParametersStorage is
+        // resolved from the Hub at call time (it is deployed AFTER ShardingTable,
+        // so it cannot be cached in initialize() without breaking deployment).
+        uint72 nodesCount = sts.nodesCount();
+        uint16 sizeLimit = ParametersStorage(hub.getContractAddress("ParametersStorage")).shardingTableSizeLimit();
+        if (nodesCount >= sizeLimit) {
+            revert ShardingTableIsFull(nodesCount, sizeLimit);
+        }
 
         if (sts.nodeExists(identityId)) {
             revert ShardingTableLib.NodeAlreadyInTheShardingTable(identityId);

--- a/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
+++ b/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
@@ -1,0 +1,75 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { randomBytes } from 'crypto';
+import hre from 'hardhat';
+
+import {
+  Hub,
+  Profile,
+  ParametersStorage,
+  ShardingTable,
+  ShardingTableStorage,
+} from '../../typechain';
+
+/**
+ * Regression: the sharding table must enforce `shardingTableSizeLimit`. The cap
+ * bounds the O(n) re-index loops in insertNode/removeNode; without it the table
+ * grows unbounded and those write-path loops can exceed the block gas limit.
+ */
+describe('@unit ShardingTable enforces shardingTableSizeLimit', () => {
+  let accounts: SignerWithAddress[];
+  let Hub: Hub;
+  let Profile: Profile;
+  let ParametersStorage: ParametersStorage;
+  let ShardingTable: ShardingTable;
+  let ShardingTableStorage: ShardingTableStorage;
+
+  async function deploy() {
+    hre.helpers.resetDeploymentsJson();
+    await hre.deployments.fixture(
+      ['ShardingTable', 'IdentityStorageV2', 'StakingV2', 'Profile', 'ParametersStorage'],
+      { keepExistingDeployments: false },
+    );
+    accounts = await hre.ethers.getSigners();
+    Hub = await hre.ethers.getContract<Hub>('Hub');
+    Profile = await hre.ethers.getContract<Profile>('Profile');
+    ParametersStorage = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+    ShardingTable = await hre.ethers.getContract<ShardingTable>('ShardingTable');
+    ShardingTableStorage = await hre.ethers.getContract<ShardingTableStorage>('ShardingTableStorage');
+    await Hub.setContractAddress('HubOwner', accounts[0].address);
+  }
+
+  async function createAndInsert(i: number): Promise<void> {
+    const nodeId = '0x' + randomBytes(32).toString('hex');
+    const rc = await (
+      await Profile.connect(accounts[i + 1]).createProfile(
+        accounts[i + 21].address, [], `N${i}`, nodeId, 0,
+      )
+    ).wait();
+    const id = Number(rc!.logs[0].topics[1]);
+    await ShardingTable['insertNode(uint72)'](id);
+  }
+
+  it('reverts ShardingTableIsFull once nodesCount reaches the limit', async () => {
+    await deploy();
+    await ParametersStorage.setShardingTableSizeLimit(3);
+
+    // Fill exactly to the cap.
+    for (let i = 0; i < 3; i++) await createAndInsert(i);
+    expect(await ShardingTableStorage.nodesCount()).to.equal(3);
+
+    // The next insert must revert at the cap — table cannot grow unbounded.
+    const nodeId = '0x' + randomBytes(32).toString('hex');
+    const rc = await (
+      await Profile.connect(accounts[10]).createProfile(accounts[11].address, [], 'overflow', nodeId, 0)
+    ).wait();
+    const overflowId = Number(rc!.logs[0].topics[1]);
+
+    await expect(ShardingTable['insertNode(uint72)'](overflowId))
+      .to.be.revertedWithCustomError(ShardingTable, 'ShardingTableIsFull')
+      .withArgs(3, 3);
+
+    // Count is unchanged — the failed insert did not grow the table.
+    expect(await ShardingTableStorage.nodesCount()).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary

The sharding table can grow **unbounded**, and its write-path re-index loops are O(n) — so at scale they exceed the block gas limit and freeze staking operations.

`ParametersStorage.shardingTableSizeLimit` (default **500**) is declared with a setter (`setShardingTableSizeLimit`) but is **enforced at no insert site** — not in `ShardingTable.insertNode`/`_insertNode`, nor at the `StakingV10` callers, and there is no `ShardingTableIsFull` error anywhere. Meanwhile both `_insertNode` and `removeNode` re-index **every node after the touched index** (O(n) `while` loops on write paths). Unbounded table × O(n) write loops ⇒ once the table is large enough, `removeNode` (reached on unstake-below-minimum), `insertNode`, and any op that re-indexes the table revert on gas — **freezing unstake / redelegate / leave and locking principal + pending claims.**

Reachable by registering many cheap **tier-0 (liquid, recoverable)** stakes to push `nodesCount` up, or simply by organic growth past the intended 500 cap.

(Measured O(n): `removeNode(head)` ≈ 240k gas at 10 nodes → 820k at 40 (~19k/node) → crosses a ~30M block at a few thousand nodes.)

## Fix

`_insertNode` reverts `ShardingTableIsFull(nodesCount, sizeLimit)` once `nodesCount` reaches `shardingTableSizeLimit`, restoring the bound the cap was designed to provide.

`ParametersStorage` is read from the Hub **at call time** rather than cached in `initialize()`, because it is deployed *after* `ShardingTable` in the deploy sequence (caching it in `initialize` reverts the deploy with `ContractDoesNotExist("ParametersStorage")`).

## Tests

- New regression test (`ShardingTable.size-cap.test.ts`): inserts up to the cap succeed; the next reverts `ShardingTableIsFull` and `nodesCount` is unchanged.
- No regression: existing `ShardingTable` (8 ✓) and the node-insert flows in `DKGStakingConvictionNFT` / `Profile` / `v10-e2e-conviction` (122 ✓) stay green. ABI refreshed for the new error.

## Follow-up (not in this PR)

The O(n) re-index loops in `insertNode`/`removeNode` are now *bounded* by the cap but still linear up to it. A swap-with-last (or linked-list) redesign would make them O(1) and remove the gas cliff entirely.

> Security note: identified during a pre-mainnet review of the rc.17 contracts; severity ~High (availability / freeze of value paths; locks principal + pending claims).
