### PR TITLE
fix(sharding-table): reject sizeLimit=0 + declare ParametersStorage deploy dep (follow-up to #1074)

### DIFF
--- a/packages/chain/abi/ParametersStorage.json
+++ b/packages/chain/abi/ParametersStorage.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ZeroShardingTableSizeLimit",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -186,7 +186,10 @@ const PINNED_DIGESTS: Record<string, string> = {
   // from staker-bound TRAC on every paid publish / update / extend by
   // `KnowledgeAssetsLifecycle` + `PublishingConviction` (no ABI change on
   // those two — internal logic + version bump only).
-  ParametersStorage:            'a152ef475986c81b4077648980156aeaa2b91541057a9ad9bfcfd969ee7feb63',
+  //
+  // Updated PR #1083: added `ZeroShardingTableSizeLimit()` for the
+  // governance guard that rejects `setShardingTableSizeLimit(0)`.
+  ParametersStorage:            '7816845cbccd120eaf44eccea56f530e9c8e8894023d0693fddcc8546161575d',
   // Added PR #470 round 3: pin the V10 NFT-backed PCA contract so that
   // any drift in its events (CostCovered / WindowSettled /
   // AccountFinalSwept / TokensAddedToEpochRange consumers) or errors

--- a/packages/evm-module/abi/ParametersStorage.json
+++ b/packages/evm-module/abi/ParametersStorage.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ZeroShardingTableSizeLimit",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/packages/evm-module/contracts/storage/ParametersStorage.sol
+++ b/packages/evm-module/contracts/storage/ParametersStorage.sol
@@ -15,6 +15,8 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
     ///         typed `address` field.
     event ProtocolTreasurySet(address indexed treasury);
 
+    error ZeroShardingTableSizeLimit();
+
     string private constant _NAME = "ParametersStorage";
     // protocol treasury fee (`protocolTreasuryFee`, `protocolTreasury`,
     // `MAX_PROTOCOL_TREASURY_FEE`) skimmed from the staker-bound TRAC on
@@ -177,7 +179,7 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
         // freeze ALL node admission (even the first insert), bricking staking. 0
         // is never a meaningful table size — reject it rather than let it act as
         // an implicit pause switch.
-        require(shardingTableSizeLimit_ > 0, "shardingTableSizeLimit must be > 0");
+        if (shardingTableSizeLimit_ == 0) revert ZeroShardingTableSizeLimit();
         shardingTableSizeLimit = shardingTableSizeLimit_;
 
         emit ParameterChanged("shardingTableSizeLimit", shardingTableSizeLimit);

--- a/packages/evm-module/contracts/storage/ParametersStorage.sol
+++ b/packages/evm-module/contracts/storage/ParametersStorage.sol
@@ -172,6 +172,12 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
     }
 
     function setShardingTableSizeLimit(uint16 shardingTableSizeLimit_) external onlyOwnerOrMultiSigOwner {
+        // Reject 0: ShardingTable._insertNode now enforces this cap
+        // (`nodesCount >= limit` reverts ShardingTableIsFull), so a 0 limit would
+        // freeze ALL node admission (even the first insert), bricking staking. 0
+        // is never a meaningful table size — reject it rather than let it act as
+        // an implicit pause switch.
+        require(shardingTableSizeLimit_ > 0, "shardingTableSizeLimit must be > 0");
         shardingTableSizeLimit = shardingTableSizeLimit_;
 
         emit ParameterChanged("shardingTableSizeLimit", shardingTableSizeLimit);

--- a/packages/evm-module/deploy/active/019_deploy_sharding_table.ts
+++ b/packages/evm-module/deploy/active/019_deploy_sharding_table.ts
@@ -39,4 +39,9 @@ func.dependencies = [
   'ShardingTableStorage',
   'StakingStorage',
   'ConvictionStakingStorage',
+  // `_insertNode` enforces `shardingTableSizeLimit` by resolving ParametersStorage
+  // from the Hub at call time. Declare the dependency so any deploy/fixture that
+  // brings up ShardingTable also Hub-registers ParametersStorage (it has no
+  // dependency on ShardingTable, so no cycle).
+  'ParametersStorage',
 ];

--- a/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
+++ b/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
@@ -75,9 +75,8 @@ describe('@unit ShardingTable enforces shardingTableSizeLimit', () => {
 
   it('rejects setting the size limit to 0 (would freeze all node admission)', async () => {
     await deploy();
-    await expect(ParametersStorage.setShardingTableSizeLimit(0)).to.be.revertedWith(
-      'shardingTableSizeLimit must be > 0',
-    );
+    await expect(ParametersStorage.setShardingTableSizeLimit(0))
+      .to.be.revertedWithCustomError(ParametersStorage, 'ZeroShardingTableSizeLimit');
     // A positive limit is still accepted.
     await ParametersStorage.setShardingTableSizeLimit(1);
     expect(await ParametersStorage.shardingTableSizeLimit()).to.equal(1);

--- a/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
+++ b/packages/evm-module/test/unit/ShardingTable.size-cap.test.ts
@@ -72,4 +72,14 @@ describe('@unit ShardingTable enforces shardingTableSizeLimit', () => {
     // Count is unchanged — the failed insert did not grow the table.
     expect(await ShardingTableStorage.nodesCount()).to.equal(3);
   });
+
+  it('rejects setting the size limit to 0 (would freeze all node admission)', async () => {
+    await deploy();
+    await expect(ParametersStorage.setShardingTableSizeLimit(0)).to.be.revertedWith(
+      'shardingTableSizeLimit must be > 0',
+    );
+    // A positive limit is still accepted.
+    await ParametersStorage.setShardingTableSizeLimit(1);
+    expect(await ParametersStorage.shardingTableSizeLimit()).to.equal(1);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to **#1074** (ShardingTable size-cap enforcement). #1074 was merged before its review-round commit landed, so the **core fix is already on `main`** (`_insertNode` reverts `ShardingTableIsFull` at the cap) but two review hardenings were merged-around. This PR adds them:

1. **`ParametersStorage.setShardingTableSizeLimit` now rejects `0`.** With the cap enforced (`nodesCount >= limit` reverts), a `0` limit would freeze **all** node admission — even the first insert — bricking staking. `0` is never a valid table size, so reject it rather than let it act as an implicit pause switch. (Owner/multisig-gated, so this is a governance-footgun guard, not an attacker path.)
2. **`019_deploy_sharding_table` declares `ParametersStorage` as a dependency.** `_insertNode` resolves `ParametersStorage` from the Hub at call time (it deploys after `ShardingTable`, so it can't be cached in `initialize`). Declaring the dependency ensures any deploy/fixture that brings up `ShardingTable` also Hub-registers `ParametersStorage`. No cycle — `ParametersStorage` doesn't depend on `ShardingTable`.

## Tests

- Adds a `0`-reject regression test to `ShardingTable.size-cap.test.ts`.
- `ShardingTable.size-cap` (2 ✓), `ShardingTable` (8 ✓), `ParametersStorage` (✓) suites green.

Addresses the two outstanding Codex review comments on #1074. Closes the HIGH-2 hardening.
