### PR TITLE
fix(#1080): on-chain getMaxKaNumberForAuthor view + client wiring (no more unbounded eth_getLogs)

### DIFF
--- a/packages/chain/abi/DKGKnowledgeAssets.json
+++ b/packages/chain/abi/DKGKnowledgeAssets.json
@@ -1547,6 +1547,25 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      }
+    ],
+    "name": "getMaxKaNumberForAuthor",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -911,10 +911,11 @@ export interface ChainAdapter {
    * for `author`, or `-1n` if the author has never minted. Used by the allocator's
    * cold-start reconciliation (`nextNumber = max(local, chainMax) + 1`) so a
    * stale-local-DB / fresh device never re-hands a burned `(author, number)`.
-   * Derived by enumerating `KnowledgeAssetCreated(id, author, ...)` logs filtered
-   * by the indexed `author` topic and taking `max(id & ((1<<96)-1))`. Optional:
-   * adapters that cannot enumerate logs may omit it (the allocator then trusts
-   * its local store and relies on the contract's `_safeMint` revert as backstop).
+   * EVM adapters prefer the O(1) `DKGKnowledgeAssets.getMaxKaNumberForAuthor`
+   * view when available and may fall back to a bounded historical
+   * `KnowledgeAssetCreated` scan for older deployments. Optional: adapters that
+   * cannot reconcile chain state may omit it (the allocator then trusts its local
+   * store and relies on the contract's `_safeMint` revert as backstop).
    */
   getMaxKaNumberForAuthor?(author: string): Promise<bigint>;
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -81,6 +81,18 @@ function isKaHighWaterViewUnavailable(err: unknown): boolean {
     || msg.includes('missing revert data');
 }
 
+async function contractAddress(contract: Contract): Promise<string> {
+  const getAddress = (contract as any).getAddress;
+  if (typeof getAddress === 'function') {
+    return ethers.getAddress(await getAddress.call(contract));
+  }
+  const target = (contract as any).target;
+  if (typeof target === 'string') {
+    return ethers.getAddress(target);
+  }
+  throw new Error('DKGKnowledgeAssets address is unavailable from the resolved contract handle.');
+}
+
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
   get deploymentId(): string {
@@ -1214,7 +1226,10 @@ export class EVMChainAdapterBase {
    *      `queryFilter(filter, 0)` scanned `[0, latest]` in one RPC call and hit
    *      provider block-range caps (#1080); this legacy path uses small bounded
    *      windows instead. Transient RPC failures are rethrown, not hidden by a
-   *      historical crawl on the same provider.
+   *      historical crawl on the same provider. Empty selector-call responses
+   *      only reach the fallback after confirming bytecode exists at the
+   *      resolved storage address, so a bad Hub address fails loudly instead of
+   *      reconciling from empty logs.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
     const storage = this.contracts.knowledgeAssetStorage;
@@ -1233,6 +1248,12 @@ export class EVMChainAdapterBase {
           throw err;
         }
       }
+    }
+
+    const storageAddress = await contractAddress(storage);
+    const code = await this.provider.getCode(storageAddress);
+    if (!code || code === '0x') {
+      throw new Error(`DKGKnowledgeAssets resolved to ${storageAddress}, but no contract code is deployed there.`);
     }
 
     const filter = storage.filters.KnowledgeAssetCreated(null, normalized);

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1194,14 +1194,13 @@ export class EVMChainAdapterBase {
    * reconciliation so a stale-local-DB / fresh device never re-hands a burned
    * `(author, number)`.
    *
-   * Resolution order:
-   *   1. The O(1) on-chain view `getMaxKaNumberForAuthor(author)` returns int256
-   *      (`DKGKnowledgeAssets` >= 10.0.4) — a single `eth_call`, natively bounded.
-   *   2. Fallback for pre-10.0.4 deployments (view absent / reverts): enumerate
-   *      `KnowledgeAssetCreated(id, author)` logs, but PAGINATED in RPC-safe
-   *      windows. The previous single `queryFilter(filter, 0)` scanned
-   *      `[0, latest]` in one shot and overflowed the `eth_getLogs` block-range
-   *      cap on networks with deep history, aborting KA create (issue #1080).
+   * Strict O(1): reads the `getMaxKaNumberForAuthor(address) -> int256` view on
+   * `DKGKnowledgeAssets` (>= 10.0.4) — a single `eth_call`, natively bounded, no
+   * `eth_getLogs` scan (#1080). The off-chain allocator's next number is
+   * `result + 1` (so a never-minted author, `-1`, starts at 0). There is no
+   * log-scan fallback by design: V10 deploys the 10.0.4 contract fresh, so the
+   * view is authoritative from genesis; an absent selector is a misconfigured
+   * deployment and should fail loudly rather than silently crawl chain history.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
     const storage = this.contracts.knowledgeAssetStorage;
@@ -1209,43 +1208,8 @@ export class EVMChainAdapterBase {
       throw new Error('DKGKnowledgeAssets not deployed on this chain.');
     }
     const normalized = ethers.getAddress(author);
-
-    // 1) Preferred: the O(1) on-chain view (no log scan, no range limits).
-    if (typeof storage.getMaxKaNumberForAuthor === 'function') {
-      try {
-        const max = await storage.getMaxKaNumberForAuthor.staticCall(normalized);
-        return BigInt(max);
-      } catch (err) {
-        // Fall back to the bounded scan for contract-level call failures
-        // (e.g. a pre-10.0.4 deployment without the selector -> empty/
-        // undecodable return data). Rethrow clearly-transient RPC/network
-        // errors so a provider blip doesn't silently degrade into a full
-        // historical `KnowledgeAssetCreated` crawl on the same provider.
-        const code = (err as { code?: string } | null)?.code;
-        if (code === 'NETWORK_ERROR' || code === 'SERVER_ERROR' || code === 'TIMEOUT') {
-          throw err;
-        }
-      }
-    }
-
-    // 2) Fallback: paginated `KnowledgeAssetCreated` scan in RPC-safe windows.
-    const filter = storage.filters.KnowledgeAssetCreated(null, normalized);
-    const head = await this.provider.getBlockNumber();
-    const PAGE = 2_000; // <= the smallest common eth_getLogs block-range cap
-    const MASK = (1n << 96n) - 1n;
-    let max = -1n;
-    for (let lo = 0; lo <= head; lo += PAGE) {
-      const hi = Math.min(lo + PAGE - 1, head);
-      const logs = await storage.queryFilter(filter, lo, hi);
-      for (const log of logs) {
-        const args = (log as ethers.EventLog).args;
-        const rawId = args?.id ?? args?.[0];
-        if (rawId === undefined || rawId === null) continue;
-        const num = BigInt(rawId) & MASK;
-        if (num > max) max = num;
-      }
-    }
-    return max;
+    const max = await storage.getMaxKaNumberForAuthor.staticCall(normalized);
+    return BigInt(max);
   }
 
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -69,6 +69,18 @@ const BOUND_CONTRACT_INVALIDATORS = new Map<string, (adapter: EVMChainAdapterBas
   ['Chronos',                    (a) => { (a as any).contracts.chronos = undefined; }],
 ]);
 
+function isKaHighWaterViewUnavailable(err: unknown): boolean {
+  if (err instanceof Error) enrichEvmError(err);
+  const code = errorCode(err);
+  const msg = errorMessage(err).toLowerCase();
+
+  if (code === 'BAD_DATA') return true;
+  return msg.includes('could not decode result data')
+    || msg.includes('function selector')
+    || msg.includes('selector not recognized')
+    || msg.includes('missing revert data');
+}
+
 export class EVMChainAdapterBase {
   /** See `ChainAdapter.deploymentId`. */
   get deploymentId(): string {
@@ -1217,7 +1229,7 @@ export class EVMChainAdapterBase {
         const max = await getMax.staticCall(normalized);
         return BigInt(max);
       } catch (err) {
-        if (!this.isKaHighWaterViewUnavailable(err)) {
+        if (!isKaHighWaterViewUnavailable(err)) {
           throw err;
         }
       }
@@ -1240,18 +1252,6 @@ export class EVMChainAdapterBase {
       }
     }
     return max;
-  }
-
-  private isKaHighWaterViewUnavailable(err: unknown): boolean {
-    if (err instanceof Error) enrichEvmError(err);
-    const code = errorCode(err);
-    const msg = errorMessage(err).toLowerCase();
-
-    if (code === 'BAD_DATA') return true;
-    return msg.includes('could not decode result data')
-      || msg.includes('function selector')
-      || msg.includes('selector not recognized')
-      || msg.includes('missing revert data');
   }
 
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1215,9 +1215,16 @@ export class EVMChainAdapterBase {
       try {
         const max = await storage.getMaxKaNumberForAuthor.staticCall(normalized);
         return BigInt(max);
-      } catch {
-        // View absent on an older-deployed contract (selector mismatch) or a
-        // transient read error — fall through to the bounded log scan.
+      } catch (err) {
+        // Fall back to the bounded scan for contract-level call failures
+        // (e.g. a pre-10.0.4 deployment without the selector -> empty/
+        // undecodable return data). Rethrow clearly-transient RPC/network
+        // errors so a provider blip doesn't silently degrade into a full
+        // historical `KnowledgeAssetCreated` crawl on the same provider.
+        const code = (err as { code?: string } | null)?.code;
+        if (code === 'NETWORK_ERROR' || code === 'SERVER_ERROR' || code === 'TIMEOUT') {
+          throw err;
+        }
       }
     }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -20,7 +20,7 @@ import { HubResolutionCache } from './hub-resolution-cache.js';
 import { KeyedSerializer } from './keyed-mutex.js';
 import { floorPublishTokenAmount } from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
-import { errorMessage, isTooLowAllowanceError, enrichEvmError, HUB_STALE_ERROR_MARKERS } from './evm-adapter-errors.js';
+import { errorCode, errorMessage, isTooLowAllowanceError, enrichEvmError, HUB_STALE_ERROR_MARKERS } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isKnownTransactionError, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE } from './evm-adapter-allowance.js';
 import { formatProviderContext } from './evm-adapter-types.js';
@@ -1194,13 +1194,15 @@ export class EVMChainAdapterBase {
    * reconciliation so a stale-local-DB / fresh device never re-hands a burned
    * `(author, number)`.
    *
-   * Strict O(1): reads the `getMaxKaNumberForAuthor(address) -> int256` view on
-   * `DKGKnowledgeAssets` (>= 10.0.4) — a single `eth_call`, natively bounded, no
-   * `eth_getLogs` scan (#1080). The off-chain allocator's next number is
-   * `result + 1` (so a never-minted author, `-1`, starts at 0). There is no
-   * log-scan fallback by design: V10 deploys the 10.0.4 contract fresh, so the
-   * view is authoritative from genesis; an absent selector is a misconfigured
-   * deployment and should fail loudly rather than silently crawl chain history.
+   * Resolution order:
+   *   1. `DKGKnowledgeAssets >= 10.0.4` exposes the O(1)
+   *      `getMaxKaNumberForAuthor(address) -> int256` view — a single `eth_call`.
+   *   2. Pre-10.0.4 deployments do not have that selector, so they fall back to
+   *      a paginated `KnowledgeAssetCreated(id, author)` scan. The previous
+   *      `queryFilter(filter, 0)` scanned `[0, latest]` in one RPC call and hit
+   *      provider block-range caps (#1080); this legacy path uses small bounded
+   *      windows instead. Transient RPC failures are rethrown, not hidden by a
+   *      historical crawl on the same provider.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
     const storage = this.contracts.knowledgeAssetStorage;
@@ -1208,8 +1210,48 @@ export class EVMChainAdapterBase {
       throw new Error('DKGKnowledgeAssets not deployed on this chain.');
     }
     const normalized = ethers.getAddress(author);
-    const max = await storage.getMaxKaNumberForAuthor.staticCall(normalized);
-    return BigInt(max);
+
+    const getMax = (storage as any).getMaxKaNumberForAuthor;
+    if (typeof getMax?.staticCall === 'function') {
+      try {
+        const max = await getMax.staticCall(normalized);
+        return BigInt(max);
+      } catch (err) {
+        if (!this.isKaHighWaterViewUnavailable(err)) {
+          throw err;
+        }
+      }
+    }
+
+    const filter = storage.filters.KnowledgeAssetCreated(null, normalized);
+    const head = await this.provider.getBlockNumber();
+    const pageSize = 2_000; // <= the smallest common eth_getLogs block-range cap
+    const mask = (1n << 96n) - 1n;
+    let max = -1n;
+    for (let lo = 0; lo <= head; lo += pageSize) {
+      const hi = Math.min(lo + pageSize - 1, head);
+      const logs = await storage.queryFilter(filter, lo, hi);
+      for (const log of logs) {
+        const args = (log as ethers.EventLog).args;
+        const rawId = args?.id ?? args?.[0];
+        if (rawId === undefined || rawId === null) continue;
+        const num = BigInt(rawId) & mask;
+        if (num > max) max = num;
+      }
+    }
+    return max;
+  }
+
+  private isKaHighWaterViewUnavailable(err: unknown): boolean {
+    if (err instanceof Error) enrichEvmError(err);
+    const code = errorCode(err);
+    const msg = errorMessage(err).toLowerCase();
+
+    if (code === 'BAD_DATA') return true;
+    return msg.includes('could not decode result data')
+      || msg.includes('function selector')
+      || msg.includes('selector not recognized')
+      || msg.includes('missing revert data');
   }
 
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -74,11 +74,13 @@ function isKaHighWaterViewUnavailable(err: unknown): boolean {
   const code = errorCode(err);
   const msg = errorMessage(err).toLowerCase();
 
-  if (code === 'BAD_DATA') return true;
-  return msg.includes('could not decode result data')
-    || msg.includes('function selector')
-    || msg.includes('selector not recognized')
-    || msg.includes('missing revert data');
+  if (code === 'BAD_DATA') {
+    return msg.includes('could not decode result data')
+      && msg.includes('value="0x"')
+      && msg.includes('getmaxkanumberforauthor');
+  }
+  return msg.includes('function selector')
+    || msg.includes('selector not recognized');
 }
 
 async function contractAddress(contract: Contract): Promise<string> {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1190,10 +1190,18 @@ export class EVMChainAdapterBase {
 
   /**
    * OT-RFC-43 Option 1 — highest per-author KA `number` already minted on chain,
-   * or `-1n` if `author` never minted. Enumerates `KnowledgeAssetCreated(id,
-   * author, ...)` logs filtered by the indexed `author` topic and returns
-   * `max(id & ((1<<96)-1))`. Backs the allocator's cold-start reconciliation so
-   * a stale-local-DB / fresh device never re-hands a burned `(author, number)`.
+   * or `-1n` if `author` never minted. Backs the allocator's cold-start
+   * reconciliation so a stale-local-DB / fresh device never re-hands a burned
+   * `(author, number)`.
+   *
+   * Resolution order:
+   *   1. The O(1) on-chain view `getMaxKaNumberForAuthor(author)` returns int256
+   *      (`DKGKnowledgeAssets` >= 10.0.4) — a single `eth_call`, natively bounded.
+   *   2. Fallback for pre-10.0.4 deployments (view absent / reverts): enumerate
+   *      `KnowledgeAssetCreated(id, author)` logs, but PAGINATED in RPC-safe
+   *      windows. The previous single `queryFilter(filter, 0)` scanned
+   *      `[0, latest]` in one shot and overflowed the `eth_getLogs` block-range
+   *      cap on networks with deep history, aborting KA create (issue #1080).
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
     const storage = this.contracts.knowledgeAssetStorage;
@@ -1201,20 +1209,34 @@ export class EVMChainAdapterBase {
       throw new Error('DKGKnowledgeAssets not deployed on this chain.');
     }
     const normalized = ethers.getAddress(author);
-    // KnowledgeAssetCreated(uint256 indexed id, address indexed author, ...):
-    // filter by the second indexed topic (author). fromBlock 0 — devnets are
-    // cheap; a production fromBlock = deployment block is a future optimization
-    // (there is no per-author counter view on-chain under variant 1a).
+
+    // 1) Preferred: the O(1) on-chain view (no log scan, no range limits).
+    if (typeof storage.getMaxKaNumberForAuthor === 'function') {
+      try {
+        const max = await storage.getMaxKaNumberForAuthor.staticCall(normalized);
+        return BigInt(max);
+      } catch {
+        // View absent on an older-deployed contract (selector mismatch) or a
+        // transient read error — fall through to the bounded log scan.
+      }
+    }
+
+    // 2) Fallback: paginated `KnowledgeAssetCreated` scan in RPC-safe windows.
     const filter = storage.filters.KnowledgeAssetCreated(null, normalized);
-    const logs = await storage.queryFilter(filter, 0);
+    const head = await this.provider.getBlockNumber();
+    const PAGE = 2_000; // <= the smallest common eth_getLogs block-range cap
     const MASK = (1n << 96n) - 1n;
     let max = -1n;
-    for (const log of logs) {
-      const args = (log as ethers.EventLog).args;
-      const rawId = args?.id ?? args?.[0];
-      if (rawId === undefined || rawId === null) continue;
-      const num = BigInt(rawId) & MASK;
-      if (num > max) max = num;
+    for (let lo = 0; lo <= head; lo += PAGE) {
+      const hi = Math.min(lo + PAGE - 1, head);
+      const logs = await storage.queryFilter(filter, lo, hi);
+      for (const log of logs) {
+        const args = (log as ethers.EventLog).args;
+        const rawId = args?.id ?? args?.[0];
+        if (rawId === undefined || rawId === null) continue;
+        const num = BigInt(rawId) & MASK;
+        if (num > max) max = num;
+      }
     }
     return max;
   }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1234,6 +1234,13 @@ export class EVMChainAdapterBase {
    *      reconciling from empty logs.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
+    // Re-resolve contract handles first. The Hub-rotation listener flips
+    // `initialized` to false but leaves the old bindings in place, so without
+    // this a long-lived adapter keeps querying the PRE-rotation
+    // DKGKnowledgeAssets after the 10.0.4 redeploy this getter exists for.
+    // Mirrors every other contract-reading method (e.g.
+    // getKnowledgeAssetsLifecycleAddress).
+    await this.init();
     const storage = this.contracts.knowledgeAssetStorage;
     if (!storage) {
       throw new Error('DKGKnowledgeAssets not deployed on this chain.');

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1159,7 +1159,7 @@ export class MockChainAdapter implements ChainAdapter {
    * OT-RFC-43 Option 1 — highest per-author KA number minted in this mock, or
    * -1n if none. Scans the in-memory collections (keyed by kaId; reservedKaId
    * publishes store the packed id) and returns `max(kaId & ((1<<96)-1))` for
-   * the author. Mirrors the EVM adapter's KnowledgeAssetCreated-by-author scan.
+   * the author. Mirrors the EVM adapter's reconciled chain high-water semantics.
    */
   async getMaxKaNumberForAuthor(author: string): Promise<bigint> {
     const target = author.toLowerCase();

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -148,7 +148,12 @@ const PINNED_DIGESTS: Record<string, string> = {
   // caller-supplied `uint256 kaId` (the packed author-namespaced id), and two
   // guard errors were added — `KaIdAlreadyMinted(uint256)` and
   // `KaIdNamespaceMismatch(uint256,address)` — plus a deprecated accessor.
-  DKGKnowledgeAssets:           'da5e46f24dd410b30c90bad66060b9da240aa4b0426c24a1550b0e1b6168b5ea',
+  // Re-pinned again (#1080): added the O(1) `getMaxKaNumberForAuthor(address)
+  // -> int256` view so the off-chain allocator reconciles its floor with one
+  // eth_call instead of an unbounded `KnowledgeAssetCreated` log scan. Pure
+  // function-only ABI addition (events + errors unchanged); the chain-local
+  // copy is refreshed in lockstep with the evm-module ABI in the same PR.
+  DKGKnowledgeAssets:           '60d8dc58619c25fd31df1da34d4944369edbc2d5d4031dcb14f6965152c718a9',
   // V8 `KnowledgeCollection` ABI was moved to `abi/archive/` in
   // `archive-non-v10-contracts`; the pin entry is intentionally dropped.
   // Updated for SPEC_CG_MEMORY_MODEL: per-CG hosting committees and

--- a/packages/chain/test/getmaxka-view-e2e.test.ts
+++ b/packages/chain/test/getmaxka-view-e2e.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ethers } from 'ethers';
+import { EVMChainAdapter } from '../src/evm-adapter.js';
+import {
+  spawnHardhatEnv,
+  killHardhat,
+  makeAdapterConfig,
+  HARDHAT_KEYS,
+  type HardhatContext,
+} from './hardhat-harness.js';
+
+let ctx: HardhatContext;
+
+describe('EVMChainAdapter.getMaxKaNumberForAuthor — on-chain view E2E (#1080)', () => {
+  beforeAll(async () => {
+    ctx = await spawnHardhatEnv(8568);
+  }, 180_000);
+  afterAll(() => killHardhat(ctx));
+
+  it('reads the per-author high-water from the deployed int256 view over real RPC', async () => {
+    const adapter = new EVMChainAdapter(
+      makeAdapterConfig(ctx.rpcUrl, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER),
+    );
+    await (adapter as any).init();
+
+    const deployer = new ethers.Wallet(HARDHAT_KEYS.DEPLOYER).address;
+    const author = ethers.getAddress('0x2222222222222222222222222222222222222222');
+    const freshAuthor = ethers.getAddress('0x3333333333333333333333333333333333333333');
+
+    // Never-minted authors -> the int256 view returns -1n over RPC.
+    expect(await adapter.getMaxKaNumberForAuthor(author)).toBe(-1n);
+    expect(await adapter.getMaxKaNumberForAuthor(freshAuthor)).toBe(-1n);
+
+    // Mint a KA (number 4) for `author` via createKnowledgeAsset (onlyContracts):
+    // register the deployer as a Hub contract, then call it as that contract.
+    // Use the adapter's own contract instances (already signer-connected).
+    const hub = (adapter as any).contracts.hub;
+    const ka = (adapter as any).contracts.knowledgeAssetStorage;
+    await (await hub.setContractAddress('TestE2EKaOp', deployer)).wait();
+    const kaId = (BigInt(author) << 96n) | 4n;
+    await (
+      await ka.createKnowledgeAsset(
+        deployer, // publisher
+        author,
+        kaId,
+        'e2e-op',
+        ethers.keccak256(ethers.toUtf8Bytes('e2e-root')),
+        1, 1000, 1, 2, 0, false, 1,
+      )
+    ).wait();
+
+    // The real adapter now reads 4 from the on-chain view (single eth_call).
+    expect(await adapter.getMaxKaNumberForAuthor(author)).toBe(4n);
+    // Other authors stay at the sentinel.
+    expect(await adapter.getMaxKaNumberForAuthor(freshAuthor)).toBe(-1n);
+  }, 120_000);
+});

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -1,12 +1,11 @@
 /**
  * `EVMChainAdapter.getMaxKaNumberForAuthor` — OT-RFC-43 Option 1 / issue #1080.
  *
- * Verifies the wiring of the on-chain getter:
- *   1. Prefers the O(1) `getMaxKaNumberForAuthor(address) -> int256` view (a
- *      single eth_call) and does NOT scan logs.
- *   2. Falls back to a PAGINATED, RPC-safe (<= 2000-block window) log scan when
- *      the view is absent (older contract) or reverts — never the old single
- *      unbounded `queryFilter(filter, 0)` that overflowed the eth_getLogs cap.
+ * Strict O(1): the adapter reads the `getMaxKaNumberForAuthor(address) -> int256`
+ * view on DKGKnowledgeAssets (a single eth_call). There is NO log-scan fallback
+ * by design — V10 deploys the 10.0.4 contract fresh, so the view is authoritative
+ * from genesis; an absent selector / read error must fail loudly, not crawl chain
+ * history.
  *
  * Private state is injected via `as any`, the same convention the rest of the
  * chain unit tests use.
@@ -30,7 +29,6 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
 }
 
 const AUTHOR = ethers.getAddress('0x1111111111111111111111111111111111111111');
-const pack = (n: bigint) => (BigInt(AUTHOR) << 96n) | n; // packed kaId for AUTHOR
 
 /** A ContractMethod-shaped mock: a function carrying a `.staticCall`. */
 function viewMock(impl: () => Promise<bigint>) {
@@ -39,102 +37,35 @@ function viewMock(impl: () => Promise<bigint>) {
   return fn;
 }
 
-function makeAdapter(storage: any, head = 0) {
+function makeAdapter(storage: any) {
   const a = new EVMChainAdapter(minimalConfig());
   (a as any).contracts = { knowledgeAssetStorage: storage };
-  (a as any).provider = { getBlockNumber: vi.fn(async () => head) };
   return a;
 }
 
-describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#1080)', () => {
-  it('uses the O(1) on-chain view and never scans logs', async () => {
-    const queryFilter = vi.fn();
-    const storage = {
-      getMaxKaNumberForAuthor: viewMock(async () => 5n),
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter,
-    };
-    const a = makeAdapter(storage, 9_999_999);
-
-    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(5n);
+describe('EVMChainAdapter.getMaxKaNumberForAuthor — strict O(1) on-chain view (#1080)', () => {
+  it('returns the high-water number from the int256 view (single eth_call)', async () => {
+    const storage = { getMaxKaNumberForAuthor: viewMock(async () => 5n) };
+    expect(await makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR)).toBe(5n);
     expect(storage.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledTimes(1);
-    expect(queryFilter).not.toHaveBeenCalled();
-    // the scan path (and its head lookup) must not run when the view answers
-    expect((a as any).provider.getBlockNumber).not.toHaveBeenCalled();
+    expect(storage.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledWith(AUTHOR);
   });
 
-  it('returns -1n from the view for a never-minted author', async () => {
-    const storage = {
-      getMaxKaNumberForAuthor: viewMock(async () => -1n),
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter: vi.fn(),
-    };
+  it('returns -1n for a never-minted author (allocator next number = 0)', async () => {
+    const storage = { getMaxKaNumberForAuthor: viewMock(async () => -1n) };
     expect(await makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
   });
 
-  it('falls back to a PAGINATED, bounded scan when the view is absent', async () => {
-    const head = 5_000;
-    const queryFilter = vi.fn(async (_f: unknown, lo: number, hi: number) =>
-      lo <= 2500 && 2500 <= hi ? [{ args: { id: pack(7n) } }] : [],
-    );
-    const storage = {
-      // no getMaxKaNumberForAuthor → emulates a pre-10.0.4 deployment
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter,
-    };
-    const a = makeAdapter(storage, head);
-
-    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(7n);
-    expect(queryFilter).toHaveBeenCalled();
-    // every call is a bounded window <= 2000 blocks — never a single [0, latest]
-    for (const [, lo, hi] of queryFilter.mock.calls as unknown as [unknown, number, number][]) {
-      expect(typeof lo).toBe('number');
-      expect(typeof hi).toBe('number');
-      expect(hi - lo + 1).toBeLessThanOrEqual(2000);
-    }
-    // head=5000 @ 2000/window => [0,1999] [2000,3999] [4000,5000]
-    expect(queryFilter).toHaveBeenCalledTimes(3);
-  });
-
-  it('falls back to the bounded scan when the view reverts', async () => {
-    const view = viewMock(async () => {
-      throw new Error('execution reverted: function selector not recognized');
-    });
-    const queryFilter = vi.fn(async () => [{ args: { id: pack(3n) } }]);
-    const storage = {
-      getMaxKaNumberForAuthor: view,
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter,
-    };
-    const a = makeAdapter(storage, 1_500);
-
-    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(3n);
-    expect(view.staticCall).toHaveBeenCalledTimes(1);
-    expect(queryFilter).toHaveBeenCalled();
-  });
-
-  it('returns -1n when neither the view nor any log yields a number', async () => {
-    const storage = {
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter: vi.fn(async () => []),
-    };
-    expect(await makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
-  });
-
-  it('rethrows a transient RPC error from the view instead of crawling logs', async () => {
-    const transient: any = new Error('rate limited');
-    transient.code = 'SERVER_ERROR';
-    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
+  it('propagates a view error — no silent fallback / log crawl', async () => {
+    const err: any = new Error('rate limited');
+    err.code = 'SERVER_ERROR';
     const storage = {
       getMaxKaNumberForAuthor: viewMock(async () => {
-        throw transient;
+        throw err;
       }),
-      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
-      queryFilter,
     };
-    const a = makeAdapter(storage, 100);
-    await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow('rate limited');
-    // A transient error must NOT degrade into a historical log crawl.
-    expect(queryFilter).not.toHaveBeenCalled();
+    await expect(
+      makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR),
+    ).rejects.toThrow('rate limited');
   });
 });

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -120,4 +120,21 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     };
     expect(await makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
   });
+
+  it('rethrows a transient RPC error from the view instead of crawling logs', async () => {
+    const transient: any = new Error('rate limited');
+    transient.code = 'SERVER_ERROR';
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => {
+        throw transient;
+      }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, 100);
+    await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow('rate limited');
+    // A transient error must NOT degrade into a historical log crawl.
+    expect(queryFilter).not.toHaveBeenCalled();
+  });
 });

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -44,8 +44,12 @@ function viewMock(impl: () => Promise<bigint>) {
 
 function makeAdapter(storage: any, head = 0) {
   const a = new EVMChainAdapter(minimalConfig());
+  storage.target ??= '0x2222222222222222222222222222222222222222';
   (a as any).contracts = { knowledgeAssetStorage: storage };
-  (a as any).provider = { getBlockNumber: vi.fn(async () => head) };
+  (a as any).provider = {
+    getBlockNumber: vi.fn(async () => head),
+    getCode: vi.fn(async () => '0x6000'),
+  };
   return a;
 }
 
@@ -117,6 +121,29 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     expect(await makeAdapter(storage, 1_500).getMaxKaNumberForAuthor(AUTHOR)).toBe(3n);
     expect(view.staticCall).toHaveBeenCalledTimes(1);
     expect(queryFilter).toHaveBeenCalledWith('F', 0, 1500);
+  });
+
+  it('fails loudly instead of scanning empty logs when the resolved storage address has no code', async () => {
+    const badData: any = new Error('could not decode result data');
+    badData.code = 'BAD_DATA';
+    const queryFilter = vi.fn(async () => []);
+    const storage = {
+      target: '0x3333333333333333333333333333333333333333',
+      getMaxKaNumberForAuthor: viewMock(async () => {
+        throw badData;
+      }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, 100);
+    (a as any).provider.getCode.mockResolvedValueOnce('0x');
+
+    await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow(
+      'no contract code is deployed there',
+    );
+    expect((a as any).provider.getCode).toHaveBeenCalledWith(storage.target);
+    expect(queryFilter).not.toHaveBeenCalled();
+    expect((a as any).provider.getBlockNumber).not.toHaveBeenCalled();
   });
 
   it('returns -1n when neither the view nor legacy logs yields a number', async () => {

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -1,11 +1,15 @@
 /**
  * `EVMChainAdapter.getMaxKaNumberForAuthor` — OT-RFC-43 Option 1 / issue #1080.
  *
- * Strict O(1): the adapter reads the `getMaxKaNumberForAuthor(address) -> int256`
- * view on DKGKnowledgeAssets (a single eth_call). There is NO log-scan fallback
- * by design — V10 deploys the 10.0.4 contract fresh, so the view is authoritative
- * from genesis; an absent selector / read error must fail loudly, not crawl chain
- * history.
+ * Verifies the wiring of the on-chain getter:
+ *   1. Prefers the O(1) `getMaxKaNumberForAuthor(address) -> int256` view (a
+ *      single eth_call) and does NOT scan logs when the view answers.
+ *   2. Falls back to a PAGINATED, RPC-safe (<= 2000-block window) log scan when
+ *      the view is absent or the selector call cannot be decoded on older
+ *      deployments. The fallback must never use the old unbounded
+ *      `queryFilter(filter, 0)` shape that overflowed provider eth_getLogs caps.
+ *   3. Propagates transient RPC failures instead of hiding them behind a
+ *      historical crawl on the same provider.
  *
  * Private state is injected via `as any`, the same convention the rest of the
  * chain unit tests use.
@@ -29,6 +33,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
 }
 
 const AUTHOR = ethers.getAddress('0x1111111111111111111111111111111111111111');
+const pack = (n: bigint) => (BigInt(AUTHOR) << 96n) | n; // packed kaId for AUTHOR
 
 /** A ContractMethod-shaped mock: a function carrying a `.staticCall`. */
 function viewMock(impl: () => Promise<bigint>) {
@@ -37,35 +42,122 @@ function viewMock(impl: () => Promise<bigint>) {
   return fn;
 }
 
-function makeAdapter(storage: any) {
+function makeAdapter(storage: any, head = 0) {
   const a = new EVMChainAdapter(minimalConfig());
   (a as any).contracts = { knowledgeAssetStorage: storage };
+  (a as any).provider = { getBlockNumber: vi.fn(async () => head) };
   return a;
 }
 
-describe('EVMChainAdapter.getMaxKaNumberForAuthor — strict O(1) on-chain view (#1080)', () => {
-  it('returns the high-water number from the int256 view (single eth_call)', async () => {
-    const storage = { getMaxKaNumberForAuthor: viewMock(async () => 5n) };
-    expect(await makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR)).toBe(5n);
+describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#1080)', () => {
+  it('uses the O(1) on-chain view and never scans logs when the view answers', async () => {
+    const queryFilter = vi.fn();
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => 5n),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, 9_999_999);
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(5n);
     expect(storage.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledTimes(1);
     expect(storage.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledWith(AUTHOR);
+    expect(queryFilter).not.toHaveBeenCalled();
+    expect((a as any).provider.getBlockNumber).not.toHaveBeenCalled();
   });
 
   it('returns -1n for a never-minted author (allocator next number = 0)', async () => {
-    const storage = { getMaxKaNumberForAuthor: viewMock(async () => -1n) };
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => -1n),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter: vi.fn(),
+    };
     expect(await makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
+    expect(storage.queryFilter).not.toHaveBeenCalled();
   });
 
-  it('propagates a view error — no silent fallback / log crawl', async () => {
+  it('falls back to a paginated bounded scan when the view is absent', async () => {
+    const head = 5_000;
+    const queryFilter = vi.fn(async (_f: unknown, lo: number, hi: number) =>
+      lo <= 2500 && 2500 <= hi ? [{ args: { id: pack(7n) } }] : [],
+    );
+    const storage = {
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, head);
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(7n);
+    expect(queryFilter).toHaveBeenCalledTimes(3);
+    for (const [, lo, hi] of queryFilter.mock.calls as unknown as [unknown, number, number][]) {
+      expect(typeof lo).toBe('number');
+      expect(typeof hi).toBe('number');
+      expect(hi - lo + 1).toBeLessThanOrEqual(2000);
+    }
+    expect(queryFilter.mock.calls).toEqual([
+      ['F', 0, 1999],
+      ['F', 2000, 3999],
+      ['F', 4000, 5000],
+    ]);
+  });
+
+  it('falls back to the bounded scan when an older deployment cannot decode the view result', async () => {
+    const badData: any = new Error('could not decode result data');
+    badData.code = 'BAD_DATA';
+    const view = viewMock(async () => {
+      throw badData;
+    });
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(3n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: view,
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+
+    expect(await makeAdapter(storage, 1_500).getMaxKaNumberForAuthor(AUTHOR)).toBe(3n);
+    expect(view.staticCall).toHaveBeenCalledTimes(1);
+    expect(queryFilter).toHaveBeenCalledWith('F', 0, 1500);
+  });
+
+  it('returns -1n when neither the view nor legacy logs yields a number', async () => {
+    const storage = {
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter: vi.fn(async () => []),
+    };
+    expect(await makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
+  });
+
+  it('rethrows a transient RPC error from the view instead of crawling logs', async () => {
     const err: any = new Error('rate limited');
     err.code = 'SERVER_ERROR';
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
     const storage = {
       getMaxKaNumberForAuthor: viewMock(async () => {
         throw err;
       }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
     };
     await expect(
-      makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR),
+      makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
     ).rejects.toThrow('rate limited');
+    expect(queryFilter).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-selector CALL_EXCEPTION errors instead of treating them as absent view', async () => {
+    const err: any = new Error('execution reverted: Paused');
+    err.code = 'CALL_EXCEPTION';
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => {
+        throw err;
+      }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    await expect(
+      makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
+    ).rejects.toThrow('Paused');
+    expect(queryFilter).not.toHaveBeenCalled();
   });
 });

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -34,6 +34,7 @@ function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterCon
 
 const AUTHOR = ethers.getAddress('0x1111111111111111111111111111111111111111');
 const pack = (n: bigint) => (BigInt(AUTHOR) << 96n) | n; // packed kaId for AUTHOR
+const EMPTY_VIEW_RESULT = 'could not decode result data (value="0x", info={ method: "getMaxKaNumberForAuthor", signature: "getMaxKaNumberForAuthor(address)" }, code=BAD_DATA, version=6.16.0)';
 
 /** A ContractMethod-shaped mock: a function carrying a `.staticCall`. */
 function viewMock(impl: () => Promise<bigint>) {
@@ -106,7 +107,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
   });
 
   it('falls back to the bounded scan when an older deployment cannot decode the view result', async () => {
-    const badData: any = new Error('could not decode result data');
+    const badData: any = new Error(EMPTY_VIEW_RESULT);
     badData.code = 'BAD_DATA';
     const view = viewMock(async () => {
       throw badData;
@@ -124,7 +125,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
   });
 
   it('fails loudly instead of scanning empty logs when the resolved storage address has no code', async () => {
-    const badData: any = new Error('could not decode result data');
+    const badData: any = new Error(EMPTY_VIEW_RESULT);
     badData.code = 'BAD_DATA';
     const queryFilter = vi.fn(async () => []);
     const storage = {
@@ -185,6 +186,42 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     await expect(
       makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
     ).rejects.toThrow('Paused');
+    expect(queryFilter).not.toHaveBeenCalled();
+  });
+
+  it('rethrows malformed BAD_DATA instead of treating every decode failure as an absent view', async () => {
+    const err: any = new Error(
+      'could not decode result data (value="0x1234", info={ method: "getMaxKaNumberForAuthor", signature: "getMaxKaNumberForAuthor(address)" }, code=BAD_DATA, version=6.16.0)',
+    );
+    err.code = 'BAD_DATA';
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => {
+        throw err;
+      }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    await expect(
+      makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
+    ).rejects.toThrow('0x1234');
+    expect(queryFilter).not.toHaveBeenCalled();
+  });
+
+  it('rethrows generic missing-revert-data errors instead of hiding call failures behind a scan', async () => {
+    const err: any = new Error('missing revert data');
+    err.code = 'CALL_EXCEPTION';
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(9n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => {
+        throw err;
+      }),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    await expect(
+      makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
+    ).rejects.toThrow('missing revert data');
     expect(queryFilter).not.toHaveBeenCalled();
   });
 });

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `EVMChainAdapter.getMaxKaNumberForAuthor` — OT-RFC-43 Option 1 / issue #1080.
+ *
+ * Verifies the wiring of the on-chain getter:
+ *   1. Prefers the O(1) `getMaxKaNumberForAuthor(address) -> int256` view (a
+ *      single eth_call) and does NOT scan logs.
+ *   2. Falls back to a PAGINATED, RPC-safe (<= 2000-block window) log scan when
+ *      the view is absent (older contract) or reverts — never the old single
+ *      unbounded `queryFilter(filter, 0)` that overflowed the eth_getLogs cap.
+ *
+ * Private state is injected via `as any`, the same convention the rest of the
+ * chain unit tests use.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ethers } from 'ethers';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    ...overrides,
+  };
+}
+
+const AUTHOR = ethers.getAddress('0x1111111111111111111111111111111111111111');
+const pack = (n: bigint) => (BigInt(AUTHOR) << 96n) | n; // packed kaId for AUTHOR
+
+/** A ContractMethod-shaped mock: a function carrying a `.staticCall`. */
+function viewMock(impl: () => Promise<bigint>) {
+  const fn: any = vi.fn();
+  fn.staticCall = vi.fn(impl);
+  return fn;
+}
+
+function makeAdapter(storage: any, head = 0) {
+  const a = new EVMChainAdapter(minimalConfig());
+  (a as any).contracts = { knowledgeAssetStorage: storage };
+  (a as any).provider = { getBlockNumber: vi.fn(async () => head) };
+  return a;
+}
+
+describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#1080)', () => {
+  it('uses the O(1) on-chain view and never scans logs', async () => {
+    const queryFilter = vi.fn();
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => 5n),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, 9_999_999);
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(5n);
+    expect(storage.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledTimes(1);
+    expect(queryFilter).not.toHaveBeenCalled();
+    // the scan path (and its head lookup) must not run when the view answers
+    expect((a as any).provider.getBlockNumber).not.toHaveBeenCalled();
+  });
+
+  it('returns -1n from the view for a never-minted author', async () => {
+    const storage = {
+      getMaxKaNumberForAuthor: viewMock(async () => -1n),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter: vi.fn(),
+    };
+    expect(await makeAdapter(storage).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
+  });
+
+  it('falls back to a PAGINATED, bounded scan when the view is absent', async () => {
+    const head = 5_000;
+    const queryFilter = vi.fn(async (_f: unknown, lo: number, hi: number) =>
+      lo <= 2500 && 2500 <= hi ? [{ args: { id: pack(7n) } }] : [],
+    );
+    const storage = {
+      // no getMaxKaNumberForAuthor → emulates a pre-10.0.4 deployment
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, head);
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(7n);
+    expect(queryFilter).toHaveBeenCalled();
+    // every call is a bounded window <= 2000 blocks — never a single [0, latest]
+    for (const [, lo, hi] of queryFilter.mock.calls as unknown as [unknown, number, number][]) {
+      expect(typeof lo).toBe('number');
+      expect(typeof hi).toBe('number');
+      expect(hi - lo + 1).toBeLessThanOrEqual(2000);
+    }
+    // head=5000 @ 2000/window => [0,1999] [2000,3999] [4000,5000]
+    expect(queryFilter).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to the bounded scan when the view reverts', async () => {
+    const view = viewMock(async () => {
+      throw new Error('execution reverted: function selector not recognized');
+    });
+    const queryFilter = vi.fn(async () => [{ args: { id: pack(3n) } }]);
+    const storage = {
+      getMaxKaNumberForAuthor: view,
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter,
+    };
+    const a = makeAdapter(storage, 1_500);
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(3n);
+    expect(view.staticCall).toHaveBeenCalledTimes(1);
+    expect(queryFilter).toHaveBeenCalled();
+  });
+
+  it('returns -1n when neither the view nor any log yields a number', async () => {
+    const storage = {
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter: vi.fn(async () => []),
+    };
+    expect(await makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
+  });
+});

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -47,6 +47,11 @@ function makeAdapter(storage: any, head = 0) {
   const a = new EVMChainAdapter(minimalConfig());
   storage.target ??= '0x2222222222222222222222222222222222222222';
   (a as any).contracts = { knowledgeAssetStorage: storage };
+  // getMaxKaNumberForAuthor now `await this.init()`s first (re-resolve handles
+  // on Hub rotation). Mark initialized so init() short-circuits and the injected
+  // mock handle is used; the post-rotation test below exercises the
+  // initialized=false re-resolution path explicitly.
+  (a as any).initialized = true;
   (a as any).provider = {
     getBlockNumber: vi.fn(async () => head),
     getCode: vi.fn(async () => '0x6000'),
@@ -187,6 +192,40 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
       makeAdapter(storage, 100).getMaxKaNumberForAuthor(AUTHOR),
     ).rejects.toThrow('Paused');
     expect(queryFilter).not.toHaveBeenCalled();
+  });
+
+  it('re-resolves the DKGKnowledgeAssets handle after a Hub rotation rather than querying the stale pre-rotation contract (#1082 review)', async () => {
+    // Long-lived adapter after the 10.0.4 redeploy: the rotation listener has
+    // set `initialized = false` but the cached binding still points at the OLD
+    // contract. The getter must `await this.init()` to re-resolve before
+    // reading, or it answers from the pre-rotation DKGKnowledgeAssets.
+    const mkStorage = (n: bigint) => ({
+      getMaxKaNumberForAuthor: viewMock(async () => n),
+      filters: { KnowledgeAssetCreated: vi.fn(() => 'F') },
+      queryFilter: vi.fn(),
+      target: '0x2222222222222222222222222222222222222222',
+    });
+    const stale = mkStorage(99n);
+    const fresh = mkStorage(7n);
+
+    const a = new EVMChainAdapter(minimalConfig());
+    (a as any).contracts = { knowledgeAssetStorage: stale };
+    (a as any).initialized = false; // post-rotation: handles need re-resolving
+    (a as any).provider = {
+      getBlockNumber: vi.fn(async () => 0),
+      getCode: vi.fn(async () => '0x6000'),
+    };
+    // What the real init() does on a re-init: swap in the fresh binding.
+    const init = vi.fn(async () => {
+      (a as any).contracts.knowledgeAssetStorage = fresh;
+      (a as any).initialized = true;
+    });
+    (a as any).init = init;
+
+    expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(7n); // FRESH, not stale 99n
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(fresh.getMaxKaNumberForAuthor.staticCall).toHaveBeenCalledTimes(1);
+    expect(stale.getMaxKaNumberForAuthor.staticCall).not.toHaveBeenCalled();
   });
 
   it('rethrows malformed BAD_DATA instead of treating every decode failure as an absent view', async () => {

--- a/packages/evm-module/abi/DKGKnowledgeAssets.json
+++ b/packages/evm-module/abi/DKGKnowledgeAssets.json
@@ -1547,6 +1547,25 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
+      }
+    ],
+    "name": "getMaxKaNumberForAuthor",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -326,6 +326,22 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     ///         `-1`) correctly starts at number 0. Returns `int256` so "never minted"
     ///         is a true sentinel rather than colliding with a legitimately-minted
     ///         number 0.
+    ///
+    ///         PRECONDITION — not backfilled across an in-place storage upgrade.
+    ///         `_authorKaNumberHighWater` is only populated by `createKnowledgeAsset`
+    ///         from this version (10.0.4) onward. On a fresh deploy or redeploy — the
+    ///         expected path, where every KA is minted under this contract — it is
+    ///         authoritative for ALL of an author's KAs. But if this storage is
+    ///         upgraded IN PLACE over a pre-10.0.4 deployment that already minted KAs,
+    ///         those historical authors read `-1` until their next mint. Callers MUST
+    ///         therefore treat this as a fast-path floor, NOT the sole allocation
+    ///         source, across such an upgrade: the off-chain allocator retains its own
+    ///         persisted counter plus a bounded `KnowledgeAssetCreated` scan as the
+    ///         reconciliation floor, and `createKnowledgeAsset`'s `KaIdAlreadyMinted`
+    ///         guard is the on-chain backstop against reusing a burned `(author,
+    ///         number)`.
+    /// @param  author The attested author address (the high 160 bits of a packed kaId).
+    /// @return The highest KA `number` already minted under `author`, or `-1` if none.
     function getMaxKaNumberForAuthor(address author) external view returns (int256) {
         uint256 highWater = _authorKaNumberHighWater[author];
         return highWater == 0 ? int256(-1) : int256(highWater) - 1;

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -84,7 +84,7 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     error GetLatestKnowledgeAssetIdDeprecated();
 
     string private constant _NAME = "DKGKnowledgeAssets";
-    string private constant _VERSION = "10.0.3";
+    string private constant _VERSION = "10.0.4";
 
     string private _tokenURI;
 
@@ -176,6 +176,17 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     /// distinct and a curated KC must not collide its random-sampling
     /// granularity with its public-projection leaf count.
     mapping(uint256 => uint32) public ciphertextChunkCounts;
+
+    /// @notice OT-RFC-43 Option 1 (variant 1a): per-author high-water KA `number`
+    ///         (the low 96 bits of the packed kaId), stored as `maxNumber + 1` so
+    ///         the default `0` unambiguously means "this author has never minted".
+    ///         Lets the off-chain allocator reconcile its cold-start floor with a
+    ///         single O(1) `getMaxKaNumberForAuthor` view instead of an unbounded
+    ///         `KnowledgeAssetCreated` log scan (which overflows the `eth_getLogs`
+    ///         block-range cap on networks with deep history). Appended at the END
+    ///         of storage to preserve the slot layout of every field above (see the
+    ///         layout note on `_deprecatedKnowledgeAssetsCounter`).
+    mapping(address => uint256) private _authorKaNumberHighWater;
 
     constructor(
         address hubAddress,
@@ -277,6 +288,18 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
 
         kc.minted = 1;
         _totalMintedKnowledgeAssetsCounter += 1;
+
+        // OT-RFC-43 Option 1: record the per-author high-water `number` BEFORE the
+        // `_safeMint` interaction (checks-effects-interactions — `_safeMint` calls
+        // `onERC721Received` on a contract recipient). Stored as `number + 1` so the
+        // default 0 means "never minted"; only ever raised, never lowered, so a
+        // gap-filling mint of a lower number can never regress the floor. Backs the
+        // O(1) `getMaxKaNumberForAuthor` allocator reconcile.
+        uint256 mintedNumber = uint96(knowledgeAssetId); // low 96 bits = per-author number
+        if (mintedNumber + 1 > _authorKaNumberHighWater[author]) {
+            _authorKaNumberHighWater[author] = mintedNumber + 1;
+        }
+
         _safeMint(author, knowledgeAssetId);
 
         emit KnowledgeAssetCreated(
@@ -292,6 +315,20 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
         );
 
         return knowledgeAssetId;
+    }
+
+    /// @notice OT-RFC-43 Option 1 (variant 1a): the highest KA `number` already
+    ///         minted under `author` (the low 96 bits of its packed kaId), or `-1`
+    ///         if `author` has never minted a KA.
+    /// @dev    O(1) replacement for enumerating `KnowledgeAssetCreated(id, author)`
+    ///         logs. The off-chain allocator's next number for `author` is
+    ///         `getMaxKaNumberForAuthor(author) + 1`, so a brand-new author (result
+    ///         `-1`) correctly starts at number 0. Returns `int256` so "never minted"
+    ///         is a true sentinel rather than colliding with a legitimately-minted
+    ///         number 0.
+    function getMaxKaNumberForAuthor(address author) external view returns (int256) {
+        uint256 highWater = _authorKaNumberHighWater[author];
+        return highWater == 0 ? int256(-1) : int256(highWater) - 1;
     }
 
     function getKnowledgeAsset(

--- a/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
+++ b/packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol
@@ -333,13 +333,11 @@ contract DKGKnowledgeAssets is INamed, IVersioned, HubDependent, ERC721, Guardia
     ///         expected path, where every KA is minted under this contract — it is
     ///         authoritative for ALL of an author's KAs. But if this storage is
     ///         upgraded IN PLACE over a pre-10.0.4 deployment that already minted KAs,
-    ///         those historical authors read `-1` until their next mint. Callers MUST
-    ///         therefore treat this as a fast-path floor, NOT the sole allocation
-    ///         source, across such an upgrade: the off-chain allocator retains its own
-    ///         persisted counter plus a bounded `KnowledgeAssetCreated` scan as the
-    ///         reconciliation floor, and `createKnowledgeAsset`'s `KaIdAlreadyMinted`
-    ///         guard is the on-chain backstop against reusing a burned `(author,
-    ///         number)`.
+    ///         those historical authors read `-1` until their next mint. Such an
+    ///         in-place upgrade is not supported unless the mapping is backfilled or
+    ///         the allocator is explicitly configured to reconcile historical mints by
+    ///         another source. The repository deployment flow is a fresh asset-storage
+    ///         redeploy/Hub rotation, not bytecode replacement over existing storage.
     /// @param  author The attested author address (the high 160 bits of a packed kaId).
     /// @return The highest KA `number` already minted under `author`, or `-1` if none.
     function getMaxKaNumberForAuthor(address author) external view returns (int256) {

--- a/packages/evm-module/scripts/KA_HIGH_WATER_GETTER_ROLLOUT_RUNBOOK.md
+++ b/packages/evm-module/scripts/KA_HIGH_WATER_GETTER_ROLLOUT_RUNBOOK.md
@@ -1,0 +1,94 @@
+# DKGKnowledgeAssets 10.0.4 high-water getter rollout
+
+Procedure for rolling out `DKGKnowledgeAssets` 10.0.4, which adds
+`getMaxKaNumberForAuthor(address)`. This is needed because a Solidity
+`_VERSION` bump does not by itself redeploy existing network metadata.
+
+## Why this is manual
+
+`hre.helpers.deploy()` first checks `deployments/<network>_contracts.json`.
+If `contracts.DKGKnowledgeAssets.deployed` is `true`, the helper returns the
+recorded address and does not compare the recorded `version` to the Solidity
+`_VERSION`.
+
+At the time this runbook was added, `base_sepolia_v10_contracts.json` still
+records:
+
+```jsonc
+"DKGKnowledgeAssets": {
+  "version": "10.0.3",
+  "deployed": true
+}
+```
+
+A plain deploy would therefore keep the old 10.0.3 address. The chain package
+has a selector-gated fallback for that state, but operators must redeploy the
+storage contract before relying on the O(1) getter path.
+
+## Base Sepolia V10 rollout
+
+Run from `packages/evm-module/` with `RPC_BASE_SEPOLIA_V10` and
+`EVM_PRIVATE_KEY_BASE_SEPOLIA_V10` configured. The deployer wallet must be the
+Hub owner for the target deployment.
+
+```bash
+npx hardhat compile
+```
+
+Force only `DKGKnowledgeAssets` through the deploy helper:
+
+```bash
+node -e '
+  const fs = require("fs");
+  const p = "deployments/base_sepolia_v10_contracts.json";
+  const j = JSON.parse(fs.readFileSync(p, "utf8"));
+  const c = j.contracts.DKGKnowledgeAssets;
+  if (!c) throw new Error(`DKGKnowledgeAssets missing from ${p}`);
+  if (c.version !== "10.0.3") {
+    throw new Error(`Expected Base Sepolia to start from 10.0.3, got ${c.version}`);
+  }
+  c.deployed = false;
+  fs.writeFileSync(p, JSON.stringify(j, null, 4) + "\n");
+  console.log("Marked DKGKnowledgeAssets for redeploy.");
+'
+```
+
+Deploy and let the helper update the Hub asset-storage pointer:
+
+```bash
+npx hardhat deploy --network base_sepolia_v10
+```
+
+Commit the resulting post-deploy metadata only after the JSON records the new
+address, `version: "10.0.4"`, and `deployed: true`.
+
+## Verification
+
+Read the deployed addresses from the post-deploy
+`deployments/base_sepolia_v10_contracts.json`:
+
+```bash
+DKG_KA_ADDR=<contracts.DKGKnowledgeAssets.evmAddress>
+HUB_ADDR=<contracts.Hub.evmAddress>
+AUTHOR=0x0000000000000000000000000000000000000001
+```
+
+The storage contract must expose the new version and getter:
+
+```bash
+cast call "$DKG_KA_ADDR" 'version()(string)' --rpc-url "$RPC_BASE_SEPOLIA_V10"
+cast call "$DKG_KA_ADDR" 'getMaxKaNumberForAuthor(address)(int256)' "$AUTHOR" --rpc-url "$RPC_BASE_SEPOLIA_V10"
+```
+
+The Hub must point `DKGKnowledgeAssets` asset storage at the redeployed address:
+
+```bash
+cast call "$HUB_ADDR" 'getAssetStorageAddress(string)(address)' DKGKnowledgeAssets --rpc-url "$RPC_BASE_SEPOLIA_V10"
+```
+
+Expected:
+
+- `version()` returns `10.0.4`.
+- `getMaxKaNumberForAuthor(AUTHOR)` returns an `int256` value.
+- `getAssetStorageAddress("DKGKnowledgeAssets")` equals `DKG_KA_ADDR`.
+

--- a/packages/evm-module/test/v10-ka-number-getter.test.ts
+++ b/packages/evm-module/test/v10-ka-number-getter.test.ts
@@ -1,0 +1,139 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import hre from 'hardhat';
+
+import { Hub, DKGKnowledgeAssets } from '../typechain';
+import { packReservedKaId } from './helpers/v10-kc-helpers';
+
+/**
+ * OT-RFC-43 Option 1 (variant 1a): `getMaxKaNumberForAuthor` is the O(1)
+ * on-chain replacement for enumerating `KnowledgeAssetCreated(id, author)` logs
+ * to recover an author's high-water KA `number`. It must reproduce the exact
+ * semantics the off-chain allocator already relies on: `-1` when the author has
+ * never minted (so the next number is `-1 + 1 = 0`), otherwise the highest
+ * minted `number`, never regressed by a gap-filling lower mint.
+ */
+async function deployFixture() {
+  await hre.deployments.fixture([
+    'Token',
+    'AskStorage',
+    'EpochStorage',
+    'Chronos',
+    'Profile',
+    'Identity',
+    'KnowledgeAssetsLifecycle',
+    'ContextGraphStorage',
+    'ContextGraphs',
+    'ContextGraphValueStorage',
+    'DKGPublishingConvictionNFT',
+    'DKGStakingConvictionNFT',
+    'StakingV10',
+  ]);
+  const accounts = await hre.ethers.getSigners();
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+  const DKGKnowledgeAssets = await hre.ethers.getContract<DKGKnowledgeAssets>(
+    'DKGKnowledgeAssets',
+  );
+  return { accounts, Hub, DKGKnowledgeAssets };
+}
+
+describe('@unit DKGKnowledgeAssets.getMaxKaNumberForAuthor (OT-RFC-43 Option 1)', () => {
+  let accounts: SignerWithAddress[];
+  let Hub: Hub;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
+  let storageOperator: SignerWithAddress;
+
+  // Mint a KA with the packed kaId for (author, number). `createKnowledgeAsset`
+  // is `onlyContracts`, so it is called from the Hub-registered storageOperator.
+  async function mint(author: string, num: number | bigint) {
+    const kaId = packReservedKaId(author, num);
+    await DKGKnowledgeAssets.connect(storageOperator).createKnowledgeAsset(
+      storageOperator.address, // publisher
+      author, // author — high 160 bits of kaId must equal this (namespace check)
+      kaId,
+      `op-${author}-${num}`,
+      ethers.keccak256(ethers.toUtf8Bytes(`root-${author}-${num}`)),
+      1, // knowledgeAssetsAmount (must be 1)
+      1000, // byteSize
+      1, // startEpoch
+      2, // endEpoch
+      0, // tokenAmount
+      false, // isImmutable
+      1, // merkleLeafCount
+    );
+    return kaId;
+  }
+
+  beforeEach(async () => {
+    ({ accounts, Hub, DKGKnowledgeAssets } = await loadFixture(deployFixture));
+    storageOperator = accounts[19];
+    await Hub.setContractAddress('TestStorageOperator', storageOperator.address);
+  });
+
+  it('returns -1 for an author that has never minted', async () => {
+    expect(
+      await DKGKnowledgeAssets.getMaxKaNumberForAuthor(accounts[1].address),
+    ).to.equal(-1n);
+  });
+
+  it('distinguishes a legitimately-minted number 0 from never-minted', async () => {
+    const authorZero = accounts[1].address;
+    const authorFive = accounts[2].address;
+    await mint(authorZero, 0);
+    await mint(authorFive, 5);
+
+    expect(
+      await DKGKnowledgeAssets.getMaxKaNumberForAuthor(authorZero),
+    ).to.equal(0n);
+    expect(
+      await DKGKnowledgeAssets.getMaxKaNumberForAuthor(authorFive),
+    ).to.equal(5n);
+    // an unrelated author is still the never-minted sentinel
+    expect(
+      await DKGKnowledgeAssets.getMaxKaNumberForAuthor(accounts[3].address),
+    ).to.equal(-1n);
+  });
+
+  it('rises with a higher number and never regresses on a gap-filling lower mint', async () => {
+    const author = accounts[2].address;
+    await mint(author, 5);
+    await mint(author, 10);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(author)).to.equal(
+      10n,
+    );
+
+    // Numbers can be sparse on-chain (reserved-but-unpublished gaps), so a later
+    // mint of a lower number must NOT lower the high-water mark.
+    await mint(author, 3);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(author)).to.equal(
+      10n,
+    );
+  });
+
+  it('reproduces the allocator floor: next number == getMaxKaNumberForAuthor + 1', async () => {
+    const author = accounts[4].address;
+    // fresh author => -1 => allocator next = 0
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(author)).to.equal(
+      -1n,
+    );
+    await mint(author, 0);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(author)).to.equal(
+      0n,
+    ); // next = 1
+    await mint(author, 1);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(author)).to.equal(
+      1n,
+    );
+  });
+
+  it('is namespaced per author (no cross-author leakage)', async () => {
+    const a = accounts[5].address;
+    const b = accounts[6].address;
+    await mint(a, 7);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(a)).to.equal(7n);
+    expect(await DKGKnowledgeAssets.getMaxKaNumberForAuthor(b)).to.equal(-1n);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `DKGKnowledgeAssets.getMaxKaNumberForAuthor(address) -> int256` and keeps the chain ABI/pinned digest in sync.
- Uses the new O(1) view as the EVM adapter fast path while preserving a selector-gated, 2,000-block paginated `KnowledgeAssetCreated` fallback for pre-10.0.4 deployments.
- Fails loudly before legacy fallback if the resolved `DKGKnowledgeAssets` address has no bytecode, so bad Hub/deployment metadata cannot reconcile from empty logs.
- Documents the unsupported unbackfilled in-place storage-upgrade case and adds the Base Sepolia 10.0.4 redeploy runbook.

## Related

- Fixes #1080.

## Files changed

- `packages/evm-module/contracts/storage/DKGKnowledgeAssets.sol`: per-author high-water tracking/getter and upgrade precondition docs.
- `packages/evm-module/abi/DKGKnowledgeAssets.json`, `packages/chain/abi/DKGKnowledgeAssets.json`, `packages/chain/test/abi-pinning.test.ts`: synced ABI + reviewed pin digest.
- `packages/chain/src/evm-adapter-base.ts`: view-first KA high-water read, bounded legacy fallback, bytecode guard, and narrow fallback error classification.
- `packages/chain/test/getmaxkanumberforauthor.unit.test.ts`, `packages/chain/test/getmaxka-view-e2e.test.ts`, `packages/evm-module/test/v10-ka-number-getter.test.ts`: targeted view/fallback/regression coverage.
- `packages/evm-module/scripts/KA_HIGH_WATER_GETTER_ROLLOUT_RUNBOOK.md`: Base Sepolia redeploy/runbook steps for DKGKnowledgeAssets 10.0.4.

## Test plan

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @origintrail-official/dkg-core run build`
- `pnpm --filter @origintrail-official/dkg-chain run build`
- `pnpm --filter @origintrail-official/dkg-evm-module run build`
- `pnpm exec vitest run test/getmaxkanumberforauthor.unit.test.ts test/mock-adapter-parity.test.ts --reporter verbose` from `packages/chain`
- `pnpm --filter @origintrail-official/dkg-chain run test`
- `pnpm exec vitest run test/getmaxka-view-e2e.test.ts --reporter verbose` from `packages/chain`
- `pnpm exec hardhat test --network hardhat --config hardhat.node.config.ts test/v10-ka-number-getter.test.ts` from `packages/evm-module`
- Recomputed `PINNED_DIGESTS.DKGKnowledgeAssets`: `60d8dc58619c25fd31df1da34d4944369edbc2d5d4031dcb14f6965152c718a9`
- `git diff --check`
- Dedicated local PR-review pass using `.codex` review instructions returned `{"comments":[]}` after the latest delta.
