### PR TITLE
fix(daemon): honor explicit finalize:false on POST /api/knowledge-assets

### DIFF
--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -280,6 +280,7 @@ function assertExclusiveAuthorFields(args: {
 
 function assertCreateFinalizeFieldsHaveQuads(args: {
   quads?: unknown[];
+  finalize?: boolean;
   authorAgentAddress?: string;
   preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
   schemeVersion?: number;
@@ -288,8 +289,11 @@ function assertCreateFinalizeFieldsHaveQuads(args: {
     args.authorAgentAddress != null ||
     args.preSignedAuthorAttestation != null ||
     args.schemeVersion !== undefined;
-  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
-    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  // These fields only take effect at finalize, so they require both non-empty
+  // quads AND finalize !== false — mirrors the daemon create-route guard.
+  const willFinalize = Array.isArray(args.quads) && args.quads.length > 0 && args.finalize !== false;
+  if (hasFinalizeOnlyField && !willFinalize) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads and finalize !== false');
   }
 }
 
@@ -1274,6 +1278,13 @@ export class DkgDaemonClient {
     opts?: {
       subGraphName?: string;
       quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+      /**
+       * Seal the draft after writing `quads` (default true). `false` keeps an
+       * editable WM draft that never touches the chain — the only lifecycle
+       * available to local-only / on-chain-unregistered CGs. Cannot be combined
+       * with `alsoShareSwm`/`alsoPublishVm` (those require a sealed assertion).
+       */
+      finalize?: boolean;
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -1112,6 +1112,33 @@ describe('DkgDaemonClient', () => {
       expect(body()).toMatchObject({ contextGraphId: 'cg-1', name: 'f', alsoShareSwm: true });
     });
 
+    it('createKnowledgeAsset forwards finalize:false for a draft-only write', async () => {
+      ok({ name: 'f', written: 1, status: 'draft-open' });
+      await client.createKnowledgeAsset('cg-1', 'f', {
+        finalize: false,
+        quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }],
+      });
+      expect(url()).toBe('http://localhost:9200/api/knowledge-assets');
+      expect(body()).toMatchObject({ contextGraphId: 'cg-1', name: 'f', finalize: false });
+    });
+
+    it('createKnowledgeAsset omits finalize when unspecified (server default seals)', async () => {
+      ok({ name: 'f', status: 'wm-sealed' });
+      await client.createKnowledgeAsset('cg-1', 'f', {
+        quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }],
+      });
+      expect(body()).not.toHaveProperty('finalize');
+    });
+
+    it('createKnowledgeAsset rejects finalize-only fields when finalize:false (parity with daemon)', async () => {
+      await expect(client.createKnowledgeAsset('cg-1', 'f', {
+        authorAgentAddress: '0xauthor',
+        finalize: false,
+        quads: [{ subject: 's', predicate: 'p', object: 'o', graph: '' }],
+      })).rejects.toThrow(/require non-empty quads and finalize !== false/);
+      expect(fetchCalls).toHaveLength(0);
+    });
+
     it('knowledgeAssetWrite URL-encodes the name and POSTs to .../wm/write', async () => {
       ok({ written: 2 });
       await client.knowledgeAssetWrite('cg-1', 'meeting notes', [

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -81,6 +81,7 @@ function assertExclusiveAuthorFields(args: {
 
 function assertCreateFinalizeFieldsHaveQuads(args: {
   quads?: unknown[];
+  finalize?: boolean;
   authorAgentAddress?: string;
   preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
   schemeVersion?: number;
@@ -89,8 +90,11 @@ function assertCreateFinalizeFieldsHaveQuads(args: {
     args.authorAgentAddress != null ||
     args.preSignedAuthorAttestation != null ||
     args.schemeVersion !== undefined;
-  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
-    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  // These fields only take effect at finalize, so they require both non-empty
+  // quads AND finalize !== false — mirrors the daemon create-route guard.
+  const willFinalize = Array.isArray(args.quads) && args.quads.length > 0 && args.finalize !== false;
+  if (hasFinalizeOnlyField && !willFinalize) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads and finalize !== false');
   }
 }
 
@@ -550,13 +554,25 @@ export class ApiClient {
   // surface). The legacy assertion/* + shared-memory/* methods below remain
   // for back-compat during the migration window.
 
-  /** Create a KA + open a WM draft (atomic: pass `quads` to auto write+finalize). */
+  /**
+   * Create a KA + open a WM draft. Pass `quads` to write them atomically; by
+   * default the draft is also sealed (finalized). Pass `finalize: false` to
+   * write a draft WITHOUT sealing — an editable WM-only assertion that never
+   * touches the chain (the only lifecycle available to local-only /
+   * on-chain-unregistered CGs).
+   */
   async createKnowledgeAsset(
     contextGraphId: string,
     name: string,
     options?: {
       subGraphName?: string;
       quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+      /**
+       * Seal the draft after writing `quads` (default true). `false` keeps an
+       * editable WM draft and never touches the chain. Cannot be combined with
+       * `alsoShareSwm`/`alsoPublishVm` (those require a sealed assertion).
+       */
+      finalize?: boolean;
       authorAgentAddress?: string;
       preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
       schemeVersion?: number;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -536,13 +536,6 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (finalize !== undefined && typeof finalize !== "boolean") {
       return jsonResponse(res, 400, { error: '"finalize" must be a boolean when supplied' });
     }
-    const alsoPublishVmRequested =
-      alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null);
-    if (finalize === false && (alsoShareSwm === true || alsoPublishVmRequested)) {
-      return jsonResponse(res, 400, {
-        error: '"finalize": false cannot be combined with "alsoShareSwm"/"alsoPublishVm" — sharing/publishing require a sealed assertion',
-      });
-    }
     // Quads are WRITTEN whenever supplied; the draft is also SEALED only when
     // `finalize` is not explicitly false. Default-true preserves the one-shot
     // `{ quads, finalize:true }` shape. An explicit `finalize:false` keeps an
@@ -552,6 +545,18 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // CG to be registered). OT-RFC-43 §10.5.5.
     const hasQuads = Array.isArray(quads) && quads.length > 0;
     const shouldFinalize = hasQuads && finalize !== false;
+    // alsoShareSwm/alsoPublishVm advance a SEALED assertion to SWM/VM, so they
+    // require this request to finalize. Reject upfront — before any create/write
+    // mutation — whenever it won't (no quads, or finalize:false); otherwise the
+    // create lands a durable draft the tail can't share/publish, turning a
+    // request-shape error into orphaned state.
+    const alsoPublishVmRequested =
+      alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null);
+    if (!shouldFinalize && (alsoShareSwm === true || alsoPublishVmRequested)) {
+      return jsonResponse(res, 400, {
+        error: '"alsoShareSwm"/"alsoPublishVm" require a finalized assertion (non-empty "quads" and "finalize" !== false)',
+      });
+    }
     if (!shouldFinalize && hasFinalizeOnlyCreateFields(parsed)) {
       return jsonResponse(res, 400, {
         error: '"authorAgentAddress", "preSignedAuthorAttestation", and "schemeVersion" require non-empty "quads" with finalize !== false',

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -490,6 +490,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       name,
       subGraphName,
       quads,
+      finalize,
       authorAgentAddress,
       preSignedAuthorAttestation,
       schemeVersion,
@@ -530,13 +531,33 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     if (alsoPublishVm !== undefined && typeof alsoPublishVm !== "boolean" && (typeof alsoPublishVm !== "object" || alsoPublishVm === null || Array.isArray(alsoPublishVm))) {
       return jsonResponse(res, 400, { error: '"alsoPublishVm" must be a boolean or an options object when supplied' });
     }
-    const shouldAutoFinalize = Array.isArray(quads) && quads.length > 0;
-    if (!shouldAutoFinalize && hasFinalizeOnlyCreateFields(parsed)) {
+    // Strict boolean for `finalize` (parity with the also* flags above): a
+    // stray `"false"` string must not silently flip sealing behavior.
+    if (finalize !== undefined && typeof finalize !== "boolean") {
+      return jsonResponse(res, 400, { error: '"finalize" must be a boolean when supplied' });
+    }
+    const alsoPublishVmRequested =
+      alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null);
+    if (finalize === false && (alsoShareSwm === true || alsoPublishVmRequested)) {
       return jsonResponse(res, 400, {
-        error: '"authorAgentAddress", "preSignedAuthorAttestation", and "schemeVersion" require non-empty "quads"',
+        error: '"finalize": false cannot be combined with "alsoShareSwm"/"alsoPublishVm" — sharing/publishing require a sealed assertion',
       });
     }
-    const finalizeOptions = shouldAutoFinalize
+    // Quads are WRITTEN whenever supplied; the draft is also SEALED only when
+    // `finalize` is not explicitly false. Default-true preserves the one-shot
+    // `{ quads, finalize:true }` shape. An explicit `finalize:false` keeps an
+    // editable WM draft that never touches the chain — the only lifecycle
+    // available to local-only / on-chain-unregistered CGs (finalize binds the
+    // author attestation and reserves the on-chain identity, so it requires the
+    // CG to be registered). OT-RFC-43 §10.5.5.
+    const hasQuads = Array.isArray(quads) && quads.length > 0;
+    const shouldFinalize = hasQuads && finalize !== false;
+    if (!shouldFinalize && hasFinalizeOnlyCreateFields(parsed)) {
+      return jsonResponse(res, 400, {
+        error: '"authorAgentAddress", "preSignedAuthorAttestation", and "schemeVersion" require non-empty "quads" with finalize !== false',
+      });
+    }
+    const finalizeOptions = shouldFinalize
       ? resolveFinalizeOptions({ subGraphName, authorAgentAddress, preSignedAuthorAttestation, schemeVersion }, res)
       : {};
     if (finalizeOptions === null) return;
@@ -560,12 +581,15 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       emitMemoryGraphChanged?.({ contextGraphId: resolvedContextGraphId, layers: ["wm"], subGraphName, operation: "assertion_created", source: "api", counts: { triples: 0 } });
       recordActivityAndNotify(ctx, { contextGraphId: resolvedContextGraphId, kind: "created", actorAgentAddress: resolvedAuthorAgentAddress ?? requestAgentAddress, subGraphName });
 
-      // autoFinalize: when quads are supplied, write + seal in the same call
-      // (OT-RFC-43 §10.5.5). `also*` are opt-in layer transitions on top.
-      if (shouldAutoFinalize) {
+      // Write quads whenever supplied; SEAL only when finalize !== false. An
+      // explicit finalize:false leaves an editable WM draft and never touches
+      // the chain (OT-RFC-43 §10.5.5). `also*` are opt-in transitions on top.
+      if (hasQuads) {
         await agent.assertion.write(resolvedContextGraphId, name, quads, { subGraphName });
         result.written = quads.length;
         emitMemoryGraphChanged?.({ contextGraphId: resolvedContextGraphId, layers: ["wm"], subGraphName, operation: "assertion_written", source: "api", counts: { triples: quads.length } });
+      }
+      if (shouldFinalize) {
         const seal = await agent.assertion.finalize(resolvedContextGraphId, name, finalizeOptions);
         result.merkleRoot = hex(seal.merkleRoot);
         result.status = "wm-sealed";

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -260,6 +260,31 @@ describe('ApiClient', () => {
       expect(body.quads).toHaveLength(1);
     });
 
+    it('createKnowledgeAsset() forwards finalize:false for a draft-only write', async () => {
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 201, body: { name: 'draft', written: 1, status: 'draft-open' } });
+      globalThis.fetch = fetch;
+      await client.createKnowledgeAsset('cg-1', 'draft', {
+        finalize: false,
+        quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+      });
+
+      expect(calls[0].url).toBe(`http://127.0.0.1:${PORT}/api/knowledge-assets`);
+      const body = JSON.parse(calls[0].opts.body as string);
+      expect(body).toMatchObject({ contextGraphId: 'cg-1', name: 'draft', finalize: false });
+      expect(body.quads).toHaveLength(1);
+    });
+
+    it('createKnowledgeAsset() omits finalize when unspecified (server default seals)', async () => {
+      const { fetch, calls } = createTrackingFetch({ ok: true, status: 201, body: { name: 'draft', status: 'wm-sealed' } });
+      globalThis.fetch = fetch;
+      await client.createKnowledgeAsset('cg-1', 'draft', {
+        quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o', graph: 'urn:g' }],
+      });
+
+      const body = JSON.parse(calls[0].opts.body as string);
+      expect(body).not.toHaveProperty('finalize');
+    });
+
     it('query() sends sparql, optional context graph id, and partition opt-in', async () => {
       const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { result: [] } });
       globalThis.fetch = fetch;

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -244,7 +244,27 @@ describe('daemon memory_graph_changed route emissions', () => {
     await handleKnowledgeAssetsRoutes(ctx);
 
     expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
-    expect(responseBody(ctx).error).toMatch(/finalize.*false cannot be combined/);
+    expect(responseBody(ctx).error).toMatch(/require a finalized assertion/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects alsoShareSwm with no quads (nothing to seal) before any mutation', async () => {
+    // The tail share/publish needs a SEALED assertion; with no quads the create
+    // never finalizes, so a naive run would land a durable empty draft and fail
+    // late. Reject the request-shape error upfront instead of orphaning state.
+    const create = vi.fn();
+    const ctx = createContext('/api/knowledge-assets', {
+      contextGraphId: 'project-a',
+      name: 'draft',
+      alsoShareSwm: true,
+    }, {
+      agent: { assertion: { create }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+    });
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(responseBody(ctx).error).toMatch(/require a finalized assertion/);
     expect(create).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -178,6 +178,76 @@ describe('daemon memory_graph_changed route emissions', () => {
     });
   });
 
+  it('honors finalize:false on POST /api/knowledge-assets — writes quads but does NOT seal', async () => {
+    // OT-RFC-43 §10.5.5: an explicit finalize:false keeps an editable WM draft.
+    // The atomic create still WRITES the quads, but must NOT finalize — finalize
+    // binds the author attestation + reserves the on-chain identity, so it would
+    // 4xx on a local-only / on-chain-unregistered CG. Regression for the
+    // integration finding where finalize:false was silently ignored when quads
+    // were present (shouldAutoFinalize = quads.length > 0).
+    const create = vi.fn().mockResolvedValue('did:dkg:context-graph:project-a/assertion/0x0/draft');
+    const write = vi.fn().mockResolvedValue(undefined);
+    const finalize = vi.fn();
+    const history = vi.fn().mockResolvedValue(null);
+    const ctx = createContext('/api/knowledge-assets', {
+      contextGraphId: 'project-a',
+      name: 'draft',
+      finalize: false,
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { assertion: { create, write, finalize, history }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+    });
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(201);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(finalize).not.toHaveBeenCalled();
+    const body = responseBody(ctx);
+    expect(body).toMatchObject({ name: 'draft', written: 1, status: 'draft-open' });
+    expect(body).not.toHaveProperty('merkleRoot');
+  });
+
+  it('auto-finalizes when finalize is omitted (default) — writes AND seals', async () => {
+    const create = vi.fn().mockResolvedValue('did:dkg:context-graph:project-a/assertion/0x0/draft');
+    const write = vi.fn().mockResolvedValue(undefined);
+    const finalize = vi.fn().mockResolvedValue({ merkleRoot: new Uint8Array(32) });
+    const history = vi.fn().mockResolvedValue(null);
+    const ctx = createContext('/api/knowledge-assets', {
+      contextGraphId: 'project-a',
+      name: 'draft',
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { assertion: { create, write, finalize, history }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+    });
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(201);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(responseBody(ctx)).toMatchObject({ name: 'draft', written: 1, status: 'wm-sealed' });
+  });
+
+  it('rejects finalize:false combined with alsoShareSwm before any mutation', async () => {
+    const create = vi.fn();
+    const ctx = createContext('/api/knowledge-assets', {
+      contextGraphId: 'project-a',
+      name: 'draft',
+      finalize: false,
+      alsoShareSwm: true,
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { assertion: { create }, resolveAgentByToken: () => undefined } as unknown as RequestContext['agent'],
+    });
+
+    await handleKnowledgeAssetsRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(responseBody(ctx).error).toMatch(/finalize.*false cannot be combined/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('emits an assertion_finalized refresh on POST /api/knowledge-assets/:name/wm/finalize', async () => {
     // Regression test for the bug found during PR #436 devnet validation:
     // the chained create handler emitted memory_graph_changed for the

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -118,6 +118,7 @@ function assertExclusiveAuthorFields(args: {
 
 function assertCreateFinalizeFieldsHaveQuads(args: {
   quads?: unknown[];
+  finalize?: boolean;
   authorAgentAddress?: string;
   preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
   schemeVersion?: number;
@@ -126,8 +127,11 @@ function assertCreateFinalizeFieldsHaveQuads(args: {
     args.authorAgentAddress != null ||
     args.preSignedAuthorAttestation != null ||
     args.schemeVersion !== undefined;
-  if (hasFinalizeOnlyField && !(Array.isArray(args.quads) && args.quads.length > 0)) {
-    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads');
+  // These fields only take effect at finalize, so they require both non-empty
+  // quads AND finalize !== false — mirrors the daemon create-route guard.
+  const willFinalize = Array.isArray(args.quads) && args.quads.length > 0 && args.finalize !== false;
+  if (hasFinalizeOnlyField && !willFinalize) {
+    throw new Error('authorAgentAddress, preSignedAuthorAttestation, and schemeVersion require non-empty quads and finalize !== false');
   }
 }
 
@@ -1224,6 +1228,13 @@ export class DkgClient {
     name: string;
     subGraphName?: string;
     quads?: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+    /**
+     * Seal the draft after writing `quads` (default true). `false` keeps an
+     * editable WM draft that never touches the chain — the only lifecycle
+     * available to local-only / on-chain-unregistered CGs. Cannot be combined
+     * with `alsoShareSwm`/`alsoPublishVm` (those require a sealed assertion).
+     */
+    finalize?: boolean;
     authorAgentAddress?: string;
     preSignedAuthorAttestation?: PreSignedAuthorAttestationPayload;
     schemeVersion?: number;
@@ -1238,6 +1249,7 @@ export class DkgClient {
     };
     if (args.subGraphName) body.subGraphName = args.subGraphName;
     if (args.quads) body.quads = args.quads;
+    if (args.finalize !== undefined) body.finalize = args.finalize;
     if (args.authorAgentAddress) body.authorAgentAddress = args.authorAgentAddress;
     if (args.preSignedAuthorAttestation) {
       body.preSignedAuthorAttestation = args.preSignedAuthorAttestation;

--- a/packages/mcp-dkg/test/knowledge-assets-client.test.ts
+++ b/packages/mcp-dkg/test/knowledge-assets-client.test.ts
@@ -190,6 +190,40 @@ describe('DkgClient knowledge-assets — publish/finalize option serialization',
     expect(calls[0].body.alsoPublishVm).toEqual({});
   });
 
+  it('createKnowledgeAsset forwards finalize:false for a draft-only write', async () => {
+    const { client, calls } = makeClient();
+    await client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      finalize: false,
+      quads: [{ subject: 's', predicate: 'p', object: 'o', graph: 'urn:g' }],
+    });
+    expect(calls[0].url).toContain('/api/knowledge-assets');
+    expect(calls[0].body).toMatchObject({ contextGraphId: 'cg-1', name: 'f', finalize: false });
+  });
+
+  it('createKnowledgeAsset omits finalize when unspecified (server default seals)', async () => {
+    const { client, calls } = makeClient();
+    await client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      quads: [{ subject: 's', predicate: 'p', object: 'o', graph: 'urn:g' }],
+    });
+    expect(calls[0].body).not.toHaveProperty('finalize');
+  });
+
+  it('createKnowledgeAsset rejects finalize-only fields when finalize:false (parity with daemon)', async () => {
+    const { client, calls } = makeClient();
+    await expect(client.createKnowledgeAsset({
+      contextGraphId: 'cg-1',
+      name: 'f',
+      authorAgentAddress: '0xauthor',
+      finalize: false,
+      quads: [{ subject: 's', predicate: 'p', object: 'o', graph: 'urn:g' }],
+    })).rejects.toThrow(/require non-empty quads and finalize !== false/);
+    expect(calls).toHaveLength(0);
+  });
+
   it('createKnowledgeAsset rejects unknown alsoPublishVm option objects', async () => {
     const { client, calls } = makeClient();
     await expect(client.createKnowledgeAsset({


### PR DESCRIPTION
## What

`POST /api/knowledge-assets` now **honors an explicit `finalize:false`** instead of always auto-finalizing when quads are present.

## Why (found by the comprehensive devnet e2e gate)

The rc.17 KA-routes-unification collapsed write + seal into one flag:

```ts
const shouldAutoFinalize = Array.isArray(quads) && quads.length > 0;  // ignores finalize:false
```

So any create-with-quads **always sealed**, silently ignoring `finalize:false`. Finalize binds the author attestation and reserves the on-chain identity, so it **requires the CG to be registered on-chain** — which means a **WM-only write to a local-only / on-chain-unregistered CG failed**:

```
"Context graph X is not registered on-chain. Run 'dkg context-graph register X' before finalizing an assertion…"
```

…even though the caller explicitly asked *not* to finalize. The old `/api/assertion/create` honored `finalize:false`. This surfaced as the 2 `local-only` failures (scenarios 6/7) in `devnet-test-everything.sh`.

To be clear, WM writes on unregistered CGs were never *fully* broken — the two-call path (`POST /api/knowledge-assets {name}` → `…/wm/write`) still works. What broke is the one-shot atomic create-with-quads draft.

## The fix

Split **write** from **seal**:

```ts
const hasQuads = Array.isArray(quads) && quads.length > 0;
const shouldFinalize = hasQuads && finalize !== false;
// …
if (hasQuads)      { await agent.assertion.write(...);    result.written = quads.length; }
if (shouldFinalize){ const seal = await agent.assertion.finalize(...); result.status = "wm-sealed"; }
```

| Request | Behavior |
|---|---|
| `{ quads }` (finalize omitted) | write **+ seal** — **unchanged default**, keeps the one-shot `{ quads, finalize:true }` shape + the `also*` publish chain |
| `{ quads, finalize:true }` | write + seal |
| `{ quads, finalize:false }` | **write only** — editable WM draft, never touches the chain (works on unregistered/local-only CGs) |
| no quads | create empty draft (unchanged) |

Plus: strict-boolean validation for `finalize` (parity with `alsoShareSwm`), and a guard rejecting `finalize:false` + `alsoShareSwm`/`alsoPublishVm` (sharing/publishing require a sealed assertion) before any mutation.

## Tests

`memory-graph-events.test.ts` (+3, all 26 pass): `finalize:false` writes-but-does-not-seal (`write` called, `finalize` not, status `draft-open`, no `merkleRoot`); omitted `finalize` auto-seals (default preserved); the combo guard 400s before calling the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)