### PR TITLE
feat(agent-tooling): rc.17 knowledge-asset lifecycle tools — MCP (PR 2/3)

### DIFF
--- a/.cursor/rules/dkg-annotate.mdc
+++ b/.cursor/rules/dkg-annotate.mdc
@@ -53,7 +53,7 @@ dkg_knowledge_asset_write({
 });
 dkg_knowledge_asset_share({
   name: `turn-anno-${sessionKey}-${N}`,
-  entities: [turnUri, ...everyMintedRootUri], // see Query gotcha (3) below
+  entities: "all", // full share — preferred; pass an explicit array only for a subset (see Query gotcha (3))
 });
 ```
 
@@ -139,7 +139,7 @@ Things that consistently bite agents writing SPARQL via `dkg_query`:
 - Scoped query: omit `view`, pass `subGraphName: "<name>"` (legacy data-path query — works fine).
 - Cross-subgraph view: pass `view: "shared-working-memory"` alone, then filter in SPARQL via `GRAPH <did:dkg:context-graph:<cg>/<sub>/_shared_memory> { ... }`.
 
-**(3) `dkg_knowledge_asset_share` needs an explicit array via MCP.** The MCP rejects `entities: "all"` (must be array) and the daemon REST rejects empty arrays. Pass the explicit list of every root URI you minted — the turn URI plus every Decision/Finding/Task/file URI. Missing entries stay in WM, invisible to peers.
+**(3) `dkg_knowledge_asset_share`: prefer `entities: "all"` for a full share.** The MCP now **accepts** `entities: "all"` (or omit `entities` entirely) to share the WHOLE assertion — prefer that over enumerating an explicit array. A large explicit array can hit the share body-size limits for big assets; `"all"` cannot. Pass an **explicit array only for a selective subset** of roots — and note (CONTRACT §5) a subset share is SWM-only and is **NOT** VM-publishable as a subset: to publish on-chain, share the full set (or `"all"`). The daemon REST still rejects an **empty** array, so never send `[]` — use `"all"` / omit for "everything". Roots you leave out of a subset share stay in WM, invisible to peers.
 
 **(4) `code:` URI segments are percent-encoded.** Files like `gnosis+base wallets.zip` or `@scope/pkg` would break IRI parsing. The scanner applies `encodeURIComponent` per path segment. When constructing a file URI by hand, do the same: `urn:dkg:code:file:<owner>/<name>/${pathSegments.map(encodeURIComponent).join('/')}`.
 
@@ -160,7 +160,7 @@ Things that consistently bite agents writing SPARQL via `dkg_query`:
 2. dkg_memory_search "<label>" → reuse or mint URIs.
 3. dkg_knowledge_asset_create({ name: turn-anno-<sessionKey>-<N>, subGraphName: <route> }).
 4. dkg_knowledge_asset_write({ name, quads: [topics, mentions, durable artifacts, code-refs] }).
-5. dkg_knowledge_asset_share({ name, entities: [<turn-uri>, ...every-minted-root-uri] }).
+5. dkg_knowledge_asset_share({ name, entities: "all" }).  // full share; explicit array only for a subset (gotcha 3)
 ```
 
 That's it. The graph grows; teammates' agents see your work via auto-recall; humans ratify on-chain when worthwhile.

--- a/.cursor/rules/dkg-annotate.mdc
+++ b/.cursor/rules/dkg-annotate.mdc
@@ -1,5 +1,5 @@
 ---
-description: Annotate every substantive chat turn into the DKG project's sub-graphs via the V10 MCP tools (assertion_create → write → promote) so shared project memory grows organically and stays navigable, with every annotation linked back to its chat:Turn by the predicted turn URI.
+description: Annotate every substantive chat turn into the DKG project's sub-graphs via the V10 MCP tools (knowledge_asset_create → write → share) so shared project memory grows organically and stays navigable, with every annotation linked back to its chat:Turn by the predicted turn URI.
 alwaysApply: true
 ---
 
@@ -32,11 +32,11 @@ Hook ordering is documented in the installed [`.cursor/hooks.json`](mdc:.cursor/
 
 Author one per-turn assertion. **Over-eagerness is not a failure mode; under-coverage is.** Skip only one-line acknowledgements.
 
-The V9 sugared `dkg_annotate_turn` is **gone** — V10 uses an explicit three-step write:
+The V9 sugared `dkg_annotate_turn` is **gone** — V10 uses an explicit three-step write (create → write → share):
 
 ```js
-dkg_assertion_create({ name: `turn-anno-${sessionKey}-${N}`, subGraphName: "decisions" });
-dkg_assertion_write({
+dkg_knowledge_asset_create({ name: `turn-anno-${sessionKey}-${N}`, subGraphName: "decisions" });
+dkg_knowledge_asset_write({
   name: `turn-anno-${sessionKey}-${N}`,
   subGraphName: "decisions",
   quads: [
@@ -51,13 +51,13 @@ dkg_assertion_write({
     //   <file-uri> code:touchedInTurnBy <agent-uri>
   ],
 });
-dkg_assertion_promote({
+dkg_knowledge_asset_share({
   name: `turn-anno-${sessionKey}-${N}`,
   entities: [turnUri, ...everyMintedRootUri], // see Query gotcha (3) below
 });
 ```
 
-**Object encoding rule**: `dkg_assertion_write`'s `object` field is EITHER a bare URI OR a literal wrapped in double quotes. Literals without quotes fail on embedded spaces.
+**Object encoding rule**: `dkg_knowledge_asset_write`'s `object` field is EITHER a bare URI OR a literal wrapped in double quotes. Literals without quotes fail on embedded spaces.
 
 ## Look-before-mint (the convergence rule)
 
@@ -119,9 +119,9 @@ File URI MUST match the scanner pattern. `dkg_memory_search` the path first — 
 
 The authoritative reference is [`packages/cli/skills/dkg-node/SKILL.md`](mdc:packages/cli/skills/dkg-node/SKILL.md). Quick map:
 
-**Read**: `dkg_memory_search` (was `dkg_search`), `dkg_query` (was `dkg_sparql`), `dkg_get_entity`, `dkg_list_context_graphs` (was `dkg_list_projects`), `dkg_sub_graph_list` (was `dkg_list_subgraphs`), `dkg_list_activity`, `dkg_get_agent`, `dkg_assertion_query`, `dkg_assertion_history`, `dkg_status`.
+**Read**: `dkg_memory_search` (was `dkg_search`), `dkg_query` (was `dkg_sparql`), `dkg_get_entity`, `dkg_list_context_graphs` (was `dkg_list_projects`), `dkg_sub_graph_list` (was `dkg_list_subgraphs`), `dkg_list_activity`, `dkg_get_agent`, `dkg_knowledge_asset_query`, `dkg_knowledge_asset_history`, `dkg_status`.
 
-**Write (auto-promoted via `autoShare: true`)**: `dkg_assertion_create` + `dkg_assertion_write` + `dkg_assertion_promote`, `dkg_assertion_discard`, `dkg_share` (direct SWM), `dkg_sub_graph_create`.
+**Write (auto-shared via `autoShare: true`)**: `dkg_knowledge_asset_create` + `dkg_knowledge_asset_write` + `dkg_knowledge_asset_share`, `dkg_knowledge_asset_discard`, `dkg_share` (direct SWM), `dkg_sub_graph_create`.
 
 **Inter-agent**: `dkg_send_message`, `dkg_check_inbox` / `dkg_read_messages`, `dkg_subscribe`.
 
@@ -139,7 +139,7 @@ Things that consistently bite agents writing SPARQL via `dkg_query`:
 - Scoped query: omit `view`, pass `subGraphName: "<name>"` (legacy data-path query — works fine).
 - Cross-subgraph view: pass `view: "shared-working-memory"` alone, then filter in SPARQL via `GRAPH <did:dkg:context-graph:<cg>/<sub>/_shared_memory> { ... }`.
 
-**(3) `dkg_assertion_promote` needs an explicit array via MCP.** The MCP rejects `entities: "all"` (must be array) and the daemon REST rejects empty arrays. Pass the explicit list of every root URI you minted — the turn URI plus every Decision/Finding/Task/file URI. Missing entries stay in WM, invisible to peers.
+**(3) `dkg_knowledge_asset_share` needs an explicit array via MCP.** The MCP rejects `entities: "all"` (must be array) and the daemon REST rejects empty arrays. Pass the explicit list of every root URI you minted — the turn URI plus every Decision/Finding/Task/file URI. Missing entries stay in WM, invisible to peers.
 
 **(4) `code:` URI segments are percent-encoded.** Files like `gnosis+base wallets.zip` or `@scope/pkg` would break IRI parsing. The scanner applies `encodeURIComponent` per path segment. When constructing a file URI by hand, do the same: `urn:dkg:code:file:<owner>/<name>/${pathSegments.map(encodeURIComponent).join('/')}`.
 
@@ -158,9 +158,9 @@ Things that consistently bite agents writing SPARQL via `dkg_query`:
 ```
 1. Read <dkg-session-context> → grab <turn-uri>, <agent-uri>.
 2. dkg_memory_search "<label>" → reuse or mint URIs.
-3. dkg_assertion_create({ name: turn-anno-<sessionKey>-<N>, subGraphName: <route> }).
-4. dkg_assertion_write({ name, quads: [topics, mentions, durable artifacts, code-refs] }).
-5. dkg_assertion_promote({ name, entities: [<turn-uri>, ...every-minted-root-uri] }).
+3. dkg_knowledge_asset_create({ name: turn-anno-<sessionKey>-<N>, subGraphName: <route> }).
+4. dkg_knowledge_asset_write({ name, quads: [topics, mentions, durable artifacts, code-refs] }).
+5. dkg_knowledge_asset_share({ name, entities: [<turn-uri>, ...every-minted-root-uri] }).
 ```
 
 That's it. The graph grows; teammates' agents see your work via auto-recall; humans ratify on-chain when worthwhile.

--- a/packages/cli/skills/dkg-importer/SKILL.md
+++ b/packages/cli/skills/dkg-importer/SKILL.md
@@ -14,7 +14,7 @@ graphs other agents and the scanners produce.
 
 For the general node API surface (auth, contextGraphs, SWM/VM publish, SPARQL)
 see [`packages/cli/skills/dkg-node/SKILL.md`](../dkg-node/SKILL.md). This skill
-sits one layer above: it assumes you already know how to call `dkg_assertion_*`
+sits one layer above: it assumes you already know how to call `dkg_knowledge_asset_*`
 and focuses on **how to call them at scale, repeatedly, without losing data on
 restart and without fragmenting the graph against parallel producers**.
 

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -2148,7 +2148,7 @@ export async function mcpSetupAction(
   console.log('Next steps:');
   console.log('  1. Restart your MCP-aware client (Cursor / Claude Code) so it picks up the new server.');
   console.log('  2. From inside the client, ask "what tools does dkg expose?" — you should see');
-  console.log('     dkg_assertion_create, dkg_assertion_write, dkg_assertion_query, and friends.');
+  console.log('     dkg_knowledge_asset_create, dkg_knowledge_asset_write, dkg_knowledge_asset_query, and friends.');
   console.log('');
   } finally {
     // Codex Round-3 Fix 3: restore the prior `DKG_HOME` (or unset

--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -174,7 +174,7 @@ The lifecycle tool family that lets agents stage memory, seal it, share it, publ
 
 | Tool | Step | What it does |
 |---|---|---|
-| `dkg_knowledge_asset_create` | 1 | Create an empty Working Memory assertion graph (knowledge asset). Idempotent — duplicate names land as `alreadyExists: true`. Slug `/^[a-z0-9-]+$/`. |
+| `dkg_knowledge_asset_create` | 1 | Create an empty Working Memory assertion graph (knowledge asset). Idempotent — duplicate names land as `alreadyExists: true`. Name validation matches the daemon's `validateAssertionName`: any IRI-safe name up to 256 chars (no `/`, no whitespace, no `` <>"{}|^`\ `` characters), and not a reserved B3 KA id — NOT restricted to a lowercase-hyphen slug. |
 | `dkg_knowledge_asset_write` | 2 | Append RDF quads into an existing WM assertion. Set-merge — duplicates collapse. To replace, call `dkg_knowledge_asset_discard` first or mint a unique name. |
 | `dkg_knowledge_asset_finalize` | 3 | **Seal** the WM draft (the "git commit"): compute the merkleRoot over the whole assertion, build + sign an EIP-712 AuthorAttestation, stamp the seal. Returns `merkleRoot`, `authorAddress`, `schemeVersion`, `chainId`, `kav10Address`, `eip712Digest`. Seals the entire draft — no subset parameter. |
 | `dkg_knowledge_asset_share` | 4 | Share a WM assertion (or specific root entities) from private WM to Shared Working Memory so teammates see it (formerly "promote"). Omit `entities` for a full share, which auto-seals best-effort; a subset share is SWM-only and not publishable to VM as a subset. |

--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -47,7 +47,7 @@ The `command` is the absolute path to the Node binary running this CLI (`process
 
 No tokens or URLs in the JSON — those live in `~/.dkg/config.yaml` and the daemon-written `~/.dkg/auth.token`. If no client is detected, run `dkg mcp setup --print-only` to emit the JSON for manual paste.
 
-After `dkg mcp setup` runs, restart your client so it discovers the MCP. Verify by asking the agent: *"What tools does dkg expose?"* The `tools/list` response must include `dkg_assertion_create`, `dkg_assertion_write`, and `dkg_memory_search`.
+After `dkg mcp setup` runs, restart your client so it discovers the MCP. Verify by asking the agent: *"What tools does dkg expose?"* The `tools/list` response must include `dkg_knowledge_asset_create`, `dkg_knowledge_asset_write`, and `dkg_memory_search`.
 
 ### Manual config (alternative)
 
@@ -138,15 +138,16 @@ autoShare: true
 
 `.dkg/` is gitignored repo-wide so this file stays local to each operator. The `tokenFile` path is resolved relative to the YAML; default of `~/.dkg/auth.token` matches what `dkg start` writes on first boot.
 
-## Tool surface (21 tools)
+## Tool surface (30 tools)
 
-All tools are available the moment `dkg mcp setup` registers the MCP with your client. They group into six categories tracking how a session typically uses memory: discover the graph, write to it, finalize it, recall from it, query it, and check it.
+All tools are available the moment `dkg mcp setup` registers the MCP with your client. They group into seven categories tracking how a session typically uses memory: check health, discover the graph, set it up, drive the knowledge-asset lifecycle (create → write → finalize → share → publish), recall from it, query it, and message other agents.
 
 ### Health / identity
 
 | Tool | What it does |
 |---|---|
 | `dkg_status` | Show DKG node status: peer ID, connected peers, multiaddrs, wallet addresses. First call most agents make to verify the daemon is running. |
+| `dkg_peer_info` | Look up a peer by peer ID: connection state, transports, and diagnostic blocks (connections, peer store, outbox). |
 | `dkg_wallet_balances` | TRAC and ETH balances per operational wallet, plus chain id and RPC URL. Use before publishing to verify funds. |
 
 ### Discovery (graph navigation)
@@ -167,30 +168,36 @@ All tools are available the moment `dkg mcp setup` registers the MCP with your c
 | `dkg_subscribe` | Subscribe to a context graph so its data syncs locally from peers. Defaults to also syncing Shared Working Memory; pass `includeSharedMemory: false` to skip SWM. |
 | `dkg_sub_graph_create` | Create a named sub-graph inside a context graph (e.g. `code`, `tasks`, `meta`). Idempotent — pre-existing sub-graphs are silently reused. |
 
-### Write (the canonical assertion lifecycle)
+### Write (the canonical knowledge-asset lifecycle)
 
-The four-tool write flow that lets agents stage memory, share it, and recover from mistakes — the canonical V10 pattern, mirrored byte-for-byte across the OpenClaw adapter and the umbrella CLI.
+The lifecycle tool family that lets agents stage memory, seal it, share it, publish it on chain, and recover from mistakes — the canonical V10 pattern, mirrored byte-for-byte across the OpenClaw adapter and the umbrella CLI. The 5-stage sequence is **create → write → finalize → share → publish**.
 
 | Tool | Step | What it does |
 |---|---|---|
-| `dkg_assertion_create` | 1 | Create an empty Working Memory assertion graph. Idempotent — duplicate names land as `alreadyExists: true`. Slug `/^[a-z0-9-]+$/`. |
-| `dkg_assertion_write` | 2 | Append RDF quads into an existing WM assertion. Set-merge — duplicates collapse. To replace, call `dkg_assertion_discard` first or mint a unique name. |
-| `dkg_assertion_promote` | 3 | Promote a WM assertion (or specific root entities) from private WM to Shared Working Memory so teammates see it. Omit `entities` to promote every root. |
-| `dkg_assertion_discard` | rollback | Discard a WM assertion without promoting it. Idempotent — no-op on a missing assertion. Use before re-writing an assertion whose name you want to keep stable. |
-| `dkg_assertion_query` | introspect | Return every quad in a WM assertion. The canonical introspection step for the create + write + promote round-trip. |
-| `dkg_assertion_import_file` | bulk | Import a local document (markdown, PDF, DOCX, HTML, txt, csv) into a WM assertion via the daemon's extraction pipeline. Useful for seeding a context graph from existing documents in one step. |
-| `dkg_assertion_history` | audit | An assertion's lifecycle descriptor: author, extraction status, promotion state, timestamps. Returns 404 if no record exists. |
+| `dkg_knowledge_asset_create` | 1 | Create an empty Working Memory assertion graph (knowledge asset). Idempotent — duplicate names land as `alreadyExists: true`. Slug `/^[a-z0-9-]+$/`. |
+| `dkg_knowledge_asset_write` | 2 | Append RDF quads into an existing WM assertion. Set-merge — duplicates collapse. To replace, call `dkg_knowledge_asset_discard` first or mint a unique name. |
+| `dkg_knowledge_asset_finalize` | 3 | **Seal** the WM draft (the "git commit"): compute the merkleRoot over the whole assertion, build + sign an EIP-712 AuthorAttestation, stamp the seal. Returns `merkleRoot`, `authorAddress`, `schemeVersion`, `chainId`, `kav10Address`, `eip712Digest`. Seals the entire draft — no subset parameter. |
+| `dkg_knowledge_asset_share` | 4 | Share a WM assertion (or specific root entities) from private WM to Shared Working Memory so teammates see it (formerly "promote"). Omit `entities` for a full share, which auto-seals best-effort; a subset share is SWM-only and not publishable to VM as a subset. |
+| `dkg_knowledge_asset_publish` | 5 | **Mint / update on chain** (the sealed assertion → Verifiable Memory). Takes no selector (the seal commits the whole assertion). Returns the **UAL** + `kaId` + `txHash` — see "The canonical round-trip" below. |
+| `dkg_knowledge_asset_pull_from` | edit-loop | Seed a fresh WM draft from the current SWM or VM state (the "git checkout"). Body `{ layer: "swm" \| "vm", onConflict?: "reject" \| "replace" }`; `409 WM_DRAFT_CONFLICT` on a dirty draft unless `replace`. |
+| `dkg_knowledge_asset_discard` | rollback | Discard a WM assertion without sharing it. Idempotent — no-op on a missing assertion. Use before re-writing an assertion whose name you want to keep stable. |
+| `dkg_knowledge_asset_query` | introspect | Return every quad in a WM assertion. The canonical introspection step for the create + write + share round-trip. |
+| `dkg_knowledge_asset_import_file` | bulk | Import a local document (markdown, PDF, DOCX, HTML, txt, csv) into a WM assertion via the daemon's extraction pipeline. Useful for seeding a context graph from existing documents in one step. |
+| `dkg_knowledge_asset_history` | audit | An assertion's lifecycle descriptor: author, extraction status, share state, timestamps. Returns 404 if no record exists. |
+| `dkg_knowledge_asset_import_artifact_resolve` | import | Re-check the metadata of a completed imported attachment. |
+| `dkg_knowledge_asset_import_artifact_read_markdown` | import | Safely read the content-addressed Markdown blob for a completed imported attachment. |
+| `dkg_knowledge_asset_semantic_enrichment_write` | import | Append model-derived semantic triples + provenance to an imported assertion. |
 
-### Publish (SWM → on-chain)
+### Publish bridges (SWM → on-chain)
 
-Two distinct surfaces (both documented in `SKILL.md §4a`):
+The canonical per-KA sealed publish is `dkg_knowledge_asset_publish` (step 5 of the lifecycle above — returns the **UAL**). Two additional SWM-bridge surfaces exist (all documented in `SKILL.md §4a`):
 
 | Tool | When to use |
 |---|---|
-| `dkg_publish` | "I have fresh quads, publish them now." Two-call helper: writes the supplied quads to SWM, then publishes the entire SWM in the CG to Verifiable Memory and clears SWM. Skip the WM staging area. |
-| `dkg_shared_memory_publish` | Canonical step-4 finalizer for the stepwise flow (`assertion_create + write + promote` → this). Publishes existing SWM (filterable by `rootEntities`), clears SWM. Pass `registerIfNeeded: true` to upgrade a local-only CG to on-chain registration in the same call (may spend gas/TRAC). |
+| `dkg_publish` | "I have fresh quads, publish them now." Two-call helper (SWM-bridge / CG-wide): writes the supplied quads to SWM, then publishes the entire SWM in the CG to Verifiable Memory and clears SWM. Skip the WM staging area. |
+| `dkg_shared_memory_publish` | SWM-bridge / CG-wide flush (legacy, retained) for the stepwise flow. Publishes existing SWM (filterable by `rootEntities`), clears SWM. Single-root-per-call — loop one root per call for multiple roots. Pass `registerIfNeeded: true` to upgrade a local-only CG to on-chain registration in the same call (may spend gas/TRAC). |
 
-Both ship ungated — no `agent.canPublishToVm` flag — to mirror the OpenClaw adapter exactly.
+All publish surfaces ship ungated — no `agent.canPublishToVm` flag — to mirror the OpenClaw adapter exactly.
 
 ### Search & query
 
@@ -199,17 +206,25 @@ Both ship ungated — no `agent.canPublishToVm` flag — to mirror the OpenClaw 
 | `dkg_memory_search` | Trust-weighted free-text recall across WM/SWM/VM in the agent-context graph (and an optional project graph). Higher-trust layers (VM > SWM > WM) collapse lower-trust hits for the same entity URI. Each hit surfaces `contextGraphId`, `layer`, and `trustWeight`. Use this for "ask my memory anything" recall. |
 | `dkg_query` | Execute SPARQL SELECT / ASK / CONSTRUCT against a context graph. Known prefixes are auto-prepended. Scope with `view`: `"working-memory"` (default), `"shared-working-memory"`, or `"verifiable-memory"`. Set `includeSharedMemory: true` alongside `view: "working-memory"` to query WM ∪ SWM in one call. |
 
+### Messaging (agent-to-agent)
+
+| Tool | What it does |
+|---|---|
+| `dkg_send_message` | Send a direct message to another agent over P2P (best-effort; fails gracefully when the peer is offline). |
+| `dkg_check_inbox` | Read inbound direct messages addressed to this node's agents. |
+
 ## The canonical round-trip
 
 Lifted from the repo-root README's [DKG V10 as agent memory quickstart](../../README.md#round-trip-write-then-recall), reproduced here for completeness:
 
-1. `dkg_assertion_create` with a slug name (idempotent — re-runs return `alreadyExists: true`).
-2. `dkg_assertion_write` with one or more quads (additive set-merge).
+1. `dkg_knowledge_asset_create` with a slug name (idempotent — re-runs return `alreadyExists: true`).
+2. `dkg_knowledge_asset_write` with one or more quads (additive set-merge).
 3. `dkg_memory_search` with a keyword from the write — the just-written triple comes back from the WM layer with `trustWeight` set.
-4. *(optional)* `dkg_assertion_promote` to advance the lifecycle to SWM and gossip to peers.
-5. *(optional)* `dkg_shared_memory_publish` to finalize on-chain (costs TRAC + gas, clears SWM).
+4. *(optional)* `dkg_knowledge_asset_finalize` to **seal** the draft (the EIP-712 "git commit" — note: this is the rc.17 *seal* verb, distinct from the on-chain mint in step 6).
+5. *(optional)* `dkg_knowledge_asset_share` to advance the lifecycle to SWM and gossip to peers (a full share auto-seals best-effort, so step 4 can be skipped for the common case).
+6. *(optional)* `dkg_knowledge_asset_publish` to **mint on chain** (costs TRAC + gas, clears SWM). The response carries the asset's **UAL** (`did:dkg:<chainId>/<addr>/<number>`) plus `kaId` and `txHash` — store the UAL to reference the asset later.
 
-For ad-hoc filtering or non-text-search queries, `dkg_query` is the lower-level SPARQL surface. For one-shot fresh-quads-to-VM writes that skip the WM staging area, use `dkg_publish` instead of the assertion lifecycle — but prefer the lifecycle for anything an agent will iterate on.
+For ad-hoc filtering or non-text-search queries, `dkg_query` is the lower-level SPARQL surface. For one-shot fresh-quads-to-VM writes that skip the WM staging area, use `dkg_publish` instead of the knowledge-asset lifecycle — but prefer the lifecycle for anything an agent will iterate on.
 
 ## View semantics
 
@@ -278,13 +293,14 @@ Per-turn state is kept in `~/.cache/dkg-mcp/sessions/*.json`; safe to delete at 
 
 | File | Purpose |
 |---|---|
-| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 21 tools. |
+| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 30 tools. |
 | `src/tools.ts` | Read tools (`dkg_list_context_graphs`, `dkg_sub_graph_list`, `dkg_query`, `dkg_get_entity`, `dkg_list_activity`, `dkg_get_agent`). |
-| `src/tools/assertions.ts` | Assertion lifecycle (`dkg_assertion_*` × 7). |
-| `src/tools/health.ts` | `dkg_status`, `dkg_wallet_balances`. |
+| `src/tools/assertions.ts` | Knowledge-asset lifecycle (`dkg_knowledge_asset_*` × 13: create/write/finalize/share/publish/pull_from/discard/query/history/import_file + import_artifact_resolve/read_markdown + semantic_enrichment_write). |
+| `src/tools/health.ts` | `dkg_status`, `dkg_peer_info`, `dkg_wallet_balances`. |
 | `src/tools/memory-search.ts` | `dkg_memory_search` with WM/SWM/VM fan-out and trust-weighted ranking. |
-| `src/tools/publish.ts` | `dkg_publish`, `dkg_shared_memory_publish`. |
+| `src/tools/publish.ts` | `dkg_publish`, `dkg_shared_memory_publish` (SWM-bridge surfaces; per-KA publish lives in `assertions.ts`). |
 | `src/tools/setup.ts` | `dkg_context_graph_create`, `dkg_subscribe`, `dkg_sub_graph_create`. |
+| `src/tools/chat.ts` | `dkg_send_message`, `dkg_check_inbox`. |
 | `src/client.ts` | `DkgClient` HTTP wrapper. Re-exported as `@origintrail-official/dkg-mcp/client`. |
 | `src/manifest/{publish,fetch,install}.ts` | Project manifest publish/install pipeline. Re-exported as `@origintrail-official/dkg-mcp/manifest/*` and consumed by the umbrella CLI's daemon routes. |
 | `hooks/capture-chat.mjs` | Cursor/Claude Code chat-turn capture hook (above). |

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1068,7 +1068,11 @@ export class DkgClient {
       predicate: q.predicate,
       object: q.object,
     }));
-    const created = await this.request<{ assertionUri?: string; seal?: Record<string, unknown> }>(
+    const created = await this.request<{
+      assertionUri?: string;
+      seal?: Record<string, unknown>;
+      errors?: Array<{ phase?: string; error?: string }>;
+    }>(
       'POST',
       '/api/knowledge-assets',
       {
@@ -1078,14 +1082,58 @@ export class DkgClient {
         promote: true,
       },
     );
-    const published = await this.request<Record<string, unknown>>(
-      'POST',
-      '/api/shared-memory/publish',
-      {
-        contextGraphId: cgId,
-        assertionName,
-      },
-    );
+
+    // FIX A — the create route returns HTTP 207 `{ created:true, …, errors:[…] }`
+    // when create+finalize succeeded but the `promote:true` share phase FAILED
+    // (knowledge-assets.ts:614). `this.request` treats 207 as success (2xx, no
+    // throw), so without this check we would publish an UNSHARED assertion and
+    // mask the real error. If the share failed, do NOT publish — surface the
+    // sealed-but-unshared asset by name so the caller can recover with the
+    // lifecycle tools instead of recreating it.
+    if (Array.isArray(created.errors) && created.errors.length > 0) {
+      const shareErr = created.errors.find((e) => e?.phase === 'swm-share') ?? created.errors[0];
+      const err = new Error(
+        `Publish aborted: the asset was created + sealed in Working Memory as "${assertionName}", but ` +
+        `sharing it to Shared Working Memory FAILED (${shareErr?.error ?? 'unknown error'}). The on-chain ` +
+        `publish was NOT attempted. Do NOT recreate — re-share + publish the existing sealed asset by name ` +
+        `via dkg_knowledge_asset_share + dkg_knowledge_asset_publish (or dkg_shared_memory_publish).`,
+      ) as Error & Record<string, unknown>;
+      err.assertionName = assertionName;
+      err.assertionUri = created.assertionUri;
+      if (created.seal) err.seal = created.seal;
+      err.phase = shareErr?.phase ?? 'swm-share';
+      err.partial = true;
+      throw err;
+    }
+
+    // FIX B — the asset is created + sealed + shared; only the on-chain publish
+    // remains. If it fails, the random `assertionName` would be lost and the next
+    // dkg_publish would mint a DUPLICATE. Catch + rethrow carrying the name so the
+    // caller can retry the publish of the existing asset, not recreate it.
+    let published: Record<string, unknown>;
+    try {
+      published = await this.request<Record<string, unknown>>(
+        'POST',
+        '/api/shared-memory/publish',
+        {
+          contextGraphId: cgId,
+          assertionName,
+        },
+      );
+    } catch (e) {
+      const err = new Error(
+        `Publish failed for asset "${assertionName}": ${e instanceof Error ? e.message : String(e)}. The asset ` +
+        `is created + sealed + shared to Shared Working Memory; only the on-chain publish failed. Do NOT ` +
+        `recreate — retry the publish of this asset by name via dkg_shared_memory_publish or ` +
+        `dkg_knowledge_asset_publish.`,
+      ) as Error & Record<string, unknown>;
+      err.assertionName = assertionName;
+      err.assertionUri = created.assertionUri;
+      if (created.seal) err.seal = created.seal;
+      err.phase = 'vm-publish';
+      err.cause = e;
+      throw err;
+    }
     return {
       ...published,
       ...(created.assertionUri ? { assertionUri: created.assertionUri } : {}),

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1070,7 +1070,9 @@ export class DkgClient {
     }));
     const created = await this.request<{
       assertionUri?: string;
-      seal?: Record<string, unknown>;
+      // The create response carries `merkleRoot` (the seal digest), not a `seal`
+      // object (knowledge-assets.ts:570).
+      merkleRoot?: string;
       errors?: Array<{ phase?: string; error?: string }>;
     }>(
       'POST',
@@ -1100,7 +1102,7 @@ export class DkgClient {
       ) as Error & Record<string, unknown>;
       err.assertionName = assertionName;
       err.assertionUri = created.assertionUri;
-      if (created.seal) err.seal = created.seal;
+      if (created.merkleRoot) err.merkleRoot = created.merkleRoot;
       err.phase = shareErr?.phase ?? 'swm-share';
       err.partial = true;
       throw err;
@@ -1128,7 +1130,7 @@ export class DkgClient {
       ) as Error & Record<string, unknown>;
       err.assertionName = assertionName;
       err.assertionUri = created.assertionUri;
-      if (created.seal) err.seal = created.seal;
+      if (created.merkleRoot) err.merkleRoot = created.merkleRoot;
       err.phase = 'vm-publish';
       err.cause = e;
       throw err;
@@ -1136,7 +1138,7 @@ export class DkgClient {
     return {
       ...published,
       ...(created.assertionUri ? { assertionUri: created.assertionUri } : {}),
-      ...(created.seal ? { seal: created.seal } : {}),
+      ...(created.merkleRoot ? { merkleRoot: created.merkleRoot } : {}),
     };
   }
 

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1094,8 +1094,10 @@ export class DkgClient {
       const err = new Error(
         `Create failed for one-shot publish (asset name "${assertionName}"): ${e instanceof Error ? e.message : String(e)}. ` +
         `The asset MAY have been created server-side even though the response failed. Before retrying, check via ` +
-        `dkg_knowledge_asset_history / dkg_knowledge_asset_query for "${assertionName}" to avoid minting a ` +
-        `DUPLICATE; if it exists, re-share + publish it by name rather than re-running this tool.`,
+        `dkg_knowledge_asset_history for "${assertionName}" to avoid minting a DUPLICATE. A created asset is ` +
+        `auto-shared to SWM (its working-memory draft is empty), so use _history (lifecycle state regardless ` +
+        `of layer) for existence — NOT dkg_knowledge_asset_query, which reads the empty WM draft and would ` +
+        `falsely report "not created". If it exists, re-share + publish it by name rather than re-running this tool.`,
       ) as Error & Record<string, unknown>;
       err.assertionName = assertionName;
       err.phase = 'create';

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1203,15 +1203,24 @@ export class DkgClient {
   async knowledgeAssetWrite(args: {
     contextGraphId: string;
     name: string;
-    // `graph` is optional: the WM-write engine (agent.assertion.write) derives
-    // the draft's named graph when omitted — the legacy triples path relied on
-    // exactly this, so callers may pass bare subject/predicate/object.
+    // `graph` is accepted on the input for caller convenience but is STRIPPED
+    // before the POST (CONTRACT §A) — the write wire shape is
+    // {subject,predicate,object} only and the daemon pins every quad to the
+    // per-KA WM graph (§0 invariant 2), overriding any client-supplied graph.
     quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>;
     subGraphName?: string;
   }): Promise<{ written: number }> {
+    // Strip any per-quad `graph` at the client (CONTRACT §A) — not just the
+    // tool schema — so a hand-built or normalizer-emitted `graph` can't reach
+    // the wire.
+    const wireQuads = args.quads.map((q) => ({
+      subject: q.subject,
+      predicate: q.predicate,
+      object: q.object,
+    }));
     const body: Record<string, unknown> = {
       contextGraphId: normalizeContextGraphId(args.contextGraphId),
-      quads: args.quads,
+      quads: wireQuads,
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
     return this.request<{ written: number }>(

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1095,8 +1095,8 @@ export class DkgClient {
       const err = new Error(
         `Publish aborted: the asset was created + sealed in Working Memory as "${assertionName}", but ` +
         `sharing it to Shared Working Memory FAILED (${shareErr?.error ?? 'unknown error'}). The on-chain ` +
-        `publish was NOT attempted. Do NOT recreate — re-share + publish the existing sealed asset by name ` +
-        `via dkg_knowledge_asset_share + dkg_knowledge_asset_publish (or dkg_shared_memory_publish).`,
+        `publish was NOT attempted. Do NOT recreate — re-share the existing sealed asset by name with ` +
+        `dkg_knowledge_asset_share, then publish it with dkg_knowledge_asset_publish.`,
       ) as Error & Record<string, unknown>;
       err.assertionName = assertionName;
       err.assertionUri = created.assertionUri;
@@ -1124,8 +1124,7 @@ export class DkgClient {
       const err = new Error(
         `Publish failed for asset "${assertionName}": ${e instanceof Error ? e.message : String(e)}. The asset ` +
         `is created + sealed + shared to Shared Working Memory; only the on-chain publish failed. Do NOT ` +
-        `recreate — retry the publish of this asset by name via dkg_shared_memory_publish or ` +
-        `dkg_knowledge_asset_publish.`,
+        `recreate — retry the publish of this asset by name with dkg_knowledge_asset_publish.`,
       ) as Error & Record<string, unknown>;
       err.assertionName = assertionName;
       err.assertionUri = created.assertionUri;

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -1068,22 +1068,40 @@ export class DkgClient {
       predicate: q.predicate,
       object: q.object,
     }));
-    const created = await this.request<{
+    // FIX W — wrap the create call: on a HARD failure the generated
+    // `assertionName` would otherwise be lost in the throw, so a retry mints a
+    // DUPLICATE if the asset was actually created (e.g. the daemon committed but
+    // the HTTP response failed). Surface the name + recovery guidance.
+    let created: {
       assertionUri?: string;
       // The create response carries `merkleRoot` (the seal digest), not a `seal`
       // object (knowledge-assets.ts:570).
       merkleRoot?: string;
       errors?: Array<{ phase?: string; error?: string }>;
-    }>(
-      'POST',
-      '/api/knowledge-assets',
-      {
-        contextGraphId: cgId,
-        name: assertionName,
-        quads: wireQuads,
-        promote: true,
-      },
-    );
+    };
+    try {
+      created = await this.request(
+        'POST',
+        '/api/knowledge-assets',
+        {
+          contextGraphId: cgId,
+          name: assertionName,
+          quads: wireQuads,
+          promote: true,
+        },
+      );
+    } catch (e) {
+      const err = new Error(
+        `Create failed for one-shot publish (asset name "${assertionName}"): ${e instanceof Error ? e.message : String(e)}. ` +
+        `The asset MAY have been created server-side even though the response failed. Before retrying, check via ` +
+        `dkg_knowledge_asset_history / dkg_knowledge_asset_query for "${assertionName}" to avoid minting a ` +
+        `DUPLICATE; if it exists, re-share + publish it by name rather than re-running this tool.`,
+      ) as Error & Record<string, unknown>;
+      err.assertionName = assertionName;
+      err.phase = 'create';
+      err.cause = e;
+      throw err;
+    }
 
     // FIX A — the create route returns HTTP 207 `{ created:true, …, errors:[…] }`
     // when create+finalize succeeded but the `promote:true` share phase FAILED

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -63,10 +63,6 @@ function optionalContextGraphId(contextGraphIdOrUri: string | undefined): string
   return normalizeContextGraphId(contextGraphIdOrUri) || undefined;
 }
 
-function toContextGraphUri(contextGraphIdOrUri: string): string {
-  return `${CONTEXT_GRAPH_URI_PREFIX}${normalizeContextGraphId(contextGraphIdOrUri)}`;
-}
-
 /**
  * Author attestation produced by an external signer. Mirrors the
  * `packages/cli/src/api-client.ts` reference so finalize / create KA flows can
@@ -1061,11 +1057,16 @@ export class DkgClient {
   }): Promise<Record<string, unknown>> {
     const cgId = normalizeContextGraphId(args.contextGraphId);
     const assertionName = `mcp-publish-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const quadsWithGraph = args.quads.map((q) => ({
+    // The write wire shape is `{subject, predicate, object}` only — the daemon
+    // pins every quad to the per-KA WM graph itself, so a client-supplied
+    // `graph` is ignored/overridden (CONTRACT §0 invariant 2). Auto-finalize is
+    // driven purely by non-empty `quads` (CONTRACT §1 Stage1), so `finalize:true`
+    // is unread and dropped. `promote:true` is kept: the create route reads it as
+    // the `alsoShareSwm` alias (CONTRACT §1 Stage1). Mirrors the OpenClaw adapter.
+    const wireQuads = args.quads.map((q) => ({
       subject: q.subject,
       predicate: q.predicate,
       object: q.object,
-      graph: q.graph || toContextGraphUri(cgId),
     }));
     const created = await this.request<{ assertionUri?: string; seal?: Record<string, unknown> }>(
       'POST',
@@ -1073,8 +1074,7 @@ export class DkgClient {
       {
         contextGraphId: cgId,
         name: assertionName,
-        quads: quadsWithGraph,
-        finalize: true,
+        quads: wireQuads,
         promote: true,
       },
     );

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -192,7 +192,9 @@ export function registerAssertionTools(
         'subset parameter). A FULL share (dkg_knowledge_asset_share with ' +
         '`entities` omitted or "all") auto-seals for you, so you only need to ' +
         'call this explicitly before sharing a SELECTIVE subset of entities, or ' +
-        'to re-seal after editing a previously-sealed draft.',
+        'to re-seal after editing a previously-sealed draft. (External-signer / ' +
+        'pre-signed attestation is a tracked follow-up and is not exposed by this ' +
+        'tool — author with authorAgentAddress.)',
       inputSchema: {
         name: z.string().describe('Existing knowledge asset name to finalize'),
         authorAgentAddress: z
@@ -202,7 +204,9 @@ export function registerAssertionTools(
             'Optional 0x author address to attest as. Omit to let the daemon ' +
             'default the author to the request token\'s agent.',
           ),
-        schemeVersion: z.number().int().optional().describe('Optional attestation scheme version'),
+        // CONTRACT §C: scheme_version is a POSITIVE integer (daemon >= 1) — zod
+        // rejects 0 / negative / non-integer at the boundary as a tool error.
+        schemeVersion: z.number().int().positive().optional().describe('Optional attestation scheme version (positive integer)'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -255,13 +259,15 @@ export function registerAssertionTools(
         'share the full asset (or model the subset as its own knowledge asset).',
       inputSchema: {
         name: z.string().describe('Existing knowledge asset name'),
+        // CONTRACT §B: accept "all" | string[] | omitted. The daemon reads
+        // parsed.entities and treats "all"/omitted as a full share.
         entities: z
-          .array(z.string())
+          .union([z.literal('all'), z.array(z.string())])
           .optional()
           .describe(
-            'Root entity URIs to share. Omit to share all roots (auto-seals + ' +
-            'publish-ready). A subset shares to SWM only and is NOT publishable ' +
-            'to Verifiable Memory.',
+            'Root entities to share. Omit (or pass the string "all") to share all ' +
+            'roots (auto-seals + publish-ready). A subset (non-empty array) shares ' +
+            'to SWM only and is NOT publishable to Verifiable Memory.',
           ),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
@@ -270,24 +276,26 @@ export function registerAssertionTools(
     async ({ name, entities, projectId, subGraphName }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
-      // Provided entities must be a non-empty array of URIs; omitted means
-      // "share all roots" (daemon-side default).
-      if (entities !== undefined && entities.length === 0) {
+      // CONTRACT §B: "all" | string[] | omitted. Pass "all" / omitted through as a
+      // full share (omitted ⇒ undefined ⇒ daemon default); a non-empty array is the
+      // subset. An empty array is rejected client-side (the daemon would 400 it) —
+      // fail fast, never coerce to "all" or omit.
+      if (Array.isArray(entities) && entities.length === 0) {
         return errResult(
-          '"entities" must be omitted or a non-empty array of root entity URIs.',
+          '"entities" must be omitted, the string "all", or a non-empty array of root entity URIs.',
         );
       }
       try {
         // WM → SWM. The KA `swm/share` route is the same engine call
         // (`agent.assertion.promote`) the legacy promote used; omit `entities`
-        // to share every root (the route's default), or pass a subset.
+        // to share every root (the route's default), pass "all", or pass a subset.
         await client.knowledgeAssetShare({
           contextGraphId: pid,
           name,
           subGraphName,
-          entities: entities && entities.length > 0 ? entities : undefined,
+          entities,
         });
-        const scope = entities && entities.length > 0
+        const scope = Array.isArray(entities)
           ? `${entities.length} entit${entities.length === 1 ? 'y' : 'ies'}`
           : 'all root entities';
         return ok(`Shared ${scope} from knowledge asset '${name}' (project '${pid}') to SWM.`);
@@ -314,6 +322,8 @@ export function registerAssertionTools(
         'SWM constraint. Fails 409 if the asset is not yet finalized + shared ' +
         '(run dkg_knowledge_asset_finalize / dkg_knowledge_asset_share first).',
       inputSchema: {
+        // CONTRACT §C: publishEpochs is a POSITIVE integer (zod rejects 0 /
+        // negative / non-integer at the boundary → a fail-fast tool error).
         name: z.string().describe('Knowledge asset name to publish (must be finalized + shared)'),
         publishEpochs: z
           .number()
@@ -321,14 +331,19 @@ export function registerAssertionTools(
           .positive()
           .optional()
           .describe('Optional number of epochs to publish for (positive integer)'),
+        // CONTRACT §C: NON-NEGATIVE integer as a decimal string (daemon /^\d+$/).
+        // Validated at the boundary so a bad value is a clear tool error, not a
+        // generic client throw.
         publisherNodeIdentityIdOverride: z
           .string()
+          .regex(/^\d+$/, 'publisher_node_identity_id_override must be a non-negative integer (decimal string)')
           .optional()
-          .describe('Optional publisher node identity id override (decimal string)'),
-        clearSharedMemoryAfter: z
-          .boolean()
-          .optional()
-          .describe('When true, clear the asset\'s Shared Working Memory after a confirmed publish'),
+          .describe('Optional publisher node identity id override (non-negative integer, decimal string)'),
+        // CONTRACT §D: clear_shared_memory_after is NOT exposed on the per-asset
+        // publish tool — on vm/publish it is graph-wide destructive (wipes every
+        // other agent's unpublished SWM under the CG/sub-graph). The this-asset
+        // cleanup runs unconditionally regardless. The CG-wide clear stays on
+        // dkg_publish / dkg_shared_memory_publish.
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -337,7 +352,6 @@ export function registerAssertionTools(
       name,
       publishEpochs,
       publisherNodeIdentityIdOverride,
-      clearSharedMemoryAfter,
       projectId,
       subGraphName,
     }): Promise<ToolResult> => {
@@ -356,7 +370,6 @@ export function registerAssertionTools(
           subGraphName,
           publishEpochs,
           publisherNodeIdentityIdOverride,
-          clearAfter: clearSharedMemoryAfter,
         });
         return ok(
           `Published knowledge asset '${name}' (project '${pid}') to Verifiable Memory:\n\n\`\`\`json\n${JSON.stringify(

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -310,6 +310,10 @@ export function registerAssertionTools(
           '"entities" must be omitted, the string "all", or a non-empty array of root entity URIs.',
         );
       }
+      // FIX K: trim each root-entity URI before forwarding — a whitespace-padded
+      // entity (" urn:a ") would otherwise reach the daemon with the spaces and
+      // resolve to the wrong (or no) root. Parity with Hermes.
+      const trimmedEntities = Array.isArray(entities) ? entities.map((e) => String(e).trim()) : entities;
       try {
         // WM → SWM. The KA `swm/share` route is the same engine call
         // (`agent.assertion.promote`) the legacy promote used; omit `entities`
@@ -318,7 +322,7 @@ export function registerAssertionTools(
           contextGraphId: pid,
           name,
           subGraphName,
-          entities,
+          entities: trimmedEntities,
         });
         const scope = Array.isArray(entities)
           ? `${entities.length} entit${entities.length === 1 ? 'y' : 'ies'}`

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -34,6 +34,21 @@ const errResult = (text: string): ToolResult => ({
 const formatError = (e: unknown): string =>
   e instanceof Error ? e.message : String(e);
 
+/**
+ * The daemon's real assertion-name rule, replicated verbatim from
+ * `@origintrail-official/dkg-core` `validateAssertionName`
+ * (core/src/constants.ts:346-352). MCP does not depend on dkg-core, so the rule
+ * is inlined here (and on Hermes) rather than imported. Any IRI-safe name up to
+ * 256 chars — NOT a lowercase-hyphen slug. Keep in sync with the core source.
+ */
+function validateAssertionName(name: string): { valid: boolean; reason?: string } {
+  if (!name || name.length === 0) return { valid: false, reason: 'Assertion name cannot be empty' };
+  if (name.includes('/')) return { valid: false, reason: 'Assertion name cannot contain "/"' };
+  if (/[<>"{}|^`\\\s]/.test(name)) return { valid: false, reason: 'Assertion name contains characters unsafe for IRIs' };
+  if (name.length > 256) return { valid: false, reason: 'Assertion name exceeds 256 characters' };
+  return { valid: true };
+}
+
 function resolveProject(
   explicit: string | undefined,
   config: DkgConfig,
@@ -59,13 +74,16 @@ export function registerAssertionTools(
       description:
         'Step 1 of the canonical write flow (create → write → finalize → share → publish): ' +
         'create an empty Working Memory draft for a knowledge asset. Idempotent — ' +
-        'duplicate names land as `alreadyExists: true` rather than throwing. Slug must match ' +
-        '/^[a-z0-9-]+$/ for new names; pre-existing assets accept any name.',
+        'duplicate names land as `alreadyExists: true` rather than throwing. Accepts any ' +
+        'valid assertion name: an IRI-safe name up to 256 chars (no "/", no whitespace, no ' +
+        '<>"{}|^`\\ characters) — NOT restricted to a lowercase-hyphen slug.',
       inputSchema: {
         name: z
           .string()
-          .regex(/^[a-z0-9-]+$/, 'Assertion name must be lowercase a-z, 0-9, or hyphen')
-          .describe('Assertion name slug (e.g. "session-2026-04-30")'),
+          .refine((n) => validateAssertionName(n).valid, (n) => ({
+            message: validateAssertionName(n).reason ?? 'Invalid assertion name',
+          }))
+          .describe('Assertion name. Any IRI-safe name up to 256 chars (e.g. "session-2026-04-30", "My_Asset.v2") — no "/", whitespace, or <>"{}|^`\\ characters.'),
         projectId: z
           .string()
           .optional()

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -142,11 +142,10 @@ export function registerAssertionTools(
                 '  Lang-tagged:     "\\"hello\\"@en"\n' +
                 'A literal without surrounding quotes will be parsed as a URI and FAIL on spaces.',
               ),
-              graph: z.string().optional().describe('Optional named graph URI (same rules as subject)'),
             }),
           )
           .min(1)
-          .describe('Non-empty array of RDF quads to append'),
+          .describe('Non-empty array of RDF triples to append'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
       },
@@ -156,15 +155,15 @@ export function registerAssertionTools(
       if (!pid) return projectErr();
       try {
         // Append to the KA's WM draft. Strip angle brackets from URIs (the
-        // engine wants bare URIs) and carry `graph` through when supplied;
-        // omitted graph lets the WM-write engine derive the draft graph.
+        // engine wants bare URIs). Wire shape is {subject, predicate, object}
+        // only — no per-quad `graph` (CONTRACT §0 invariant 2; the daemon pins
+        // every triple to the per-KA WM graph and overrides any client value).
         const strip = (t: string): string =>
           t.startsWith('<') && t.endsWith('>') ? t.slice(1, -1) : t;
         const kaQuads = quads.map((q) => ({
           subject: strip(q.subject),
           predicate: strip(q.predicate),
           object: q.object,
-          ...(q.graph ? { graph: strip(q.graph) } : {}),
         }));
         const { written } = await client.knowledgeAssetWrite({
           contextGraphId: pid,

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -320,7 +320,9 @@ export function registerAssertionTools(
         'Prefer this over dkg_shared_memory_publish when publishing a single ' +
         'named asset; it is multi-root-safe and avoids the legacy single-root ' +
         'SWM constraint. Fails 409 if the asset is not yet finalized + shared ' +
-        '(run dkg_knowledge_asset_finalize / dkg_knowledge_asset_share first).',
+        '(run dkg_knowledge_asset_finalize / dkg_knowledge_asset_share first). ' +
+        'vm/publish requires the context graph to be registered on-chain — set ' +
+        '`registerIfNeeded: true` to register it first (idempotent) before publishing.',
       inputSchema: {
         // CONTRACT §C: publishEpochs is a POSITIVE integer (zod rejects 0 /
         // negative / non-integer at the boundary → a fail-fast tool error).
@@ -339,6 +341,21 @@ export function registerAssertionTools(
           .regex(/^\d+$/, 'publisher_node_identity_id_override must be a non-negative integer (decimal string)')
           .optional()
           .describe('Optional publisher node identity id override (non-negative integer, decimal string)'),
+        // CONTRACT §G: vm/publish requires the CG to be registered on-chain and
+        // does NOT auto-register. registerIfNeeded registers first (idempotent),
+        // mirroring dkg_shared_memory_publish.
+        registerIfNeeded: z
+          .boolean()
+          .optional()
+          .describe(
+            'If the context graph is not yet registered on-chain, register it first (idempotent), then ' +
+            'publish. Registration may spend gas/TRAC; opt-in. Default false — when false and the CG is ' +
+            'unregistered, publish fails with the daemon\'s not-registered error.',
+          ),
+        accessPolicy: z
+          .union([z.literal(0), z.literal(1)])
+          .optional()
+          .describe('Used only when `registerIfNeeded: true`. 0 = open, 1 = private.'),
         // CONTRACT §D: clear_shared_memory_after is NOT exposed on the per-asset
         // publish tool — on vm/publish it is graph-wide destructive (wipes every
         // other agent's unpublished SWM under the CG/sub-graph). The this-asset
@@ -352,11 +369,25 @@ export function registerAssertionTools(
       name,
       publishEpochs,
       publisherNodeIdentityIdOverride,
+      registerIfNeeded,
+      accessPolicy,
       projectId,
       subGraphName,
     }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
+      // CONTRACT §G: vm/publish requires the CG to be registered on-chain and does
+      // NOT auto-register. When registerIfNeeded is true, register first (the
+      // client short-circuits an already-registered CG via alreadyRegistered), then
+      // publish — mirroring dkg_shared_memory_publish. A hard registration failure
+      // is a tool error: do NOT publish.
+      if (registerIfNeeded === true) {
+        try {
+          await client.registerContextGraph({ id: pid, accessPolicy });
+        } catch (err) {
+          return errResult(`Failed to register context graph: ${formatError(err)}`);
+        }
+      }
       try {
         // Per-KA sealed publish (CONTRACT §1 Stage5). The seal selects the author
         // and the whole asset, so author/selection overrides are never sent. The

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -251,7 +251,11 @@ export function registerAssertionTools(
         'Shared Working Memory so teammates see it. A FULL share (omit ' +
         '`entities` or pass "all") auto-seals the draft best-effort and is ' +
         'publish-ready — follow it with dkg_knowledge_asset_publish to mint the ' +
-        'asset on-chain (Verifiable Memory). A SELECTIVE subset (`entities` set ' +
+        'asset on-chain (Verifiable Memory). The auto-seal uses DEFAULT finalize ' +
+        'options; if you need custom finalize/attestation options ' +
+        '(authorAgentAddress / schemeVersion), call dkg_knowledge_asset_finalize ' +
+        'EXPLICITLY first (even for a full share) — share\'s auto-seal cannot ' +
+        'carry those. A SELECTIVE subset (`entities` set ' +
         'to a proper subset) shares to SWM only for peer visibility, is NOT ' +
         'auto-sealed, and is NOT publishable to Verifiable Memory: ' +
         'dkg_knowledge_asset_publish reconstructs the seal\'s full root set and ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -379,12 +379,17 @@ export function registerAssertionTools(
           .describe(
             'If the context graph is not yet registered on-chain, register it first (idempotent), then ' +
             'publish. Registration may spend gas/TRAC; opt-in. Default false — when false and the CG is ' +
-            'unregistered, publish fails with the daemon\'s not-registered error.',
+            'unregistered, publish fails with the daemon\'s not-registered error. CAVEAT: this uses the ' +
+            'explicit register route, which registers with the daemon\'s DEFAULT publishPolicy (derived from ' +
+            'accessPolicy) and does NOT preserve a context graph\'s stored custom publishPolicy / ' +
+            'contribution governance. For a CG created with a non-default publishPolicy/PCA, register it ' +
+            'explicitly with the desired policy first rather than relying on registerIfNeeded. (Read access ' +
+            'is unaffected; daemon-side rehydration tracked in OriginTrail/dkg#1085.)',
           ),
         accessPolicy: z
           .union([z.literal(0), z.literal(1)])
           .optional()
-          .describe('0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.'),
+          .describe('0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise. Sets only the access policy; it does NOT preserve a stored custom publishPolicy (see registerIfNeeded; OriginTrail/dkg#1085).'),
         // CONTRACT §D: clear_shared_memory_after is NOT exposed on the per-asset
         // publish tool — on vm/publish it is graph-wide destructive (wipes every
         // other agent's unpublished SWM under the CG/sub-graph). The this-asset

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -406,6 +406,21 @@ export function registerAssertionTools(
           publishEpochs,
           publisherNodeIdentityIdOverride,
         });
+        // CONTRACT §1 Stage5 / §7: vm/publish returns HTTP 207 (treated as success
+        // by DkgClient.request, which only throws on !res.ok) when the KA minted
+        // on-chain but the context-graph binding FAILED — `contextGraphError` is
+        // present in the body. The UAL/kaId are valid (the asset IS on-chain), so
+        // this is NOT a hard failure, but it must NOT be reported as full success:
+        // surface a clear PARTIAL warning so the agent can retry the CG binding.
+        const contextGraphError = (result as Record<string, unknown>).contextGraphError;
+        if (typeof contextGraphError === 'string' && contextGraphError.length > 0) {
+          return ok(
+            `PARTIAL publish of knowledge asset '${name}' (project '${pid}'): the asset was minted ` +
+            `on-chain (UAL/kaId below are valid), but the context-graph binding FAILED ` +
+            `(${contextGraphError}). The on-chain asset is published; retry the publish to re-attempt ` +
+            `the context-graph binding.\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``,
+          );
+        }
         return ok(
           `Published knowledge asset '${name}' (project '${pid}') to Verifiable Memory:\n\n\`\`\`json\n${JSON.stringify(
             result,

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -384,7 +384,7 @@ export function registerAssertionTools(
         accessPolicy: z
           .union([z.literal(0), z.literal(1)])
           .optional()
-          .describe('Used only when `registerIfNeeded: true`. 0 = open, 1 = private.'),
+          .describe('0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.'),
         // CONTRACT §D: clear_shared_memory_after is NOT exposed on the per-asset
         // publish tool — on vm/publish it is graph-wide destructive (wipes every
         // other agent's unpublished SWM under the CG/sub-graph). The this-asset
@@ -405,6 +405,11 @@ export function registerAssertionTools(
     }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
+      // FIX S: accessPolicy only applies when registering the CG — reject it
+      // (rather than silently drop the privacy setting) when registerIfNeeded != true.
+      if (accessPolicy !== undefined && registerIfNeeded !== true) {
+        return errResult('"accessPolicy" requires "registerIfNeeded": true — it only applies when registering the context graph.');
+      }
       // CONTRACT §G: vm/publish requires the CG to be registered on-chain and does
       // NOT auto-register. When registerIfNeeded is true, register first (the
       // client short-circuits an already-registered CG via alreadyRegistered), then

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -10,7 +10,7 @@
  *
  * Argument-key alignment per matrix v0.5 OQ-a: `name` flows through every
  * tool unchanged, matching the OpenClaw adapter (`DkgNodePlugin.ts:2399+`).
- * The `name` regex on `dkg_assertion_create` is creator-side input
+ * The `name` regex on `dkg_knowledge_asset_create` is creator-side input
  * validation only; read-side and import paths accept any pre-existing
  * assertion name.
  */
@@ -51,16 +51,16 @@ export function registerAssertionTools(
   client: DkgClient,
   config: DkgConfig,
 ): void {
-  // ── dkg_assertion_create ────────────────────────────────────────
+  // ── dkg_knowledge_asset_create ──────────────────────────────────
   server.registerTool(
-    'dkg_assertion_create',
+    'dkg_knowledge_asset_create',
     {
-      title: 'Create Assertion',
+      title: 'Create Knowledge Asset',
       description:
-        'Step 1 of the canonical write flow: create an empty Working Memory ' +
-        'assertion graph. Idempotent — duplicate names land as ' +
-        '`alreadyExists: true` rather than throwing. Slug must match ' +
-        '/^[a-z0-9-]+$/ for new names; pre-existing assertions accept any name.',
+        'Step 1 of the canonical write flow (create → write → finalize → share → publish): ' +
+        'create an empty Working Memory draft for a knowledge asset. Idempotent — ' +
+        'duplicate names land as `alreadyExists: true` rather than throwing. Slug must match ' +
+        '/^[a-z0-9-]+$/ for new names; pre-existing assets accept any name.',
       inputSchema: {
         name: z
           .string()
@@ -102,16 +102,16 @@ export function registerAssertionTools(
     },
   );
 
-  // ── dkg_assertion_write ─────────────────────────────────────────
+  // ── dkg_knowledge_asset_write ───────────────────────────────────
   server.registerTool(
-    'dkg_assertion_write',
+    'dkg_knowledge_asset_write',
     {
-      title: 'Write Quads to Assertion',
+      title: 'Write Quads to Knowledge Asset',
       description:
         'Step 2 of the canonical write flow: append RDF quads into an ' +
-        'existing Working Memory assertion. Writes are additive (set-merge); ' +
-        'callers that want replace semantics should call `dkg_assertion_discard` ' +
-        'first or mint a unique assertion name per snapshot.\n\n' +
+        'existing Working Memory draft. Writes are additive (set-merge); ' +
+        'callers that want replace semantics should call `dkg_knowledge_asset_discard` ' +
+        'first or mint a unique asset name per snapshot.\n\n' +
         'IMPORTANT — quad shape: each quad has subject/predicate/object/graph. ' +
         'Subjects and predicates are ALWAYS URIs (no spaces). The `object` field ' +
         'accepts EITHER a URI (no surrounding quotes) OR a literal string ' +
@@ -181,23 +181,88 @@ export function registerAssertionTools(
     },
   );
 
-  // ── dkg_assertion_promote ───────────────────────────────────────
+  // ── dkg_knowledge_asset_finalize ────────────────────────────────
   server.registerTool(
-    'dkg_assertion_promote',
+    'dkg_knowledge_asset_finalize',
     {
-      title: 'Promote Assertion to SWM',
+      title: 'Finalize (Seal) Knowledge Asset',
       description:
-        'Step 3 of the canonical write flow: promote a Working Memory ' +
-        'assertion (or specific root entities within it) from private WM to ' +
-        'Shared Working Memory so teammates see it. Omit `entities` to ' +
-        'promote every root entity.',
+        'Step 3 of the canonical write flow: seal a knowledge asset\'s Working ' +
+        'Memory draft — computes the merkle root and signs the EIP-712 ' +
+        'AuthorAttestation. Finalize always seals the WHOLE draft (there is no ' +
+        'subset parameter). A FULL share (dkg_knowledge_asset_share with ' +
+        '`entities` omitted or "all") auto-seals for you, so you only need to ' +
+        'call this explicitly before sharing a SELECTIVE subset of entities, or ' +
+        'to re-seal after editing a previously-sealed draft.',
       inputSchema: {
-        name: z.string().describe('Existing assertion name'),
+        name: z.string().describe('Existing knowledge asset name to finalize'),
+        authorAgentAddress: z
+          .string()
+          .optional()
+          .describe(
+            'Optional 0x author address to attest as. Omit to let the daemon ' +
+            'default the author to the request token\'s agent.',
+          ),
+        schemeVersion: z.number().int().optional().describe('Optional attestation scheme version'),
+        projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
+        subGraphName: z.string().optional(),
+      },
+    },
+    async ({ name, authorAgentAddress, schemeVersion, projectId, subGraphName }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        // Seal the WHOLE WM draft (CONTRACT §1 Stage3 — no subset scope on
+        // finalize). The author defaults to the request token's agent when
+        // `authorAgentAddress` is omitted; pre-signed attestations are not
+        // surfaced on this tool (they require the packed reservedKaId — out of
+        // scope here), matching the OpenClaw adapter.
+        const result = await client.knowledgeAssetFinalize({
+          contextGraphId: pid,
+          name,
+          subGraphName,
+          authorAgentAddress,
+          schemeVersion,
+        });
+        return ok(
+          `Finalized (sealed) knowledge asset '${name}' (project '${pid}'):\n\n\`\`\`json\n${JSON.stringify(
+            result,
+            null,
+            2,
+          )}\n\`\`\``,
+        );
+      } catch (e) {
+        return errResult(`Failed to finalize knowledge asset: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_knowledge_asset_share ───────────────────────────────────
+  server.registerTool(
+    'dkg_knowledge_asset_share',
+    {
+      title: 'Share Knowledge Asset to SWM',
+      description:
+        'Step 4 of the canonical write flow: share a knowledge asset (or ' +
+        'specific root entities within it) from private Working Memory to ' +
+        'Shared Working Memory so teammates see it. A FULL share (omit ' +
+        '`entities` or pass "all") auto-seals the draft best-effort and is ' +
+        'publish-ready — follow it with dkg_knowledge_asset_publish to mint the ' +
+        'asset on-chain (Verifiable Memory). A SELECTIVE subset (`entities` set ' +
+        'to a proper subset) shares to SWM only for peer visibility, is NOT ' +
+        'auto-sealed, and is NOT publishable to Verifiable Memory: ' +
+        'dkg_knowledge_asset_publish reconstructs the seal\'s full root set and ' +
+        'rejects a truncated SWM with a merkleRoot mismatch. To publish on-chain, ' +
+        'share the full asset (or model the subset as its own knowledge asset).',
+      inputSchema: {
+        name: z.string().describe('Existing knowledge asset name'),
         entities: z
           .array(z.string())
           .optional()
           .describe(
-            'Root entity URIs to promote. Omit to promote all roots.',
+            'Root entity URIs to share. Omit to share all roots (auto-seals + ' +
+            'publish-ready). A subset shares to SWM only and is NOT publishable ' +
+            'to Verifiable Memory.',
           ),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         subGraphName: z.string().optional(),
@@ -207,7 +272,7 @@ export function registerAssertionTools(
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
       // Provided entities must be a non-empty array of URIs; omitted means
-      // "promote all roots" (daemon-side default).
+      // "share all roots" (daemon-side default).
       if (entities !== undefined && entities.length === 0) {
         return errResult(
           '"entities" must be omitted or a non-empty array of root entity URIs.',
@@ -226,21 +291,147 @@ export function registerAssertionTools(
         const scope = entities && entities.length > 0
           ? `${entities.length} entit${entities.length === 1 ? 'y' : 'ies'}`
           : 'all root entities';
-        return ok(`Promoted ${scope} from assertion '${name}' (project '${pid}') to SWM.`);
+        return ok(`Shared ${scope} from knowledge asset '${name}' (project '${pid}') to SWM.`);
       } catch (e) {
-        return errResult(`Failed to promote assertion: ${formatError(e)}`);
+        return errResult(`Failed to share knowledge asset: ${formatError(e)}`);
       }
     },
   );
 
-  // ── dkg_assertion_discard ───────────────────────────────────────
+  // ── dkg_knowledge_asset_publish ─────────────────────────────────
   server.registerTool(
-    'dkg_assertion_discard',
+    'dkg_knowledge_asset_publish',
     {
-      title: 'Discard Assertion',
+      title: 'Publish Knowledge Asset to VM',
       description:
-        'Discard a Working Memory assertion without promoting it. Idempotent — ' +
-        'no-op on a missing assertion. Use before re-writing an assertion ' +
+        'Step 5 of the canonical write flow: publish ONE finalized + shared ' +
+        'knowledge asset (by name) from Shared Working Memory to Verifiable ' +
+        'Memory on-chain, minting or updating it. Returns the asset\'s UAL ' +
+        '(Universal Asset Locator, `did:dkg:<chainId>/<author>/<number>`) plus ' +
+        '`kaId`, `txHash`, `status`, and `kas`. The seal already selects the ' +
+        'author and the whole asset — do not pass author or selection overrides. ' +
+        'Prefer this over dkg_shared_memory_publish when publishing a single ' +
+        'named asset; it is multi-root-safe and avoids the legacy single-root ' +
+        'SWM constraint. Fails 409 if the asset is not yet finalized + shared ' +
+        '(run dkg_knowledge_asset_finalize / dkg_knowledge_asset_share first).',
+      inputSchema: {
+        name: z.string().describe('Knowledge asset name to publish (must be finalized + shared)'),
+        publishEpochs: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Optional number of epochs to publish for (positive integer)'),
+        publisherNodeIdentityIdOverride: z
+          .string()
+          .optional()
+          .describe('Optional publisher node identity id override (decimal string)'),
+        clearSharedMemoryAfter: z
+          .boolean()
+          .optional()
+          .describe('When true, clear the asset\'s Shared Working Memory after a confirmed publish'),
+        projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
+        subGraphName: z.string().optional(),
+      },
+    },
+    async ({
+      name,
+      publishEpochs,
+      publisherNodeIdentityIdOverride,
+      clearSharedMemoryAfter,
+      projectId,
+      subGraphName,
+    }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        // Per-KA sealed publish (CONTRACT §1 Stage5). The seal selects the author
+        // and the whole asset, so author/selection overrides are never sent. The
+        // daemon returns the UAL plus kaId/txHash/status/kas; 409
+        // VM_PUBLISH_PRECONDITION (not finalized / empty SWM) and 502 (on-chain
+        // not-confirmed) surface verbatim. MCP is JSON-facing, so the node
+        // identity id override is a decimal string (not a JS number).
+        const result = await client.knowledgeAssetPublish({
+          contextGraphId: pid,
+          name,
+          subGraphName,
+          publishEpochs,
+          publisherNodeIdentityIdOverride,
+          clearAfter: clearSharedMemoryAfter,
+        });
+        return ok(
+          `Published knowledge asset '${name}' (project '${pid}') to Verifiable Memory:\n\n\`\`\`json\n${JSON.stringify(
+            result,
+            null,
+            2,
+          )}\n\`\`\``,
+        );
+      } catch (e) {
+        return errResult(`Failed to publish knowledge asset: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_knowledge_asset_pull_from ───────────────────────────────
+  server.registerTool(
+    'dkg_knowledge_asset_pull_from',
+    {
+      title: 'Pull Knowledge Asset into WM Draft',
+      description:
+        'Seed a fresh Working Memory draft for a knowledge asset from its ' +
+        'current Shared Working Memory (swm) or Verifiable Memory (vm) state — ' +
+        'the edit-loop primitive (like git checkout). Use this to re-open an ' +
+        'already-shared or published asset for editing. Fails 409 ' +
+        '(WM_DRAFT_CONFLICT) if an open draft already exists; pass ' +
+        '`onConflict: "replace"` to overwrite it or discard the draft first.',
+      inputSchema: {
+        name: z.string().describe('Knowledge asset name to seed a draft for'),
+        layer: z
+          .enum(['swm', 'vm'])
+          .describe('Which layer to seed the draft from: "swm" (Shared Working Memory) or "vm" (Verifiable Memory)'),
+        onConflict: z
+          .enum(['reject', 'replace'])
+          .optional()
+          .describe('What to do if an open WM draft already exists. Defaults to "reject".'),
+        projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
+        subGraphName: z.string().optional(),
+      },
+    },
+    async ({ name, layer, onConflict, projectId, subGraphName }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      try {
+        // Seed a fresh WM draft from SWM/VM (CONTRACT §1 side-verbs). A dirty
+        // draft → 409 WM_DRAFT_CONFLICT, surfaced verbatim; the agent can retry
+        // with onConflict:"replace".
+        const result = await client.knowledgeAssetPullFrom({
+          contextGraphId: pid,
+          name,
+          layer,
+          onConflict,
+          subGraphName,
+        });
+        return ok(
+          `Seeded a WM draft for knowledge asset '${name}' (project '${pid}') from ${layer.toUpperCase()}:\n\n\`\`\`json\n${JSON.stringify(
+            result,
+            null,
+            2,
+          )}\n\`\`\``,
+        );
+      } catch (e) {
+        return errResult(`Failed to pull knowledge asset into a WM draft: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_knowledge_asset_discard ─────────────────────────────────
+  server.registerTool(
+    'dkg_knowledge_asset_discard',
+    {
+      title: 'Discard Knowledge Asset Draft',
+      description:
+        'Discard a Working Memory draft without sharing it. Idempotent — ' +
+        'no-op on a missing draft. Use before re-writing an asset ' +
         'whose name you want to keep stable but whose contents you want to ' +
         '*replace* rather than *merge*.',
       inputSchema: {
@@ -265,16 +456,16 @@ export function registerAssertionTools(
     },
   );
 
-  // ── dkg_assertion_query ─────────────────────────────────────────
+  // ── dkg_knowledge_asset_query ───────────────────────────────────
   server.registerTool(
-    'dkg_assertion_query',
+    'dkg_knowledge_asset_query',
     {
-      title: 'Dump Assertion Quads',
+      title: 'Dump Knowledge Asset Quads',
       description:
-        'Return every quad in a Working Memory assertion. Not a SPARQL ' +
-        'endpoint — for ad-hoc filtering use `dkg_query` with ' +
+        'Return every quad in a knowledge asset\'s Working Memory draft. Not a ' +
+        'SPARQL endpoint — for ad-hoc filtering use `dkg_query` with ' +
         '`view: "working-memory"`. The canonical introspection step for the ' +
-        '`assertion_create + assertion_write + assertion_promote` round-trip.',
+        '`knowledge_asset_create + write + share` round-trip.',
       inputSchema: {
         name: z.string().describe('Existing assertion name'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
@@ -302,13 +493,13 @@ export function registerAssertionTools(
     },
   );
 
-  // ── dkg_assertion_import_file ───────────────────────────────────
+  // ── dkg_knowledge_asset_import_file ─────────────────────────────
   // Wave-2 P1 add (audit §7 item 4). Wraps
   // `POST /api/knowledge-assets/{name}/wm/import-file` (multipart/form-data) —
   // the daemon's extraction pipeline turns markdown / PDF / DOCX /
   // etc. into RDF triples and writes them into the assertion's graph.
   server.registerTool(
-    'dkg_import_artifact_resolve',
+    'dkg_knowledge_asset_import_artifact_resolve',
     {
       title: 'Resolve Imported Artifact',
       description:
@@ -338,7 +529,7 @@ export function registerAssertionTools(
   );
 
   server.registerTool(
-    'dkg_import_artifact_read_markdown',
+    'dkg_knowledge_asset_import_artifact_read_markdown',
     {
       title: 'Read Imported Artifact Markdown',
       description:
@@ -370,7 +561,7 @@ export function registerAssertionTools(
   );
 
   server.registerTool(
-    'dkg_semantic_enrichment_write',
+    'dkg_knowledge_asset_semantic_enrichment_write',
     {
       title: 'Write Semantic Enrichment',
       description:
@@ -428,12 +619,12 @@ export function registerAssertionTools(
   );
 
   server.registerTool(
-    'dkg_assertion_import_file',
+    'dkg_knowledge_asset_import_file',
     {
-      title: 'Import File into Assertion',
+      title: 'Import File into Knowledge Asset',
       description:
         'Import a local document (markdown, PDF, DOCX, etc.) into a ' +
-        'Working Memory assertion: the daemon runs its extraction ' +
+        'Working Memory draft: the daemon runs its extraction ' +
         'pipeline and writes the resulting triples. text/markdown is ' +
         'native; other types need a registered converter (extraction ' +
         'returns `status: "skipped"` if none). Useful for seeding a ' +
@@ -537,13 +728,13 @@ export function registerAssertionTools(
     },
   );
 
-  // ── dkg_assertion_history ───────────────────────────────────────
+  // ── dkg_knowledge_asset_history ─────────────────────────────────
   // Wave-2 P3 add (audit §7 item 12). Wraps
   // `GET /api/knowledge-assets/{name}` — lifecycle introspection.
   server.registerTool(
-    'dkg_assertion_history',
+    'dkg_knowledge_asset_history',
     {
-      title: 'Assertion History',
+      title: 'Knowledge Asset History',
       description:
         "Fetch an assertion's lifecycle descriptor: author, " +
         'extraction status, promotion state, timestamps. Returns a ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -249,13 +249,16 @@ export function registerAssertionTools(
         'Step 4 of the canonical write flow: share a knowledge asset (or ' +
         'specific root entities within it) from private Working Memory to ' +
         'Shared Working Memory so teammates see it. A FULL share (omit ' +
-        '`entities` or pass "all") auto-seals the draft best-effort and is ' +
-        'publish-ready — follow it with dkg_knowledge_asset_publish to mint the ' +
-        'asset on-chain (Verifiable Memory). The auto-seal uses DEFAULT finalize ' +
-        'options; if you need custom finalize/attestation options ' +
-        '(authorAgentAddress / schemeVersion), call dkg_knowledge_asset_finalize ' +
-        'EXPLICITLY first (even for a full share) — share\'s auto-seal cannot ' +
-        'carry those. A SELECTIVE subset (`entities` set ' +
+        '`entities` or pass "all") attempts a best-effort auto-seal: when the ' +
+        'seal SUCCEEDS the asset is publish-ready — follow it with ' +
+        'dkg_knowledge_asset_publish to mint the asset on-chain (Verifiable ' +
+        'Memory). But on a capability/signing gap (no local signing key / ' +
+        'non-V10 adapter / unregistered CG) the auto-seal is skipped and the ' +
+        'asset is shared UNSEALED — a later dkg_knowledge_asset_publish then ' +
+        '409s requiring an explicit finalize. For predictable publishing, call ' +
+        'dkg_knowledge_asset_finalize EXPLICITLY first (this is also required to ' +
+        'carry custom finalize/attestation options — authorAgentAddress / ' +
+        'schemeVersion — which the auto-seal cannot). A SELECTIVE subset (`entities` set ' +
         'to a proper subset) shares to SWM only for peer visibility, is NOT ' +
         'auto-sealed, and is NOT publishable to Verifiable Memory: ' +
         'dkg_knowledge_asset_publish reconstructs the seal\'s full root set and ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -343,7 +343,9 @@ export function registerAssertionTools(
         'Step 5 of the canonical write flow: publish ONE finalized + shared ' +
         'knowledge asset (by name) from Shared Working Memory to Verifiable ' +
         'Memory on-chain, minting or updating it. Returns the asset\'s UAL ' +
-        '(Universal Asset Locator, `did:dkg:<chainId>/<author>/<number>`) plus ' +
+        '(Universal Asset Locator, `did:dkg:<chainId>/<knowledgeAssetsContractAddress>/<number>` — ' +
+        'the middle segment is the KnowledgeAssets (KAV10) contract address, NOT the author; the ' +
+        'separate `authorAddress` response field is the (different) seal author) plus ' +
         '`kaId`, `txHash`, `status`, and `kas`. The seal already selects the ' +
         'author and the whole asset — do not pass author or selection overrides. ' +
         'Prefer this over dkg_shared_memory_publish when publishing a single ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -112,7 +112,7 @@ export function registerAssertionTools(
         'existing Working Memory draft. Writes are additive (set-merge); ' +
         'callers that want replace semantics should call `dkg_knowledge_asset_discard` ' +
         'first or mint a unique asset name per snapshot.\n\n' +
-        'IMPORTANT — quad shape: each quad has subject/predicate/object/graph. ' +
+        'IMPORTANT — triple shape: each triple has subject/predicate/object. ' +
         'Subjects and predicates are ALWAYS URIs (no spaces). The `object` field ' +
         'accepts EITHER a URI (no surrounding quotes) OR a literal string ' +
         'WRAPPED IN DOUBLE QUOTES. Most common mistake: passing free-text ' +

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -412,16 +412,20 @@ export function registerAssertionTools(
         // CONTRACT §1 Stage5 / §7: vm/publish returns HTTP 207 (treated as success
         // by DkgClient.request, which only throws on !res.ok) when the KA minted
         // on-chain but the context-graph binding FAILED — `contextGraphError` is
-        // present in the body. The UAL/kaId are valid (the asset IS on-chain), so
-        // this is NOT a hard failure, but it must NOT be reported as full success:
-        // surface a clear PARTIAL warning so the agent can retry the CG binding.
+        // present in the body. The UAL/kaId are valid and the asset IS published
+        // on-chain, so this is NOT a hard failure and must NOT be reported as full
+        // success — but the agent must NOT re-publish: a confirmed publish clears
+        // SWM, so a retry 409s VM_PUBLISH_PRECONDITION (and never re-binds the CG).
+        // The CG-binding retry is an operator/daemon concern.
         const contextGraphError = (result as Record<string, unknown>).contextGraphError;
         if (typeof contextGraphError === 'string' && contextGraphError.length > 0) {
           return ok(
-            `PARTIAL publish of knowledge asset '${name}' (project '${pid}'): the asset was minted ` +
-            `on-chain (UAL/kaId below are valid), but the context-graph binding FAILED ` +
-            `(${contextGraphError}). The on-chain asset is published; retry the publish to re-attempt ` +
-            `the context-graph binding.\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``,
+            `PARTIAL publish of knowledge asset '${name}' (project '${pid}'): the asset IS published ` +
+            `on-chain (the UAL/kaId below are valid and final) — only the context-graph binding FAILED ` +
+            `(${contextGraphError}). Do NOT re-publish: the asset is already minted, the publish cleared ` +
+            `Shared Working Memory, and a retry will fail the VM precondition without re-binding the context ` +
+            `graph. Surface this to the operator to re-attempt the context-graph binding.` +
+            `\n\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``,
           );
         }
         return ok(

--- a/packages/mcp-dkg/src/tools/assertions.ts
+++ b/packages/mcp-dkg/src/tools/assertions.ts
@@ -505,10 +505,13 @@ export function registerAssertionTools(
     {
       title: 'Dump Knowledge Asset Quads',
       description:
-        'Return every quad in a knowledge asset\'s Working Memory draft. Not a ' +
-        'SPARQL endpoint — for ad-hoc filtering use `dkg_query` with ' +
-        '`view: "working-memory"`. The canonical introspection step for the ' +
-        '`knowledge_asset_create + write + share` round-trip.',
+        'Return every quad in a knowledge asset\'s Working Memory DRAFT (the ' +
+        'un-shared working copy). Query it BEFORE sharing: a FULL share empties ' +
+        'the WM draft, so a query after sharing returns 0 quads. To inspect ' +
+        'already-shared content use `dkg_query` with `view: ' +
+        '"shared-working-memory"` (or `"verifiable-memory"` once published). Not ' +
+        'a SPARQL endpoint — for ad-hoc filtering of the draft use `dkg_query` ' +
+        'with `view: "working-memory"`.',
       inputSchema: {
         name: z.string().describe('Existing assertion name'),
         projectId: z.string().optional().describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -114,9 +114,13 @@ export function registerPublishTools(
       title: 'Publish Fresh Quads',
       description:
         '"I have fresh quads, write+publish now." Two-call helper: ' +
-        'writes the supplied quads to Shared Working Memory, then ' +
-        'publishes the entire SWM in the CG to Verifiable Memory ' +
-        '(on-chain) and clears SWM. For the canonical step-wise flow ' +
+        'creates a fresh auto-named assertion from the supplied quads ' +
+        '(seal + share), then publishes THAT one assertion to Verifiable ' +
+        'Memory (on-chain). NOTE: this is two HTTP calls (create, then ' +
+        'publish), not a single transactional operation — either phase can ' +
+        'partially fail (a share-phase failure aborts before publish; a ' +
+        'context-graph-binding failure still mints the asset on-chain). For ' +
+        'the canonical step-wise flow ' +
         '(create → write → finalize → share → publish) use ' +
         '`dkg_knowledge_asset_create / write / finalize / share` followed ' +
         'by `dkg_knowledge_asset_publish` — that path keeps WM as a draft ' +
@@ -202,16 +206,19 @@ export function registerPublishTools(
         // {assertionName}, which (like vm/publish) returns HTTP 207 with
         // `contextGraphError` set when the KA minted on-chain but the context-graph
         // binding FAILED (memory.ts:1772). `this.request` treats 207 as success, so
-        // without this the partial reads as clean success. The UAL/kaId are valid
-        // (the asset IS on-chain) — surface a PARTIAL warning so the agent can retry
-        // the CG bind, mirroring dkg_knowledge_asset_publish.
+        // without this the partial reads as clean success. The UAL/kaId are valid and
+        // the asset IS published on-chain — surface a PARTIAL warning. The agent must
+        // NOT re-run dkg_publish: each call mints a FRESH assertion, so a retry would
+        // DUPLICATE the published asset and still not re-bind the CG. The CG-binding
+        // retry is an operator/daemon concern.
         const contextGraphError = (result as Record<string, unknown>).contextGraphError;
         const ual = (result as Record<string, unknown>).ual as string | undefined;
         const summary = [
           typeof contextGraphError === 'string' && contextGraphError.length > 0
-            ? `PARTIAL publish to '${cgId}': the asset was minted on-chain (KC/UAL below are valid), but the ` +
-              `context-graph binding FAILED (${contextGraphError}). The on-chain asset is published; retry ` +
-              `dkg_publish to re-attempt the context-graph binding.`
+            ? `PARTIAL publish to '${cgId}': the asset IS published on-chain (KC/UAL below are valid and ` +
+              `final) — only the context-graph binding FAILED (${contextGraphError}). Do NOT re-run ` +
+              `dkg_publish: it would mint a DUPLICATE asset and still not re-bind the context graph. Surface ` +
+              `this to the operator to re-attempt the context-graph binding.`
             : `Published ${wireQuads.length} quad(s) to '${cgId}'.`,
           registered ? `Registered context graph '${cgId}' on-chain.` : null,
           kaId ? `KC: ${kaId}` : null,

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -118,11 +118,11 @@ export function registerPublishTools(
         'writes the supplied quads to Shared Working Memory, then ' +
         'publishes the entire SWM in the CG to Verifiable Memory ' +
         '(on-chain) and clears SWM. For the canonical step-wise flow ' +
-        '(write → promote → publish) use `dkg_assertion_create / write ' +
-        '/ promote` followed by `dkg_shared_memory_publish` — that ' +
-        'path keeps WM as a draft staging area before SWM. Use ' +
-        '`dkg_publish` only when you have fresh quads to anchor ' +
-        'immediately.',
+        '(create → write → finalize → share → publish) use ' +
+        '`dkg_knowledge_asset_create / write / finalize / share` followed ' +
+        'by `dkg_knowledge_asset_publish` — that path keeps WM as a draft ' +
+        'staging area before SWM. Use `dkg_publish` only when you have ' +
+        'fresh quads to anchor immediately.',
       inputSchema: {
         contextGraphId: z.string().min(1).describe(`Target context graph id. ${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION}`),
         quads: z
@@ -192,15 +192,18 @@ export function registerPublishTools(
     {
       title: 'Publish Shared Working Memory',
       description:
-        'Canonical step-4 finalizer for "publish existing SWM" (one HTTP ' +
-        'call). Publishes all Shared Working Memory in a context graph to ' +
-        'Verifiable Memory (on-chain) and clears SWM. Use after ' +
-        '`dkg_assertion_promote` to finalize promoted data. Pass ' +
-        '`rootEntities` to publish only specific roots (subset publishes ' +
-        'default to NOT clearing SWM, so other unpublished roots are not ' +
-        'dropped). Set `registerIfNeeded: true` to upgrade a local-only CG ' +
-        'to on-chain registration before publishing — note this MAY spend ' +
-        'gas/TRAC; opt-in only.',
+        'SWM-bridge / CG-wide publish (legacy, retained). Publishes all ' +
+        'Shared Working Memory in a context graph to Verifiable Memory ' +
+        '(on-chain) and clears SWM. To publish a SINGLE named knowledge ' +
+        'asset, prefer `dkg_knowledge_asset_publish` (multi-root-safe); this ' +
+        'bulk route is single-root-per-call and returns 409 ' +
+        'MULTI_ROOT_PUBLISH_NOT_ATOMIC when more than one root entity is in ' +
+        'SWM. Use after `dkg_knowledge_asset_share`. Pass `rootEntities` to ' +
+        'publish only specific roots (subset publishes default to NOT ' +
+        'clearing SWM, so other unpublished roots are not dropped). Set ' +
+        '`registerIfNeeded: true` to upgrade a local-only CG to on-chain ' +
+        'registration before publishing — note this MAY spend gas/TRAC; ' +
+        'opt-in only.',
       inputSchema: {
         contextGraphId: z.string().min(1).describe(`Target context graph id. ${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION}`),
         rootEntities: z

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -146,7 +146,7 @@ export function registerPublishTools(
           .union([z.literal(0), z.literal(1)])
           .optional()
           .describe(
-            'Used only when `registerIfNeeded: true`. 0 = open, 1 = private.',
+            '0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.',
           ),
       },
     },
@@ -155,6 +155,11 @@ export function registerPublishTools(
       if (!cgId) return errResult('"contextGraphId" is required.');
       if (!quads.length) {
         return errResult('"quads" must be a non-empty array.');
+      }
+      // FIX S: accessPolicy only applies when registering the CG — reject it
+      // (rather than silently drop the privacy setting) when registerIfNeeded != true.
+      if (accessPolicy !== undefined && registerIfNeeded !== true) {
+        return errResult('"accessPolicy" requires "registerIfNeeded": true — it only applies when registering the context graph.');
       }
       // Auto-type the object: URI vs literal. Mirrors the adapter's
       // handlePublish at `DkgNodePlugin.ts:2721-2729` byte-for-byte so
@@ -281,7 +286,7 @@ export function registerPublishTools(
           .union([z.literal(0), z.literal(1)])
           .optional()
           .describe(
-            'Used only when `registerIfNeeded: true`. 0 = open, 1 = private.',
+            '0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.',
           ),
       },
     },
@@ -294,6 +299,11 @@ export function registerPublishTools(
     }): Promise<ToolResult> => {
       const cgId = contextGraphId.trim();
       if (!cgId) return errResult('"contextGraphId" is required.');
+      // FIX S: accessPolicy only applies when registering the CG — reject it
+      // (rather than silently drop the privacy setting) when registerIfNeeded != true.
+      if (accessPolicy !== undefined && registerIfNeeded !== true) {
+        return errResult('"accessPolicy" requires "registerIfNeeded": true — it only applies when registering the context graph.');
+      }
       // Mirror handleAssertionPromote's `entities` validation: omit →
       // daemon-side default (selection="all"); non-empty array of
       // strings only — no other shapes silently 400 at the daemon.

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -121,7 +121,9 @@ export function registerPublishTools(
         '`dkg_knowledge_asset_create / write / finalize / share` followed ' +
         'by `dkg_knowledge_asset_publish` — that path keeps WM as a draft ' +
         'staging area before SWM. Use `dkg_publish` only when you have ' +
-        'fresh quads to anchor immediately.',
+        'fresh quads to anchor immediately. Publishing requires the context ' +
+        'graph to be registered on-chain — set `registerIfNeeded: true` to ' +
+        'register it first (idempotent) before publishing.',
       inputSchema: {
         contextGraphId: z.string().min(1).describe(`Target context graph id. ${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION}`),
         quads: z
@@ -130,9 +132,21 @@ export function registerPublishTools(
           .describe(
             'Non-empty array of quads to publish. Object values are auto-typed (URI vs literal).',
           ),
+        registerIfNeeded: z
+          .boolean()
+          .optional()
+          .describe(
+            'When true, register the CG on-chain before publishing if needed. May spend gas/TRAC; opt-in only.',
+          ),
+        accessPolicy: z
+          .union([z.literal(0), z.literal(1)])
+          .optional()
+          .describe(
+            'Used only when `registerIfNeeded: true`. 0 = open, 1 = private.',
+          ),
       },
     },
-    async ({ contextGraphId, quads }): Promise<ToolResult> => {
+    async ({ contextGraphId, quads, registerIfNeeded, accessPolicy }): Promise<ToolResult> => {
       const cgId = contextGraphId.trim();
       if (!cgId) return errResult('"contextGraphId" is required.');
       if (!quads.length) {
@@ -151,6 +165,23 @@ export function registerPublishTools(
           object: isUri(objVal) ? objVal : `"${escapeRdfLiteral(objVal)}"`,
         };
       });
+
+      // CONTRACT §G: publishing requires the CG to be registered on-chain and the
+      // daemon does NOT auto-register. When registerIfNeeded is true, register
+      // first (the client short-circuits an already-registered CG via its typed
+      // alreadyRegistered flag — no double-mint), mirroring dkg_shared_memory_publish.
+      // A hard registration failure is a tool error: do NOT publish.
+      let registered = false;
+      if (registerIfNeeded === true) {
+        try {
+          const reg = await client.registerContextGraph({ id: cgId, accessPolicy });
+          registered = !reg.alreadyRegistered;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return errResult(`Failed to register context graph: ${message}`);
+        }
+      }
+
       try {
         const result = await client.publishQuads({
           contextGraphId: cgId,
@@ -169,6 +200,7 @@ export function registerPublishTools(
         const chainId = await resolveChainId(client);
         const summary = [
           `Published ${wireQuads.length} quad(s) to '${cgId}'.`,
+          registered ? `Registered context graph '${cgId}' on-chain.` : null,
           kaId ? `KC: ${kaId}` : null,
           kas?.length ? `KAs: ${kas.length}` : null,
           txHash ? `Tx: ${txHash}` : null,

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -140,13 +140,18 @@ export function registerPublishTools(
           .boolean()
           .optional()
           .describe(
-            'When true, register the CG on-chain before publishing if needed. May spend gas/TRAC; opt-in only.',
+            'When true, register the CG on-chain before publishing if needed. May spend gas/TRAC; opt-in only. ' +
+            'CAVEAT: this uses the explicit register route, which registers with the daemon\'s DEFAULT ' +
+            'publishPolicy (derived from accessPolicy) and does NOT preserve a context graph\'s stored custom ' +
+            'publishPolicy / contribution governance. For a CG created with a non-default publishPolicy/PCA, ' +
+            'register it explicitly with the desired policy first rather than relying on registerIfNeeded. ' +
+            '(Read access is unaffected; daemon-side rehydration tracked in OriginTrail/dkg#1085.)',
           ),
         accessPolicy: z
           .union([z.literal(0), z.literal(1)])
           .optional()
           .describe(
-            '0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.',
+            '0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise. Sets only the access policy; it does NOT preserve a stored custom publishPolicy (see registerIfNeeded; OriginTrail/dkg#1085).',
           ),
       },
     },

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -198,10 +198,24 @@ export function registerPublishTools(
         // succeeds; if the wallet-balances probe itself fails the
         // publish stands and we just omit the chain line.
         const chainId = await resolveChainId(client);
+        // FIX E — the dkg_publish path publishes via POST /api/shared-memory/publish
+        // {assertionName}, which (like vm/publish) returns HTTP 207 with
+        // `contextGraphError` set when the KA minted on-chain but the context-graph
+        // binding FAILED (memory.ts:1772). `this.request` treats 207 as success, so
+        // without this the partial reads as clean success. The UAL/kaId are valid
+        // (the asset IS on-chain) — surface a PARTIAL warning so the agent can retry
+        // the CG bind, mirroring dkg_knowledge_asset_publish.
+        const contextGraphError = (result as Record<string, unknown>).contextGraphError;
+        const ual = (result as Record<string, unknown>).ual as string | undefined;
         const summary = [
-          `Published ${wireQuads.length} quad(s) to '${cgId}'.`,
+          typeof contextGraphError === 'string' && contextGraphError.length > 0
+            ? `PARTIAL publish to '${cgId}': the asset was minted on-chain (KC/UAL below are valid), but the ` +
+              `context-graph binding FAILED (${contextGraphError}). The on-chain asset is published; retry ` +
+              `dkg_publish to re-attempt the context-graph binding.`
+            : `Published ${wireQuads.length} quad(s) to '${cgId}'.`,
           registered ? `Registered context graph '${cgId}' on-chain.` : null,
           kaId ? `KC: ${kaId}` : null,
+          ual ? `UAL: ${ual}` : null,
           kas?.length ? `KAs: ${kas.length}` : null,
           txHash ? `Tx: ${txHash}` : null,
           chainId ? `Chain: ${chainId}` : null,

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -258,10 +258,11 @@ export function registerPublishTools(
         'MULTI_ROOT_PUBLISH_NOT_ATOMIC when more than one root entity is in ' +
         'SWM. Use after `dkg_knowledge_asset_share`. Pass `rootEntities` to ' +
         'publish only specific roots (subset publishes default to NOT ' +
-        'clearing SWM, so other unpublished roots are not dropped). Set ' +
-        '`registerIfNeeded: true` to upgrade a local-only CG to on-chain ' +
-        'registration before publishing — note this MAY spend gas/TRAC; ' +
-        'opt-in only.',
+        'clearing SWM, so other unpublished roots are not dropped). NOTE: this ' +
+        'CG-wide publish AUTO-registers an unregistered context graph on-chain at ' +
+        'gas/TRAC cost regardless of `registerIfNeeded` — omitting the flag is ' +
+        'NOT gas-free. `registerIfNeeded` only lets you set the registration\'s ' +
+        '`accessPolicy`.',
       inputSchema: {
         contextGraphId: z.string().min(1).describe(`Target context graph id. ${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION}`),
         rootEntities: z
@@ -280,13 +281,13 @@ export function registerPublishTools(
           .boolean()
           .optional()
           .describe(
-            'When true, register the CG on-chain before publishing if needed. May spend gas/TRAC; opt-in only.',
+            'Run an EXPLICIT on-chain registration before publishing, which lets you set `accessPolicy` on that registration. NOTE: this does NOT gate whether registration happens — a CG-wide publish AUTO-registers an unregistered context graph at gas/TRAC cost regardless of this flag. Set it only to choose the registration\'s accessPolicy (the implicit auto-register on publish otherwise defaults the policy).',
           ),
         accessPolicy: z
           .union([z.literal(0), z.literal(1)])
           .optional()
           .describe(
-            '0 = open, 1 = private. Requires `registerIfNeeded: true` — it only applies when registering the CG, and is rejected otherwise.',
+            '0 = open, 1 = private — for the EXPLICIT registration. Requires `registerIfNeeded: true` — it only applies to that explicit registration and is rejected otherwise (the implicit auto-register on publish defaults the policy).',
           ),
       },
     },

--- a/packages/mcp-dkg/src/tools/publish.ts
+++ b/packages/mcp-dkg/src/tools/publish.ts
@@ -96,7 +96,6 @@ const QuadSchema = z.object({
     .describe(
       'Object — URI or literal. Auto-detected: values starting with http://, https://, urn:, or did: pass as URIs; anything else becomes a literal.',
     ),
-  graph: z.string().optional().describe('Optional named graph URI'),
 });
 
 export function registerPublishTools(
@@ -142,13 +141,14 @@ export function registerPublishTools(
       // Auto-type the object: URI vs literal. Mirrors the adapter's
       // handlePublish at `DkgNodePlugin.ts:2721-2729` byte-for-byte so
       // a memory written via either surface lands as identical triples.
+      // Wire shape is {subject, predicate, object} only — no per-quad `graph`
+      // (CONTRACT §0 invariant 2; the daemon pins quads to the per-KA WM graph).
       const wireQuads = quads.map((q) => {
         const objVal = String(q.object ?? '');
         return {
           subject: String(q.subject ?? ''),
           predicate: String(q.predicate ?? ''),
           object: isUri(objVal) ? objVal : `"${escapeRdfLiteral(objVal)}"`,
-          graph: q.graph ? String(q.graph) : '',
         };
       });
       try {

--- a/packages/mcp-dkg/src/tools/setup.ts
+++ b/packages/mcp-dkg/src/tools/setup.ts
@@ -141,7 +141,7 @@ export function registerSetupTools(
           accessPolicy,
           publishPolicy,
         });
-        // Mirror dkg_assertion_create's idempotency surfacing: distinct
+        // Mirror dkg_knowledge_asset_create's idempotency surfacing: distinct
         // success messages for "newly created" vs "already existed" so
         // callers don't have to do an extra `dkg_list_context_graphs`
         // round-trip to figure out which path the daemon took.
@@ -209,7 +209,7 @@ export function registerSetupTools(
   //
   // Rationale (the create-family-wide view): the three `*_create`
   // tools have asymmetric daemon-side idempotency:
-  //   - dkg_assertion_create   → daemon-idempotent (`alreadyExists: true`)
+  //   - dkg_knowledge_asset_create → daemon-idempotent (`alreadyExists: true`)
   //   - dkg_context_graph_create → daemon-idempotent (returns existing CG)
   //   - dkg_sub_graph_create   → daemon-strict (409 on duplicate)
   //

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -343,6 +343,11 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     // CONTRACT §G: per-KA publish can register the CG on-chain first (mirrors
     // dkg_shared_memory_publish) — vm/publish requires a registered CG.
     expect(schema).toHaveProperty('registerIfNeeded');
+    // FIX X (#1076:2396 / Option A): the explicit-register route uses the daemon's
+    // DEFAULT publishPolicy and does NOT preserve a stored custom publishPolicy
+    // (daemon-side rehydration tracked in dkg#1085). The caveat must be present here.
+    expect((schema.registerIfNeeded as { description?: string }).description).toContain('DEFAULT publishPolicy');
+    expect((schema.registerIfNeeded as { description?: string }).description).toContain('OriginTrail/dkg#1085');
     // CONTRACT §D: clear-after is DROPPED from the per-asset publish tool — on
     // vm/publish it is graph-wide destructive (wipes other agents' SWM). The
     // CG-wide clear stays on dkg_publish / dkg_shared_memory_publish.

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -136,13 +136,10 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     expect(written.isError).toBeFalsy();
     expect(written.content[0].text).toMatch(/Wrote 2 quad\(s\)/);
 
-    const shared = await server.call('dkg_knowledge_asset_share', {
-      name: 'session-2026',
-      entities: ['urn:x:1'],
-    });
-    expect(shared.isError).toBeFalsy();
-    expect(shared.content[0].text).toMatch(/Shared 1 entity/);
-
+    // Dump the WM draft BEFORE sharing — `dkg_knowledge_asset_query` reads the
+    // WM draft, and production promote MOVES the shared quads to SWM and DELETES
+    // them from WM (`dkg-publisher.ts:4665-4669`), so the @en round-trip must be
+    // verified on the WM draft pre-share.
     const queried = await server.call('dkg_knowledge_asset_query', { name: 'session-2026' });
     expect(queried.isError).toBeFalsy();
     expect(queried.content[0].text).toMatch(/2 quad\(s\)/);
@@ -152,13 +149,29 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     // unescaped form on the raw stored quad below.
     expect(queried.content[0].text).toContain('\\"hello world\\"@en');
 
+    const cellBeforeShare = client.assertions.get('test-cg::session-2026');
+    expect(cellBeforeShare).toBeDefined();
+    expect(cellBeforeShare!.quads).toHaveLength(2);
+    // Object stored verbatim — language-tagged literal is preserved in WM.
+    expect(cellBeforeShare!.quads[0].object).toBe(langTagged);
+
+    const shared = await server.call('dkg_knowledge_asset_share', {
+      name: 'session-2026',
+      entities: ['urn:x:1'],
+    });
+    expect(shared.isError).toBeFalsy();
+    expect(shared.content[0].text).toMatch(/Shared 1 entity/);
+
+    // After sharing `urn:x:1`, BOTH quads (both have subject `urn:x:1`) move
+    // WM → SWM and are deleted from the WM draft — so a post-share WM query
+    // returns 0 quads. (This is the lifecycle reality the harness now models;
+    // SWM is the layer that holds the shared content.)
     const cell = client.assertions.get('test-cg::session-2026');
     expect(cell).toBeDefined();
-    expect(cell!.quads).toHaveLength(2);
     expect(cell!.promotedRoots.has('urn:x:1')).toBe(true);
-    // Object stored verbatim — language-tagged literal is preserved on
-    // both the wire and in the memory fixture.
-    expect(cell!.quads[0].object).toBe(langTagged);
+    expect(cell!.quads).toHaveLength(0);
+    const queriedAfter = await server.call('dkg_knowledge_asset_query', { name: 'session-2026' });
+    expect(queriedAfter.content[0].text).toMatch(/0 quad\(s\)/);
   });
 
   it('create is idempotent: a duplicate name reports alreadyExists rather than erroring', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -15,31 +15,47 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     registerAssertionTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
   });
 
-  it('registers all ten assertion-family tools', () => {
+  it('registers all thirteen knowledge-asset-family tools (rc.17 rename + 3 new verbs)', () => {
     const expected = [
-      'dkg_assertion_create',
-      'dkg_assertion_write',
-      'dkg_assertion_promote',
-      'dkg_assertion_discard',
-      'dkg_assertion_query',
-      'dkg_import_artifact_resolve',
-      'dkg_import_artifact_read_markdown',
-      'dkg_semantic_enrichment_write',
-      'dkg_assertion_import_file',
-      'dkg_assertion_history',
+      'dkg_knowledge_asset_create',
+      'dkg_knowledge_asset_write',
+      'dkg_knowledge_asset_finalize',
+      'dkg_knowledge_asset_share',
+      'dkg_knowledge_asset_publish',
+      'dkg_knowledge_asset_pull_from',
+      'dkg_knowledge_asset_discard',
+      'dkg_knowledge_asset_query',
+      'dkg_knowledge_asset_import_artifact_resolve',
+      'dkg_knowledge_asset_import_artifact_read_markdown',
+      'dkg_knowledge_asset_semantic_enrichment_write',
+      'dkg_knowledge_asset_import_file',
+      'dkg_knowledge_asset_history',
     ];
     for (const name of expected) {
       expect(server.tools.has(name)).toBe(true);
     }
+    // No dkg_assertion_* / dkg_import_artifact_* / dkg_semantic_enrichment_*
+    // back-compat names survive the clean cut (CONTRACT §2).
+    for (const legacy of [
+      'dkg_assertion_create',
+      'dkg_assertion_promote',
+      'dkg_import_artifact_resolve',
+      'dkg_semantic_enrichment_write',
+    ]) {
+      expect(server.tools.has(legacy)).toBe(false);
+    }
   });
 
-  it('documents canonical context graph ids for assertion write tools', () => {
+  it('documents canonical context graph ids for knowledge-asset write tools', () => {
     for (const name of [
-      'dkg_assertion_create',
-      'dkg_assertion_write',
-      'dkg_assertion_promote',
-      'dkg_assertion_discard',
-      'dkg_assertion_query',
+      'dkg_knowledge_asset_create',
+      'dkg_knowledge_asset_write',
+      'dkg_knowledge_asset_finalize',
+      'dkg_knowledge_asset_share',
+      'dkg_knowledge_asset_publish',
+      'dkg_knowledge_asset_pull_from',
+      'dkg_knowledge_asset_discard',
+      'dkg_knowledge_asset_query',
     ]) {
       const projectId = server.get(name).config.inputSchema?.projectId;
       expect(projectId?.description).toContain('dkg_list_context_graphs');
@@ -52,20 +68,20 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
   it('exposes imported attachment resolve/read/enrichment helpers without promoting', async () => {
     const assertionUri = 'did:dkg:context-graph:test-cg/assertion/peer-test/imported-doc';
 
-    const resolved = await server.call('dkg_import_artifact_resolve', {
+    const resolved = await server.call('dkg_knowledge_asset_import_artifact_resolve', {
       assertionUri,
     });
     expect(resolved.isError).toBeFalsy();
     expect(resolved.content[0].text).toContain('"canReadMarkdown": true');
 
-    const markdown = await server.call('dkg_import_artifact_read_markdown', {
+    const markdown = await server.call('dkg_knowledge_asset_import_artifact_read_markdown', {
       assertionUri,
       maxBytes: 1024,
     });
     expect(markdown.isError).toBeFalsy();
     expect(markdown.content[0].text).toContain('# Imported');
 
-    const enrichment = await server.call('dkg_semantic_enrichment_write', {
+    const enrichment = await server.call('dkg_knowledge_asset_semantic_enrichment_write', {
       assertionUri,
       semanticQuads: [
         { subject: 'urn:dkg:doc:imported', predicate: 'http://schema.org/about', object: '"Semantic topic"' },
@@ -79,7 +95,7 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
   });
 
   it('does not expose a target assertion name on the semantic enrichment schema', () => {
-    const tool = server.tools.get('dkg_semantic_enrichment_write');
+    const tool = server.tools.get('dkg_knowledge_asset_semantic_enrichment_write');
     expect(tool).toBeTruthy();
     expect(tool!.config.description).toMatch(/Append model-derived semantic triples/);
     expect(tool!.config.description).not.toMatch(/separate Working Memory assertion/);
@@ -90,7 +106,7 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     const assertionUri = 'did:dkg:context-graph:test-cg/assertion/peer-test/imported-doc';
 
     await expect(
-      server.call('dkg_semantic_enrichment_write', {
+      server.call('dkg_knowledge_asset_semantic_enrichment_write', {
         assertionUri,
         semanticQuads: [
           {
@@ -104,13 +120,13 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     ).rejects.toThrow();
   });
 
-  it('round-trips create → write → promote → query, preserving @en language tags on literals', async () => {
-    const created = await server.call('dkg_assertion_create', { name: 'session-2026' });
+  it('round-trips create → write → share → query, preserving @en language tags on literals', async () => {
+    const created = await server.call('dkg_knowledge_asset_create', { name: 'session-2026' });
     expect(created.isError).toBeFalsy();
     expect(created.content[0].text).toMatch(/Created assertion 'session-2026'/);
 
     const langTagged = '"hello world"@en';
-    const written = await server.call('dkg_assertion_write', {
+    const written = await server.call('dkg_knowledge_asset_write', {
       name: 'session-2026',
       quads: [
         { subject: 'urn:x:1', predicate: 'urn:p:label', object: langTagged },
@@ -120,14 +136,14 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     expect(written.isError).toBeFalsy();
     expect(written.content[0].text).toMatch(/Wrote 2 quad\(s\)/);
 
-    const promoted = await server.call('dkg_assertion_promote', {
+    const shared = await server.call('dkg_knowledge_asset_share', {
       name: 'session-2026',
       entities: ['urn:x:1'],
     });
-    expect(promoted.isError).toBeFalsy();
-    expect(promoted.content[0].text).toMatch(/Promoted 1 entity/);
+    expect(shared.isError).toBeFalsy();
+    expect(shared.content[0].text).toMatch(/Shared 1 entity/);
 
-    const queried = await server.call('dkg_assertion_query', { name: 'session-2026' });
+    const queried = await server.call('dkg_knowledge_asset_query', { name: 'session-2026' });
     expect(queried.isError).toBeFalsy();
     expect(queried.content[0].text).toMatch(/2 quad\(s\)/);
     // @en lang-tag must round-trip byte-for-byte through the JSON dump.
@@ -146,32 +162,32 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
   });
 
   it('create is idempotent: a duplicate name reports alreadyExists rather than erroring', async () => {
-    await server.call('dkg_assertion_create', { name: 'dupe' });
-    const second = await server.call('dkg_assertion_create', { name: 'dupe' });
+    await server.call('dkg_knowledge_asset_create', { name: 'dupe' });
+    const second = await server.call('dkg_knowledge_asset_create', { name: 'dupe' });
     expect(second.isError).toBeFalsy();
     expect(second.content[0].text).toMatch(/already exists/);
   });
 
   it('rejects bad assertion-name slugs at the schema layer (zod regex)', async () => {
     await expect(
-      server.call('dkg_assertion_create', { name: 'Invalid Name With Spaces' }),
+      server.call('dkg_knowledge_asset_create', { name: 'Invalid Name With Spaces' }),
     ).rejects.toThrow();
   });
 
   it('write requires a non-empty quads array', async () => {
-    await server.call('dkg_assertion_create', { name: 'empty' });
+    await server.call('dkg_knowledge_asset_create', { name: 'empty' });
     await expect(
-      server.call('dkg_assertion_write', { name: 'empty', quads: [] }),
+      server.call('dkg_knowledge_asset_write', { name: 'empty', quads: [] }),
     ).rejects.toThrow();
   });
 
-  it('promote rejects an empty entities array (must be omitted or non-empty)', async () => {
-    await server.call('dkg_assertion_create', { name: 'rollback' });
-    await server.call('dkg_assertion_write', {
+  it('share rejects an empty entities array (must be omitted or non-empty)', async () => {
+    await server.call('dkg_knowledge_asset_create', { name: 'rollback' });
+    await server.call('dkg_knowledge_asset_write', {
       name: 'rollback',
       quads: [{ subject: 'urn:r', predicate: 'urn:p', object: '"v"' }],
     });
-    const result = await server.call('dkg_assertion_promote', {
+    const result = await server.call('dkg_knowledge_asset_share', {
       name: 'rollback',
       entities: [],
     });
@@ -180,10 +196,10 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
   });
 
   it('discard marks the assertion discarded; subsequent writes fail', async () => {
-    await server.call('dkg_assertion_create', { name: 'rollback' });
-    await server.call('dkg_assertion_discard', { name: 'rollback' });
+    await server.call('dkg_knowledge_asset_create', { name: 'rollback' });
+    await server.call('dkg_knowledge_asset_discard', { name: 'rollback' });
     expect(client.assertions.get('test-cg::rollback')!.discarded).toBe(true);
-    const writeAfterDiscard = await server.call('dkg_assertion_write', {
+    const writeAfterDiscard = await server.call('dkg_knowledge_asset_write', {
       name: 'rollback',
       quads: [{ subject: 'urn:r', predicate: 'urn:p', object: '"v"' }],
     });
@@ -198,13 +214,171 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
       noProjectClient.asDkgClient(),
       makeConfig({ defaultProject: null }),
     );
-    const result = await noProjectServer.call('dkg_assertion_query', { name: 'x' });
+    const result = await noProjectServer.call('dkg_knowledge_asset_query', { name: 'x' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/No project specified/);
   });
 });
 
-describe('dkg_assertion_import_file — wave-2 P1 add', () => {
+describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with OpenClaw PR1)', () => {
+  let server: FakeServer;
+  let client: FakeClient;
+
+  beforeEach(() => {
+    server = new FakeServer();
+    client = new FakeClient();
+    registerAssertionTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+  });
+
+  // finalize surfaces author_agent_address (token-resolved author) but NOT the
+  // raw preSignedAuthorAttestation — colocated-agent attribution by design
+  // (CONTRACT §1 Stage3), matching the OpenClaw adapter.
+  it('finalize schema surfaces authorAgentAddress + schemeVersion but not preSignedAuthorAttestation', () => {
+    const schema = server.get('dkg_knowledge_asset_finalize').config.inputSchema!;
+    expect(schema).toHaveProperty('authorAgentAddress');
+    expect(schema).toHaveProperty('schemeVersion');
+    expect(schema).not.toHaveProperty('preSignedAuthorAttestation');
+    expect(schema).not.toHaveProperty('entities'); // whole-draft seal, no subset
+  });
+
+  it('finalize seals the whole WM draft (sets the seal flag)', async () => {
+    await server.call('dkg_knowledge_asset_create', { name: 'doc' });
+    await server.call('dkg_knowledge_asset_write', {
+      name: 'doc',
+      quads: [{ subject: 'urn:a', predicate: 'urn:p', object: '"v"' }],
+    });
+    const sealed = await server.call('dkg_knowledge_asset_finalize', { name: 'doc' });
+    expect(sealed.isError).toBeFalsy();
+    expect(sealed.content[0].text).toMatch(/Finalized \(sealed\) knowledge asset 'doc'/);
+    expect(client.assertions.get('test-cg::doc')!.finalized).toBe(true);
+  });
+
+  // publish must NOT expose author/selection overrides — the seal selects them
+  // (CONTRACT §1 Stage5 / §3). It exposes only the finalized-publish options,
+  // byte-for-byte with OpenClaw.
+  it('publish schema exposes only finalized-publish options, no author/selection', () => {
+    const schema = server.get('dkg_knowledge_asset_publish').config.inputSchema!;
+    expect(schema).toHaveProperty('publishEpochs');
+    expect(schema).toHaveProperty('publisherNodeIdentityIdOverride');
+    expect(schema).toHaveProperty('clearSharedMemoryAfter');
+    expect(schema).not.toHaveProperty('authorAgentAddress');
+    expect(schema).not.toHaveProperty('preSignedAuthorAttestation');
+    expect(schema).not.toHaveProperty('entities');
+    expect(schema).not.toHaveProperty('selection');
+  });
+
+  it('publish forwards the finalized-publish options and returns the UAL', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetPublish: async (args) => {
+        Object.assign(captured, args);
+        return { kaId: 'ka-1', status: 'confirmed', ual: 'did:dkg:31337/0xauthor/7', txHash: '0xpub' };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_publish', {
+      name: 'doc',
+      publishEpochs: 2,
+      clearSharedMemoryAfter: true,
+      publisherNodeIdentityIdOverride: '12',
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('"ual": "did:dkg:31337/0xauthor/7"');
+    // The tool maps clearSharedMemoryAfter → clearAfter on the client call
+    // (the client then translates to the daemon's clearSharedMemoryAfter key).
+    expect(captured.clearAfter).toBe(true);
+    expect(captured.publishEpochs).toBe(2);
+    expect(captured.publisherNodeIdentityIdOverride).toBe('12');
+    expect(captured).not.toHaveProperty('authorAgentAddress');
+  });
+
+  it('pull_from seeds a fresh WM draft from swm/vm with layer + onConflict', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetPullFrom: async (args) => {
+        Object.assign(captured, args);
+        return { wmDraft: 'open', seededFrom: { layer: args.layer } };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_pull_from', {
+      name: 'doc',
+      layer: 'swm',
+      onConflict: 'replace',
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/Seeded a WM draft for knowledge asset 'doc'.*from SWM/s);
+    expect(captured.layer).toBe('swm');
+    expect(captured.onConflict).toBe('replace');
+  });
+
+  it('pull_from rejects an invalid layer at the schema boundary (swm|vm enum)', async () => {
+    await expect(
+      server.call('dkg_knowledge_asset_pull_from', { name: 'doc', layer: 'wm' }),
+    ).rejects.toThrow();
+  });
+
+  it('pull_from surfaces 409 WM_DRAFT_CONFLICT verbatim onto a dirty draft', async () => {
+    await server.call('dkg_knowledge_asset_create', { name: 'doc' });
+    await server.call('dkg_knowledge_asset_write', {
+      name: 'doc',
+      quads: [{ subject: 'urn:a', predicate: 'urn:p', object: '"v"' }],
+    });
+    const res = await server.call('dkg_knowledge_asset_pull_from', { name: 'doc', layer: 'vm' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('WM_DRAFT_CONFLICT');
+  });
+
+  // The crux of CONTRACT §5 (H2): a SUBSET share is NOT auto-sealed, so
+  // publish 409s; a FULL share (or an explicit finalize) seals and publish
+  // succeeds. This models the seal-before-publish invariant.
+  it('subset share → publish FAILS (not finalized); full share → publish SUCCEEDS', async () => {
+    await server.call('dkg_knowledge_asset_create', { name: 'multi' });
+    await server.call('dkg_knowledge_asset_write', {
+      name: 'multi',
+      quads: [
+        { subject: 'urn:a', predicate: 'urn:p', object: '"a"' },
+        { subject: 'urn:b', predicate: 'urn:p', object: '"b"' },
+      ],
+    });
+    // SUBSET share — SWM-only, NOT auto-sealed.
+    const subset = await server.call('dkg_knowledge_asset_share', { name: 'multi', entities: ['urn:a'] });
+    expect(subset.isError).toBeFalsy();
+    expect(client.assertions.get('test-cg::multi')!.finalized).toBe(false);
+
+    const failed = await server.call('dkg_knowledge_asset_publish', { name: 'multi' });
+    expect(failed.isError).toBe(true);
+    expect(failed.content[0].text).toContain('VM_PUBLISH_PRECONDITION');
+
+    // FULL share auto-seals → publish now succeeds and returns the UAL.
+    const full = await server.call('dkg_knowledge_asset_share', { name: 'multi' });
+    expect(full.isError).toBeFalsy();
+    expect(client.assertions.get('test-cg::multi')!.finalized).toBe(true);
+
+    const ok = await server.call('dkg_knowledge_asset_publish', { name: 'multi' });
+    expect(ok.isError).toBeFalsy();
+    expect(ok.content[0].text).toContain('"ual"');
+  });
+
+  it('explicit finalize before a subset share also makes publish succeed', async () => {
+    await server.call('dkg_knowledge_asset_create', { name: 'sealed' });
+    await server.call('dkg_knowledge_asset_write', {
+      name: 'sealed',
+      quads: [{ subject: 'urn:a', predicate: 'urn:p', object: '"a"' }],
+    });
+    await server.call('dkg_knowledge_asset_finalize', { name: 'sealed' });
+    await server.call('dkg_knowledge_asset_share', { name: 'sealed', entities: ['urn:a'] });
+    const res = await server.call('dkg_knowledge_asset_publish', { name: 'sealed' });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('"ual"');
+  });
+});
+
+describe('dkg_knowledge_asset_import_file — wave-2 P1 add', () => {
   let server: FakeServer;
   let client: FakeClient;
   let tempDir: string;
@@ -233,7 +407,7 @@ describe('dkg_assertion_import_file — wave-2 P1 add', () => {
     const localServer = new FakeServer();
     registerAssertionTools(localServer.asMcpServer(), client.asDkgClient(), makeConfig());
 
-    const result = await localServer.call('dkg_assertion_import_file', {
+    const result = await localServer.call('dkg_knowledge_asset_import_file', {
       name: 'imported',
       filePath,
     });
@@ -247,7 +421,7 @@ describe('dkg_assertion_import_file — wave-2 P1 add', () => {
   });
 
   it('surfaces a tool error when the file path does not exist', async () => {
-    const result = await server.call('dkg_assertion_import_file', {
+    const result = await server.call('dkg_knowledge_asset_import_file', {
       name: 'missing',
       filePath: path.join(tempDir, 'no-such-file.md'),
     });
@@ -258,7 +432,7 @@ describe('dkg_assertion_import_file — wave-2 P1 add', () => {
   });
 });
 
-describe('dkg_assertion_history — wave-2 P3 add', () => {
+describe('dkg_knowledge_asset_history — wave-2 P3 add', () => {
   let server: FakeServer;
   let client: FakeClient;
 
@@ -269,7 +443,7 @@ describe('dkg_assertion_history — wave-2 P3 add', () => {
   });
 
   it('returns the lifecycle JSON block for a known assertion', async () => {
-    const result = await server.call('dkg_assertion_history', { name: 'session-2026' });
+    const result = await server.call('dkg_knowledge_asset_history', { name: 'session-2026' });
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toMatch(/History for assertion 'session-2026'/);
     expect(result.content[0].text).toContain('"author": "urn:dkg:agent:test"');

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -230,6 +230,20 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     registerAssertionTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
   });
 
+  // CONTRACT §0 invariant 2 (parity with PR1's OpenClaw plugin.part-06 guard):
+  // the dkg_knowledge_asset_write quad element schema must NOT advertise a
+  // per-quad `graph` field. The daemon pins every triple to the per-KA WM graph,
+  // so a client `graph` is daemon-overridden; the agent-facing schema must not
+  // teach it. (`.element.shape` is zod's stable object-shape introspection.)
+  it('write schema exposes no per-quad graph field (subject/predicate/object only)', () => {
+    const schema = server.get('dkg_knowledge_asset_write').config.inputSchema!;
+    const quadShape = (schema.quads as unknown as { element: { shape: Record<string, unknown> } }).element.shape;
+    expect(quadShape).toHaveProperty('subject');
+    expect(quadShape).toHaveProperty('predicate');
+    expect(quadShape).toHaveProperty('object');
+    expect(quadShape).not.toHaveProperty('graph');
+  });
+
   // finalize surfaces author_agent_address (token-resolved author) but NOT the
   // raw preSignedAuthorAttestation — colocated-agent attribution by design
   // (CONTRACT §1 Stage3), matching the OpenClaw adapter.

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -241,6 +241,26 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     expect(captured.entities).toBe('all');
   });
 
+  it('share trims whitespace from each entity URI before forwarding (FIX K)', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetShare: async (args) => {
+        Object.assign(captured, args);
+        return { swmShared: true, promotedCount: 2 };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_share', {
+      name: 'doc',
+      entities: [' urn:root-1 ', '\turn:root-2\n'],
+    });
+    expect(res.isError).toBeFalsy();
+    // A whitespace-padded entity must reach the daemon trimmed (else wrong root).
+    expect(captured.entities).toEqual(['urn:root-1', 'urn:root-2']);
+  });
+
   it('discard marks the assertion discarded; subsequent writes fail', async () => {
     await server.call('dkg_knowledge_asset_create', { name: 'rollback' });
     await server.call('dkg_knowledge_asset_discard', { name: 'rollback' });

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -302,6 +302,35 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(schema).not.toHaveProperty('selection');
   });
 
+  // CONTRACT §C (float-truncation parity — Codex round-2 flagged this on Hermes):
+  // a present-but-non-integral numeric must be REJECTED at the zod boundary, never
+  // silently truncated (1.9 → 1). publishEpochs + schemeVersion use .int(); the
+  // override regex /^\d+$/ rejects "1.9" and "-1".
+  it('rejects non-integral / negative numeric options at the schema boundary (CONTRACT §C)', async () => {
+    // publishEpochs 1.9 → .int() rejects (no truncation to 1).
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', publishEpochs: 1.9 }),
+    ).rejects.toThrow();
+    // publishEpochs 0 / negative → .positive() rejects.
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', publishEpochs: 0 }),
+    ).rejects.toThrow();
+    // publisher_node_identity_id_override "1.9" and "-1" → /^\d+$/ rejects.
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', publisherNodeIdentityIdOverride: '1.9' }),
+    ).rejects.toThrow();
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', publisherNodeIdentityIdOverride: '-1' }),
+    ).rejects.toThrow();
+    // scheme_version 1.9 / 0 → .int().positive() rejects.
+    await expect(
+      server.call('dkg_knowledge_asset_finalize', { name: 'doc', schemeVersion: 1.9 }),
+    ).rejects.toThrow();
+    await expect(
+      server.call('dkg_knowledge_asset_finalize', { name: 'doc', schemeVersion: 0 }),
+    ).rejects.toThrow();
+  });
+
   it('publish forwards the finalized-publish options and returns the UAL', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -373,6 +373,46 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(captured).not.toHaveProperty('clearSharedMemoryAfter');
   });
 
+  it('publish surfaces a 207 partial (KA minted, CG bind failed) as a WARNING, not plain success (#1077:409)', async () => {
+    // The client treats HTTP 207 as success and returns the body; a present
+    // contextGraphError means the asset minted on-chain but the CG binding failed.
+    const localClient = new FakeClient({
+      knowledgeAssetPublish: async () => ({
+        kaId: 'ka-1',
+        status: 'confirmed',
+        ual: 'did:dkg:31337/0xauthor/7',
+        txHash: '0xpub',
+        contextGraphError: 'context-graph binding timed out',
+      }),
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_publish', { name: 'doc' });
+    // Not a hard failure (the asset minted) but clearly flagged as partial.
+    expect(res.content[0].text).toMatch(/PARTIAL/);
+    expect(res.content[0].text).toContain('context-graph binding timed out');
+    expect(res.content[0].text).toContain('"ual": "did:dkg:31337/0xauthor/7"'); // UAL still valid
+  });
+
+  it('publish reports plain success on a 200 (no contextGraphError)', async () => {
+    const localClient = new FakeClient({
+      knowledgeAssetPublish: async () => ({
+        kaId: 'ka-1',
+        status: 'confirmed',
+        ual: 'did:dkg:31337/0xauthor/7',
+        txHash: '0xpub',
+      }),
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_publish', { name: 'doc' });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/Published knowledge asset 'doc'/);
+    expect(res.content[0].text).not.toMatch(/PARTIAL/);
+  });
+
   // ── CONTRACT §G — registerIfNeeded on per-KA publish ──────────────────────
   const setupPublishWithRegisterTracking = (opts: {
     registerImpl?: (args: { id: string; accessPolicy?: number }) => Promise<Record<string, unknown>>;

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -181,9 +181,25 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     expect(second.content[0].text).toMatch(/already exists/);
   });
 
-  it('rejects bad assertion-name slugs at the schema layer (zod regex)', async () => {
+  it('create accepts any valid (IRI-safe) assertion name, not just a lowercase-hyphen slug (FIX P)', async () => {
+    // The daemon's real rule (validateAssertionName) accepts mixed-case, dots,
+    // and underscores — the old /^[a-z0-9-]+$/ slug regex was artificially strict.
+    for (const name of ['My_Asset.v2', 'Session2026', 'urn-ish_NAME.1']) {
+      const res = await server.call('dkg_knowledge_asset_create', { name });
+      expect(res.isError).toBeFalsy();
+    }
+  });
+
+  it('create rejects IRI-unsafe assertion names at the schema layer (FIX P)', async () => {
+    // Whitespace, "/", and >256 chars are rejected (validateAssertionName).
     await expect(
       server.call('dkg_knowledge_asset_create', { name: 'Invalid Name With Spaces' }),
+    ).rejects.toThrow();
+    await expect(
+      server.call('dkg_knowledge_asset_create', { name: 'has/slash' }),
+    ).rejects.toThrow();
+    await expect(
+      server.call('dkg_knowledge_asset_create', { name: 'a'.repeat(257) }),
     ).rejects.toThrow();
   });
 

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -393,6 +393,9 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(res.content[0].text).toMatch(/PARTIAL/);
     expect(res.content[0].text).toContain('context-graph binding timed out');
     expect(res.content[0].text).toContain('"ual": "did:dkg:31337/0xauthor/7"'); // UAL still valid
+    // FIX I: a confirmed publish cleared SWM, so do NOT re-publish — surface to operator.
+    expect(res.content[0].text).toMatch(/do not re-publish/i);
+    expect(res.content[0].text).toMatch(/operator/i);
   });
 
   it('publish reports plain success on a 200 (no contextGraphError)', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -195,6 +195,23 @@ describe('assertion CRUD quintet — round-trip with @en literal preservation', 
     expect(result.content[0].text).toMatch(/non-empty array/);
   });
 
+  it('share accepts the "all" sentinel and passes it through unchanged (CONTRACT §B)', async () => {
+    const captured: Record<string, unknown> = {};
+    const localClient = new FakeClient({
+      knowledgeAssetShare: async (args) => {
+        Object.assign(captured, args);
+        return { swmShared: true, promotedCount: 2 };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const res = await localServer.call('dkg_knowledge_asset_share', { name: 'doc', entities: 'all' });
+    expect(res.isError).toBeFalsy();
+    // CONTRACT §B: "all" is forwarded verbatim (NOT coerced to [] or omitted).
+    expect(captured.entities).toBe('all');
+  });
+
   it('discard marks the assertion discarded; subsequent writes fail', async () => {
     await server.call('dkg_knowledge_asset_create', { name: 'rollback' });
     await server.call('dkg_knowledge_asset_discard', { name: 'rollback' });
@@ -270,11 +287,15 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
   // publish must NOT expose author/selection overrides — the seal selects them
   // (CONTRACT §1 Stage5 / §3). It exposes only the finalized-publish options,
   // byte-for-byte with OpenClaw.
-  it('publish schema exposes only finalized-publish options, no author/selection', () => {
+  it('publish schema exposes only finalized-publish options, no author/selection/clear-after', () => {
     const schema = server.get('dkg_knowledge_asset_publish').config.inputSchema!;
     expect(schema).toHaveProperty('publishEpochs');
     expect(schema).toHaveProperty('publisherNodeIdentityIdOverride');
-    expect(schema).toHaveProperty('clearSharedMemoryAfter');
+    // CONTRACT §D: clear-after is DROPPED from the per-asset publish tool — on
+    // vm/publish it is graph-wide destructive (wipes other agents' SWM). The
+    // CG-wide clear stays on dkg_publish / dkg_shared_memory_publish.
+    expect(schema).not.toHaveProperty('clearSharedMemoryAfter');
+    expect(schema).not.toHaveProperty('clearAfter');
     expect(schema).not.toHaveProperty('authorAgentAddress');
     expect(schema).not.toHaveProperty('preSignedAuthorAttestation');
     expect(schema).not.toHaveProperty('entities');
@@ -295,17 +316,16 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     const res = await localServer.call('dkg_knowledge_asset_publish', {
       name: 'doc',
       publishEpochs: 2,
-      clearSharedMemoryAfter: true,
       publisherNodeIdentityIdOverride: '12',
     });
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain('"ual": "did:dkg:31337/0xauthor/7"');
-    // The tool maps clearSharedMemoryAfter → clearAfter on the client call
-    // (the client then translates to the daemon's clearSharedMemoryAfter key).
-    expect(captured.clearAfter).toBe(true);
     expect(captured.publishEpochs).toBe(2);
     expect(captured.publisherNodeIdentityIdOverride).toBe('12');
     expect(captured).not.toHaveProperty('authorAgentAddress');
+    // CONTRACT §D: the per-asset publish never forwards a clear-after flag.
+    expect(captured).not.toHaveProperty('clearAfter');
+    expect(captured).not.toHaveProperty('clearSharedMemoryAfter');
   });
 
   it('pull_from seeds a fresh WM draft from swm/vm with layer + onConflict', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -304,6 +304,9 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     const schema = server.get('dkg_knowledge_asset_publish').config.inputSchema!;
     expect(schema).toHaveProperty('publishEpochs');
     expect(schema).toHaveProperty('publisherNodeIdentityIdOverride');
+    // CONTRACT §G: per-KA publish can register the CG on-chain first (mirrors
+    // dkg_shared_memory_publish) — vm/publish requires a registered CG.
+    expect(schema).toHaveProperty('registerIfNeeded');
     // CONTRACT §D: clear-after is DROPPED from the per-asset publish tool — on
     // vm/publish it is graph-wide destructive (wipes other agents' SWM). The
     // CG-wide clear stays on dkg_publish / dkg_shared_memory_publish.
@@ -368,6 +371,78 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     // CONTRACT §D: the per-asset publish never forwards a clear-after flag.
     expect(captured).not.toHaveProperty('clearAfter');
     expect(captured).not.toHaveProperty('clearSharedMemoryAfter');
+  });
+
+  // ── CONTRACT §G — registerIfNeeded on per-KA publish ──────────────────────
+  const setupPublishWithRegisterTracking = (opts: {
+    registerImpl?: (args: { id: string; accessPolicy?: number }) => Promise<Record<string, unknown>>;
+  } = {}) => {
+    const events: string[] = [];
+    const registerCalls: Array<{ id: string; accessPolicy?: number }> = [];
+    const localClient = new FakeClient({
+      registerContextGraph: async (args: { id: string; accessPolicy?: number }) => {
+        events.push('register');
+        registerCalls.push(args);
+        if (opts.registerImpl) return opts.registerImpl(args);
+        return { registered: args.id, onChainId: `chain:${args.id}`, txHash: '0xreg', alreadyRegistered: false };
+      },
+      knowledgeAssetPublish: async () => {
+        events.push('publish');
+        return { kaId: 'ka-1', status: 'confirmed', ual: 'did:dkg:31337/0xauthor/7', txHash: '0xpub' };
+      },
+    });
+    const localServer = new FakeServer();
+    registerAssertionTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+    return { localServer, events, registerCalls };
+  };
+
+  it('publish with registerIfNeeded=true registers THEN publishes (CONTRACT §G)', async () => {
+    const { localServer, events, registerCalls } = setupPublishWithRegisterTracking();
+    const res = await localServer.call('dkg_knowledge_asset_publish', {
+      name: 'doc',
+      registerIfNeeded: true,
+      accessPolicy: 1,
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('"ual": "did:dkg:31337/0xauthor/7"');
+    expect(events).toEqual(['register', 'publish']); // register first, then publish
+    expect(registerCalls).toEqual([{ id: 'test-cg', accessPolicy: 1 }]);
+  });
+
+  it('publish does NOT register when registerIfNeeded is omitted (CONTRACT §G)', async () => {
+    const { localServer, events } = setupPublishWithRegisterTracking();
+    const res = await localServer.call('dkg_knowledge_asset_publish', { name: 'doc' });
+    expect(res.isError).toBeFalsy();
+    expect(events).toEqual(['publish']); // no register call
+  });
+
+  it('publish with registerIfNeeded=true short-circuits an already-registered CG, still publishes (CONTRACT §G)', async () => {
+    const { localServer, events, registerCalls } = setupPublishWithRegisterTracking({
+      // The client surfaces alreadyRegistered:true (it swallows the daemon 409) —
+      // no throw, no double-mint.
+      registerImpl: async (args) => ({ registered: args.id, alreadyRegistered: true }),
+    });
+    const res = await localServer.call('dkg_knowledge_asset_publish', { name: 'doc', registerIfNeeded: true });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('"ual"');
+    expect(events).toEqual(['register', 'publish']);
+    expect(registerCalls).toHaveLength(1); // exactly one register attempt
+  });
+
+  it('publish surfaces a register HARD failure and does NOT publish (CONTRACT §G)', async () => {
+    const { localServer, events } = setupPublishWithRegisterTracking({
+      registerImpl: async () => { throw new Error('rpc unreachable'); },
+    });
+    const res = await localServer.call('dkg_knowledge_asset_publish', { name: 'doc', registerIfNeeded: true });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Failed to register context graph: rpc unreachable/);
+    expect(events).toEqual(['register']); // publish NOT attempted
+  });
+
+  it('publish rejects a non-boolean registerIfNeeded at the schema boundary (CONTRACT §G)', async () => {
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', registerIfNeeded: 'yes' }),
+    ).rejects.toThrow();
   });
 
   it('publish rejects a non-integral publishEpochs at the schema boundary (CONTRACT §C)', async () => {

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -328,6 +328,20 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     expect(captured).not.toHaveProperty('clearSharedMemoryAfter');
   });
 
+  it('publish rejects a non-integral publishEpochs at the schema boundary (CONTRACT §C)', async () => {
+    // 1.9 must be REJECTED (zod .int()), not coerced to 1 — a present-but-invalid
+    // numeric is a tool error, same as 0 / -1.
+    await expect(
+      server.call('dkg_knowledge_asset_publish', { name: 'doc', publishEpochs: 1.9 }),
+    ).rejects.toThrow();
+  });
+
+  it('finalize rejects a non-integral schemeVersion at the schema boundary (CONTRACT §C)', async () => {
+    await expect(
+      server.call('dkg_knowledge_asset_finalize', { name: 'doc', schemeVersion: 1.9 }),
+    ).rejects.toThrow();
+  });
+
   it('pull_from seeds a fresh WM draft from swm/vm with layer + onConflict', async () => {
     const captured: Record<string, unknown> = {};
     const localClient = new FakeClient({

--- a/packages/mcp-dkg/test/assertion-lifecycle.test.ts
+++ b/packages/mcp-dkg/test/assertion-lifecycle.test.ts
@@ -524,6 +524,12 @@ describe('rc.17 lifecycle verbs — finalize / publish / pull_from (parity with 
     ).rejects.toThrow();
   });
 
+  it('publish rejects accessPolicy without registerIfNeeded (FIX S)', async () => {
+    const res = await server.call('dkg_knowledge_asset_publish', { name: 'doc', accessPolicy: 1 });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/accessPolicy.*requires.*registerIfNeeded/i);
+  });
+
   it('publish rejects a non-integral publishEpochs at the schema boundary (CONTRACT §C)', async () => {
     // 1.9 must be REJECTED (zod .int()), not coerced to 1 — a present-but-invalid
     // numeric is a tool error, same as 0 / -1.

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -17,12 +17,13 @@
  * 2. **Read-side regex-scope guard** — per matrix v0.5 §4.16 alignment
  *    paragraph, the `/^[a-z0-9-]+$/` regex on the assertion `name` argument
  *    is creator-side input validation only. Read-side / lookup-side tools
- *    (`dkg_assertion_write / promote / discard / query` + `_history` +
- *    `_import_file`) MUST NOT inherit it — they look up assertions that
- *    may have been minted by other agents whose names don't conform.
+ *    (`dkg_knowledge_asset_write / share / finalize / publish / pull_from /
+ *    discard / query` + `_history` + `_import_file`) MUST NOT inherit it —
+ *    they look up assets that may have been minted by other agents whose
+ *    names don't conform.
  *
  *    The bug-class-most-likely is an implementer copying the regex from
- *    `dkg_assertion_create` to all five tools because they look symmetric
+ *    `dkg_knowledge_asset_create` to all the lookup tools because they look symmetric
  *    ("name should always be slug-shaped, right?"). This test asserts the
  *    asymmetry by passing a non-conforming name to each read-side tool
  *    and confirming the schema does NOT reject it.
@@ -104,14 +105,19 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
   // in `DROPPED_TOOLS` for the trust-boundary rationale. Bump again
   // when a new tool is intentionally added, drop when a tool is
   // removed, and keep a comment trail so future drops are auditable.
-  it('registered surface contains exactly 25 tools (post-PR locked count)', () => {
-    expect(server.tools.size).toBe(25);
+  // rc.17 agent-tooling PR2: +3 net-new knowledge-asset lifecycle verbs
+  // (finalize / publish / pull_from) under registerAssertionTools take the
+  // 6-module surface counted here from 25 → 28. (The full production surface in
+  // src/index.ts also registers registerChatTools (+2), so the README's
+  // "30 tools" = these 28 + 2 chat tools.)
+  it('registered surface contains exactly 28 tools (post-PR locked count)', () => {
+    expect(server.tools.size).toBe(28);
   });
 });
 
 /**
  * Regex-scope guard. Production source (matrix v0.5 §4.16 alignment paragraph)
- * documents that the slug regex applies ONLY to `dkg_assertion_create`'s
+ * documents that the slug regex applies ONLY to `dkg_knowledge_asset_create`'s
  * `name` arg. Every other tool that takes a `name` argument must accept
  * richer strings.
  *
@@ -132,14 +138,17 @@ describe('regex-scope guard — read-side `name` arg accepts non-conforming slug
     registerAssertionTools(server.asMcpServer(), client.asDkgClient(), config);
   });
 
-  // The four read-side / lookup-side assertion tools. `dkg_assertion_create` is
-  // INTENTIONALLY excluded — it IS the regex-bearing tool.
+  // The read-side / lookup-side knowledge-asset tools. `dkg_knowledge_asset_create`
+  // is INTENTIONALLY excluded — it IS the regex-bearing tool.
   it.each([
-    ['dkg_assertion_write', { name: 'Bad Name With Spaces', quads: [{ subject: 'urn:x', predicate: 'urn:p', object: '"v"' }] }],
-    ['dkg_assertion_promote', { name: 'Bad Name With Spaces' }],
-    ['dkg_assertion_discard', { name: 'Bad Name With Spaces' }],
-    ['dkg_assertion_query', { name: 'Bad Name With Spaces' }],
-    ['dkg_assertion_history', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_write', { name: 'Bad Name With Spaces', quads: [{ subject: 'urn:x', predicate: 'urn:p', object: '"v"' }] }],
+    ['dkg_knowledge_asset_share', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_finalize', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_publish', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_pull_from', { name: 'Bad Name With Spaces', layer: 'swm' }],
+    ['dkg_knowledge_asset_discard', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_query', { name: 'Bad Name With Spaces' }],
+    ['dkg_knowledge_asset_history', { name: 'Bad Name With Spaces' }],
   ])('%s schema accepts non-slug `name` (no zod throw at input boundary)', async (toolName, args) => {
     // Don't care what the handler returns — it'll behaviourally produce a
     // not-found result against the empty FakeClient state. The assertion
@@ -149,13 +158,13 @@ describe('regex-scope guard — read-side `name` arg accepts non-conforming slug
     await expect(server.call(toolName, args)).resolves.toBeDefined();
   });
 
-  // Positive control: dkg_assertion_create DOES enforce the regex (per
+  // Positive control: dkg_knowledge_asset_create DOES enforce the regex (per
   // assertion-lifecycle.test.ts:81). Re-asserting here so the asymmetry is
   // visible in this file alone — a reviewer reading just `drop-sweep.test.ts`
   // can see why the read-side test exists.
-  it('positive control: dkg_assertion_create rejects non-slug `name` (regex IS enforced creator-side)', async () => {
+  it('positive control: dkg_knowledge_asset_create rejects non-slug `name` (regex IS enforced creator-side)', async () => {
     await expect(
-      server.call('dkg_assertion_create', { name: 'Bad Name With Spaces' }),
+      server.call('dkg_knowledge_asset_create', { name: 'Bad Name With Spaces' }),
     ).rejects.toThrow();
   });
 });

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -14,9 +14,10 @@
  *    Discipline mirrors §0.8 fixture 4 ("the cheap blanket guard"). Single
  *    array of names, single forEach assertion, one test.
  *
- * 2. **Read-side regex-scope guard** — per matrix v0.5 §4.16 alignment
- *    paragraph, the `/^[a-z0-9-]+$/` regex on the assertion `name` argument
- *    is creator-side input validation only. Read-side / lookup-side tools
+ * 2. **Read-side name-scope guard** — the create-side assertion-`name`
+ *    validation (`validateAssertionName` — IRI-safe, ≤256 chars; FIX P aligned
+ *    it to the daemon rule and dropped the old `/^[a-z0-9-]+$/` slug regex) is
+ *    creator-side input validation only. Read-side / lookup-side tools
  *    (`dkg_knowledge_asset_write / share / finalize / publish / pull_from /
  *    discard / query` + `_history` + `_import_file`) MUST NOT inherit it —
  *    they look up assets that may have been minted by other agents whose
@@ -116,10 +117,9 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
 });
 
 /**
- * Regex-scope guard. Production source (matrix v0.5 §4.16 alignment paragraph)
- * documents that the slug regex applies ONLY to `dkg_knowledge_asset_create`'s
- * `name` arg. Every other tool that takes a `name` argument must accept
- * richer strings.
+ * Name-scope guard. The create-side `name` validation (`validateAssertionName`,
+ * FIX P) applies ONLY to `dkg_knowledge_asset_create`'s `name` arg. Every other
+ * tool that takes a `name` argument must accept richer strings.
  *
  * Test strategy: try a deliberately non-conforming name on each read-side
  * tool. The schema MUST NOT reject it (no -32602 / no zod throw at the
@@ -158,11 +158,11 @@ describe('regex-scope guard — read-side `name` arg accepts non-conforming slug
     await expect(server.call(toolName, args)).resolves.toBeDefined();
   });
 
-  // Positive control: dkg_knowledge_asset_create DOES enforce the regex (per
-  // assertion-lifecycle.test.ts:81). Re-asserting here so the asymmetry is
-  // visible in this file alone — a reviewer reading just `drop-sweep.test.ts`
-  // can see why the read-side test exists.
-  it('positive control: dkg_knowledge_asset_create rejects non-slug `name` (regex IS enforced creator-side)', async () => {
+  // Positive control: dkg_knowledge_asset_create DOES validate the name
+  // (validateAssertionName — rejects IRI-unsafe names like one with spaces).
+  // Re-asserting here so the asymmetry is visible in this file alone — a reviewer
+  // reading just `drop-sweep.test.ts` can see why the read-side test exists.
+  it('positive control: dkg_knowledge_asset_create rejects an IRI-unsafe `name` (validated creator-side)', async () => {
     await expect(
       server.call('dkg_knowledge_asset_create', { name: 'Bad Name With Spaces' }),
     ).rejects.toThrow();

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -29,11 +29,11 @@
  *    asymmetry by passing a non-conforming name to each read-side tool
  *    and confirming the schema does NOT reject it.
  *
- * Both tests register every production-side tool module (6 register
- * functions, mirroring `src/index.ts`) so the assertions run against the
- * full surface. Adding a new register function in production without
- * adding it here means this file silently under-covers — an explicit
- * regression in the next wave's W?-Q audit.
+ * The drop-sweep + tool-count test registers every production-side tool
+ * module (all 7 register functions, mirroring `src/index.ts`) so the
+ * assertions run against the full surface. Adding a new register function in
+ * production without adding it here means this file silently under-covers — an
+ * explicit regression in the next wave's W?-Q audit.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { registerReadTools } from '../src/tools.js';
@@ -42,6 +42,7 @@ import { registerMemorySearchTool } from '../src/tools/memory-search.js';
 import { registerSetupTools } from '../src/tools/setup.js';
 import { registerHealthTools } from '../src/tools/health.js';
 import { registerPublishTools } from '../src/tools/publish.js';
+import { registerChatTools } from '../src/tools/chat.js';
 import { FakeServer, FakeClient, makeConfig } from './harness.js';
 
 /**
@@ -80,13 +81,15 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
     server = new FakeServer();
     const client = new FakeClient();
     const config = makeConfig();
-    // Mirror src/index.ts. If a new register* call lands in production, add it here too.
+    // Mirror src/index.ts (all 7 register* calls). If a new register* call lands
+    // in production, add it here too.
     registerReadTools(server.asMcpServer(), client.asDkgClient(), config);
     registerAssertionTools(server.asMcpServer(), client.asDkgClient(), config);
     registerMemorySearchTool(server.asMcpServer(), client.asDkgClient(), config);
     registerSetupTools(server.asMcpServer(), client.asDkgClient(), config);
     registerHealthTools(server.asMcpServer(), client.asDkgClient(), config);
     registerPublishTools(server.asMcpServer(), client.asDkgClient(), config);
+    registerChatTools(server.asMcpServer(), client.asDkgClient(), config);
   });
 
   it.each(DROPPED_TOOLS)('does not register %s', (name) => {
@@ -107,12 +110,14 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
   // when a new tool is intentionally added, drop when a tool is
   // removed, and keep a comment trail so future drops are auditable.
   // rc.17 agent-tooling PR2: +3 net-new knowledge-asset lifecycle verbs
-  // (finalize / publish / pull_from) under registerAssertionTools take the
-  // 6-module surface counted here from 25 → 28. (The full production surface in
-  // src/index.ts also registers registerChatTools (+2), so the README's
-  // "30 tools" = these 28 + 2 chat tools.)
-  it('registered surface contains exactly 28 tools (post-PR locked count)', () => {
-    expect(server.tools.size).toBe(28);
+  // (finalize / publish / pull_from) under registerAssertionTools took the
+  // assertion-module surface from 25 → 28. This fixture now registers ALL 7
+  // production modules (incl. registerChatTools, +2), matching src/index.ts and
+  // the README's "30 tools" — so the locked count is the full 30-tool surface
+  // (previously this guard registered only 6 modules and locked 28, silently
+  // under-covering registerChatTools).
+  it('registered surface contains exactly 30 tools (full production surface, post-PR locked count)', () => {
+    expect(server.tools.size).toBe(30);
   });
 });
 

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -319,10 +319,20 @@ export class FakeClient {
     if (!cell) throw new Error(`assertion not created: ${key}`);
     const isSubset = Array.isArray(args.entities) && args.entities.length > 0;
     if (isSubset) {
+      const entitySet = new Set(args.entities as string[]);
       for (const e of args.entities as string[]) cell.promotedRoots.add(e);
+      // Production promote MOVES the promoted triples WM → SWM and DELETES them
+      // from the WM draft (`dkg-publisher.ts:4665-4669`, `store.delete(... graph:
+      // wmGraphUri)`). A SELECTIVE share deletes ONLY the shared subset's quads
+      // (production filters `quadsToPromote` to the subset at :4518-4526); the
+      // rest stay in WM. Model that so a post-share WM `query` reflects reality.
+      cell.quads = cell.quads.filter((q) => !entitySet.has(q.subject));
       // CONTRACT §5 / §1 Stage4: a SUBSET share is NOT auto-sealed.
     } else {
       for (const q of cell.quads) cell.promotedRoots.add(q.subject);
+      // A FULL share promotes every root, so production empties the WM draft
+      // entirely (every quad is deleted from the WM graph). Clear WM here too.
+      cell.quads = [];
       // CONTRACT §1 Stage4: a FULL share ("all"/omitted) auto-seals best-effort
       // and is publish-ready.
       cell.finalized = true;

--- a/packages/mcp-dkg/test/harness.ts
+++ b/packages/mcp-dkg/test/harness.ts
@@ -112,10 +112,16 @@ type ClientMethods = Partial<{
 
 export class FakeClient {
   // Round-trip storage for the assertion quintet.
+  //
+  // `finalized` models the rc.17 seal (CONTRACT §1 Stage3): finalize seals the
+  // WHOLE draft; a FULL share auto-seals best-effort; a SUBSET share does NOT
+  // auto-seal; and vm/publish reconstructs the seal's full root set, so it
+  // hard-fails (409 VM_PUBLISH_PRECONDITION) unless the draft is finalized.
   readonly assertions = new Map<string, {
     quads: Array<{ subject: string; predicate: string; object: string }>;
     promotedRoots: Set<string>;
     discarded: boolean;
+    finalized: boolean;
   }>();
   readonly contextGraphs = new Set<string>();
   readonly subGraphs = new Set<string>();
@@ -167,7 +173,7 @@ export class FakeClient {
     if (this.assertions.has(key)) {
       return { assertionUri: null, alreadyExists: true };
     }
-    this.assertions.set(key, { quads: [], promotedRoots: new Set(), discarded: false });
+    this.assertions.set(key, { quads: [], promotedRoots: new Set(), discarded: false, finalized: false });
     return {
       assertionUri: `urn:dkg:assertion:${args.contextGraphId}:${args.assertionName}`,
       alreadyExists: false,
@@ -305,18 +311,88 @@ export class FakeClient {
   async knowledgeAssetShare(args: {
     contextGraphId: string;
     name: string;
-    entities?: string[];
+    entities?: string[] | 'all';
   }) {
     if (this.overrides.knowledgeAssetShare) return this.overrides.knowledgeAssetShare.call(this, args);
     const key = `${args.contextGraphId}::${args.name}`;
     const cell = this.assertions.get(key);
     if (!cell) throw new Error(`assertion not created: ${key}`);
-    if (args.entities && args.entities.length > 0) {
-      for (const e of args.entities) cell.promotedRoots.add(e);
+    const isSubset = Array.isArray(args.entities) && args.entities.length > 0;
+    if (isSubset) {
+      for (const e of args.entities as string[]) cell.promotedRoots.add(e);
+      // CONTRACT §5 / §1 Stage4: a SUBSET share is NOT auto-sealed.
     } else {
       for (const q of cell.quads) cell.promotedRoots.add(q.subject);
+      // CONTRACT §1 Stage4: a FULL share ("all"/omitted) auto-seals best-effort
+      // and is publish-ready.
+      cell.finalized = true;
     }
     return { swmShared: true, promotedCount: cell.promotedRoots.size };
+  }
+
+  // ── Seal / publish / pull-from (rc.17 lifecycle) ────────────────
+  async knowledgeAssetFinalize(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+    authorAgentAddress?: string;
+    schemeVersion?: number;
+  }) {
+    if (this.overrides.knowledgeAssetFinalize) return this.overrides.knowledgeAssetFinalize.call(this, args);
+    const key = `${args.contextGraphId}::${args.name}`;
+    const cell = this.assertions.get(key);
+    if (!cell) throw new Error(`assertion not created: ${key}`);
+    // Finalize always seals the WHOLE draft (CONTRACT §1 Stage3 — no subset).
+    cell.finalized = true;
+    return { merkleRoot: '0xroot', eip712Digest: '0xdigest', authorAddress: args.authorAgentAddress ?? '0xtoken' };
+  }
+
+  async knowledgeAssetPublish(args: {
+    contextGraphId: string;
+    name: string;
+    subGraphName?: string;
+    clearAfter?: boolean;
+    publishEpochs?: number;
+    publisherNodeIdentityIdOverride?: string;
+  }) {
+    if (this.overrides.knowledgeAssetPublish) return this.overrides.knowledgeAssetPublish.call(this, args);
+    const key = `${args.contextGraphId}::${args.name}`;
+    const cell = this.assertions.get(key);
+    if (!cell) throw new Error(`assertion not created: ${key}`);
+    // vm/publish reconstructs the seal's full root set; an unsealed draft hard-
+    // fails with the daemon's 409 VM_PUBLISH_PRECONDITION (CONTRACT §1 Stage5 /
+    // §5). This is the seal-before-share/publish invariant the mock enforces.
+    if (!cell.finalized) {
+      throw new Error('DKG daemon /vm/publish responded 409: VM_PUBLISH_PRECONDITION assertion is not finalized');
+    }
+    if (args.clearAfter) cell.promotedRoots.clear();
+    return {
+      kaId: 'ka-published',
+      status: 'confirmed',
+      ual: `did:dkg:31337/0xauthor/7`,
+      txHash: '0xpub',
+      kas: [{ tokenId: '7', rootEntity: cell.quads[0]?.subject ?? 'urn:x' }],
+    };
+  }
+
+  async knowledgeAssetPullFrom(args: {
+    contextGraphId: string;
+    name: string;
+    layer: 'swm' | 'vm';
+    subGraphName?: string;
+    onConflict?: 'reject' | 'replace';
+  }) {
+    if (this.overrides.knowledgeAssetPullFrom) return this.overrides.knowledgeAssetPullFrom.call(this, args);
+    const key = `${args.contextGraphId}::${args.name}`;
+    const existing = this.assertions.get(key);
+    // A dirty (non-discarded) open draft + onConflict:"reject" → 409
+    // WM_DRAFT_CONFLICT (CONTRACT §1 side-verbs / §7).
+    if (existing && !existing.discarded && args.onConflict !== 'replace') {
+      throw new Error('DKG daemon /wm/pull-from responded 409: WM_DRAFT_CONFLICT an open draft already exists');
+    }
+    // Seed a fresh WM draft from the named layer (unsealed).
+    this.assertions.set(key, { quads: [], promotedRoots: new Set(), discarded: false, finalized: false });
+    return { wmDraft: 'open', seededFrom: { layer: args.layer } };
   }
 
   async knowledgeAssetDiscard(args: { contextGraphId: string; name: string }) {

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -214,4 +214,58 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     })).rejects.toThrow(/require non-empty quads/);
     expect(calls).toHaveLength(0);
   });
+
+  // A sequenced fetcher: returns responses[i] for the i-th call (create, then publish).
+  const makeSequencedClient = (responses: Array<{ status: number; body: unknown }>) => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    let i = 0;
+    const client = new DkgClient({
+      config: makeConfig(),
+      fetcher: (async (url, init) => {
+        calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+        const r = responses[i++] ?? { status: 200, body: {} };
+        return new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch,
+    });
+    return { client, calls };
+  };
+
+  // FIX A — publishQuads aborts (no publish) on a create 207 share-phase failure.
+  it('publishQuads aborts without publishing when create returns a 207 share-phase partial-failure', async () => {
+    const { client, calls } = makeSequencedClient([
+      { status: 207, body: { created: true, name: 'mcp-publish-x', assertionUri: 'urn:assertion:x', status: 'wm-sealed', errors: [{ phase: 'swm-share', error: 'gossip peer unreachable' }] } },
+    ]);
+    await expect(
+      client.publishQuads({ contextGraphId: 'cg-1', quads: [{ subject: 's', predicate: 'p', object: 'o' }] }),
+    ).rejects.toThrow(/gossip peer unreachable/);
+    // re-run to inspect the structured error fields + that publish was never called.
+    const { client: c2, calls: calls2 } = makeSequencedClient([
+      { status: 207, body: { created: true, name: 'mcp-publish-x', assertionUri: 'urn:assertion:x', status: 'wm-sealed', errors: [{ phase: 'swm-share', error: 'gossip peer unreachable' }] } },
+    ]);
+    const err = await c2.publishQuads({ contextGraphId: 'cg-1', quads: [{ subject: 's', predicate: 'p', object: 'o' }] }).catch((e) => e);
+    expect(err.assertionName).toMatch(/mcp-publish-/);
+    expect(err.message).toMatch(/do not recreate/i);
+    // only the create call was made — /api/shared-memory/publish was NEVER called.
+    expect(calls2).toHaveLength(1);
+    expect(calls2[0].url).toContain('/api/knowledge-assets');
+    void calls;
+  });
+
+  // FIX B — publishQuads carries the assertionName when the publish call fails.
+  it('publishQuads surfaces the created assertionName when the publish call fails after a successful create', async () => {
+    const { client, calls } = makeSequencedClient([
+      { status: 201, body: { assertionUri: 'urn:assertion:y', status: 'swm-shared' } }, // create OK
+      { status: 502, body: { error: 'on-chain revert' } },                              // publish fails
+    ]);
+    const err = await client.publishQuads({ contextGraphId: 'cg-1', quads: [{ subject: 's', predicate: 'p', object: 'o' }] }).catch((e) => e);
+    expect(err.assertionName).toMatch(/mcp-publish-/);
+    expect(err.message).toMatch(/do not recreate/i);
+    expect(err.message).toMatch(/retry the publish/i);
+    // both calls were made — the failure was the publish (2nd) call.
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toContain('/api/shared-memory/publish');
+  });
 });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -88,6 +88,24 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(0);
   });
 
+  it('knowledgeAssetWrite strips any per-quad `graph` at the client (CONTRACT §A)', async () => {
+    const { client, calls } = makeClient();
+    // Even a NON-EMPTY graph must be dropped before the POST — the daemon pins
+    // every quad to the per-KA WM graph, so the write wire shape is
+    // {subject,predicate,object} only. Stripping at the client (not just the
+    // tool schema) defends a hand-built or normalizer-emitted `graph`.
+    await client.knowledgeAssetWrite({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      quads: [{ subject: 's', predicate: 'p', object: 'o', graph: 'urn:my-graph:forged' }],
+    });
+    expect(calls[0].url).toContain('/api/knowledge-assets/f/wm/write');
+    const quads = calls[0].body.quads as Array<Record<string, unknown>>;
+    expect(quads).toHaveLength(1);
+    expect(quads[0]).not.toHaveProperty('graph');
+    expect(quads[0]).toEqual({ subject: 's', predicate: 'p', object: 'o' });
+  });
+
   it('knowledgeAssetFinalize forwards authorAgentAddress', async () => {
     const { client, calls } = makeClient();
     await client.knowledgeAssetFinalize({

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -268,4 +268,19 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls).toHaveLength(2);
     expect(calls[1].url).toContain('/api/shared-memory/publish');
   });
+
+  // FIX W — create HARD failure surfaces the generated assertionName for recovery.
+  it('publishQuads surfaces the generated assertionName when the create call HARD-fails', async () => {
+    const { client, calls } = makeSequencedClient([
+      { status: 500, body: { error: 'daemon timeout after commit' } }, // create fails (may have committed)
+    ]);
+    const err = await client.publishQuads({ contextGraphId: 'cg-1', quads: [{ subject: 's', predicate: 'p', object: 'o' }] }).catch((e) => e);
+    expect(err.assertionName).toMatch(/mcp-publish-/);
+    expect(err.phase).toBe('create');
+    expect(err.message).toMatch(/dkg_knowledge_asset_history|dkg_knowledge_asset_query/i); // check-before-recreate
+    expect(err.message).toMatch(/duplicate/i);
+    // only the create call was made — no publish.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('/api/knowledge-assets');
+  });
 });

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -277,7 +277,11 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     const err = await client.publishQuads({ contextGraphId: 'cg-1', quads: [{ subject: 's', predicate: 'p', object: 'o' }] }).catch((e) => e);
     expect(err.assertionName).toMatch(/mcp-publish-/);
     expect(err.phase).toBe('create');
-    expect(err.message).toMatch(/dkg_knowledge_asset_history|dkg_knowledge_asset_query/i); // check-before-recreate
+    // FIX Y: point recovery at _history (lifecycle state, any layer) — the WM
+    // draft is empty after the create's promote, so _query would falsely read
+    // "not created".
+    expect(err.message).toMatch(/dkg_knowledge_asset_history/);
+    expect(err.message).toMatch(/NOT dkg_knowledge_asset_query/i);
     expect(err.message).toMatch(/duplicate/i);
     // only the create call was made — no publish.
     expect(calls).toHaveLength(1);

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -456,6 +456,9 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(result.content[0].text).toContain('context-graph binding timed out');
     expect(result.content[0].text).toContain('kc-z');                 // kaId kept
     expect(result.content[0].text).toContain('did:dkg:1/0xauthor/9'); // UAL kept
+    // FIX I: do NOT advise re-running dkg_publish (mints a duplicate) — surface to operator.
+    expect(result.content[0].text).toMatch(/do not re-run dkg_publish/i);
+    expect(result.content[0].text).toMatch(/operator/i);
   });
 
   it('dkg_publish reports plain success on a 200 publish (no contextGraphError)', async () => {

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -155,6 +155,19 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(server.tools.has('dkg_shared_memory_publish')).toBe(true);
   });
 
+  // CONTRACT §0 invariant 2 (parity with PR1's OpenClaw query-tools guard): the
+  // dkg_publish one-shot quad element schema must NOT advertise a per-quad
+  // `graph` — the daemon pins quads to the per-KA WM graph and overrides any
+  // client value. (`.element.shape` is zod's stable object-shape introspection.)
+  it('dkg_publish schema exposes no per-quad graph field (subject/predicate/object only)', () => {
+    const schema = server.get('dkg_publish').config.inputSchema!;
+    const quadShape = (schema.quads as unknown as { element: { shape: Record<string, unknown> } }).element.shape;
+    expect(quadShape).toHaveProperty('subject');
+    expect(quadShape).toHaveProperty('predicate');
+    expect(quadShape).toHaveProperty('object');
+    expect(quadShape).not.toHaveProperty('graph');
+  });
+
   it('documents canonical context graph ids for publish tools', () => {
     for (const name of ['dkg_publish', 'dkg_shared_memory_publish']) {
       const contextGraphId = server.get(name).config.inputSchema?.contextGraphId;

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -61,7 +61,7 @@ describe('setup tools — context graph + sub-graph + subscribe', () => {
   // F2: surface the daemon's already-exists signal so callers can
   // distinguish "newly created" from "already existed" without doing
   // an extra dkg_list_context_graphs round-trip. Mirrors
-  // dkg_assertion_create's idempotency surfacing.
+  // dkg_knowledge_asset_create's idempotency surfacing.
   it('first create reports "Created"; second create with same id reports "already exists"', async () => {
     const r1 = await server.call('dkg_context_graph_create', { name: 'My Project' });
     expect(r1.isError).toBeFalsy();
@@ -188,7 +188,13 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     });
 
     expect(bodies[0].contextGraphId).toBe('0xabc/my-cg');
-    expect(bodies[0].quads[0].graph).toBe(fullDid);
+    // CONTRACT §0 invariant 2 / §1 Stage1 (OpenClaw parity): the create/write
+    // body drops the per-quad `graph` (daemon-pinned) and the unread
+    // `finalize:true`; `promote:true` stays (read as the alsoShareSwm alias).
+    expect(bodies[0].quads[0]).not.toHaveProperty('graph');
+    expect(bodies[0].finalize).toBeUndefined();
+    expect(bodies[0].promote).toBe(true);
+    expect(bodies[0].quads[0]).toEqual({ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' });
     expect(bodies[1].contextGraphId).toBe('0xabc/my-cg');
   });
 

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -435,6 +435,45 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(result.content[0].text).toMatch(/Chain: base-sepolia/);
   });
 
+  // ── FIX E — dkg_publish 207 contextGraphError → PARTIAL warning ───────────
+  it('dkg_publish surfaces a 207 partial (minted on-chain, CG bind failed) as a WARNING', async () => {
+    const localClient = new FakeClient({
+      publishQuads: async () => ({
+        kaId: 'kc-z',
+        ual: 'did:dkg:1/0xauthor/9',
+        status: 'confirmed',
+        contextGraphError: 'context-graph binding timed out',
+      }),
+    });
+    const localServer = new FakeServer();
+    registerPublishTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+    });
+    expect(result.content[0].text).toMatch(/PARTIAL/);
+    expect(result.content[0].text).toContain('context-graph binding timed out');
+    expect(result.content[0].text).toContain('kc-z');                 // kaId kept
+    expect(result.content[0].text).toContain('did:dkg:1/0xauthor/9'); // UAL kept
+  });
+
+  it('dkg_publish reports plain success on a 200 publish (no contextGraphError)', async () => {
+    const localClient = new FakeClient({
+      publishQuads: async () => ({ kaId: 'kc-ok', ual: 'did:dkg:1/0xauthor/10', kas: [], txHash: '0xok' }),
+    });
+    const localServer = new FakeServer();
+    registerPublishTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/Published 1 quad/);
+    expect(result.content[0].text).not.toMatch(/PARTIAL/);
+  });
+
   it('F3+F13: dkg_shared_memory_publish success summary echoes the configured chainId', async () => {
     const result = await server.call('dkg_shared_memory_publish', { contextGraphId: 'cg' });
     expect(result.isError).toBeFalsy();

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -439,6 +439,17 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(result.content[0].text).toMatch(/accessPolicy.*requires.*registerIfNeeded/i);
   });
 
+  it('dkg_shared_memory_publish registerIfNeeded description states the auto-register reality (FIX V)', () => {
+    const registerIfNeeded = server.get('dkg_shared_memory_publish').config.inputSchema?.registerIfNeeded;
+    // The CG-wide selection publish AUTO-registers an unregistered CG at gas/TRAC
+    // cost regardless of registerIfNeeded (memory.ts:1928); the flag only sets the
+    // registration's accessPolicy. The description must not imply it gates whether
+    // registration happens.
+    expect(registerIfNeeded?.description).toMatch(/does NOT gate whether registration happens/i);
+    expect(registerIfNeeded?.description).toMatch(/AUTO-register/i);
+    expect(registerIfNeeded?.description).toContain('gas/TRAC');
+  });
+
   // F3+F13 (qa-review-round-1 F3 + qa-review-round-2 F13): chain
   // provenance echoed on publish responses so callers can verify
   // post-hoc which chain the publish landed on. User explicit:

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -362,6 +362,63 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(result.content[0].text).toMatch(/Failed to register context graph: rpc unreachable/);
   });
 
+  // ── CONTRACT §G — registerIfNeeded on the one-shot dkg_publish ────────────
+  it('dkg_publish runs registerContextGraph first when registerIfNeeded: true', async () => {
+    const localClient = new FakeClient();
+    let registered = false;
+    localClient.registerContextGraph = (async () => {
+      registered = true;
+      return { registered: 'cg', onChainId: 'chain:cg', txHash: '0xreg', alreadyRegistered: false };
+    }) as never;
+    const localServer = new FakeServer();
+    registerPublishTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+      registerIfNeeded: true,
+      accessPolicy: 1,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(registered).toBe(true);
+    expect(result.content[0].text).toMatch(/Registered context graph 'cg' on-chain/);
+  });
+
+  it('dkg_publish tolerates an already-registered CG and still publishes (no double-mint claim)', async () => {
+    const localClient = new FakeClient({
+      registerContextGraph: async () => ({ registered: 'cg', alreadyRegistered: true }) as any,
+    });
+    const localServer = new FakeServer();
+    registerPublishTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+      registerIfNeeded: true,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/Registered context graph/);
+  });
+
+  it('dkg_publish surfaces a register HARD failure and does NOT publish', async () => {
+    let published = false;
+    const localClient = new FakeClient({
+      registerContextGraph: async () => { throw new Error('rpc unreachable'); },
+      publishQuads: async () => { published = true; return { kaId: 'kc-x', kas: [] }; },
+    });
+    const localServer = new FakeServer();
+    registerPublishTools(localServer.asMcpServer(), localClient.asDkgClient(), makeConfig());
+
+    const result = await localServer.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+      registerIfNeeded: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Failed to register context graph: rpc unreachable/);
+    expect(published).toBe(false); // publish NOT attempted
+  });
+
   // F3+F13 (qa-review-round-1 F3 + qa-review-round-2 F13): chain
   // provenance echoed on publish responses so callers can verify
   // post-hoc which chain the publish landed on. User explicit:

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -419,6 +419,26 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(published).toBe(false); // publish NOT attempted
   });
 
+  // ── FIX S — accessPolicy requires registerIfNeeded ────────────────────────
+  it('dkg_publish rejects accessPolicy without registerIfNeeded (FIX S)', async () => {
+    const result = await server.call('dkg_publish', {
+      contextGraphId: 'cg',
+      quads: [{ subject: 'urn:s:1', predicate: 'urn:p:type', object: 'urn:Note' }],
+      accessPolicy: 1, // valid 0|1 but no registerIfNeeded
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/accessPolicy.*requires.*registerIfNeeded/i);
+  });
+
+  it('dkg_shared_memory_publish rejects accessPolicy without registerIfNeeded (FIX S)', async () => {
+    const result = await server.call('dkg_shared_memory_publish', {
+      contextGraphId: 'cg',
+      accessPolicy: 1,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/accessPolicy.*requires.*registerIfNeeded/i);
+  });
+
   // F3+F13 (qa-review-round-1 F3 + qa-review-round-2 F13): chain
   // provenance echoed on publish responses so callers can verify
   // post-hoc which chain the publish landed on. User explicit:

--- a/packages/mcp-dkg/test/setup-publish-health.test.ts
+++ b/packages/mcp-dkg/test/setup-publish-health.test.ts
@@ -450,6 +450,20 @@ describe('publish tools — write+publish helper + canonical SWM finalizer', () 
     expect(registerIfNeeded?.description).toContain('gas/TRAC');
   });
 
+  it('FIX X: dkg_publish carries the explicit-register publishPolicy caveat, dkg_shared_memory_publish does NOT', () => {
+    // The explicit-register route uses the daemon's DEFAULT publishPolicy and does
+    // not preserve a stored custom publishPolicy (daemon-side rehydration = dkg#1085).
+    // The caveat belongs on dkg_publish (explicit register) but NOT on the safe
+    // rehydrating auto-register path of dkg_shared_memory_publish.
+    const pubDesc = server.get('dkg_publish').config.inputSchema?.registerIfNeeded?.description as string;
+    expect(pubDesc).toContain('DEFAULT publishPolicy');
+    expect(pubDesc).toContain('OriginTrail/dkg#1085');
+
+    const sharedDesc = server.get('dkg_shared_memory_publish').config.inputSchema?.registerIfNeeded?.description as string;
+    expect(sharedDesc).not.toContain('DEFAULT publishPolicy');
+    expect(sharedDesc).not.toContain('dkg#1085');
+  });
+
   // F3+F13 (qa-review-round-1 F3 + qa-review-round-2 F13): chain
   // provenance echoed on publish responses so callers can verify
   // post-hoc which chain the publish landed on. User explicit:


### PR DESCRIPTION
## rc.17 agent-tooling sync — PR 2 of 3 (MCP)

Mirrors **#1076 (PR 1)** over the MCP server's existing client methods. Same canonical knowledge-asset lifecycle, identical wire contract.

> **Merge after #1076 (PR 1).** This branch was cut off `main` before PR 1 merged; the 5 `mcp-dkg` ontology agent-guides are fixed in PR 1 and arrive here via rebase (PR 2 does not touch them).

### What this PR does
**MCP tools (`packages/mcp-dkg/src`):**
- **Renamed the lifecycle tool family `dkg_assertion_*` → `dkg_knowledge_asset_*`** (incl. `promote` → `share`), **no aliases** — byte-for-byte matching PR 1's OpenClaw surface.
- **Added 3 tools** over the existing client methods: `dkg_knowledge_asset_finalize` (`/wm/finalize`), `dkg_knowledge_asset_publish` (`/vm/publish`, surfaces the UAL), `dkg_knowledge_asset_pull_from` (`/wm/pull-from`). `vm/publish` nests `options` via the same normalizer as OpenClaw and sends no author/selection; `finalize` surfaces `authorAgentAddress` (not raw `preSignedAuthorAttestation`), same as OpenClaw.
- **Parity contract fixes:** dropped the per-quad `graph` param from the write + `dkg_publish` tool schemas, and dropped the unread `finalize:true` (+ per-quad `graph`) from the one-shot publish body (`promote:true` kept). Matches PR 1 exactly.

**Docs:** `packages/mcp-dkg/README.md` — tool rows renamed + 3 new rows, tool count corrected to **30** (the stale "21" undercounted; enumerated 27 base — incl. the previously-missing `dkg_peer_info` + 2 chat tools — plus the 3 new), "finalize on-chain" round-trip wording disambiguated, UAL surfaced. `.cursor/rules/dkg-annotate.mdc` renamed (carried over from PR 1's QA sweep, since it's the MCP/Cursor runtime's reference).

### Tests
- mcp-dkg suite: **182 pass**. Hardened `harness.ts` to model the seal (`finalized` flag: finalize sets it, a **full** share auto-seals, a **subset** share does not); added the §5 crux test — **subset-share → `vm/publish` FAILS (not finalized); full-share or explicit finalize → publish SUCCEEDS + returns the UAL**; finalize/publish/pull_from dispatch tests; registration guard pins 13 lifecycle tools + asserts legacy names are gone.
- **2 pre-existing failures unrelated to this PR** and disregarded: `inject-inbox-hook.test.ts` + `inject-session-context-hook.test.ts` (`SyntaxError` — a host/vitest unicode-transform choke; both byte-identical to `main`, untouched by this PR).

### ⚠️ Breaking + merge coordination
- Tool family renamed with **no aliases** (same clean cut as PR 1).
- **#1075** (`test/mcp-daemon-contract-guardrails`, open) pins the OLD `dkg_assertion_*` names. Its integration suites are `describe.skipIf`-gated on `MCP_INTEGRATION_TEST` → **no unit-CI breakage** when both land, but: (a) file-level git conflicts on `setup-publish-health.test.ts` + `knowledge-assets-client.test.ts`, and (b) a live semantic conflict (those calls hit "tool not registered" after the rename). **Recommendation: merge this PR first, then rebase #1075 onto it swapping to `dkg_knowledge_asset_*` (+ `promote`→`share`).** Our names are what #1075 should expect post-rebase.

### Follow-ups (not this PR)
- Cosmetic internal `graph:''` residue on the write client wire (daemon re-pins; agent schema already forbids `graph`).
- `dkg_update` verb for the pull-from → edit → update loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
