### PR TITLE
fix(hermes): one-shot dkg_publish via atomic assertionName fork + register_if_needed (rc.17 fast-follow)

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1807,6 +1807,10 @@ class DKGMemoryProvider(MemoryProvider):
                 # Any other registration failure is fatal: surface it and do NOT publish.
                 if "already registered" not in error and "already exists" not in error:
                     return json.dumps(registration)
+                # Normalize the already-registered short-circuit to a success
+                # shape (Codex #1084:1810) — leaving the raw {success:false,...} on
+                # result["registration"] makes a clean publish look partly failed.
+                registration = {"alreadyRegistered": True}
         # Publish via the ATOMIC assertionName fork (parity with OpenClaw + MCP):
         # create a fresh uniquely-named assertion with these quads (auto-finalize
         # + promote), then publish that ONE sealed assertion by name. The daemon
@@ -1819,13 +1823,24 @@ class DKGMemoryProvider(MemoryProvider):
             quads,
             sub_graph_name=_first_text(args, "sub_graph_name"),
         )
-        # Only stamp the per-call counts on a non-hard-failure result (FIX N /
-        # Codex #1079:1784): the client returns a partial-failure dict
-        # ({success:false, failedRoot, ...}) when a root mint fails — attaching
-        # quadsPublished/rootEntities there would falsely imply everything
-        # published. Confirmed / 207-partial results are fine to annotate.
-        if isinstance(result, dict) and not _client_result_failed(result):
-            result["quadsPublished"] = len(quads)
+        # The publish leg goes through /api/shared-memory/publish, which returns
+        # HTTP 207 with a non-empty contextGraphError when the asset is minted
+        # on-chain (UAL valid) but the CG-binding failed (memory.ts:1772). Surface
+        # that as a PARTIAL/warning (Codex #1077:1115 parity), keeping ual/kaId/
+        # assertionName visible. A clean 200 is untouched; no-op on the FIX A/B
+        # partial-failure dicts (they carry no contextGraphError).
+        result = _annotate_vm_publish_partial(result)
+        if isinstance(result, dict):
+            # Only stamp the per-call count on a non-hard-failure result (FIX N /
+            # Codex #1084:1821): publish_quads returns a partial-failure dict
+            # ({success:false, ...}) on create-207 / publish-fail — stamping
+            # quadsPublished there would falsely imply it published. A confirmed
+            # result or a 207-partial (minted) is fine to annotate.
+            if not _client_result_failed(result):
+                result["quadsPublished"] = len(quads)
+            # Registration context stays on any result (incl. a publish failure):
+            # the register step itself succeeded / was already-registered, so it
+            # is not misleading and aids recovery.
             if registration is not None:
                 result["registration"] = registration
         return json.dumps(result)

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -360,10 +360,16 @@ DKG_PUBLISH_SCHEMA = {
                     "If the context graph is not yet registered on-chain, register it first "
                     "(idempotent), then publish. Registration may spend gas/TRAC. Default false -- "
                     "when false and the CG is unregistered, publish fails with the daemon's "
-                    "not-registered error."
+                    "not-registered error. CAVEAT: this uses the explicit register route, which "
+                    "registers with the daemon's DEFAULT publishPolicy (derived from access_policy) "
+                    "and does NOT preserve a context graph's stored custom publishPolicy / "
+                    "contribution governance. For a CG created with a non-default publishPolicy/PCA, "
+                    "register it explicitly with the desired policy first rather than relying on "
+                    "register_if_needed. (Read access is unaffected; daemon-side rehydration tracked "
+                    "in OriginTrail/dkg#1085.)"
                 ),
             },
-            "access_policy": {"type": "integer", "description": "Optional registration access policy (0 open, 1 private). REQUIRES register_if_needed: true — it only applies when registering the context graph, and is rejected if sent without it."},
+            "access_policy": {"type": "integer", "description": "Optional registration access policy (0 open, 1 private). REQUIRES register_if_needed: true — it only applies when registering the context graph, and is rejected if sent without it. Sets only the access policy; it does NOT preserve a stored custom publishPolicy (see register_if_needed; OriginTrail/dkg#1085)."},
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph scope."},
         },
         "required": ["context_graph_id", "quads"],

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -320,16 +320,12 @@ DKG_SHARE_SCHEMA = {
 DKG_PUBLISH_SCHEMA = {
     "name": "dkg_publish",
     "description": (
-        "One-shot write + publish helper: write supplied quads to Shared Working Memory, "
-        "then publish SWM to Verifiable Memory. Chain-anchored, permanent, costs TRAC. "
-        "Object values starting with http://, https://, urn:, or did: are treated as "
-        "URIs. Everything else becomes a string literal automatically.\n"
-        "NON-ATOMIC for multiple root subjects: this legacy path mints ONE root per call "
-        "(the daemon rejects atomic multi-root). On a partial failure, already-published "
-        "roots stay on-chain (TRAC spent, irreversible) and the result reports which "
-        "published vs failed vs were not attempted — re-publish only the failed/remaining "
-        "roots. For a single named asset prefer dkg_knowledge_asset_publish, which seals the "
-        "whole asset and is the atomic-safe path.\n"
+        "One-shot write + publish helper: writes the supplied quads as a single fresh, "
+        "uniquely-named sealed assertion and publishes it to Verifiable Memory in one ATOMIC "
+        "operation. Chain-anchored, permanent, costs TRAC. Multi-root-safe: all subjects in the "
+        "quads publish together as one sealed assertion in a single atomic mint. Object "
+        "values starting with http://, https://, urn:, or did: are treated as URIs; everything "
+        "else becomes a string literal automatically.\n"
         "Always call dkg_wallet_balances first to verify sufficient TRAC."
     ),
     "parameters": {
@@ -1777,31 +1773,16 @@ class DKGMemoryProvider(MemoryProvider):
         quads = _normalize_quads(args.get("quads"))
         if not quads:
             return tool_error("quads must contain at least one item with subject, predicate, and object.")
-        share_result = self._client.share(cg, quads, sub_graph_name=_first_text(args, "sub_graph_name"))
-        if share_result.get("success") is False:
-            return json.dumps(share_result)
-        roots = _quad_root_entities(quads)
-        # ALWAYS publish the EXPLICIT roots this call just wrote — never "all".
-        # selection="all" publishes the WHOLE shared-memory graph (every
-        # unpublished root in the CG/sub-graph), so a one-shot dkg_publish would
-        # over-scope and mint other agents'/calls' unpublished SWM content
-        # (Codex #1750). Passing the explicit list also makes the client loop
-        # one-root-per-call (dedup + clearAfter-on-last + partial-failure
-        # transparency all apply uniformly, single or multi root). The CG-wide
-        # "all" remains available only on dkg_shared_memory_publish, where the
-        # agent explicitly opts in.
-        result = self._client.publish(
+        # Publish via the ATOMIC assertionName fork (parity with OpenClaw + MCP):
+        # create a fresh uniquely-named assertion with these quads (auto-finalize
+        # + promote), then publish that ONE sealed assertion by name. The daemon
+        # publishes only that assertion's exact merkleRoot — multi-root-safe,
+        # correctly scoped, in a single atomic operation. No per-root loop, no
+        # dedup, no partial-failure shape (those apply only to the explicit
+        # CG-wide dkg_shared_memory_publish, which stays on the selection path).
+        result = self._client.publish_quads(
             cg,
-            selection=roots,
-            # clear_after=False (FIX M / Codex #1079:1781): on the selection path,
-            # clearSharedMemoryAfter=true makes the daemon wipe the WHOLE SWM
-            # remainder (deleteByPattern over every SWM graph under the bucket, no
-            # subject filter — dkg-publisher.ts:1528-1535), destroying every other
-            # call's/agent's unpublished roots. dkg_publish only owns the roots it
-            # just wrote, so it must NOT clear the remainder. (The published roots
-            # are cleared unconditionally regardless.) Matches the sibling
-            # dkg_shared_memory_publish default for an explicit-root selection.
-            clear_after=False,
+            quads,
             sub_graph_name=_first_text(args, "sub_graph_name"),
         )
         # Only stamp the per-call counts on a non-hard-failure result (FIX N /
@@ -1811,7 +1792,6 @@ class DKGMemoryProvider(MemoryProvider):
         # published. Confirmed / 207-partial results are fine to annotate.
         if isinstance(result, dict) and not _client_result_failed(result):
             result["quadsPublished"] = len(quads)
-            result["rootEntities"] = roots
         return json.dumps(result)
 
     def _handle_shared_memory_publish(self, args: Dict[str, Any]) -> str:
@@ -2856,15 +2836,6 @@ def _normalize_semantic_quads(raw_quads: Any) -> Tuple[List[Dict[str, str]], Opt
             "object": object_value if _is_safe_iri(object_value) or object_value.startswith('"') else _quote_literal(object_value),
         })
     return quads, None
-
-
-def _quad_root_entities(quads: List[Dict[str, str]]) -> List[str]:
-    roots: List[str] = []
-    for quad in quads:
-        subject = str(quad.get("subject", "")).strip()
-        if subject and subject not in roots:
-            roots.append(subject)
-    return roots
 
 
 def _coerce_limit(value: Any, default: int, maximum: int) -> int:

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -321,11 +321,13 @@ DKG_PUBLISH_SCHEMA = {
     "name": "dkg_publish",
     "description": (
         "One-shot write + publish helper: writes the supplied quads as a single fresh, "
-        "uniquely-named sealed assertion and publishes it to Verifiable Memory in one ATOMIC "
-        "operation. Chain-anchored, permanent, costs TRAC. Multi-root-safe: all subjects in the "
-        "quads publish together as one sealed assertion in a single atomic mint. Object "
-        "values starting with http://, https://, urn:, or did: are treated as URIs; everything "
-        "else becomes a string literal automatically.\n"
+        "uniquely-named sealed assertion, then publishes it to Verifiable Memory. The on-chain "
+        "MINT is atomic and multi-root-safe -- all subjects publish together as one sealed "
+        "assertion in a single mint. This is a TWO-STEP helper (create-and-seal, then publish), "
+        "so it can partially fail between steps; on a partial failure the result reports the "
+        "assertionName so you can recover by name (do not recreate). Chain-anchored, permanent, "
+        "costs TRAC. Object values starting with http://, https://, urn:, or did: are treated as "
+        "URIs; everything else becomes a string literal automatically.\n"
         "This atomic path requires the context graph to be registered on-chain; pass "
         "register_if_needed=true to register it first on a fresh CG.\n"
         "Always call dkg_wallet_balances first to verify sufficient TRAC."

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -363,7 +363,7 @@ DKG_PUBLISH_SCHEMA = {
                     "not-registered error."
                 ),
             },
-            "access_policy": {"type": "integer", "description": "Optional registration access policy used only with register_if_needed: 0 open, 1 private."},
+            "access_policy": {"type": "integer", "description": "Optional registration access policy (0 open, 1 private). REQUIRES register_if_needed: true — it only applies when registering the context graph, and is rejected if sent without it."},
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph scope."},
         },
         "required": ["context_graph_id", "quads"],
@@ -1797,6 +1797,9 @@ class DKGMemoryProvider(MemoryProvider):
         registration = None
         if args.get("register_if_needed") is not None and not isinstance(args.get("register_if_needed"), bool):
             return tool_error("register_if_needed must be a boolean.")
+        access_policy_dep_error = _access_policy_requires_register_error(args)
+        if access_policy_dep_error:
+            return tool_error(access_policy_dep_error)
         if args.get("register_if_needed") is True:
             access_policy = args.get("access_policy")
             access_policy_error = _validate_access_policy(access_policy)
@@ -1825,12 +1828,12 @@ class DKGMemoryProvider(MemoryProvider):
             quads,
             sub_graph_name=_first_text(args, "sub_graph_name"),
         )
-        # The publish leg goes through /api/shared-memory/publish, which returns
-        # HTTP 207 with a non-empty contextGraphError when the asset is minted
-        # on-chain (UAL valid) but the CG-binding failed (memory.ts:1772). Surface
-        # that as a PARTIAL/warning (Codex #1077:1115 parity), keeping ual/kaId/
-        # assertionName visible. A clean 200 is untouched; no-op on the FIX A/B
-        # partial-failure dicts (they carry no contextGraphError).
+        # publish_quads already annotates a 207 (contextGraphError) partial at the
+        # client (FIX R / Codex #1084:787), so this is an IDEMPOTENT safety net:
+        # re-annotating an already-partial result re-sets the same partial/warning
+        # (no-op), and it still catches a raw 207 if the client path is ever
+        # bypassed. A clean 200 / FIX A/B failure dict (no contextGraphError) is
+        # left untouched.
         result = _annotate_vm_publish_partial(result)
         if isinstance(result, dict):
             # Only stamp the per-call count on a non-hard-failure result (FIX N /

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -326,6 +326,8 @@ DKG_PUBLISH_SCHEMA = {
         "quads publish together as one sealed assertion in a single atomic mint. Object "
         "values starting with http://, https://, urn:, or did: are treated as URIs; everything "
         "else becomes a string literal automatically.\n"
+        "This atomic path requires the context graph to be registered on-chain; pass "
+        "register_if_needed=true to register it first on a fresh CG.\n"
         "Always call dkg_wallet_balances first to verify sufficient TRAC."
     ),
     "parameters": {
@@ -350,6 +352,16 @@ DKG_PUBLISH_SCHEMA = {
                 },
                 "description": "Array of RDF triples to write and publish.",
             },
+            "register_if_needed": {
+                "type": "boolean",
+                "description": (
+                    "If the context graph is not yet registered on-chain, register it first "
+                    "(idempotent), then publish. Registration may spend gas/TRAC. Default false -- "
+                    "when false and the CG is unregistered, publish fails with the daemon's "
+                    "not-registered error."
+                ),
+            },
+            "access_policy": {"type": "integer", "description": "Optional registration access policy used only with register_if_needed: 0 open, 1 private."},
             "sub_graph_name": {"type": "string", "description": "Optional sub-graph scope."},
         },
         "required": ["context_graph_id", "quads"],
@@ -1773,6 +1785,28 @@ class DKGMemoryProvider(MemoryProvider):
         quads = _normalize_quads(args.get("quads"))
         if not quads:
             return tool_error("quads must contain at least one item with subject, predicate, and object.")
+        # register_if_needed: the atomic assertionName fork (publish_quads) does
+        # NOT auto-register the CG (LU-6 transparent register-then-publish is the
+        # selection fork only, memory.ts:1874+), so on a fresh, never-registered
+        # CG the publish would fail "not registered on-chain" on a real chain.
+        # When true, register the CG first (idempotent — short-circuits if already
+        # registered) BEFORE publishing, so this one-shot is self-contained on a
+        # fresh CG. Mirrors the §G register block on dkg_knowledge_asset_publish.
+        registration = None
+        if args.get("register_if_needed") is not None and not isinstance(args.get("register_if_needed"), bool):
+            return tool_error("register_if_needed must be a boolean.")
+        if args.get("register_if_needed") is True:
+            access_policy = args.get("access_policy")
+            access_policy_error = _validate_access_policy(access_policy)
+            if access_policy_error:
+                return tool_error(access_policy_error)
+            registration = self._client.register_context_graph(cg, access_policy)
+            if _client_result_failed(registration):
+                error = str(registration.get("error") or registration.get("message") or "").lower()
+                # "already registered"/"already exists" is success — continue.
+                # Any other registration failure is fatal: surface it and do NOT publish.
+                if "already registered" not in error and "already exists" not in error:
+                    return json.dumps(registration)
         # Publish via the ATOMIC assertionName fork (parity with OpenClaw + MCP):
         # create a fresh uniquely-named assertion with these quads (auto-finalize
         # + promote), then publish that ONE sealed assertion by name. The daemon
@@ -1792,6 +1826,8 @@ class DKGMemoryProvider(MemoryProvider):
         # published. Confirmed / 207-partial results are fine to annotate.
         if isinstance(result, dict) and not _client_result_failed(result):
             result["quadsPublished"] = len(quads)
+            if registration is not None:
+                result["registration"] = registration
         return json.dumps(result)
 
     def _handle_shared_memory_publish(self, args: Dict[str, Any]) -> str:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -171,6 +171,35 @@ def _client_result_failed(result: Any) -> bool:
     return result.get("success") is False or result.get("ok") is False or bool(result.get("error"))
 
 
+def _annotate_207_partial(result: Any) -> Any:
+    """Flag a vm/publish 207 (minted, CG-binding failed) at the client.
+
+    A 207 carries a non-empty ``contextGraphError`` but no ``success:false``, so it
+    flows back as apparent success. Annotating it HERE makes the client
+    safe-by-default (Codex #1084:787) — a caller that does not re-wrap still sees
+    the partial state. Mirrors ``_annotate_vm_publish_partial`` in ``__init__.py``
+    (which the handler can re-apply idempotently); the client cannot import that
+    helper without a circular dependency, so the same shape/text lives here.
+    """
+    if not isinstance(result, dict):
+        return result
+    context_graph_error = result.get("contextGraphError")
+    if isinstance(context_graph_error, str) and context_graph_error:
+        return {
+            **result,
+            "partial": True,
+            "warning": (
+                "Partial publish: the knowledge asset was minted on-chain (UAL/kaId are valid) "
+                f"and IS published, but the context-graph binding failed ({context_graph_error}). "
+                "Do NOT re-run publish — dkg_publish would mint a duplicate and "
+                "dkg_knowledge_asset_publish would fail the VM precondition (a confirmed publish "
+                "clears Shared Working Memory), and neither re-binds the context graph. Surface "
+                "this binding failure to the node operator."
+            ),
+        }
+    return result
+
+
 def _to_write_quads(quads: List[Dict[str, str]]) -> List[Dict[str, str]]:
     """Map each quad to exactly {subject, predicate, object} for a WM write.
 
@@ -793,7 +822,11 @@ class DKGClient:
             if created.get("merkleRoot") is not None:
                 result["merkleRoot"] = created["merkleRoot"]
         result["assertionName"] = assertion_name
-        return result
+        # FIX R (Codex #1084:787): annotate a 207 (contextGraphError) HERE so the
+        # client is safe-by-default — a caller that does not re-wrap still sees the
+        # partial state. The handler's _annotate_vm_publish_partial re-applies the
+        # same fields idempotently.
+        return _annotate_207_partial(result)
 
     def publish_one_root(self, context_graph_id: str, root_entity: str,
                          clear_after: bool,

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -741,7 +741,30 @@ class DKGClient:
             create_payload["subGraphName"] = sub_graph_name
         created = self._post("/api/knowledge-assets", create_payload)
         if _client_result_failed(created):
-            return created
+            # The create call surfaced an error, but the asset is created under a
+            # client-generated assertion_name BEFORE the response is read. A lost/
+            # garbled response (timeout, transport blip) can therefore report a
+            # hard failure while the asset actually landed daemon-side. Returning
+            # the raw error verbatim drops that name, so the agent recreates it
+            # (orphaning the first). Surface assertionName (+ subGraphName) on the
+            # create-failure too — mirroring the share/publish-failure branches
+            # below — so the caller can recover by name instead of recreating
+            # (Codex #1084:743).
+            failure = dict(created) if isinstance(created, dict) else {"error": str(created)}
+            failure["success"] = False
+            failure["assertionName"] = assertion_name
+            if sub_graph_name:
+                failure["subGraphName"] = sub_graph_name
+            base_error = str(failure.get("error") or failure.get("message") or "create failed")
+            sub_graph_hint = f" (sub-graph '{sub_graph_name}')" if sub_graph_name else ""
+            failure["error"] = (
+                f"Creating knowledge asset '{assertion_name}'{sub_graph_hint} failed ({base_error}). "
+                f"It most likely was NOT created, but if the daemon response was lost the asset may "
+                f"exist under this assertionName -- first check/recover by name with "
+                f"dkg_knowledge_asset_history or dkg_knowledge_asset_query (this assertionName and "
+                f"sub_graph_name) before recreating, to avoid orphaning a created asset."
+            )
+            return failure
         # The create route returns HTTP 207 { created:true, ..., errors:[{phase,
         # error}] } when create+finalize succeeded but an opt-in tail FAILED — for
         # us that is the promote/swm-share (knowledge-assets.ts:575-614). _post

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -728,6 +728,10 @@ class DKGClient:
             failure = dict(created)
             failure["success"] = False
             failure["assertionName"] = assertion_name
+            # Carry subGraphName too (Codex #1084:730) — recovery by name needs the
+            # same sub-graph the asset was created in.
+            if sub_graph_name:
+                failure["subGraphName"] = sub_graph_name
             if created.get("assertionUri") is not None:
                 failure["assertionUri"] = created["assertionUri"]
             # The create route returns merkleRoot (a hex string), NOT a `seal`
@@ -738,11 +742,13 @@ class DKGClient:
             phases = ", ".join(
                 str(e.get("phase")) for e in create_errors if isinstance(e, dict) and e.get("phase")
             )
+            sub_graph_hint = f" (sub-graph '{sub_graph_name}')" if sub_graph_name else ""
             failure["error"] = (
-                f"Knowledge asset '{assertion_name}' was created and sealed but a later stage "
-                f"failed ({phases or 'share'}), so it was NOT shared to SWM and was NOT published. "
-                f"Share it with dkg_knowledge_asset_share (this name), then publish with "
-                f"dkg_knowledge_asset_publish (this name) -- do NOT recreate the asset."
+                f"Knowledge asset '{assertion_name}'{sub_graph_hint} was created and sealed but a "
+                f"later stage failed ({phases or 'share'}), so it was NOT shared to SWM and was NOT "
+                f"published. Share it with dkg_knowledge_asset_share (this name and sub_graph_name), "
+                f"then publish with dkg_knowledge_asset_publish (this name and sub_graph_name) -- do "
+                f"NOT recreate the asset."
             )
             return failure
         publish_payload: Dict[str, Any] = {
@@ -761,16 +767,21 @@ class DKGClient:
             failure = dict(published) if isinstance(published, dict) else {"error": str(published)}
             failure["success"] = False
             failure["assertionName"] = assertion_name
+            # Carry subGraphName too (Codex #1084:730) — recovery by name needs it.
+            if sub_graph_name:
+                failure["subGraphName"] = sub_graph_name
             if isinstance(created, dict):
                 if created.get("assertionUri") is not None:
                     failure["assertionUri"] = created["assertionUri"]
                 if created.get("merkleRoot") is not None:
                     failure["merkleRoot"] = created["merkleRoot"]
             base_error = str(failure.get("error") or failure.get("message") or "publish failed")
+            sub_graph_hint = f" (sub-graph '{sub_graph_name}')" if sub_graph_name else ""
             failure["error"] = (
-                f"Knowledge asset '{assertion_name}' was created, sealed, and shared to SWM, but the "
-                f"on-chain publish failed ({base_error}). Retry the publish by name with "
-                f"dkg_knowledge_asset_publish (this assertionName) -- do NOT recreate the asset."
+                f"Knowledge asset '{assertion_name}'{sub_graph_hint} was created, sealed, and shared "
+                f"to SWM, but the on-chain publish failed ({base_error}). Retry the publish by name "
+                f"with dkg_knowledge_asset_publish (this assertionName and sub_graph_name) -- do NOT "
+                f"recreate the asset."
             )
             return failure
         result: Dict[str, Any] = dict(published) if isinstance(published, dict) else {"result": published}

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -676,6 +676,61 @@ class DKGClient:
             payload["subGraphName"] = sub_graph_name
         return self._post("/api/shared-memory/write", payload)
 
+    def publish_quads(self, context_graph_id: str, quads: List[Dict[str, str]],
+                      sub_graph_name: Optional[str] = None) -> Dict[str, Any]:
+        """One-shot publish via the ATOMIC assertionName fork (mirrors OpenClaw +
+        MCP).
+
+        Creates a fresh, uniquely-named assertion with the supplied quads
+        (auto-finalize is driven by non-empty quads — CONTRACT §1 Stage1 — and
+        ``promote:true`` shares it into SWM in the same call), then publishes
+        that single sealed assertion by name. The daemon's assertionName fork
+        (memory.ts:1703-1808) reads the seal keyed to the assertion's exact
+        merkleRoot and publishes ONLY that assertion ATOMICALLY — multi-root-safe,
+        correctly scoped, no per-root loop, no partial-failure.
+
+        The write wire shape is ``{subject, predicate, object}`` only; any
+        per-quad ``graph`` is stripped (CONTRACT §0 invariant 2). ``finalize:true``
+        is unread and dropped; ``promote:true`` is the create route's
+        ``alsoShareSwm`` alias.
+
+        NOTE: unlike the selection fork, the assertionName fork does NOT
+        auto-register the CG (LU-6 transparent register-then-publish is
+        selection-fork only, memory.ts:1874+); on a fresh, never-registered CG on
+        a REAL chain it surfaces the daemon's "not registered on-chain" error
+        (skipped for mock/none chains — publisher dkg-publisher.ts:1198-1222).
+        """
+        cg_id = _normalize_context_graph_id(context_graph_id)
+        assertion_name = f"hermes-publish-{uuid.uuid4().hex}"
+        create_payload: Dict[str, Any] = {
+            "contextGraphId": cg_id,
+            "name": assertion_name,
+            "quads": _to_write_quads(quads),
+            "promote": True,
+        }
+        if sub_graph_name:
+            create_payload["subGraphName"] = sub_graph_name
+        created = self._post("/api/knowledge-assets", create_payload)
+        if _client_result_failed(created):
+            return created
+        publish_payload: Dict[str, Any] = {
+            "contextGraphId": cg_id,
+            "assertionName": assertion_name,
+        }
+        if sub_graph_name:
+            publish_payload["subGraphName"] = sub_graph_name
+        published = self._post("/api/shared-memory/publish", publish_payload)
+        if _client_result_failed(published):
+            return published
+        result: Dict[str, Any] = dict(published) if isinstance(published, dict) else {"result": published}
+        if isinstance(created, dict):
+            if created.get("assertionUri") is not None:
+                result["assertionUri"] = created["assertionUri"]
+            if created.get("seal") is not None:
+                result["seal"] = created["seal"]
+        result["assertionName"] = assertion_name
+        return result
+
     def publish_one_root(self, context_graph_id: str, root_entity: str,
                          clear_after: bool,
                          sub_graph_name: Optional[str] = None) -> Dict[str, Any]:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -761,8 +761,10 @@ class DKGClient:
                 f"Creating knowledge asset '{assertion_name}'{sub_graph_hint} failed ({base_error}). "
                 f"It most likely was NOT created, but if the daemon response was lost the asset may "
                 f"exist under this assertionName -- first check/recover by name with "
-                f"dkg_knowledge_asset_history or dkg_knowledge_asset_query (this assertionName and "
-                f"sub_graph_name) before recreating, to avoid orphaning a created asset."
+                f"dkg_knowledge_asset_history (this assertionName and sub_graph_name) before "
+                f"recreating, to avoid orphaning a created asset. NOTE: a created asset is "
+                f"auto-shared to SWM (its working-memory draft is empty), so use _history (lifecycle "
+                f"state regardless of layer) for existence, not dkg_knowledge_asset_query (Codex #1076:1047)."
             )
             return failure
         # The create route returns HTTP 207 { created:true, ..., errors:[{phase,

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -713,6 +713,36 @@ class DKGClient:
         created = self._post("/api/knowledge-assets", create_payload)
         if _client_result_failed(created):
             return created
+        # The create route returns HTTP 207 { created:true, ..., errors:[{phase,
+        # error}] } when create+finalize succeeded but an opt-in tail FAILED — for
+        # us that is the promote/swm-share (knowledge-assets.ts:575-614). _post
+        # does not raise on 207 and _client_result_failed does not inspect
+        # errors[], so without this check we would publish an assertion that was
+        # sealed but NEVER SHARED (Codex #1084:714). Do NOT touch the global
+        # _client_result_failed (the multi-root loop shares it) — check errors[]
+        # here, targeted. On a share-phase failure, do not publish; surface the
+        # error AND the assertionName so the caller can recover (share then
+        # publish by name) without recreating the asset.
+        create_errors = created.get("errors") if isinstance(created, dict) else None
+        if isinstance(create_errors, list) and create_errors:
+            failure = dict(created)
+            failure["success"] = False
+            failure["assertionName"] = assertion_name
+            if created.get("assertionUri") is not None:
+                failure["assertionUri"] = created["assertionUri"]
+            if created.get("seal") is not None:
+                failure["seal"] = created["seal"]
+            phases = ", ".join(
+                str(e.get("phase")) for e in create_errors if isinstance(e, dict) and e.get("phase")
+            )
+            failure["error"] = (
+                f"Knowledge asset '{assertion_name}' was created and sealed but a later stage "
+                f"failed ({phases or 'share'}), so it was NOT shared to SWM and was NOT published. "
+                f"Share it (dkg_knowledge_asset_share with this name) and then publish "
+                f"(dkg_knowledge_asset_publish / dkg_shared_memory_publish with this name) — do "
+                f"NOT recreate the asset."
+            )
+            return failure
         publish_payload: Dict[str, Any] = {
             "contextGraphId": cg_id,
             "assertionName": assertion_name,
@@ -721,7 +751,27 @@ class DKGClient:
             publish_payload["subGraphName"] = sub_graph_name
         published = self._post("/api/shared-memory/publish", publish_payload)
         if _client_result_failed(published):
-            return published
+            # The on-chain publish failed AFTER the asset was created+sealed+shared
+            # under the random assertion_name. Returning `published` verbatim would
+            # drop that name and the agent would recreate the asset (orphaning the
+            # first) — Codex #1084:723. Merge the assertionName (+ assertionUri/seal)
+            # into the failure with a retry-not-recreate message.
+            failure = dict(published) if isinstance(published, dict) else {"error": str(published)}
+            failure["success"] = False
+            failure["assertionName"] = assertion_name
+            if isinstance(created, dict):
+                if created.get("assertionUri") is not None:
+                    failure["assertionUri"] = created["assertionUri"]
+                if created.get("seal") is not None:
+                    failure["seal"] = created["seal"]
+            base_error = str(failure.get("error") or failure.get("message") or "publish failed")
+            failure["error"] = (
+                f"Knowledge asset '{assertion_name}' was created, sealed, and shared to SWM, but the "
+                f"on-chain publish failed ({base_error}). Retry the publish by name "
+                f"(dkg_knowledge_asset_publish / dkg_shared_memory_publish with this assertionName) — "
+                f"do NOT recreate the asset."
+            )
+            return failure
         result: Dict[str, Any] = dict(published) if isinstance(published, dict) else {"result": published}
         if isinstance(created, dict):
             if created.get("assertionUri") is not None:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -730,8 +730,11 @@ class DKGClient:
             failure["assertionName"] = assertion_name
             if created.get("assertionUri") is not None:
                 failure["assertionUri"] = created["assertionUri"]
-            if created.get("seal") is not None:
-                failure["seal"] = created["seal"]
+            # The create route returns merkleRoot (a hex string), NOT a `seal`
+            # object — created.get("seal") was always None, dropping the proof
+            # (Codex #1084:733). Carry merkleRoot.
+            if created.get("merkleRoot") is not None:
+                failure["merkleRoot"] = created["merkleRoot"]
             phases = ", ".join(
                 str(e.get("phase")) for e in create_errors if isinstance(e, dict) and e.get("phase")
             )
@@ -753,16 +756,16 @@ class DKGClient:
             # The on-chain publish failed AFTER the asset was created+sealed+shared
             # under the random assertion_name. Returning `published` verbatim would
             # drop that name and the agent would recreate the asset (orphaning the
-            # first) — Codex #1084:723. Merge the assertionName (+ assertionUri/seal)
-            # into the failure with a retry-not-recreate message.
+            # first) — Codex #1084:723. Merge the assertionName (+ assertionUri/
+            # merkleRoot) into the failure with a retry-not-recreate message.
             failure = dict(published) if isinstance(published, dict) else {"error": str(published)}
             failure["success"] = False
             failure["assertionName"] = assertion_name
             if isinstance(created, dict):
                 if created.get("assertionUri") is not None:
                     failure["assertionUri"] = created["assertionUri"]
-                if created.get("seal") is not None:
-                    failure["seal"] = created["seal"]
+                if created.get("merkleRoot") is not None:
+                    failure["merkleRoot"] = created["merkleRoot"]
             base_error = str(failure.get("error") or failure.get("message") or "publish failed")
             failure["error"] = (
                 f"Knowledge asset '{assertion_name}' was created, sealed, and shared to SWM, but the "
@@ -774,8 +777,10 @@ class DKGClient:
         if isinstance(created, dict):
             if created.get("assertionUri") is not None:
                 result["assertionUri"] = created["assertionUri"]
-            if created.get("seal") is not None:
-                result["seal"] = created["seal"]
+            # Carry merkleRoot (the create proof), not the always-None seal
+            # (Codex #1084:733).
+            if created.get("merkleRoot") is not None:
+                result["merkleRoot"] = created["merkleRoot"]
         result["assertionName"] = assertion_name
         return result
 

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -738,9 +738,8 @@ class DKGClient:
             failure["error"] = (
                 f"Knowledge asset '{assertion_name}' was created and sealed but a later stage "
                 f"failed ({phases or 'share'}), so it was NOT shared to SWM and was NOT published. "
-                f"Share it (dkg_knowledge_asset_share with this name) and then publish "
-                f"(dkg_knowledge_asset_publish / dkg_shared_memory_publish with this name) — do "
-                f"NOT recreate the asset."
+                f"Share it with dkg_knowledge_asset_share (this name), then publish with "
+                f"dkg_knowledge_asset_publish (this name) -- do NOT recreate the asset."
             )
             return failure
         publish_payload: Dict[str, Any] = {
@@ -767,9 +766,8 @@ class DKGClient:
             base_error = str(failure.get("error") or failure.get("message") or "publish failed")
             failure["error"] = (
                 f"Knowledge asset '{assertion_name}' was created, sealed, and shared to SWM, but the "
-                f"on-chain publish failed ({base_error}). Retry the publish by name "
-                f"(dkg_knowledge_asset_publish / dkg_shared_memory_publish with this assertionName) — "
-                f"do NOT recreate the asset."
+                f"on-chain publish failed ({base_error}). Retry the publish by name with "
+                f"dkg_knowledge_asset_publish (this assertionName) -- do NOT recreate the asset."
             )
             return failure
         result: Dict[str, Any] = dict(published) if isinstance(published, dict) else {"result": published}

--- a/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
+++ b/packages/adapter-hermes/pytests/test_lifecycle_tool_handlers.py
@@ -815,28 +815,25 @@ def test_new_handlers_require_context_graph_id(provider, tool):
     assert "context_graph_id is required" in out["error"]
 
 
-# -- FIX M/N (#1079): dkg_publish clear_after=False + counts only on success --
+# -- FIX N (#1084:1821): dkg_publish quadsPublished only on a non-hard-failure --
+# (On #1084 dkg_publish uses the atomic publish_quads fork — FIX M's clear_after
+#  is N/A here; only the quadsPublished count needs the failure guard.)
 
-class _SelectionPublishProbe:
-    """Fake client for the #1079 _handle_publish selection path."""
+class _PublishQuadsProbe:
+    """Fake client for the #1084 _handle_publish publish_quads path."""
 
-    def __init__(self, publish_response):
-        self.publish_call = None
-        self.publish_response = publish_response
+    def __init__(self, publish_quads_response):
+        self.publish_quads_response = publish_quads_response
 
-    def share(self, context_graph_id, quads, sub_graph_name=None):
-        return {"success": True}
-
-    def publish(self, context_graph_id, selection="all", clear_after=True, sub_graph_name=None):
-        self.publish_call = {"selection": selection, "clear_after": clear_after}
-        return self.publish_response
+    def publish_quads(self, context_graph_id, quads, sub_graph_name=None):
+        return self.publish_quads_response
 
 
-def _selection_publish_provider(plugin_module, publish_response):
+def _publish_quads_provider(plugin_module, publish_quads_response):
     p = plugin_module.DKGMemoryProvider()
     p._offline = False
     p._config = {"publish_tool": "direct", "allow_direct_publish": True}
-    p._client = _SelectionPublishProbe(publish_response)
+    p._client = _PublishQuadsProbe(publish_quads_response)
     return p
 
 
@@ -846,50 +843,32 @@ _PUB_Q2 = [
 ]
 
 
-def test_dkg_publish_passes_clear_after_false(plugin_module):
-    # FIX M (#1079:1781): clear_after=True would wipe the whole SWM remainder
-    # (deleteByPattern over the bucket, no subject filter) — dkg_publish only
-    # owns the roots it wrote, so it must pass clear_after=False.
-    p = _selection_publish_provider(plugin_module, {
-        "success": True, "partial": False,
-        "published": [{"rootEntity": "urn:r1"}], "rootEntities": ["urn:r1", "urn:r2"],
-    })
-    p.handle_tool_call("dkg_publish", {"context_graph_id": "cg", "quads": _PUB_Q2})
-    assert p._client.publish_call["clear_after"] is False
-    assert p._client.publish_call["selection"] == ["urn:r1", "urn:r2"]
-
-
-def test_dkg_publish_no_counts_on_hard_failure(plugin_module):
-    # FIX N (#1079:1784): quadsPublished/rootEntities must NOT be stamped on a
-    # partial-failure dict — that would falsely imply everything published.
-    p = _selection_publish_provider(plugin_module, {
-        "success": False, "partial": True, "failedRoot": "urn:r2",
-        "publishedRoots": ["urn:r1"], "error": "mint failed",
+def test_dkg_publish_no_quads_published_on_hard_failure(plugin_module):
+    # FIX N (#1084:1821): publish_quads returns a partial-failure dict on
+    # create-207 / publish-fail — quadsPublished must NOT be stamped there.
+    p = _publish_quads_provider(plugin_module, {
+        "success": False, "assertionName": "hermes-publish-x", "error": "not shared",
     })
     out = json.loads(p.handle_tool_call("dkg_publish", {"context_graph_id": "cg", "quads": _PUB_Q2}))
     assert out["success"] is False
     assert "quadsPublished" not in out
-    assert "rootEntities" not in out
-    assert out["failedRoot"] == "urn:r2"
+    assert out["assertionName"] == "hermes-publish-x"
 
 
-def test_dkg_publish_counts_on_success(plugin_module):
-    p = _selection_publish_provider(plugin_module, {"success": True, "partial": False})
+def test_dkg_publish_quads_published_on_confirmed(plugin_module):
+    p = _publish_quads_provider(plugin_module, {"kaId": "k", "ual": "u", "status": "confirmed"})
     out = json.loads(p.handle_tool_call("dkg_publish", {"context_graph_id": "cg", "quads": _PUB_Q2}))
     assert out["quadsPublished"] == 2
-    assert out["rootEntities"] == ["urn:r1", "urn:r2"]
 
 
-def test_dkg_publish_counts_on_confirmed_raw_body(plugin_module):
-    # a single-root passthrough returns the raw daemon body (no success key) —
-    # that is a confirmed publish and should be annotated.
-    p = _selection_publish_provider(plugin_module, {"kaId": "k", "ual": "u", "status": "confirmed"})
-    out = json.loads(p.handle_tool_call("dkg_publish", {
-        "context_graph_id": "cg",
-        "quads": [{"subject": "urn:solo", "predicate": "urn:p", "object": "o"}],
-    }))
-    assert out["quadsPublished"] == 1
-    assert out["rootEntities"] == ["urn:solo"]
+def test_dkg_publish_quads_published_on_207_partial(plugin_module):
+    # a 207-partial (minted, CG-bind failed) is NOT a hard failure -> annotate.
+    p = _publish_quads_provider(plugin_module, {
+        "kaId": "k", "ual": "u", "status": "confirmed", "contextGraphError": "bind failed",
+    })
+    out = json.loads(p.handle_tool_call("dkg_publish", {"context_graph_id": "cg", "quads": _PUB_Q2}))
+    assert out["partial"] is True
+    assert out["quadsPublished"] == 2
 
 
 # -- FIX P (#1077:63 parity): create name desc states the real validation ------

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -389,6 +389,45 @@ def test_publish_quads_publish_failure_merges_assertion_name(recording_client):
     assert "dkg_shared_memory_publish" not in result["error"]
 
 
+# -- FIX O (#1084:730): recovery payloads carry subGraphName + mention it -------
+
+def test_publish_quads_create_207_carries_sub_graph_name(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"created": True, "assertionUri": "urn:a", "merkleRoot": "0xr",
+         "errors": [{"phase": "swm-share", "error": "x"}]}
+        if path == "/api/knowledge-assets" else {"status": "confirmed"}
+    )
+    result = client.publish_quads("cg", _Q, sub_graph_name="notes")
+    assert result["subGraphName"] == "notes"
+    assert "sub-graph 'notes'" in result["error"]
+    assert "sub_graph_name" in result["error"]  # guidance mentions it for recovery
+
+
+def test_publish_quads_publish_fail_carries_sub_graph_name(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"assertionUri": "urn:a", "merkleRoot": "0xr", "swmShared": True}
+        if path == "/api/knowledge-assets"
+        else {"success": False, "error": "chain revert"}
+    )
+    result = client.publish_quads("cg", _Q, sub_graph_name="notes")
+    assert result["subGraphName"] == "notes"
+    assert "sub-graph 'notes'" in result["error"]
+    assert "sub_graph_name" in result["error"]
+
+
+def test_publish_quads_recovery_omits_sub_graph_name_when_absent(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"created": True, "errors": [{"phase": "swm-share", "error": "x"}]}
+        if path == "/api/knowledge-assets" else {"status": "confirmed"}
+    )
+    result = client.publish_quads("cg", _Q)
+    assert "subGraphName" not in result
+    assert "sub-graph" not in result["error"]
+
+
 # -- Phase B (fast-follow): register_if_needed on the one-shot dkg_publish ----
 # The atomic assertionName fork does NOT auto-register the CG (LU-6 is selection-
 # fork only), so dkg_publish gets its own register lever (mirrors §G).

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -323,6 +323,11 @@ def test_publish_quads_create_failure_short_circuits(recording_client):
     assert "boom" in result["error"]
     assert result["assertionName"] in result["error"]
     assert "before recreating" in result["error"]
+    # FIX Y (#1076:1047): a created asset is auto-shared to SWM (WM draft empty), so
+    # recovery must point at dkg_knowledge_asset_history (lifecycle state, any layer)
+    # and NOT dkg_knowledge_asset_query (the WM-draft reader, which would read 0).
+    assert "dkg_knowledge_asset_history" in result["error"]
+    assert "not dkg_knowledge_asset_query" in result["error"]
     # publish was never attempted
     assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]
 

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -244,10 +244,17 @@ def test_handle_publish_result_has_no_per_root_shape(plugin_module):
         assert key not in out, key
 
 
-def test_dkg_publish_description_is_atomic(plugin_module):
+def test_dkg_publish_description_atomic_mint_two_step(plugin_module):
+    # FIX L (#1084:324): the ATOMIC claim is scoped to the on-chain MINT
+    # (multi-root-safe); the whole helper is a TWO-STEP create-then-publish that
+    # can partially fail — it must NOT be called "one ATOMIC operation".
     p = _publish_provider(plugin_module)
     desc = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")["description"]
-    assert "ATOMIC" in desc or "atomic" in desc
+    assert "atomic" in desc.lower()
+    assert "one ATOMIC operation" not in desc
+    assert "TWO-STEP" in desc or "two-step" in desc.lower()
+    assert "partially fail" in desc.lower()
+    assert "multi-root-safe" in desc
     assert "NON-ATOMIC" not in desc
     assert "per-root" not in desc.lower()
 
@@ -259,7 +266,8 @@ def test_publish_quads_two_calls_create_then_publish_by_name(recording_client):
 
     def responder(path, body):
         if path == "/api/knowledge-assets":
-            return {"assertionUri": "urn:a", "seal": {"merkleRoot": "0xr"}}
+            # the create route returns merkleRoot (a hex string), not a seal object
+            return {"assertionUri": "urn:a", "merkleRoot": "0xr"}
         return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
 
     client.responder = responder
@@ -279,10 +287,11 @@ def test_publish_quads_two_calls_create_then_publish_by_name(recording_client):
     # assertionName fork — name only, NO selection
     assert publish_body == {"contextGraphId": "cg", "assertionName": create_body["name"]}
     assert "selection" not in publish_body
-    # merged result surfaces ual/assertionUri/seal/assertionName
+    # merged result surfaces ual/assertionUri/merkleRoot/assertionName
     assert result["ual"] == "did:dkg:1/0xabc/5"
     assert result["assertionUri"] == "urn:a"
-    assert result["seal"] == {"merkleRoot": "0xr"}
+    assert result["merkleRoot"] == "0xr"
+    assert "seal" not in result  # FIX J: the always-None seal is gone
     assert result["assertionName"] == create_body["name"]
 
 
@@ -316,7 +325,7 @@ def test_publish_quads_create_207_errors_does_not_publish(recording_client):
     client = recording_client
     client.responder = lambda path, body: (
         {
-            "created": True, "assertionUri": "urn:a", "seal": {"merkleRoot": "0xr"},
+            "created": True, "assertionUri": "urn:a", "merkleRoot": "0xr",
             "status": "wm-sealed",
             "errors": [{"phase": "swm-share", "error": "gossip timeout"}],
         }
@@ -329,7 +338,9 @@ def test_publish_quads_create_207_errors_does_not_publish(recording_client):
     # assertionName + recovery context surfaced
     assert result["assertionName"].startswith("hermes-publish-")
     assert result["assertionUri"] == "urn:a"
-    assert result["seal"] == {"merkleRoot": "0xr"}
+    # FIX J (#1084:733): carry merkleRoot (the create proof), not the always-None seal
+    assert result["merkleRoot"] == "0xr"
+    assert "seal" not in result
     assert "swm-share" in result["error"]
     assert "NOT shared" in result["error"]
     assert "recreate" in result["error"].lower()
@@ -356,7 +367,7 @@ def test_publish_quads_create_empty_errors_publishes(recording_client):
 def test_publish_quads_publish_failure_merges_assertion_name(recording_client):
     client = recording_client
     client.responder = lambda path, body: (
-        {"assertionUri": "urn:a", "seal": {"m": "r"}, "swmShared": True}
+        {"assertionUri": "urn:a", "merkleRoot": "0xr", "swmShared": True}
         if path == "/api/knowledge-assets"
         else {"success": False, "error": "chain revert: insufficient TRAC"}
     )
@@ -366,7 +377,9 @@ def test_publish_quads_publish_failure_merges_assertion_name(recording_client):
     # the random name is kept (don't recreate — retry by name)
     assert result["assertionName"].startswith("hermes-publish-")
     assert result["assertionUri"] == "urn:a"
-    assert result["seal"] == {"m": "r"}
+    # FIX J (#1084:733): carry merkleRoot, not the always-None seal
+    assert result["merkleRoot"] == "0xr"
+    assert "seal" not in result
     assert "insufficient TRAC" in result["error"]
     assert "shared to SWM" in result["error"]
     assert "Retry the publish" in result["error"]

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -333,6 +333,11 @@ def test_publish_quads_create_207_errors_does_not_publish(recording_client):
     assert "swm-share" in result["error"]
     assert "NOT shared" in result["error"]
     assert "recreate" in result["error"].lower()
+    # FIX F (#1084:742): point to dkg_knowledge_asset_share + _publish, NOT
+    # dkg_shared_memory_publish (which can't retry by name).
+    assert "dkg_knowledge_asset_share" in result["error"]
+    assert "dkg_knowledge_asset_publish" in result["error"]
+    assert "dkg_shared_memory_publish" not in result["error"]
 
 
 def test_publish_quads_create_empty_errors_publishes(recording_client):
@@ -366,6 +371,9 @@ def test_publish_quads_publish_failure_merges_assertion_name(recording_client):
     assert "shared to SWM" in result["error"]
     assert "Retry the publish" in result["error"]
     assert "recreate" in result["error"].lower()
+    # FIX F (#1084:742): retry-by-name points to dkg_knowledge_asset_publish only.
+    assert "dkg_knowledge_asset_publish" in result["error"]
+    assert "dkg_shared_memory_publish" not in result["error"]
 
 
 # -- Phase B (fast-follow): register_if_needed on the one-shot dkg_publish ----
@@ -378,9 +386,12 @@ _Q = [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}]
 class _RegisterProbe:
     """Fake client recording register + publish_quads for dkg_publish."""
 
-    def __init__(self, register_response):
+    def __init__(self, register_response, publish_response=None):
         self.calls = []
         self.register_response = register_response
+        self.publish_response = publish_response or {
+            "kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed",
+        }
 
     def register_context_graph(self, context_graph_id, access_policy=None):
         self.calls.append(("register", context_graph_id, access_policy))
@@ -388,14 +399,14 @@ class _RegisterProbe:
 
     def publish_quads(self, context_graph_id, quads, sub_graph_name=None):
         self.calls.append(("publish", context_graph_id, len(quads)))
-        return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
+        return self.publish_response
 
 
-def _register_provider(plugin_module, register_response):
+def _register_provider(plugin_module, register_response, publish_response=None):
     p = plugin_module.DKGMemoryProvider()
     p._offline = False
     p._config = {"publish_tool": "direct", "allow_direct_publish": True}
-    p._client = _RegisterProbe(register_response)
+    p._client = _RegisterProbe(register_response, publish_response)
     return p
 
 
@@ -431,6 +442,38 @@ def test_publish_register_already_registered_short_circuits(plugin_module):
     }))
     assert _kinds(p) == ["register", "publish"]
     assert out["ual"] == "did:dkg:1/0xabc/5"
+    # FIX H (#1084:1810): the already-registered short-circuit normalizes the
+    # registration to a success shape — NOT the raw {success:false}.
+    assert out["registration"] == {"alreadyRegistered": True}
+    assert out["registration"].get("success") is not False
+
+
+# -- FIX E (#1077:1115): dkg_publish 207 contextGraphError -> partial/warning --
+
+def test_publish_207_context_graph_error_surfaces_partial(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"}, publish_response={
+        "kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed",
+        "assertionName": "hermes-publish-x", "contextGraphError": "cg bind timed out",
+    })
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q,
+    }))
+    assert out["partial"] is True
+    assert "Partial publish" in out["warning"]
+    assert "cg bind timed out" in out["warning"]
+    # minted-on-chain identifiers stay visible
+    assert out["ual"] == "did:dkg:1/0xabc/5"
+    assert out["kaId"] == "ka"
+    assert out["assertionName"] == "hermes-publish-x"
+
+
+def test_publish_clean_200_not_marked_partial(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q,
+    }))
+    assert "partial" not in out
+    assert "warning" not in out
 
 
 def test_publish_register_hard_failure_no_publish(plugin_module):

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -663,3 +663,18 @@ def test_publish_access_policy_description_notes_register_dependency(plugin_modu
     pub = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")
     desc = pub["parameters"]["properties"]["access_policy"]["description"]
     assert "REQUIRES register_if_needed" in desc
+
+
+# -- FIX X (#1076:2396 / Option A): dkg_publish explicit-register publishPolicy caveat
+# dkg_publish exposes the explicit register route (no rehydration), so its
+# register_if_needed must carry the default-publishPolicy caveat (daemon-side
+# rehydration tracked in dkg#1085).
+
+def test_publish_register_desc_carries_publish_policy_caveat(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    pub = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")
+    desc = pub["parameters"]["properties"]["register_if_needed"]["description"]
+    assert "DEFAULT publishPolicy" in desc
+    assert "does NOT preserve" in desc
+    assert "Read access is unaffected" in desc
+    assert "dkg#1085" in desc

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -308,3 +308,112 @@ def test_publish_quads_create_failure_short_circuits(recording_client):
     assert result == {"success": False, "error": "boom"}
     # publish was never attempted
     assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]
+
+
+# -- Phase B (fast-follow): register_if_needed on the one-shot dkg_publish ----
+# The atomic assertionName fork does NOT auto-register the CG (LU-6 is selection-
+# fork only), so dkg_publish gets its own register lever (mirrors §G).
+
+_Q = [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}]
+
+
+class _RegisterProbe:
+    """Fake client recording register + publish_quads for dkg_publish."""
+
+    def __init__(self, register_response):
+        self.calls = []
+        self.register_response = register_response
+
+    def register_context_graph(self, context_graph_id, access_policy=None):
+        self.calls.append(("register", context_graph_id, access_policy))
+        return self.register_response
+
+    def publish_quads(self, context_graph_id, quads, sub_graph_name=None):
+        self.calls.append(("publish", context_graph_id, len(quads)))
+        return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
+
+
+def _register_provider(plugin_module, register_response):
+    p = plugin_module.DKGMemoryProvider()
+    p._offline = False
+    p._config = {"publish_tool": "direct", "allow_direct_publish": True}
+    p._client = _RegisterProbe(register_response)
+    return p
+
+
+def _kinds(p):
+    return [c[0] for c in p._client.calls]
+
+
+def test_publish_register_if_needed_fresh_cg(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg", "onChainId": "42"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q, "register_if_needed": True,
+    }))
+    assert _kinds(p) == ["register", "publish"]  # register BEFORE publish
+    assert out["registration"] == {"registered": "cg", "onChainId": "42"}
+    assert out["ual"] == "did:dkg:1/0xabc/5"
+
+
+def test_publish_default_no_register(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q,
+    }))
+    assert _kinds(p) == ["publish"]
+    assert "registration" not in out
+
+
+def test_publish_register_already_registered_short_circuits(plugin_module):
+    p = _register_provider(plugin_module, {
+        "success": False, "error": "Context graph already registered on-chain",
+    })
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q, "register_if_needed": True,
+    }))
+    assert _kinds(p) == ["register", "publish"]
+    assert out["ual"] == "did:dkg:1/0xabc/5"
+
+
+def test_publish_register_hard_failure_no_publish(plugin_module):
+    p = _register_provider(plugin_module, {"success": False, "error": "insufficient gas"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q, "register_if_needed": True,
+    }))
+    assert _kinds(p) == ["register"]  # publish NOT attempted
+    assert out["success"] is False
+    assert "insufficient gas" in out["error"]
+
+
+def test_publish_register_if_needed_bool_and_access_policy_guards(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q, "register_if_needed": "yes",
+    }))
+    assert "register_if_needed must be a boolean" in out["error"]
+    assert p._client.calls == []
+    # bool access_policy rejected (Phase-A guard), register not attempted
+    for bad in (True, False, 5):
+        out = json.loads(p.handle_tool_call("dkg_publish", {
+            "context_graph_id": "cg", "quads": _Q,
+            "register_if_needed": True, "access_policy": bad,
+        }))
+        assert "access_policy" in out["error"], bad
+        assert p._client.calls == [], bad
+
+
+def test_publish_register_access_policy_forwarded(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q,
+        "register_if_needed": True, "access_policy": 1,
+    })
+    assert p._client.calls[0] == ("register", "cg", 1)
+
+
+def test_publish_schema_has_register_if_needed(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    pub = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")
+    props = pub["parameters"]["properties"]
+    assert props["register_if_needed"]["type"] == "boolean"
+    assert "access_policy" in props

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -428,6 +428,46 @@ def test_publish_quads_recovery_omits_sub_graph_name_when_absent(recording_clien
     assert "sub-graph" not in result["error"]
 
 
+# -- FIX R (#1084:787): publish_quads annotates a 207 at the client ------------
+
+def test_publish_quads_annotates_207_partial_at_client(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"assertionUri": "urn:a", "merkleRoot": "0xr"}
+        if path == "/api/knowledge-assets"
+        else {"kaId": "k", "ual": "u", "status": "confirmed", "contextGraphError": "bind failed"}
+    )
+    # the client itself (no handler wrap) returns the partial-annotated result
+    result = client.publish_quads("cg", _Q)
+    assert result["partial"] is True
+    assert "Partial publish" in result["warning"]
+    assert "bind failed" in result["warning"]
+    assert result["ual"] == "u"
+    assert result["assertionName"].startswith("hermes-publish-")
+
+
+def test_publish_quads_clean_200_not_partial(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"assertionUri": "urn:a", "merkleRoot": "0xr"}
+        if path == "/api/knowledge-assets"
+        else {"kaId": "k", "ual": "u", "status": "confirmed"}
+    )
+    result = client.publish_quads("cg", _Q)
+    assert "partial" not in result
+    assert "warning" not in result
+
+
+def test_annotate_207_partial_client_helper(client_module):
+    f = client_module._annotate_207_partial
+    r = f({"ual": "u", "contextGraphError": "boom"})
+    assert r["partial"] is True and "boom" in r["warning"] and r["ual"] == "u"
+    assert "retry the publish" not in r["warning"].lower()
+    assert "partial" not in f({"ual": "u"})
+    assert "partial" not in f({"ual": "u", "contextGraphError": ""})
+    assert f("x") == "x"
+
+
 # -- Phase B (fast-follow): register_if_needed on the one-shot dkg_publish ----
 # The atomic assertionName fork does NOT auto-register the CG (LU-6 is selection-
 # fork only), so dkg_publish gets its own register lever (mirrors §G).
@@ -570,3 +610,34 @@ def test_publish_schema_has_register_if_needed(plugin_module):
     props = pub["parameters"]["properties"]
     assert props["register_if_needed"]["type"] == "boolean"
     assert "access_policy" in props
+
+
+# -- FIX S (#1084:1792): access_policy on dkg_publish requires register_if_needed
+# access_policy is only honoured inside the register_if_needed branch, so sending
+# it WITHOUT register_if_needed silently dropped the privacy setting — reject it.
+
+def test_publish_rejects_access_policy_without_register(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q, "access_policy": 1,
+    }))
+    assert "access_policy requires register_if_needed" in out["error"]
+    # rejected before any register/publish — the privacy setting is never dropped
+    assert p._client.calls == []
+
+
+def test_publish_allows_access_policy_with_register(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg", "quads": _Q,
+        "register_if_needed": True, "access_policy": 1,
+    }))
+    assert "access_policy requires register_if_needed" not in out.get("error", "")
+    assert p._client.calls[0] == ("register", "cg", 1)
+
+
+def test_publish_access_policy_description_notes_register_dependency(plugin_module):
+    p = _register_provider(plugin_module, {"registered": "cg"})
+    pub = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")
+    desc = pub["parameters"]["properties"]["access_policy"]["description"]
+    assert "REQUIRES register_if_needed" in desc

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -176,54 +176,135 @@ def test_all_duplicate_roots_collapse_to_single_call(recording_client):
     assert body["clearAfter"] is True
 
 
-# -- #1750: dkg_publish publishes the EXPLICIT roots it wrote, never "all" ----
+# -- dkg_publish (one-shot) uses the ATOMIC assertionName fork --------------
+# (Fast-follow: parity with OpenClaw + MCP. The selection/loop/dedup above is
+#  still used by the explicit CG-wide dkg_shared_memory_publish tool.)
 
-class _PublishProbe:
-    """Minimal fake client for _handle_publish: records the share + publish args."""
+import json
+
+
+class _AssertionNameProbe:
+    """Fake client recording the assertionName-fork one-shot publish."""
 
     def __init__(self):
-        self.published = None
+        self.publish_quads_call = None
 
-    def share(self, context_graph_id, quads, sub_graph_name=None):
-        return {"success": True}
-
-    def publish(self, context_graph_id, selection="all", clear_after=True,
-                sub_graph_name=None):
-        self.published = {"contextGraphId": context_graph_id, "selection": selection,
-                          "clearAfter": clear_after}
-        return {"success": True}
+    def publish_quads(self, context_graph_id, quads, sub_graph_name=None):
+        self.publish_quads_call = {
+            "contextGraphId": context_graph_id,
+            "quads": quads,
+            "subGraphName": sub_graph_name,
+        }
+        return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
 
 
 def _publish_provider(plugin_module):
     p = plugin_module.DKGMemoryProvider()
     p._offline = False
     p._config = {"publish_tool": "direct", "allow_direct_publish": True}
-    p._client = _PublishProbe()
+    p._client = _AssertionNameProbe()
     return p
 
 
-def test_handle_publish_single_root_uses_explicit_list_not_all(plugin_module):
-    import json
+def test_handle_publish_routes_to_assertionname_fork(plugin_module):
     p = _publish_provider(plugin_module)
-    json.loads(p.handle_tool_call("dkg_publish", {
+    out = json.loads(p.handle_tool_call("dkg_publish", {
         "context_graph_id": "cg:test",
-        "quads": [
-            {"subject": "urn:root:solo", "predicate": "urn:p", "object": "one"},
-            {"subject": "urn:root:solo", "predicate": "urn:p2", "object": "two"},
-        ],
+        "quads": [{"subject": "urn:root:solo", "predicate": "urn:p", "object": "one"}],
     }))
-    # NOT "all" — only the root this call wrote (Codex #1750).
-    assert p._client.published["selection"] == ["urn:root:solo"]
+    # one atomic publish_quads call — no per-root selection/loop
+    assert p._client.publish_quads_call["contextGraphId"] == "cg:test"
+    assert out["ual"] == "did:dkg:1/0xabc/5"
+    assert out["quadsPublished"] == 1
 
 
-def test_handle_publish_multi_root_uses_explicit_list(plugin_module):
-    import json
+def test_handle_publish_multi_subject_one_atomic_call(plugin_module):
     p = _publish_provider(plugin_module)
-    json.loads(p.handle_tool_call("dkg_publish", {
+    out = json.loads(p.handle_tool_call("dkg_publish", {
         "context_graph_id": "cg:test",
         "quads": [
             {"subject": "urn:root:1", "predicate": "urn:p", "object": "x"},
             {"subject": "urn:root:2", "predicate": "urn:p", "object": "y"},
         ],
     }))
-    assert p._client.published["selection"] == ["urn:root:1", "urn:root:2"]
+    # multi-subject publishes atomically in ONE call — no 409, no over-scope
+    assert len(p._client.publish_quads_call["quads"]) == 2
+    assert out["ual"] == "did:dkg:1/0xabc/5"
+
+
+def test_handle_publish_result_has_no_per_root_shape(plugin_module):
+    p = _publish_provider(plugin_module)
+    out = json.loads(p.handle_tool_call("dkg_publish", {
+        "context_graph_id": "cg:test",
+        "quads": [{"subject": "urn:r", "predicate": "urn:p", "object": "o"}],
+    }))
+    # the obsolete selection-fork result fields are gone
+    for key in ("rootEntities", "partial", "publishedRoots",
+                "failedRoot", "notAttemptedRoots"):
+        assert key not in out, key
+
+
+def test_dkg_publish_description_is_atomic(plugin_module):
+    p = _publish_provider(plugin_module)
+    desc = next(s for s in p.get_tool_schemas() if s["name"] == "dkg_publish")["description"]
+    assert "ATOMIC" in desc or "atomic" in desc
+    assert "NON-ATOMIC" not in desc
+    assert "per-root" not in desc.lower()
+
+
+# -- client.publish_quads payload shaping (assertionName fork) ---------------
+
+def test_publish_quads_two_calls_create_then_publish_by_name(recording_client):
+    client = recording_client
+
+    def responder(path, body):
+        if path == "/api/knowledge-assets":
+            return {"assertionUri": "urn:a", "seal": {"merkleRoot": "0xr"}}
+        return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
+
+    client.responder = responder
+    result = client.publish_quads("did:dkg:context-graph:cg", [
+        {"subject": "urn:s1", "predicate": "urn:p", "object": "x", "graph": "urn:g"},
+        {"subject": "urn:s2", "predicate": "urn:p", "object": "y"},
+    ])
+    paths = [p for p, _ in client.posts]
+    assert paths == ["/api/knowledge-assets", "/api/shared-memory/publish"]
+    create_body = client.posts[0][1]
+    assert create_body["contextGraphId"] == "cg"
+    assert create_body["promote"] is True
+    assert create_body["name"].startswith("hermes-publish-")
+    # graph stripped on the create quads (CONTRACT §0 invariant 2)
+    assert all(set(q.keys()) == {"subject", "predicate", "object"} for q in create_body["quads"])
+    publish_body = client.posts[1][1]
+    # assertionName fork — name only, NO selection
+    assert publish_body == {"contextGraphId": "cg", "assertionName": create_body["name"]}
+    assert "selection" not in publish_body
+    # merged result surfaces ual/assertionUri/seal/assertionName
+    assert result["ual"] == "did:dkg:1/0xabc/5"
+    assert result["assertionUri"] == "urn:a"
+    assert result["seal"] == {"merkleRoot": "0xr"}
+    assert result["assertionName"] == create_body["name"]
+
+
+def test_publish_quads_unique_name_per_call(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"assertionUri": "u"} if path == "/api/knowledge-assets" else {"status": "confirmed"}
+    )
+    client.publish_quads("cg", [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}])
+    n1 = client.posts[0][1]["name"]
+    client.posts.clear()
+    client.publish_quads("cg", [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}])
+    n2 = client.posts[0][1]["name"]
+    assert n1 != n2
+
+
+def test_publish_quads_create_failure_short_circuits(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"success": False, "error": "boom"} if path == "/api/knowledge-assets" else {"status": "confirmed"}
+    )
+    result = client.publish_quads("cg", [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}])
+    assert result == {"success": False, "error": "boom"}
+    # publish was never attempted
+    assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -310,6 +310,64 @@ def test_publish_quads_create_failure_short_circuits(recording_client):
     assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]
 
 
+# -- FIX A (#1084:714): create 207 with errors[] (share failed) -> no publish -
+
+def test_publish_quads_create_207_errors_does_not_publish(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {
+            "created": True, "assertionUri": "urn:a", "seal": {"merkleRoot": "0xr"},
+            "status": "wm-sealed",
+            "errors": [{"phase": "swm-share", "error": "gossip timeout"}],
+        }
+        if path == "/api/knowledge-assets" else {"kaId": "k", "ual": "u", "status": "confirmed"}
+    )
+    result = client.publish_quads("cg", _Q)
+    # the assertion was sealed but NOT shared -> must NOT publish
+    assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]
+    assert result["success"] is False
+    # assertionName + recovery context surfaced
+    assert result["assertionName"].startswith("hermes-publish-")
+    assert result["assertionUri"] == "urn:a"
+    assert result["seal"] == {"merkleRoot": "0xr"}
+    assert "swm-share" in result["error"]
+    assert "NOT shared" in result["error"]
+    assert "recreate" in result["error"].lower()
+
+
+def test_publish_quads_create_empty_errors_publishes(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"created": True, "assertionUri": "urn:a", "errors": []}
+        if path == "/api/knowledge-assets" else {"kaId": "k", "ual": "u", "status": "confirmed"}
+    )
+    result = client.publish_quads("cg", _Q)
+    assert [p for p, _ in client.posts] == ["/api/knowledge-assets", "/api/shared-memory/publish"]
+    assert result["ual"] == "u"
+
+
+# -- FIX B (#1084:723): publish fails after create+share -> keep assertionName -
+
+def test_publish_quads_publish_failure_merges_assertion_name(recording_client):
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"assertionUri": "urn:a", "seal": {"m": "r"}, "swmShared": True}
+        if path == "/api/knowledge-assets"
+        else {"success": False, "error": "chain revert: insufficient TRAC"}
+    )
+    result = client.publish_quads("cg", _Q)
+    assert [p for p, _ in client.posts] == ["/api/knowledge-assets", "/api/shared-memory/publish"]
+    assert result["success"] is False
+    # the random name is kept (don't recreate — retry by name)
+    assert result["assertionName"].startswith("hermes-publish-")
+    assert result["assertionUri"] == "urn:a"
+    assert result["seal"] == {"m": "r"}
+    assert "insufficient TRAC" in result["error"]
+    assert "shared to SWM" in result["error"]
+    assert "Retry the publish" in result["error"]
+    assert "recreate" in result["error"].lower()
+
+
 # -- Phase B (fast-follow): register_if_needed on the one-shot dkg_publish ----
 # The atomic assertionName fork does NOT auto-register the CG (LU-6 is selection-
 # fork only), so dkg_publish gets its own register lever (mirrors §G).

--- a/packages/adapter-hermes/pytests/test_multi_root_publish.py
+++ b/packages/adapter-hermes/pytests/test_multi_root_publish.py
@@ -309,14 +309,36 @@ def test_publish_quads_unique_name_per_call(recording_client):
 
 
 def test_publish_quads_create_failure_short_circuits(recording_client):
+    # FIX W (#1084:743): the create HARD-failure must surface the assertionName so a
+    # created-but-lost-response is recoverable by name (mirrors the share/publish
+    # failure branches) — NOT return the raw error verbatim, which drops the name.
     client = recording_client
     client.responder = lambda path, body: (
         {"success": False, "error": "boom"} if path == "/api/knowledge-assets" else {"status": "confirmed"}
     )
     result = client.publish_quads("cg", [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}])
-    assert result == {"success": False, "error": "boom"}
+    assert result["success"] is False
+    assert result["assertionName"].startswith("hermes-publish-")
+    # the original daemon error stays visible, wrapped in recover-by-name guidance
+    assert "boom" in result["error"]
+    assert result["assertionName"] in result["error"]
+    assert "before recreating" in result["error"]
     # publish was never attempted
     assert [p for p, _ in client.posts] == ["/api/knowledge-assets"]
+
+
+def test_publish_quads_create_failure_carries_sub_graph_name(recording_client):
+    # FIX W: recovery by name needs the sub-graph the create targeted.
+    client = recording_client
+    client.responder = lambda path, body: (
+        {"success": False, "error": "boom"} if path == "/api/knowledge-assets" else {"status": "confirmed"}
+    )
+    result = client.publish_quads(
+        "cg", [{"subject": "urn:s", "predicate": "urn:p", "object": "o"}],
+        sub_graph_name="evidence",
+    )
+    assert result["subGraphName"] == "evidence"
+    assert "sub-graph 'evidence'" in result["error"]
 
 
 # -- FIX A (#1084:714): create 207 with errors[] (share failed) -> no publish -

--- a/packages/adapter-hermes/test/hermes-adapter.part-11.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.part-11.test.ts
@@ -445,18 +445,16 @@ assert result["success"] is True and provider._client.published is True, result
 # registration to a success shape — it must NOT carry the raw {success:false}.
 assert result["registration"] == {"alreadyRegistered": True}, result
 
+# dkg_publish (one-shot) routes through the ATOMIC assertionName fork
+# (client.publish_quads): create a uniquely-named sealed assertion + publish it
+# by name in one atomic mint — no per-root selection/loop (parity w/ OpenClaw+MCP).
 class PublishClient:
     def __init__(self):
-        self.shared = None
-        self.published = None
+        self.publish_quads_call = None
 
-    def share(self, context_graph_id, quads, sub_graph_name=None):
-        self.shared = (context_graph_id, quads, sub_graph_name)
-        return {"success": True}
-
-    def publish(self, context_graph_id, **kwargs):
-        self.published = (context_graph_id, kwargs)
-        return {"success": True}
+    def publish_quads(self, context_graph_id, quads, sub_graph_name=None):
+        self.publish_quads_call = (context_graph_id, quads, sub_graph_name)
+        return {"kaId": "ka", "ual": "did:dkg:1/0xabc/5", "status": "confirmed"}
 
 provider._client = PublishClient()
 result = json.loads(provider.handle_tool_call("dkg_publish", {
@@ -467,35 +465,14 @@ result = json.loads(provider.handle_tool_call("dkg_publish", {
         {"subject": "urn:root:1", "predicate": "urn:p2", "object": "three"},
     ],
 }))
-assert result["success"] is True, result
-assert result["rootEntities"] == ["urn:root:1", "urn:root:2"], result
-# Multi-root publish passes the explicit root list (not "all") so the client
-# loops one root per call and avoids the 409 MULTI_ROOT_PUBLISH_NOT_ATOMIC
-# single-root guard on /api/shared-memory/publish. clear_after MUST be False
-# (FIX M): clear_after=True wipes the whole SWM remainder, destroying other
-# calls'/agents' unpublished roots; dkg_publish only owns what it just wrote.
-assert provider._client.published == (
-    "cg:test",
-    {"selection": ["urn:root:1", "urn:root:2"], "clear_after": False, "sub_graph_name": ""},
-), provider._client.published
-
-# Single-subject dkg_publish publishes the EXPLICIT root it just wrote, never
-# "all" (which would over-scope to every unpublished root in the CG — Codex #1750).
-provider._client = PublishClient()
-result = json.loads(provider.handle_tool_call("dkg_publish", {
-    "context_graph_id": "cg:test",
-    "quads": [
-        {"subject": "urn:root:solo", "predicate": "urn:p", "object": "one"},
-        {"subject": "urn:root:solo", "predicate": "urn:p2", "object": "two"},
-    ],
-}))
-assert result["success"] is True, result
-assert result["rootEntities"] == ["urn:root:solo"], result
-# clear_after MUST be False (FIX M) — never wipe the SWM remainder.
-assert provider._client.published == (
-    "cg:test",
-    {"selection": ["urn:root:solo"], "clear_after": False, "sub_graph_name": ""},
-), provider._client.published
+# Multi-subject quads publish atomically in ONE call — no 409, no over-scope.
+assert result["ual"] == "did:dkg:1/0xabc/5", result
+assert result["quadsPublished"] == 3, result
+assert provider._client.publish_quads_call[0] == "cg:test", provider._client.publish_quads_call
+assert len(provider._client.publish_quads_call[1]) == 3, provider._client.publish_quads_call
+# The obsolete selection-fork result fields are gone.
+for _k in ("rootEntities", "partial", "publishedRoots", "failedRoot", "notAttemptedRoots"):
+    assert _k not in result, _k
 `;
     const result = spawnSync('python', ['-B', '-c', script], {
       cwd: process.cwd(),


### PR DESCRIPTION
## rc.17 Hermes fast-follow — `dkg_publish` atomicity + register parity

**Stacked on #1079** (base `feat/rc17-hermes-ka-tooling`). Merge #1079 first; the diff here is just the 4 fast-follow commits.

### What
Aligns the Hermes one-shot `dkg_publish` with OpenClaw (#1076) and MCP (#1077) for true three-adapter parity:

1. **Atomic `assertionName` fork** (`1e5b748e5`): `dkg_publish` now creates a fresh uniquely-named assertion (`POST /api/knowledge-assets`, auto-seal + share) and publishes it by `assertionName` via the atomic finalized-assertion fork of `/api/shared-memory/publish` — **multi-root-safe** (the seal commits the whole assertion). This supersedes the legacy `selection`-fork one-root-per-call loop (and its `409 MULTI_ROOT_PUBLISH_NOT_ATOMIC` handling) that the main #1079 PR carried for `dkg_publish`.
2. **`register_if_needed` + `access_policy`** (`607fb85e0`): the atomic fork does **not** auto-register the CG (LU-6 transparent register-then-publish is `selection`-fork-only), so `dkg_publish` gains the same §G register lever as `dkg_knowledge_asset_publish` / `dkg_shared_memory_publish` — register-then-publish (idempotent; already-registered → continue; hard-fail → tool error, no publish), with the bool-safe `access_policy` guard (`type(value) is int`).

### Why
The legacy selection fork is non-atomic (multi-root → one-root-per-call loop + partial-failure surface). The assertionName fork publishes one sealed assertion atomically and matches what OC/MCP already do, so all three adapters now behave identically for "I have loose quads, anchor now". The canonical SKILL.md `dkg_publish` mechanism description was corrected to match (in #1076).

### Commits
- `1e5b748e5` — one-shot `dkg_publish` via the atomic assertionName fork
- `9652786cd` — assertionName-fork tests
- `607fb85e0` — `register_if_needed` register lever on `dkg_publish`
- `71c32a88a` — register-lever tests

### Tests
pytest **98 passed**; adapter-hermes vitest **90 passed** (`--test-timeout=30000`); cli daemon-hermes **92**.

### ⚠️ Breaking (within rc.17)
`dkg_publish` is now multi-root-safe and no longer loops one-root-per-call — callers that previously chunked multi-root quads can pass them in a single call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
