### PR TITLE
fix(evm-module): carry orphaned epoch rewards across redelegate/relock

### DIFF
--- a/packages/evm-module/abi/ConvictionStakingStorage.json
+++ b/packages/evm-module/abi/ConvictionStakingStorage.json
@@ -687,6 +687,62 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "maxEpoch",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "removed",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardCarriesCleared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "epoch",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "delegatorKey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RewardCarryAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "receiver",
         "type": "address"
@@ -772,6 +828,19 @@
     "type": "event"
   },
   {
+    "inputs": [],
+    "name": "MAX_REWARD_CARRIES",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -785,6 +854,34 @@
       }
     ],
     "name": "addCumulativeRewardsClaimed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint32",
+        "name": "epoch",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "delegatorKey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "addRewardCarry",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -836,6 +933,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "maxEpoch",
+        "type": "uint32"
+      }
+    ],
+    "name": "clearRewardCarries",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1502,6 +1617,42 @@
         "internalType": "struct ConvictionStakingStorage.Position",
         "name": "",
         "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRewardCarries",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint72",
+            "name": "identityId",
+            "type": "uint72"
+          },
+          {
+            "internalType": "uint32",
+            "name": "epoch",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "delegatorKey",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct ConvictionStakingStorage.RewardCarry[]",
+        "name": "",
+        "type": "tuple[]"
       }
     ],
     "stateMutability": "view",

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -128,7 +128,15 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     //             new `expiryShortenedBy` arg (CSS v4.1.0). `stake` always
     //             passes 0; `_convertToNFT` passes 0 except for eligible
     //             6m/12m migrants.
-    string private constant _VERSION = "10.0.2";
+    //   10.0.3 — Audit fix: mid-epoch `redelegate`/`relock` orphaned the
+    //           current epoch's settled delegator score (the old
+    //           (epoch, node, key) RSS slot was never read again after the
+    //           identity flip / tokenId re-key).
+    //           * `redelegate` / `relock` record a `RewardCarry` pointer in
+    //             CSS when the settled score is non-zero.
+    //           * `_claim` integrates matured carries (epoch closed) via the
+    //             extracted `_nodeEpochReward` helper, then clears them.
+    string private constant _VERSION = "10.0.3";
 
     // ========================================================================
     // Constants
@@ -424,16 +432,38 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // is already in rest state; any non-zero expiry must have elapsed.
         if (pos.expiryTimestamp != 0 && block.timestamp < uint256(pos.expiryTimestamp)) revert LockStillActive();
 
-        _prepareForStakeChangeV10(chronos.getCurrentEpoch(), oldTokenId, pos.identityId);
+        uint256 currentEpoch = chronos.getCurrentEpoch();
+        uint256 settledEpochScore18 = _prepareForStakeChangeV10(currentEpoch, oldTokenId, pos.identityId);
+
+        // v10.0.3 — baseline the NEW tokenId's settlement cursor at the
+        // current score-per-stake BEFORE the position exists under it
+        // (cursor-bump-only branch: `positions[newTokenId].identityId == 0`).
+        // Without this the new key re-integrates the epoch's score from 0
+        // at the NEW multiplier — over-crediting the delegator and
+        // overdrawing the node's epoch pool. Mirrors the `stake` baseline.
+        _prepareForStakeChangeV10(currentEpoch, newTokenId, pos.identityId);
 
         // M1 + L11 — same-identity relock. CSS reads the multiplier from the
-        //            tier table; no need to pass it in.
+        //            tier table; no need to pass it in. Migrates any existing
+        //            reward carries from oldTokenId to newTokenId (v10.0.3).
         convictionStorage.createNewPositionFromExisting(
             oldTokenId,
             newTokenId,
             pos.identityId,
             newLockTier
         );
+
+        // v10.0.3 — the score settled this epoch lives in RSS under the OLD
+        // tokenId's delegator key, which `_claim(newTokenId)` would never
+        // read. Carry the pointer across the burn-mint.
+        if (settledEpochScore18 > 0) {
+            convictionStorage.addRewardCarry(
+                newTokenId,
+                pos.identityId,
+                uint32(currentEpoch),
+                bytes32(oldTokenId)
+            );
+        }
 
         ConvictionStakingStorage.Position memory posAfter = convictionStorage.getPosition(newTokenId);
         emit Relocked(newTokenId, newLockTier, uint64(posAfter.expiryTimestamp));
@@ -487,8 +517,21 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // effective stake (which shifts the delegator's contribution
         // between the two nodes at `currentEpoch`).
         uint256 currentEpoch = chronos.getCurrentEpoch();
-        _prepareForStakeChangeV10(currentEpoch, tokenId, oldIdentityId);
+        uint256 oldNodeEpochScore18 = _prepareForStakeChangeV10(currentEpoch, tokenId, oldIdentityId);
         _prepareForStakeChangeV10(currentEpoch, tokenId, newIdentityId);
+
+        // v10.0.3 — the score settled on the OLD node for the in-progress
+        // epoch becomes unreachable once `pos.identityId` flips (later
+        // claims read only the current node). Record a carry pointer so
+        // the next claim integrates it against the old node's pool.
+        if (oldNodeEpochScore18 > 0) {
+            convictionStorage.addRewardCarry(
+                tokenId,
+                oldIdentityId,
+                uint32(currentEpoch),
+                bytes32(tokenId)
+            );
+        }
 
         // D25 — in-place node swap. tokenId + expiryEpoch + reward cursor
         // preserved; per-node diffs + per-node raw + pending expiry
@@ -770,42 +813,40 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
             );
             uint256 delegatorScore18 = settledDelegatorScore18 + unsettledDelegatorScore18;
 
-            uint256 nodeScore18 = randomSamplingStorage.getNodeEpochScore(e, identityId);
+            rewardTotal += _nodeEpochReward(e, identityId, delegatorScore18);
+        }
 
-            // H1 — on epochs with `scorePerStake36 > 0 && nodeScore18 == 0` we
-            // still fall through here. That combination is essentially
-            // impossible in production (score-per-stake can only be advanced
-            // by submitProof, which also adds to node score), but defensive:
-            // there is no fee to collect and no reward, so epochReward stays 0.
-            uint256 epochReward = 0;
-            if (nodeScore18 > 0) {
-                uint256 netNodeRewards;
-                if (!convictionStorage.isOperatorFeeClaimedForEpoch(identityId, e)) {
-                    uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
-                    if (allNodesScore18 > 0) {
-                        uint256 grossNodeRewards = (epochStorage.getEpochPool(EPOCH_POOL_INDEX, e)
-                            * nodeScore18) / allNodesScore18;
-                        uint96 operatorFeeAmount = uint96(
-                            (grossNodeRewards
-                                * profileStorage.getOperatorFeePercentageByTimestampReverse(identityId, chronos.timestampForEpoch(e + 1) - 1))
-                                / parametersStorage.maxOperatorFee()
-                        );
-                        netNodeRewards = grossNodeRewards - operatorFeeAmount;
-                        convictionStorage.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
-                        convictionStorage.setNetNodeEpochRewards(identityId, e, netNodeRewards);
-                        // v4.0.0 — operator-fee balance lives on CSS now.
-                        convictionStorage.increaseOperatorFeeBalance(identityId, operatorFeeAmount);
-                    }
-                } else {
-                    netNodeRewards = convictionStorage.getNetNodeEpochRewards(identityId, e);
+        // v10.0.3 — integrate matured reward carries (pointers to RSS score
+        // slots recorded by mid-epoch `redelegate`/`relock`; see CSS struct
+        // docs). A carry matures once its epoch is <= `claimToEpoch`.
+        {
+            ConvictionStakingStorage.RewardCarry[] memory carries =
+                convictionStorage.getRewardCarries(tokenId);
+            bool carriesMatured = false;
+            for (uint256 i = 0; i < carries.length; i++) {
+                if (uint256(carries[i].epoch) > claimToEpoch) continue;
+                carriesMatured = true;
+                // The main loop above already integrated the position's
+                // CURRENT (node, key) slot for every epoch in the window —
+                // skip a carry that points at it (e.g. A→B→A round-trip).
+                if (carries[i].identityId == identityId && carries[i].delegatorKey == delegatorKey) {
+                    continue;
                 }
-
-                if (delegatorScore18 > 0) {
-                    epochReward = (delegatorScore18 * netNodeRewards) / nodeScore18;
-                }
+                uint256 carryScore18 = randomSamplingStorage.getEpochNodeDelegatorScore(
+                    uint256(carries[i].epoch),
+                    carries[i].identityId,
+                    carries[i].delegatorKey
+                );
+                if (carryScore18 == 0) continue;
+                rewardTotal += _nodeEpochReward(
+                    uint256(carries[i].epoch),
+                    carries[i].identityId,
+                    carryScore18
+                );
             }
-
-            rewardTotal += epochReward;
+            if (carriesMatured) {
+                convictionStorage.clearRewardCarries(tokenId, uint32(claimToEpoch));
+            }
         }
 
         if (rewardTotal == 0) {
@@ -1056,6 +1097,52 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     // ========================================================================
     // Internal helpers — V10 score-per-stake settlement
     // ========================================================================
+
+    /**
+     * @dev Convert a delegator's epoch score on `identityId` into TRAC,
+     *      lazily materializing the node's operator-fee split for `(e,
+     *      identityId)` on first touch. Extracted from the `_claim` epoch
+     *      loop (v10.0.3) so reward carries share the exact same math.
+     *
+     *      H1 note — on epochs with `scorePerStake36 > 0 && nodeScore18 ==
+     *      0` this returns 0. That combination is essentially impossible in
+     *      production (score-per-stake can only be advanced by submitProof,
+     *      which also adds to node score), but defensive: there is no fee
+     *      to collect and no reward.
+     */
+    function _nodeEpochReward(
+        uint256 e,
+        uint72 identityId,
+        uint256 delegatorScore18
+    ) internal returns (uint256 epochReward) {
+        uint256 nodeScore18 = randomSamplingStorage.getNodeEpochScore(e, identityId);
+        if (nodeScore18 == 0) return 0;
+
+        uint256 netNodeRewards;
+        if (!convictionStorage.isOperatorFeeClaimedForEpoch(identityId, e)) {
+            uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
+            if (allNodesScore18 > 0) {
+                uint256 grossNodeRewards = (epochStorage.getEpochPool(EPOCH_POOL_INDEX, e)
+                    * nodeScore18) / allNodesScore18;
+                uint96 operatorFeeAmount = uint96(
+                    (grossNodeRewards
+                        * profileStorage.getOperatorFeePercentageByTimestampReverse(identityId, chronos.timestampForEpoch(e + 1) - 1))
+                        / parametersStorage.maxOperatorFee()
+                );
+                netNodeRewards = grossNodeRewards - operatorFeeAmount;
+                convictionStorage.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
+                convictionStorage.setNetNodeEpochRewards(identityId, e, netNodeRewards);
+                // v4.0.0 — operator-fee balance lives on CSS now.
+                convictionStorage.increaseOperatorFeeBalance(identityId, operatorFeeAmount);
+            }
+        } else {
+            netNodeRewards = convictionStorage.getNetNodeEpochRewards(identityId, e);
+        }
+
+        if (delegatorScore18 > 0) {
+            epochReward = (delegatorScore18 * netNodeRewards) / nodeScore18;
+        }
+    }
 
     /**
      * @dev D26 — settle the delegator's score accumulator for `epoch` up to

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -134,7 +134,16 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     //             the 60 days preceding V10 launch. Validated against
     //             `_tierDuration(lockTier)` and the current block
     //             timestamp; tier-0 callers MUST pass 0.
-    string private constant _VERSION = "10.0.2";
+    //   10.0.3 — Reward carries (audit fix: mid-epoch redelegate/relock
+    //           orphaned the current epoch's settled delegator score).
+    //           * NEW `RewardCarry` struct + `rewardCarries` mapping:
+    //             pointers to RSS (epoch, identityId, delegatorKey) score
+    //             slots that the position's CURRENT node/key no longer
+    //             reaches. Written by `StakingV10.redelegate` / `relock`,
+    //             drained by `StakingV10._claim`.
+    //           * `createNewPositionFromExisting` migrates carries across
+    //             the relock burn-mint; `deletePosition` deletes them.
+    string private constant _VERSION = "10.0.3";
 
     // Multiplier scale, matches DKGStakingConvictionNFT._convictionMultiplier
     // (returns 1e18-scaled values so fractional tiers like 1.5x and 3.5x
@@ -342,6 +351,40 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     // ============================================================
     mapping(uint40 => TierConfig) internal _tiers;
     uint40[] public tierIds;
+
+    // ============================================================
+    //   v10.0.3 — Reward carries (mid-epoch redelegate / relock)
+    // ============================================================
+    //
+    // A mid-epoch `redelegate` flips `pos.identityId`, and a `relock`
+    // re-keys the position under a fresh tokenId. In both cases the
+    // delegator score already settled in RandomSamplingStorage under the
+    // OLD (epoch, identityId, delegatorKey) slot becomes unreachable from
+    // `StakingV10._claim`, which reads only the position's CURRENT node +
+    // key — silently forfeiting up to one epoch's rewards. Each carry is
+    // a POINTER to such a slot; the score value itself stays in RSS.
+    // `StakingV10._claim` integrates matured carries (epoch closed) and
+    // clears them.
+    struct RewardCarry {
+        uint72 identityId;
+        uint32 epoch;
+        bytes32 delegatorKey;
+    }
+
+    // Bounded so a position's claim/withdraw can never be self-bricked by
+    // an excessive number of same-epoch redelegations (carries from past
+    // epochs are flushed on every claim).
+    uint256 public constant MAX_REWARD_CARRIES = 32;
+
+    mapping(uint256 => RewardCarry[]) internal rewardCarries;
+
+    event RewardCarryAdded(
+        uint256 indexed tokenId,
+        uint72 indexed identityId,
+        uint32 epoch,
+        bytes32 delegatorKey
+    );
+    event RewardCarriesCleared(uint256 indexed tokenId, uint32 maxEpoch, uint256 removed);
 
     // ============================================================
     //          Tier admin events (v2.1.0)
@@ -1119,6 +1162,20 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
         _popNodeToken(identityId, oldTokenId);
         _pushNodeToken(identityId, newTokenId);
 
+        // v10.0.3 — carries follow the position across the burn-mint so
+        // same-epoch redelegate→relock sequences keep their pointers.
+        // `newTokenId` is freshly minted (monotonic counter, "New token
+        // used" guard above) so its carry list starts empty.
+        RewardCarry[] storage oldCarries = rewardCarries[oldTokenId];
+        uint256 carryCount = oldCarries.length;
+        if (carryCount > 0) {
+            RewardCarry[] storage newCarries = rewardCarries[newTokenId];
+            for (uint256 i; i < carryCount; i++) {
+                newCarries.push(oldCarries[i]);
+            }
+            delete rewardCarries[oldTokenId];
+        }
+
         // nodeStakeV10 is invariant — same identity, same raw. No emit.
 
         emit PositionReplaced(
@@ -1136,6 +1193,59 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
         require(positions[tokenId].identityId != 0, "No position");
         positions[tokenId].lastClaimedEpoch = epoch;
         emit LastClaimedEpochUpdated(tokenId, epoch);
+    }
+
+    // ============================================================
+    //        v10.0.3 — Reward-carry mutators (see struct docs)
+    // ============================================================
+
+    /// @notice Record a pointer to an RSS delegator-score slot the
+    ///         position's current node/key no longer reaches. Idempotent
+    ///         per (identityId, epoch, delegatorKey): the RSS slot
+    ///         accumulates across repeat visits (e.g. A→B→A→C in one
+    ///         epoch), so a single pointer integrates all of them.
+    function addRewardCarry(
+        uint256 tokenId,
+        uint72 identityId,
+        uint32 epoch,
+        bytes32 delegatorKey
+    ) external onlyContracts {
+        require(positions[tokenId].identityId != 0, "No position");
+        RewardCarry[] storage list = rewardCarries[tokenId];
+        uint256 len = list.length;
+        for (uint256 i; i < len; i++) {
+            RewardCarry storage c = list[i];
+            if (c.identityId == identityId && c.epoch == epoch && c.delegatorKey == delegatorKey) {
+                return;
+            }
+        }
+        require(len < MAX_REWARD_CARRIES, "Carry limit");
+        list.push(RewardCarry({identityId: identityId, epoch: epoch, delegatorKey: delegatorKey}));
+        emit RewardCarryAdded(tokenId, identityId, epoch, delegatorKey);
+    }
+
+    /// @notice Drop every carry with `epoch <= maxEpoch` (already
+    ///         integrated by the caller's claim pass). Swap-and-pop from
+    ///         the tail so each swapped-in element was already visited.
+    function clearRewardCarries(uint256 tokenId, uint32 maxEpoch) external onlyContracts {
+        RewardCarry[] storage list = rewardCarries[tokenId];
+        uint256 removed;
+        uint256 i = list.length;
+        while (i > 0) {
+            i--;
+            if (list[i].epoch <= maxEpoch) {
+                list[i] = list[list.length - 1];
+                list.pop();
+                removed++;
+            }
+        }
+        if (removed > 0) {
+            emit RewardCarriesCleared(tokenId, maxEpoch, removed);
+        }
+    }
+
+    function getRewardCarries(uint256 tokenId) external view returns (RewardCarry[] memory) {
+        return rewardCarries[tokenId];
     }
 
     function setMigrationEpoch(uint256 tokenId, uint32 epoch) external onlyContracts {
@@ -1182,6 +1292,10 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
         }
 
         delete positions[tokenId];
+        // v10.0.3 — drop any leftover carries. `StakingV10.withdraw`
+        // auto-claims first, so only current-epoch (immature) carries can
+        // remain here — forfeited like all other current-epoch score.
+        delete rewardCarries[tokenId];
         emit PositionDeleted(tokenId);
     }
 

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -78,7 +78,7 @@ describe('@unit ConvictionStakingStorage', () => {
     expect(await ConvictionStakingStorage.name()).to.equal('ConvictionStakingStorage');
     // v4.1.0 — `createPosition` accepts the `expiryShortenedBy` arg used
     // by `StakingV10._convertToNFT` for the V8→V10 conviction credit.
-    expect(await ConvictionStakingStorage.version()).to.equal('10.0.2');
+    expect(await ConvictionStakingStorage.version()).to.equal('10.0.3');
   });
 
   // ------------------------------------------------------------

--- a/packages/evm-module/test/v10-reward-carry.test.ts
+++ b/packages/evm-module/test/v10-reward-carry.test.ts
@@ -1,0 +1,356 @@
+// =============================================================================
+// V10 — reward-carry regression suite (audit fix, v10.0.3)
+// =============================================================================
+//
+// Mid-epoch `redelegate` flips `pos.identityId`, and `relock` re-keys the
+// position under a fresh tokenId. Pre-fix, the delegator score already
+// settled in RandomSamplingStorage under the OLD (epoch, identityId,
+// delegatorKey) slot was never read again by `StakingV10._claim` (which
+// reads only the position's CURRENT node + key) — silently forfeiting up
+// to one epoch's rewards.
+//
+// The fix records a `RewardCarry` pointer in ConvictionStakingStorage at
+// redelegate/relock time and integrates matured carries (epoch closed) in
+// the next claim, via the same `_nodeEpochReward` math as the main loop.
+//
+// Scenarios covered:
+//   1. redelegate A→B mid-epoch: old-node stint pays out on next claim;
+//      immature carries are NOT consumed by a same-epoch claim.
+//   2. round-trip A→B→A: the (A, E) carry is skipped (main loop already
+//      integrates that slot) — no double-count.
+//   3. relock: stint score under the OLD tokenId's key pays out on the
+//      NEW tokenId's claim.
+
+import { randomBytes } from 'crypto';
+
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  Chronos,
+  ConvictionStakingStorage,
+  DKGStakingConvictionNFT,
+  EpochStorage,
+  Hub,
+  Profile,
+  RandomSamplingStorage,
+  StakingV10,
+  Token,
+} from '../typechain';
+
+const SCALE18 = 10n ** 18n;
+const SIX_X = 6n * SCALE18;
+
+type Fixture = {
+  accounts: SignerWithAddress[];
+  Hub: Hub;
+  NFT: DKGStakingConvictionNFT;
+  StakingV10: StakingV10;
+  ConvictionStakingStorage: ConvictionStakingStorage;
+  RandomSamplingStorage: RandomSamplingStorage;
+  Profile: Profile;
+  Token: Token;
+  Chronos: Chronos;
+  EpochStorage: EpochStorage;
+};
+
+async function deployFixture(): Promise<Fixture> {
+  await hre.deployments.fixture([
+    'DKGStakingConvictionNFT',
+    'StakingV10',
+    'Profile',
+  ]);
+
+  const accounts = await hre.ethers.getSigners();
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+  // HubOwner grant lets the test drive privileged storage setters
+  // (score injection) directly.
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+
+  return {
+    accounts,
+    Hub,
+    NFT: await hre.ethers.getContract<DKGStakingConvictionNFT>(
+      'DKGStakingConvictionNFT',
+    ),
+    StakingV10: await hre.ethers.getContract<StakingV10>('StakingV10'),
+    ConvictionStakingStorage:
+      await hre.ethers.getContract<ConvictionStakingStorage>(
+        'ConvictionStakingStorage',
+      ),
+    RandomSamplingStorage:
+      await hre.ethers.getContract<RandomSamplingStorage>(
+        'RandomSamplingStorage',
+      ),
+    Profile: await hre.ethers.getContract<Profile>('Profile'),
+    Token: await hre.ethers.getContract<Token>('Token'),
+    Chronos: await hre.ethers.getContract<Chronos>('Chronos'),
+    EpochStorage: await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
+  };
+}
+
+describe('@integration V10 — reward carries (redelegate / relock orphan fix)', function () {
+  let accounts: SignerWithAddress[];
+  let NFT: DKGStakingConvictionNFT;
+  let StakingV10Contract: StakingV10;
+  let CSS: ConvictionStakingStorage;
+  let RSS: RandomSamplingStorage;
+  let ProfileContract: Profile;
+  let Token: Token;
+  let ChronosContract: Chronos;
+  let EpochStorageContract: EpochStorage;
+
+  beforeEach(async () => {
+    hre.helpers.resetDeploymentsJson();
+    const fixture = await loadFixture(deployFixture);
+    ({ accounts, NFT, Token } = fixture);
+    StakingV10Contract = fixture.StakingV10;
+    CSS = fixture.ConvictionStakingStorage;
+    RSS = fixture.RandomSamplingStorage;
+    ProfileContract = fixture.Profile;
+    ChronosContract = fixture.Chronos;
+    EpochStorageContract = fixture.EpochStorage;
+    nextOperational = 1;
+  });
+
+  // One operational signer per profile — the identity registry rejects a
+  // second profile under the same operational key.
+  let nextOperational = 1;
+  const createProfile = async () => {
+    const nodeId = '0x' + randomBytes(32).toString('hex');
+    const tx = await ProfileContract.connect(
+      accounts[nextOperational++],
+    ).createProfile(
+      accounts[0].address,
+      [],
+      `Node ${Math.floor(Math.random() * 1_000_000)}`,
+      nodeId,
+      0,
+    );
+    const receipt = await tx.wait();
+    const identityId = Number(receipt!.logs[0].topics[1]);
+    return { nodeId, identityId };
+  };
+
+  const mintAndApprove = async (staker: SignerWithAddress, amount: bigint) => {
+    await Token.mint(staker.address, amount);
+    await Token.connect(staker).approve(
+      await StakingV10Contract.getAddress(),
+      amount,
+    );
+  };
+
+  // Inject the full reward surface for `(epoch, identityId)`:
+  // score-per-stake (drives delegator settlement), node score +
+  // all-nodes score (drives the pool split), and the epoch pool itself.
+  const injectEpochRewards = async (
+    epoch: bigint,
+    identityId: number,
+    scorePerStake36: bigint,
+    nodeScore18: bigint,
+    allNodesScore18: bigint,
+    epochPool: bigint,
+  ) => {
+    if (scorePerStake36 > 0n) {
+      await RSS.connect(accounts[0]).setNodeEpochScorePerStake(
+        epoch,
+        identityId,
+        scorePerStake36,
+      );
+    }
+    await RSS.connect(accounts[0]).setNodeEpochScore(
+      epoch,
+      identityId,
+      nodeScore18,
+    );
+    await RSS.connect(accounts[0]).setAllNodesEpochScore(
+      epoch,
+      allNodesScore18,
+    );
+    await EpochStorageContract.connect(accounts[0]).addTokensToEpochRange(
+      1,
+      epoch,
+      epoch,
+      epochPool,
+    );
+  };
+
+  // --------------------------------------------------------------------------
+  // Test 1 — redelegate orphan regression + immature-carry protection
+  // --------------------------------------------------------------------------
+  it('redelegate mid-epoch: old-node stint score pays out on the next claim (was silently forfeited)', async () => {
+    const { identityId: nodeA } = await createProfile();
+    const { identityId: nodeB } = await createProfile();
+
+    const amount = hre.ethers.parseEther('1000');
+    await mintAndApprove(accounts[0], amount);
+    await NFT.connect(accounts[0]).createConviction(nodeA, amount, 12);
+
+    const epochE = await ChronosContract.getCurrentEpoch();
+
+    // Node A earns score while the position is staked on it.
+    const scorePerStake36 = hre.ethers.parseEther('0.001'); // 1e15
+    const nodeScore18 = hre.ethers.parseEther('100');
+    const epochPool = hre.ethers.parseEther('1000');
+    await injectEpochRewards(
+      epochE,
+      nodeA,
+      scorePerStake36,
+      nodeScore18,
+      nodeScore18,
+      epochPool,
+    );
+
+    // Mid-epoch redelegate A→B. Pre-fix this stranded the settled score.
+    await expect(NFT.connect(accounts[0]).redelegate(1, nodeB))
+      .to.emit(CSS, 'RewardCarryAdded')
+      .withArgs(
+        1n,
+        BigInt(nodeA),
+        epochE,
+        hre.ethers.zeroPadValue(hre.ethers.toBeHex(1), 32),
+      );
+
+    const carries = await CSS.getRewardCarries(1);
+    expect(carries.length).to.equal(1);
+    expect(carries[0].identityId).to.equal(BigInt(nodeA));
+    expect(carries[0].epoch).to.equal(epochE);
+
+    // Same-epoch claim is a no-op: the carry is immature (epoch still
+    // open) and must survive untouched.
+    const posBefore = await CSS.getPosition(1);
+    await NFT.connect(accounts[0]).claim(1);
+    expect((await CSS.getRewardCarries(1)).length).to.equal(1);
+    expect((await CSS.getPosition(1)).raw).to.equal(posBefore.raw);
+
+    // Close the epoch and claim. The carry matures and pays the A-stint.
+    const epochLength = await ChronosContract.epochLength();
+    await time.increase(Number(epochLength));
+
+    // Expected: full settled stint on A (6x boosted, pre-expiry).
+    const effStake = (amount * SIX_X) / SCALE18;
+    const delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+    const grossNodeRewards = (epochPool * nodeScore18) / nodeScore18; // single node
+    const expectedReward = (delegatorScore18 * grossNodeRewards) / nodeScore18;
+    expect(expectedReward).to.be.greaterThan(0n);
+
+    await expect(NFT.connect(accounts[0]).claim(1))
+      .to.emit(StakingV10Contract, 'RewardsClaimed')
+      .withArgs(1n, expectedReward)
+      .and.to.emit(CSS, 'RewardCarriesCleared');
+
+    const pos = await CSS.getPosition(1);
+    expect(pos.raw).to.equal(amount + expectedReward);
+    expect(pos.identityId).to.equal(BigInt(nodeB));
+    expect((await CSS.getRewardCarries(1)).length).to.equal(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 2 — round-trip A→B→A: no double-count
+  // --------------------------------------------------------------------------
+  it('round-trip A→B→A in one epoch: the (A, E) slot is integrated exactly once', async () => {
+    const { identityId: nodeA } = await createProfile();
+    const { identityId: nodeB } = await createProfile();
+
+    const amount = hre.ethers.parseEther('1000');
+    await mintAndApprove(accounts[0], amount);
+    await NFT.connect(accounts[0]).createConviction(nodeA, amount, 12);
+
+    const epochE = await ChronosContract.getCurrentEpoch();
+
+    const scorePerStake36 = hre.ethers.parseEther('0.001');
+    const nodeScore18 = hre.ethers.parseEther('100');
+    const epochPool = hre.ethers.parseEther('1000');
+    await injectEpochRewards(
+      epochE,
+      nodeA,
+      scorePerStake36,
+      nodeScore18,
+      nodeScore18,
+      epochPool,
+    );
+
+    // Hop 1: A→B records a carry for (A, E).
+    await NFT.connect(accounts[0]).redelegate(1, nodeB);
+    expect((await CSS.getRewardCarries(1)).length).to.equal(1);
+
+    // Hop 2: B→A. Node B never advanced score-per-stake, so the settled
+    // B-score is 0 and NO carry is recorded for (B, E).
+    await NFT.connect(accounts[0]).redelegate(1, nodeA);
+    expect((await CSS.getRewardCarries(1)).length).to.equal(1);
+
+    const epochLength = await ChronosContract.epochLength();
+    await time.increase(Number(epochLength));
+
+    // The main claim loop integrates the (E, A, key) slot (position is
+    // back on A); the (A, E) carry MUST be skipped or the stint would be
+    // paid twice.
+    const effStake = (amount * SIX_X) / SCALE18;
+    const delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+    const expectedReward = (delegatorScore18 * epochPool) / nodeScore18;
+
+    await expect(NFT.connect(accounts[0]).claim(1))
+      .to.emit(StakingV10Contract, 'RewardsClaimed')
+      .withArgs(1n, expectedReward);
+
+    const pos = await CSS.getPosition(1);
+    expect(pos.raw).to.equal(amount + expectedReward);
+    expect((await CSS.getRewardCarries(1)).length).to.equal(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 3 — relock: stint score under the old tokenId's key is carried
+  // --------------------------------------------------------------------------
+  it('relock mid-epoch: stint score under the OLD tokenId key pays out on the new tokenId claim', async () => {
+    const { identityId: nodeA } = await createProfile();
+
+    const amount = hre.ethers.parseEther('1000');
+    await mintAndApprove(accounts[0], amount);
+    // Tier 0 — rest state (1x, no lock) so relock is allowed immediately.
+    await NFT.connect(accounts[0]).createConviction(nodeA, amount, 0);
+
+    const epochE = await ChronosContract.getCurrentEpoch();
+
+    const scorePerStake36 = hre.ethers.parseEther('0.001');
+    const nodeScore18 = hre.ethers.parseEther('100');
+    const epochPool = hre.ethers.parseEther('1000');
+    await injectEpochRewards(
+      epochE,
+      nodeA,
+      scorePerStake36,
+      nodeScore18,
+      nodeScore18,
+      epochPool,
+    );
+
+    // Burn-mint relock tokenId 1 → 2 under tier 12. The settled stint
+    // lives under key bytes32(1); the new position claims under
+    // bytes32(2) and pre-fix would never see it.
+    await expect(NFT.connect(accounts[0]).relock(1, 12))
+      .to.emit(CSS, 'RewardCarryAdded')
+      .withArgs(
+        2n,
+        BigInt(nodeA),
+        epochE,
+        hre.ethers.zeroPadValue(hre.ethers.toBeHex(1), 32),
+      );
+
+    const epochLength = await ChronosContract.epochLength();
+    await time.increase(Number(epochLength));
+
+    // Tier-0 stint → 1x effective stake.
+    const delegatorScore18 = (amount * scorePerStake36) / SCALE18;
+    const expectedReward = (delegatorScore18 * epochPool) / nodeScore18;
+    expect(expectedReward).to.be.greaterThan(0n);
+
+    await expect(NFT.connect(accounts[0]).claim(2))
+      .to.emit(StakingV10Contract, 'RewardsClaimed')
+      .withArgs(2n, expectedReward);
+
+    const pos = await CSS.getPosition(2);
+    expect(pos.raw).to.equal(amount + expectedReward);
+    expect((await CSS.getRewardCarries(2)).length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary

Security-review finding (M severity): a **mid-epoch `redelegate`** flips `pos.identityId` before the current epoch's settled delegator score on the old node is ever read — `StakingV10._claim` only reads the position's *current* node + key, so that score was silently forfeited. **`relock`** has the same bug through a different door: the burn-mint re-keys the position under a fresh tokenId, stranding the score settled under `bytes32(oldTokenId)`.

- **CSS v10.0.3** — new bounded `RewardCarry` pointer list per tokenId (`identityId`, `epoch`, `delegatorKey`): written by `redelegate`/`relock` when the settled score is non-zero, deduped per slot, migrated across the relock burn-mint, deleted with the position, capped at 32 (flushed on every claim, so the cap only binds within a single epoch).
- **StakingV10 v10.0.3** — `_claim` integrates matured carries (epoch closed) via the extracted `_nodeEpochReward` helper (identical math to the main epoch loop, including lazy operator-fee materialization) and clears them. Carries pointing at the position's current (node, key) slot are skipped — the main loop already covers it (A→B→A round-trip).
- **Second fix found while testing**: `relock` never baselined the NEW tokenId's settlement cursor, so the new key re-integrated the epoch's score-per-stake *from zero* at the *new* multiplier — over-crediting the delegator and overdrawing the node's epoch pool. `relock` now mirrors `stake`'s baseline cursor bump.

Conservation note: carried rewards are paid against the **old** node's epoch pool slice (`delegatorScore * netNodeRewards / nodeScore`), so per-node delegator payouts still sum to ≤ `netNodeRewards` — no cross-node score migration.

## Test plan

- [x] `test/v10-reward-carry.test.ts` (new): redelegate orphan pays out on next claim + immature carries survive a same-epoch claim; A→B→A round-trip integrates the slot exactly once; relock carry pays out under the new tokenId.
- [x] Existing suites green: `v10-conviction`, `unit/DKGStakingConvictionNFT`, `unit/ConvictionStakingStorage` (121 passing), `v10-e2e-conviction`, `v10-migration-conviction-credit`, `v10-operator-fee-timestamp-binding`, `v10-converttonft-drain-fix` (21 passing).
- [ ] Redeploy CSS + StakingV10 (storage append only — new mapping after existing layout; both versions bumped to 10.0.3).

Made with [Cursor](https://cursor.com)