### PR TITLE
fix(evm-module): drop grindable inputs from RandomSampling challenge seed (audit interim)

### DIFF
--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -26,7 +26,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "RandomSampling";
-    string private constant _VERSION = "10.0.3";
+    string private constant _VERSION = "10.0.4";
     uint256 public constant SCALE18 = 1e18;
 
     /// @notice Maximum number of in-CG resamples when the picker hits an
@@ -452,9 +452,23 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     }
 
     /**
-     * @dev Builds the per-call randomness seed from block state + caller. Same
-     *      entropy mix as the V8 implementation — kept identical to preserve
-     *      seed quality across the Phase 10 upgrade.
+     * @dev Builds the per-call randomness seed from block state + caller.
+     *
+     *      AUDIT INTERIM (v10.0.4): `tx.gasprice` and `block.timestamp` were
+     *      removed from the mix. `tx.gasprice` is fully chosen by the caller
+     *      at zero cost, and `previewChallengeForSeed` is public — together
+     *      they let a node grind gas price off-chain in a SINGLE tx until the
+     *      drawn challenge lands on a chunk it actually stores, defeating the
+     *      proof-of-storage guarantee. `block.timestamp` adds proposer wiggle
+     *      to the same search. Dropping both downgrades the attack from
+     *      "free deterministic targeting in one tx" to "must be the block
+     *      proposer and grind constrained block fields".
+     *
+     *      This is NOT a complete fix: the remaining `prevrandao` /
+     *      `blockhash` inputs are still proposer-influenceable. The durable
+     *      fix is commit–reveal (commit in period N, draw against period
+     *      N+1's then-unknown block) or a VRF the node cannot grind — a
+     *      coordinated node+contract release tracked separately.
      */
     function _deriveChallengeSeed(address originalSender) internal view returns (bytes32) {
         return
@@ -463,8 +477,6 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
                     block.difficulty,
                     blockhash(block.number - ((block.difficulty % 256) + 1)),
                     originalSender,
-                    block.timestamp,
-                    tx.gasprice,
                     uint8(1) // sector = 1 by default
                 )
             );

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -253,7 +253,7 @@ describe('@unit RandomSampling', () => {
 
   describe('version()', () => {
     it('Should return correct version', async () => {
-      expect(await RandomSampling.version()).to.equal('10.0.3');
+      expect(await RandomSampling.version()).to.equal('10.0.4');
     });
   });
 


### PR DESCRIPTION
## Summary

Security-review finding (H severity), **interim mitigation**. `RandomSampling._deriveChallengeSeed` derived the proof-of-storage challenge seed from `tx.gasprice` (fully caller-chosen, zero cost) and `block.timestamp` (proposer wiggle), alongside `prevrandao`/`blockhash`. Because `previewChallengeForSeed` is public, a node could grind gas price off-chain **in a single tx** until the drawn challenge landed on a chunk it actually stores — collecting proof rewards while hosting only a subset of its data, defeating the proof-of-storage guarantee.

This PR removes `tx.gasprice` and `block.timestamp` from the seed. That downgrades the attack from "free deterministic targeting in one tx" to "must be the block proposer and grind constrained block fields". **ABI-unchanged**, so it ships independently of the node client.

This is **not** a complete fix — `prevrandao`/`blockhash` remain proposer-influenceable. The durable fix (commit–reveal or VRF) is a coordinated node+contract release tracked separately.

## Test plan

- [x] `test/unit/RandomSampling.test.ts` + `RandomSamplingStorage.test.ts` green (83 passing); version assertion bumped to 10.0.4.
- [x] Compiles clean; `abi/RandomSampling.json` unchanged (confirms ABI compatibility).
- [ ] Confirm the node's challenge-derivation mirror (if any) doesn't independently recompute the old seed formula off-chain.
- [ ] Redeploy RandomSampling (logic-only, no storage change).

Made with [Cursor](https://cursor.com)