### PR TITLE
fix(evm): publisher DoS via consent-free agent registration — conviction branch falls through to direct spend

### DIFF
--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -798,19 +798,19 @@ export interface ChainAdapter {
   getConvictionAccountLockDurationEpochs?(accountId: bigint): Promise<number>;
 
   /**
-   * Currently-spendable allowance (current-window base remaining + top-up
-   * buffer), in TRAC wei, for the PCA `accountId`. `0n` once the account is
-   * expired, has exhausted this window with no buffer, or was never
-   * meaningfully funded.
+   * Whether the PCA `accountId` can cover the DISCOUNTED cost of a publish
+   * whose undiscounted base cost is `baseCost`, right now (discount tier
+   * applied, compared against the account's remaining current-window
+   * allowance + top-up buffer; `false` when expired/exhausted/missing).
    *
    * The publisher SDK gates the `publishEpochs → lockDurationEpochs`
-   * coercion on this being `> 0n`, so a registered-but-unfundable agent
-   * (e.g. a consent-free squat against a 1-wei PCA) keeps the caller's
-   * requested lifetime instead of snapping to the PCA lock and
+   * coercion on this, so a registered-but-unfundable agent (a consent-free
+   * squat, or any account short for this specific publish) keeps the
+   * caller's requested lifetime instead of snapping to the PCA lock and
    * direct-spending at that lifetime/full price. Adapters that omit this
    * method preserve the legacy unconditional coercion.
    */
-  getConvictionAccountSpendableAllowance?(accountId: bigint): Promise<bigint>;
+  convictionAccountCanCover?(accountId: bigint, baseCost: bigint): Promise<boolean>;
 
   // ----- V10 Publishing Conviction NFT write+read surface -----
   // Wraps `DKGPublishingConvictionNFT`. Optional; owner-gated writes

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -797,6 +797,21 @@ export interface ChainAdapter {
    */
   getConvictionAccountLockDurationEpochs?(accountId: bigint): Promise<number>;
 
+  /**
+   * Currently-spendable allowance (current-window base remaining + top-up
+   * buffer), in TRAC wei, for the PCA `accountId`. `0n` once the account is
+   * expired, has exhausted this window with no buffer, or was never
+   * meaningfully funded.
+   *
+   * The publisher SDK gates the `publishEpochs → lockDurationEpochs`
+   * coercion on this being `> 0n`, so a registered-but-unfundable agent
+   * (e.g. a consent-free squat against a 1-wei PCA) keeps the caller's
+   * requested lifetime instead of snapping to the PCA lock and
+   * direct-spending at that lifetime/full price. Adapters that omit this
+   * method preserve the legacy unconditional coercion.
+   */
+  getConvictionAccountSpendableAllowance?(accountId: bigint): Promise<bigint>;
+
   // ----- V10 Publishing Conviction NFT write+read surface -----
   // Wraps `DKGPublishingConvictionNFT`. Optional; owner-gated writes
   // MUST surface the owner revert (→ 403), never swallow it.

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -66,33 +66,46 @@ export class ConvictionMethods extends EVMChainAdapterBase {
   }
 
   /**
-   * Currently-spendable allowance (current-window base remaining + top-up
-   * buffer) for `accountId`, in TRAC wei. `0n` once the account is expired,
-   * has exhausted this window with no buffer, or was never meaningfully
-   * funded.
+   * Whether the PCA `accountId` can cover the DISCOUNTED cost of a publish
+   * whose undiscounted (base) cost is `baseCost`, right now.
    *
-   * Mirrors the exact quantity `PublishingConviction.coverPublishingCost`
-   * checks before reverting `InsufficientAllowance`
-   * (`getRemainingAllowance` already folds in the top-up buffer and returns
-   * 0 outside the account's active lifetime). The publisher SDK uses this to
-   * gate the `publishEpochs → lockDurationEpochs` coercion: a registered
-   * agent on an UNFUNDABLE account (e.g. a third party squatted this signer
-   * against a 1-wei PCA — agent registration is consent-free, RFC-001 §3.6)
-   * would otherwise snap the lifetime to the PCA lock and, post the
-   * conviction fall-through fix, direct-spend at that lifetime/full price
-   * instead of the caller's intended default. Gating on `> 0n` keeps the
-   * discount path for genuinely funded accounts while leaving everyone else
-   * at their requested lifetime.
+   * Mirrors `PublishingConviction.coverPublishingCost` exactly so the SDK's
+   * pre-flight matches the on-chain decision: apply the account's discount
+   * tier (`discountedCost = baseCost * (BPS_DENOMINATOR - discountBps) /
+   * BPS_DENOMINATOR`, with the contract's post-discount 1-wei floor), then
+   * compare against `getRemainingAllowance(accountId, currentEpoch)` — which
+   * already folds in the top-up buffer and returns 0 once the account is
+   * expired or has exhausted the current window.
    *
-   * Returns `0n` when the NFT is not deployed, the id is non-positive, or
-   * the chain call reverts — callers treat the unknown case as "cannot
-   * fund", which fails safe to "do not coerce".
+   * The publisher SDK gates the `publishEpochs → lockDurationEpochs`
+   * coercion on this: agent registration is consent-free (RFC-001 §3.6) and
+   * the contract's conviction branch now falls through to direct spend
+   * instead of reverting, so coercing an account that can't actually fund
+   * THIS publish would direct-spend at the PCA-lock lifetime AND full price
+   * instead of the caller's default. A coarse "balance > 0" check is not
+   * enough — a nonzero-but-insufficient account (or a squat funded with a
+   * few wei so its base allowance rounds up to ≥1) would still slip through;
+   * gating on real coverage of the pending cost closes that.
+   *
+   * Returns `false` when the NFT is not deployed, the id is non-positive,
+   * the account is missing, or the chain call reverts — callers treat the
+   * unknown case as "cannot fund", which fails safe to "do not coerce".
+   * `baseCost <= 0` is treated as trivially coverable.
    */
-  async getConvictionAccountSpendableAllowance(accountId: bigint): Promise<bigint> {
+  async convictionAccountCanCover(accountId: bigint, baseCost: bigint): Promise<boolean> {
     await this.init();
-    if (!this.contracts.dkgPublishingConvictionNFT) return 0n;
-    if (accountId <= 0n) return 0n;
+    if (!this.contracts.dkgPublishingConvictionNFT) return false;
+    if (accountId <= 0n) return false;
+    if (baseCost <= 0n) return true;
     try {
+      const info = await this.getPublishingConvictionAccountInfo(accountId);
+      if (!info) return false;
+      // Mirror PublishingConviction's discount math + post-discount floor.
+      const BPS_DENOMINATOR = 10_000n;
+      const discountBps = BigInt(info.discountBps);
+      let discountedCost = (baseCost * (BPS_DENOMINATOR - discountBps)) / BPS_DENOMINATOR;
+      if (discountedCost === 0n && baseCost > 0n) discountedCost = 1n;
+
       if (!this.contracts.chronos) {
         this.contracts.chronos = await this.resolveContract('Chronos');
       }
@@ -101,9 +114,9 @@ export class ConvictionMethods extends EVMChainAdapterBase {
         accountId,
         currentEpoch,
       );
-      return BigInt(remaining);
+      return BigInt(remaining) >= discountedCost;
     } catch (err: any) {
-      if (err?.code === 'CALL_EXCEPTION') return 0n;
+      if (err?.code === 'CALL_EXCEPTION') return false;
       throw err;
     }
   }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -70,12 +70,13 @@ export class ConvictionMethods extends EVMChainAdapterBase {
    * whose undiscounted (base) cost is `baseCost`, right now.
    *
    * Mirrors `PublishingConviction.coverPublishingCost` exactly so the SDK's
-   * pre-flight matches the on-chain decision: apply the account's discount
-   * tier (`discountedCost = baseCost * (BPS_DENOMINATOR - discountBps) /
-   * BPS_DENOMINATOR`, with the contract's post-discount 1-wei floor), then
-   * compare against `getRemainingAllowance(accountId, currentEpoch)` — which
-   * already folds in the top-up buffer and returns 0 once the account is
-   * expired or has exhausted the current window.
+   * pre-flight matches the on-chain decision: reject once the account is past
+   * its (TIMESTAMP-based) `expiresAtTimestamp`, then apply the account's
+   * discount tier (`discountedCost = baseCost * (BPS_DENOMINATOR -
+   * discountBps) / BPS_DENOMINATOR`, with the contract's post-discount 1-wei
+   * floor), then compare against `getRemainingAllowance(accountId,
+   * currentEpoch)` — which folds in the top-up buffer and the current-window
+   * spend.
    *
    * The publisher SDK gates the `publishEpochs → lockDurationEpochs`
    * coercion on this: agent registration is consent-free (RFC-001 §3.6) and
@@ -100,6 +101,20 @@ export class ConvictionMethods extends EVMChainAdapterBase {
     try {
       const info = await this.getPublishingConvictionAccountInfo(accountId);
       if (!info) return false;
+
+      // Expiry is TIMESTAMP-based on-chain: `coverPublishingCost` reverts
+      // `AccountExpired` on `block.timestamp >= expiresAtTimestamp`. The
+      // epoch-based `getRemainingAllowance` below still reports allowance
+      // during the tail of the expiry epoch (for mid-epoch-created accounts
+      // `expiresAtEpoch` rounds up past `expiresAtTimestamp`), so check the
+      // wall clock first to mirror the contract exactly — otherwise the SDK
+      // would coerce, then fall through to full-price direct spend.
+      if (info.expiresAtTimestamp > 0) {
+        const latestBlock = await this.provider.getBlock('latest');
+        const nowTs = latestBlock ? Number(latestBlock.timestamp) : Math.floor(Date.now() / 1000);
+        if (nowTs >= info.expiresAtTimestamp) return false;
+      }
+
       // Mirror PublishingConviction's discount math + post-discount floor.
       const BPS_DENOMINATOR = 10_000n;
       const discountBps = BigInt(info.discountBps);

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -65,6 +65,49 @@ export class ConvictionMethods extends EVMChainAdapterBase {
     }
   }
 
+  /**
+   * Currently-spendable allowance (current-window base remaining + top-up
+   * buffer) for `accountId`, in TRAC wei. `0n` once the account is expired,
+   * has exhausted this window with no buffer, or was never meaningfully
+   * funded.
+   *
+   * Mirrors the exact quantity `PublishingConviction.coverPublishingCost`
+   * checks before reverting `InsufficientAllowance`
+   * (`getRemainingAllowance` already folds in the top-up buffer and returns
+   * 0 outside the account's active lifetime). The publisher SDK uses this to
+   * gate the `publishEpochs → lockDurationEpochs` coercion: a registered
+   * agent on an UNFUNDABLE account (e.g. a third party squatted this signer
+   * against a 1-wei PCA — agent registration is consent-free, RFC-001 §3.6)
+   * would otherwise snap the lifetime to the PCA lock and, post the
+   * conviction fall-through fix, direct-spend at that lifetime/full price
+   * instead of the caller's intended default. Gating on `> 0n` keeps the
+   * discount path for genuinely funded accounts while leaving everyone else
+   * at their requested lifetime.
+   *
+   * Returns `0n` when the NFT is not deployed, the id is non-positive, or
+   * the chain call reverts — callers treat the unknown case as "cannot
+   * fund", which fails safe to "do not coerce".
+   */
+  async getConvictionAccountSpendableAllowance(accountId: bigint): Promise<bigint> {
+    await this.init();
+    if (!this.contracts.dkgPublishingConvictionNFT) return 0n;
+    if (accountId <= 0n) return 0n;
+    try {
+      if (!this.contracts.chronos) {
+        this.contracts.chronos = await this.resolveContract('Chronos');
+      }
+      const currentEpoch: bigint = BigInt(await this.contracts.chronos.getCurrentEpoch());
+      const remaining: bigint = await this.contracts.dkgPublishingConvictionNFT.getRemainingAllowance(
+        accountId,
+        currentEpoch,
+      );
+      return BigInt(remaining);
+    } catch (err: any) {
+      if (err?.code === 'CALL_EXCEPTION') return 0n;
+      throw err;
+    }
+  }
+
   async getPublishingConvictionAccountOwner(accountId: bigint): Promise<string> {
     await this.init();
     const nft = await this.resolveContract('DKGPublishingConvictionNFT');

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -656,18 +656,24 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /**
-   * Mock parity for the publisher SDK's fundability gate: per-epoch base
-   * allowance (`committedTRAC / lockDurationEpochs`, matching the contract's
-   * integer division — so a 1-wei squat floors to 0) plus the top-up
-   * buffer. The mock doesn't track per-window publish spend, so this is the
-   * account's nominal current capacity, which is all the SDK gate needs to
-   * tell a funded account from a squatted/empty one.
+   * Mock parity for the publisher SDK's fundability gate. Mirrors
+   * `PublishingConviction.coverPublishingCost`: discount the base cost by the
+   * account's tier (with the 1-wei post-discount floor), then compare against
+   * the per-epoch base allowance (`committedTRAC / lockDurationEpochs`,
+   * integer-divided so a few-wei squat floors to 0) plus the top-up buffer.
+   * The mock doesn't track per-window publish spend, so this is the account's
+   * nominal current capacity — enough to tell a genuinely-funding account
+   * from a squatted/underfunded one for THIS publish's cost.
    */
-  async getConvictionAccountSpendableAllowance(accountId: bigint): Promise<bigint> {
+  async convictionAccountCanCover(accountId: bigint, baseCost: bigint): Promise<boolean> {
+    if (baseCost <= 0n) return true;
     const acct = this.convictionAccounts.get(accountId);
-    if (!acct || acct.lockDurationEpochs <= 0) return 0n;
+    if (!acct || acct.lockDurationEpochs <= 0) return false;
+    const BPS_DENOMINATOR = 10_000n;
+    let discountedCost = (baseCost * (BPS_DENOMINATOR - BigInt(acct.discountBps))) / BPS_DENOMINATOR;
+    if (discountedCost === 0n && baseCost > 0n) discountedCost = 1n;
     const baseEpochAllowance = acct.committedTRAC / BigInt(acct.lockDurationEpochs);
-    return baseEpochAllowance + acct.topUpBuffer;
+    return baseEpochAllowance + acct.topUpBuffer >= discountedCost;
   }
 
   /**

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -656,6 +656,21 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /**
+   * Mock parity for the publisher SDK's fundability gate: per-epoch base
+   * allowance (`committedTRAC / lockDurationEpochs`, matching the contract's
+   * integer division — so a 1-wei squat floors to 0) plus the top-up
+   * buffer. The mock doesn't track per-window publish spend, so this is the
+   * account's nominal current capacity, which is all the SDK gate needs to
+   * tell a funded account from a squatted/empty one.
+   */
+  async getConvictionAccountSpendableAllowance(accountId: bigint): Promise<bigint> {
+    const acct = this.convictionAccounts.get(accountId);
+    if (!acct || acct.lockDurationEpochs <= 0) return 0n;
+    const baseEpochAllowance = acct.committedTRAC / BigInt(acct.lockDurationEpochs);
+    return baseEpochAllowance + acct.topUpBuffer;
+  }
+
+  /**
    * Mock owner-lookup for the daemon's curated-CG registration
    * preflight (`local curator == ownerOf(pcaAccountId)`).
    */

--- a/packages/evm-module/abi/IPublishingConvictionErrors.json
+++ b/packages/evm-module/abi/IPublishingConvictionErrors.json
@@ -1,0 +1,44 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint40",
+        "name": "expiresAtEpoch",
+        "type": "uint40"
+      }
+    ],
+    "name": "AccountExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint40",
+        "name": "epoch",
+        "type": "uint40"
+      },
+      {
+        "internalType": "uint96",
+        "name": "required",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint96",
+        "name": "available",
+        "type": "uint96"
+      }
+    ],
+    "name": "InsufficientAllowance",
+    "type": "error"
+  }
+]

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -105,12 +105,23 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     // 10.0.3 → 10.0.4: curated publishes and paid legacy curated updates
     // must carry a ciphertext commitment before entering value-weighted
     // random-sampling state.
+    // 10.0.4 → 10.0.5: audit fix — the conviction (PCA discount) branch in
+    // `publish`/`update` now FALLS THROUGH to direct spend instead of
+    // reverting when `coverPublishingCost` fails for a payment reason
+    // (`InsufficientAllowance` / `AccountExpired`). Agent registration is
+    // permissionless and requires no consent (RFC-001 §3.6), so a hard
+    // revert on the conviction branch let anyone register a victim against
+    // a deliberately-underfunded account and brick that victim's paid
+    // publishes/updates indefinitely. This extends the existing
+    // "stale registration MUST NOT brick the publisher" intent (already
+    // applied to the expired / epoch-mismatch gate) to the
+    // underfunded-active case.
     // 2.0.0 → 2.0.1 (PATCH): protocol treasury fee skimmed inside
     // `_addTokens` (publisher pays the same gross amount; the fee is taken
     // out of the staker-bound net). Patch-level on purpose — the EIP-712
     // author-attestation domain version (`_EIP712_VERSION_HASH`) MUST stay
     // pinned at "2.0.0" so previously signed attestations keep verifying.
-    string private constant _VERSION = "10.0.4";
+    string private constant _VERSION = "10.0.5";
 
     // --- V10 publish input (grouped to bypass the 16-arg stack limit) ---
 
@@ -353,6 +364,20 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     ///      successful signature check. `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`.
     bytes4 private constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
 
+    /// @dev Selectors of the PaymentConviction-side errors that mean "this
+    ///      account cannot fund the publish via the discount branch right
+    ///      now". On these (and ONLY these) the publish/update falls through
+    ///      to direct spend instead of bricking — see the version changelog
+    ///      and {_coverViaConvictionOrFallThrough}. Any other revert from
+    ///      `coverPublishingCost` is a genuine fault and bubbles up.
+    ///      Signatures mirror `PublishingConviction`:
+    ///        InsufficientAllowance(uint256 accountId, uint40 epoch, uint96 required, uint96 available)
+    ///        AccountExpired(uint256 accountId, uint40 expiresAtEpoch)
+    bytes4 private constant _PCA_INSUFFICIENT_ALLOWANCE_SELECTOR =
+        bytes4(keccak256("InsufficientAllowance(uint256,uint40,uint96,uint96)"));
+    bytes4 private constant _PCA_ACCOUNT_EXPIRED_SELECTOR =
+        bytes4(keccak256("AccountExpired(uint256,uint40)"));
+
     // --- Update-specific errors (V10 Phase 8 Task 2) ---
 
     /// @dev Update would reduce the KC's `tokenAmount` below its current
@@ -504,20 +529,20 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                 p.epochs == uint256(lockDurationEpochs);
         }
 
+        // Discount branch when eligible; otherwise (or on a PCA-side payment
+        // failure) direct spend. The conviction attempt MUST NOT brick the
+        // publisher — agent registration is permissionless and consent-free,
+        // so an underfunded account a third party registered us against falls
+        // through here instead of reverting. See {_coverViaConvictionOrFallThrough}.
         if (useConviction) {
-            // Discount branch. The NFT auto-resolves the paying account
-            // from `agentToAccountId[msg.sender]`, deducts the discounted
-            // cost, distributes it across the KC's epoch range (active
-            // sink), and lazily settles any elapsed billing windows
-            // (passive sink). KAv10 MUST NOT call `_distributeTokens`
-            // here — the NFT is the funding agent on this branch.
-            publishingConvictionNFT.coverPublishingCost(
-                msg.sender,
+            useConviction = _coverViaConvictionOrFallThrough(
                 p.tokenAmount,
                 currentEpoch,
                 uint40(p.epochs)
             );
-        } else {
+        }
+
+        if (!useConviction) {
             // Direct-spend branch. `transferFrom(msg.sender, CSS, fullCost)`
             // + epoch-range distribution. The named core (if non-zero) still
             // earns publishing-factor credit through `_executePublishCore`'s
@@ -528,6 +553,59 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
         }
 
         return kaId;
+    }
+
+    /**
+     * @dev Attempt to fund a publish/update via the caller's conviction
+     *      account (PCA discount branch). Returns `true` if the cost was
+     *      covered via conviction, `false` if the caller should fall through
+     *      to direct spend.
+     *
+     *      Audit fix: agent registration is permissionless and requires no
+     *      consent from the agent (RFC-001 §3.6). A hard revert here let an
+     *      attacker register a victim against a deliberately-underfunded
+     *      account and brick that victim's paid publishes/updates. We
+     *      therefore swallow ONLY the PCA-side "cannot pay" errors
+     *      (`InsufficientAllowance`, `AccountExpired`) and fall through to
+     *      direct spend — mirroring the gate's existing
+     *      "stale registration MUST NOT brick the publisher" intent. Any
+     *      other revert is a genuine fault and is re-thrown unchanged so we
+     *      never mask real bugs or silently downgrade on unexpected state.
+     *
+     *      `coverPublishingCost` is an external call to the NFT contract, so
+     *      a revert rolls back all of its state writes atomically — the
+     *      fall-through starts from clean state with no partial PCA effects.
+     */
+    function _coverViaConvictionOrFallThrough(
+        uint96 baseCost,
+        uint40 kcStartEpoch,
+        uint40 kcEpochs
+    ) internal returns (bool covered) {
+        try publishingConvictionNFT.coverPublishingCost(msg.sender, baseCost, kcStartEpoch, kcEpochs) returns (
+            uint96
+        ) {
+            return true;
+        } catch (bytes memory reason) {
+            bytes4 selector;
+            if (reason.length >= 4) {
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    selector := mload(add(reason, 0x20))
+                }
+            }
+            if (
+                selector == _PCA_INSUFFICIENT_ALLOWANCE_SELECTOR ||
+                selector == _PCA_ACCOUNT_EXPIRED_SELECTOR
+            ) {
+                // Expected "cannot pay via conviction" — fall through.
+                return false;
+            }
+            // Unexpected fault — bubble up verbatim.
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                revert(add(reason, 0x20), mload(reason))
+            }
+        }
     }
 
     // ========================================================================
@@ -1199,19 +1277,19 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                 remainingEpochs <= uint40(lockDurationEpochs);
         }
 
+        // Discount branch when eligible; otherwise (or on a PCA-side payment
+        // failure) direct spend. As in `publish`, the conviction attempt MUST
+        // NOT brick the updater — a consent-free agent registration on an
+        // underfunded account falls through here rather than reverting.
         if (useConviction) {
-            // Discount branch — delta funds the KC's REMAINING epoch range
-            // `[currentEpoch, currentEpoch + remainingEpochs - 1]` via the
-            // active sink. The active sink may extend past the conviction
-            // account's `expiresAtEpoch` (harmless — the staker pool just
-            // gets funded normally for those epochs).
-            publishingConvictionNFT.coverPublishingCost(
-                msg.sender,
+            useConviction = _coverViaConvictionOrFallThrough(
                 deltaTokenAmount,
                 currentEpoch,
                 remainingEpochs
             );
-        } else {
+        }
+
+        if (!useConviction) {
             uint96 netDeltaTokenAmount = _addTokens(deltaTokenAmount);
             _distributeTokens(netDeltaTokenAmount, uint256(remainingEpochs), currentEpoch);
         }

--- a/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
+++ b/packages/evm-module/contracts/KnowledgeAssetsLifecycle.sol
@@ -21,6 +21,7 @@ import {INamed} from "./interfaces/INamed.sol";
 import {IVersioned} from "./interfaces/IVersioned.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {IDKGPublishingConvictionNFT} from "./interfaces/IDKGPublishingConvictionNFT.sol";
+import {IPublishingConvictionErrors} from "./interfaces/IPublishingConvictionErrors.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
@@ -364,20 +365,6 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
     ///      successful signature check. `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`.
     bytes4 private constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
 
-    /// @dev Selectors of the PaymentConviction-side errors that mean "this
-    ///      account cannot fund the publish via the discount branch right
-    ///      now". On these (and ONLY these) the publish/update falls through
-    ///      to direct spend instead of bricking — see the version changelog
-    ///      and {_coverViaConvictionOrFallThrough}. Any other revert from
-    ///      `coverPublishingCost` is a genuine fault and bubbles up.
-    ///      Signatures mirror `PublishingConviction`:
-    ///        InsufficientAllowance(uint256 accountId, uint40 epoch, uint96 required, uint96 available)
-    ///        AccountExpired(uint256 accountId, uint40 expiresAtEpoch)
-    bytes4 private constant _PCA_INSUFFICIENT_ALLOWANCE_SELECTOR =
-        bytes4(keccak256("InsufficientAllowance(uint256,uint40,uint96,uint96)"));
-    bytes4 private constant _PCA_ACCOUNT_EXPIRED_SELECTOR =
-        bytes4(keccak256("AccountExpired(uint256,uint40)"));
-
     // --- Update-specific errors (V10 Phase 8 Task 2) ---
 
     /// @dev Update would reduce the KC's `tokenAmount` below its current
@@ -593,9 +580,13 @@ contract KnowledgeAssetsLifecycle is INamed, IVersioned, ContractStatus, IInitia
                     selector := mload(add(reason, 0x20))
                 }
             }
+            // Selectors come from {IPublishingConvictionErrors} — the SAME
+            // declarations `PublishingConviction` reverts with — so the
+            // compiler keeps the catch side and the revert side in lock-step;
+            // a signature change there breaks this file too.
             if (
-                selector == _PCA_INSUFFICIENT_ALLOWANCE_SELECTOR ||
-                selector == _PCA_ACCOUNT_EXPIRED_SELECTOR
+                selector == IPublishingConvictionErrors.InsufficientAllowance.selector ||
+                selector == IPublishingConvictionErrors.AccountExpired.selector
             ) {
                 // Expected "cannot pay via conviction" — fall through.
                 return false;

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 import {INamed} from "./interfaces/INamed.sol";
 import {IVersioned} from "./interfaces/IVersioned.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
+import {IPublishingConvictionErrors} from "./interfaces/IPublishingConvictionErrors.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {EpochStorage} from "./storage/EpochStorage.sol";
@@ -87,7 +88,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  *     (including a staker pool watcher) can flush pending sweeps. The
  *     account's `fullySwept` flag short-circuits redundant work.
  */
-contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializable {
+contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializable, IPublishingConvictionErrors {
     string private constant _NAME = "PublishingConviction";
     // Version history:
     //   1.0.0 — initial split-out from `DKGPublishingConvictionNFT` v2.0.0.
@@ -206,8 +207,9 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     error ZeroAddressDependency(string name);
     error OnlyConvictionNFT(address caller);
     error NoConvictionAccount(address publishingAgent);
-    error InsufficientAllowance(uint256 accountId, uint40 epoch, uint96 required, uint96 available);
-    error AccountExpired(uint256 accountId, uint40 expiresAtEpoch);
+    // `InsufficientAllowance` / `AccountExpired` are declared in
+    // {IPublishingConvictionErrors} (shared with KnowledgeAssetsLifecycle's
+    // fall-through catch) so the two contracts can never drift on selector.
     error InvalidAmount();
     error ZeroAgentAddress();
     error AgentCapReached(uint256 accountId, uint256 cap);

--- a/packages/evm-module/contracts/interfaces/IPublishingConvictionErrors.sol
+++ b/packages/evm-module/contracts/interfaces/IPublishingConvictionErrors.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+/**
+ * @title IPublishingConvictionErrors
+ * @notice Single source of truth for the publishing-conviction "cannot pay
+ *         via this account right now" errors.
+ *
+ *         These are declared here — rather than locally on
+ *         {PublishingConviction} — because more than one contract must agree
+ *         on their selectors:
+ *
+ *           - {PublishingConviction} REVERTS with them inside
+ *             `coverPublishingCost` when an account cannot fund a publish.
+ *           - {KnowledgeAssetsLifecycle} CATCHES them by selector and falls
+ *             through to direct spend instead of bricking the publisher
+ *             (consent-free agent-registration DoS fix).
+ *
+ *         Keeping a single declaration makes the compiler enforce that the
+ *         catch side and the revert side never drift: renaming or re-typing
+ *         an error here breaks both call sites at compile time, so the
+ *         fall-through can never be silently disabled.
+ */
+interface IPublishingConvictionErrors {
+    /// @notice The resolved conviction account cannot cover the (discounted)
+    ///         cost for `epoch` — its base allowance plus top-up buffer fall
+    ///         short of `required`.
+    error InsufficientAllowance(uint256 accountId, uint40 epoch, uint96 required, uint96 available);
+
+    /// @notice The conviction account is past `expiresAtEpoch` and can no
+    ///         longer fund publishes.
+    error AccountExpired(uint256 accountId, uint40 expiresAtEpoch);
+}

--- a/packages/evm-module/test/v10-pca-agent-dos.test.ts
+++ b/packages/evm-module/test/v10-pca-agent-dos.test.ts
@@ -1,0 +1,387 @@
+// =============================================================================
+// V10 PCA — consent-free agent-registration DoS regression (audit fix)
+// =============================================================================
+//
+// Agent registration on a publishing-conviction account (PCA) is
+// permissionless and requires NO consent from the agent (RFC-001 §3.6). The
+// publish/update entrypoints auto-route a registered agent into the discount
+// branch based only on (registered, not-expired, epoch-match) — NOT on whether
+// the account can actually fund the cost.
+//
+// Pre-fix, an attacker could:
+//   1. createAccount(1 wei)            -> active PCA, baseAllowance = 1/12 = 0
+//   2. registerAgent(accountId, victim) (no consent needed)
+// and any victim publish with `epochs == lockDurationEpochs` (or any paid
+// victim update) would route into `coverPublishingCost`, hit
+// `InsufficientAllowance`, and REVERT — bricking the victim's paid publishes
+// and updates indefinitely. The victim cannot self-deregister and cannot
+// register their own address (the global reverse map is taken).
+//
+// The fix makes the conviction branch FALL THROUGH to direct spend on the
+// PCA-side payment errors (`InsufficientAllowance` / `AccountExpired`) instead
+// of reverting — so a consent-free registration can never block a publisher;
+// it just loses the (non-existent) discount and the victim pays full price.
+//
+// This suite proves: with the attacker's underfunded registration in place and
+// the conviction gate ACTIVE (epochs == lockDurationEpochs), the victim's
+// publish still succeeds via direct spend (victim's own TRAC moves, KC minted).
+
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import hre from 'hardhat';
+
+import {
+  Chronos,
+  ContextGraphs,
+  ContextGraphStorage,
+  DKGKnowledgeAssets,
+  DKGPublishingConvictionNFT,
+  DKGStakingConvictionNFT,
+  EpochStorage,
+  Hub,
+  KnowledgeAssetsLifecycle,
+  Profile,
+  StakingV10,
+  Token,
+} from '../typechain';
+import { createProfile, createProfiles } from './helpers/profile-helpers';
+import {
+  getDefaultPublishingNode,
+  getDefaultReceivingNodes,
+  getDefaultKCCreator,
+} from './helpers/setup-helpers';
+import {
+  buildPublishParams,
+  packReservedKaId,
+  DEFAULT_CHAIN_ID,
+} from './helpers/v10-kc-helpers';
+
+const MIN_STAKE = ethers.parseEther('50000');
+const STAKER_SHARD_ID = 1n;
+
+type Fixture = {
+  accounts: SignerWithAddress[];
+  Hub: Hub;
+  Token: Token;
+  Chronos: Chronos;
+  Profile: Profile;
+  StakingV10: StakingV10;
+  StakingNFT: DKGStakingConvictionNFT;
+  KnowledgeAssetsLifecycle: KnowledgeAssetsLifecycle;
+  DKGKnowledgeAssets: DKGKnowledgeAssets;
+  EpochStorage: EpochStorage;
+  ContextGraphs: ContextGraphs;
+  ContextGraphStorage: ContextGraphStorage;
+  NFT: DKGPublishingConvictionNFT;
+};
+
+async function deployFixture(): Promise<Fixture> {
+  await hre.deployments.fixture([
+    'Token',
+    'AskStorage',
+    'EpochStorage',
+    'Chronos',
+    'Profile',
+    'Identity',
+    'KnowledgeAssetsLifecycle',
+    'ContextGraphStorage',
+    'ContextGraphs',
+    'ContextGraphValueStorage',
+    'DKGPublishingConvictionNFT',
+    'DKGStakingConvictionNFT',
+    'StakingV10',
+  ]);
+
+  const accounts = await hre.ethers.getSigners();
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+
+  return {
+    accounts,
+    Hub,
+    Token: await hre.ethers.getContract<Token>('Token'),
+    Chronos: await hre.ethers.getContract<Chronos>('Chronos'),
+    Profile: await hre.ethers.getContract<Profile>('Profile'),
+    StakingV10: await hre.ethers.getContract<StakingV10>('StakingV10'),
+    StakingNFT: await hre.ethers.getContract<DKGStakingConvictionNFT>(
+      'DKGStakingConvictionNFT',
+    ),
+    KnowledgeAssetsLifecycle:
+      await hre.ethers.getContract<KnowledgeAssetsLifecycle>(
+        'KnowledgeAssetsLifecycle',
+      ),
+    DKGKnowledgeAssets: await hre.ethers.getContract<DKGKnowledgeAssets>(
+      'DKGKnowledgeAssets',
+    ),
+    EpochStorage: await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
+    ContextGraphs: await hre.ethers.getContract<ContextGraphs>('ContextGraphs'),
+    ContextGraphStorage: await hre.ethers.getContract<ContextGraphStorage>(
+      'ContextGraphStorage',
+    ),
+    NFT: await hre.ethers.getContract<DKGPublishingConvictionNFT>(
+      'DKGPublishingConvictionNFT',
+    ),
+  };
+}
+
+describe('@integration V10 PCA — consent-free agent DoS (audit fix)', function () {
+  let accounts: SignerWithAddress[];
+  let Token: Token;
+  let Chronos: Chronos;
+  let ProfileContract: Profile;
+  let StakingV10Contract: StakingV10;
+  let StakingNFT: DKGStakingConvictionNFT;
+  let KAV10: KnowledgeAssetsLifecycle;
+  let DKGKnowledgeAssets: DKGKnowledgeAssets;
+  let EpochStorageContract: EpochStorage;
+  let CGFacade: ContextGraphs;
+  let CGS: ContextGraphStorage;
+  let NFT: DKGPublishingConvictionNFT;
+
+  beforeEach(async () => {
+    hre.helpers.resetDeploymentsJson();
+    ({
+      accounts,
+      Token,
+      Chronos,
+      Profile: ProfileContract,
+      StakingV10: StakingV10Contract,
+      StakingNFT,
+      KnowledgeAssetsLifecycle: KAV10,
+      DKGKnowledgeAssets,
+      EpochStorage: EpochStorageContract,
+      ContextGraphs: CGFacade,
+      ContextGraphStorage: CGS,
+      NFT,
+    } = await loadFixture(deployFixture));
+  });
+
+  const stakeV10 = async (
+    staker: SignerWithAddress,
+    identityId: number,
+    amount: bigint,
+  ) => {
+    await Token.mint(staker.address, amount);
+    await Token.connect(staker).approve(
+      await StakingV10Contract.getAddress(),
+      amount,
+    );
+    await StakingNFT.connect(staker).createConviction(identityId, amount, 1);
+  };
+
+  const sumActiveSink = (
+    logs: readonly { address: string; topics: readonly string[]; data: string }[],
+    epochStorageAddr: string,
+  ): bigint => {
+    let sum = 0n;
+    for (const log of logs) {
+      if (log.address.toLowerCase() !== epochStorageAddr) continue;
+      try {
+        const parsed = EpochStorageContract.interface.parseLog({
+          topics: [...log.topics],
+          data: log.data,
+        });
+        if (parsed?.name === 'TokensAddedToEpochRange') {
+          expect(BigInt(parsed.args.shardId)).to.equal(STAKER_SHARD_ID);
+          sum += BigInt(parsed.args.tokenAmount);
+        }
+      } catch {
+        // not our event
+      }
+    }
+    return sum;
+  };
+
+  it('attacker-registered, underfunded PCA no longer bricks a victim publish (falls through to direct spend)', async () => {
+    // ---- Nodes (V10-staked for the ACK signer gate) ----
+    const publishingNode = getDefaultPublishingNode(accounts);
+    const receivingNodes = getDefaultReceivingNodes(accounts);
+    const { identityId: publisherIdentityId } = await createProfile(
+      ProfileContract,
+      publishingNode,
+    );
+    const receiverProfiles = await createProfiles(ProfileContract, receivingNodes);
+    const receiverIdentityIds = receiverProfiles.map((p) => p.identityId);
+
+    await stakeV10(publishingNode.operational, publisherIdentityId, MIN_STAKE);
+    for (let i = 0; i < receivingNodes.length; i++) {
+      await stakeV10(
+        receivingNodes[i].operational,
+        receiverProfiles[i].identityId,
+        MIN_STAKE,
+      );
+    }
+
+    // ---- Attack: 1-wei PCA, register the victim as a paying agent ----
+    const attacker = accounts[8];
+    const victim = getDefaultKCCreator(accounts); // accounts[9]
+
+    await Token.mint(attacker.address, 1n);
+    await Token.connect(attacker).approve(await NFT.getAddress(), 1n);
+    await NFT.connect(attacker).createAccount(1n);
+    const attackerAccountId = await NFT.totalSupply();
+
+    await NFT.connect(attacker).registerAgent(attackerAccountId, victim.address);
+    // The victim is now globally routed to the attacker's underfunded account.
+    expect(await NFT.agentToAccountId(victim.address)).to.equal(
+      attackerAccountId,
+    );
+
+    // The conviction branch is ACTIVE for this publish: the account is fresh
+    // (not expired) and we publish with epochs == lockDurationEpochs. So the
+    // publish MUST enter `coverPublishingCost` and rely on the fall-through.
+    const lockDurationEpochs = Number((await NFT.accounts(attackerAccountId))[5]);
+
+    // ---- Victim's own context graph (open publish policy) ----
+    await CGFacade.connect(victim).createContextGraph(
+      [],
+      0,
+      0,
+      1, // open publish policy
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroHash,
+    );
+    const cgId = await CGS.getLatestContextGraphId();
+    expect(await CGFacade.isAuthorizedPublisher(cgId, victim.address)).to.be
+      .true;
+
+    // ---- Victim funds a DIRECT spend (full price) — what they fall back to ----
+    const tokenAmount = ethers.parseEther('1000');
+    await Token.mint(victim.address, tokenAmount);
+    await Token.connect(victim).approve(await KAV10.getAddress(), tokenAmount);
+
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const merkleRoot = ethers.keccak256(ethers.toUtf8Bytes('pca-dos-regression'));
+    const reservedKaId = packReservedKaId(victim.address, 1);
+    const p = await buildPublishParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes,
+      publisherIdentityId,
+      receiverIdentityIds,
+      author: victim,
+      contextGraphId: cgId,
+      merkleRoot,
+      knowledgeAssetsAmount: 1,
+      byteSize: 1000,
+      epochs: lockDurationEpochs,
+      tokenAmount,
+      isImmutable: false,
+      publishOperationId: 'pca-dos-op',
+      reservedKaId,
+    });
+
+    const victimBalBefore = await Token.balanceOf(victim.address);
+
+    // Pre-fix this reverted InsufficientAllowance and minted no KC.
+    const tx = await KAV10.connect(victim).publish(p);
+    const receipt = await tx.wait();
+    expect(receipt!.status).to.equal(1);
+
+    // Proof it took the DIRECT-spend fall-through, not the discount branch:
+    // the victim's own TRAC funded the staker pool (conviction branch would
+    // have drawn from the PCA escrow and left the victim's balance intact —
+    // and could not have succeeded anyway since the PCA holds 1 wei).
+    const epochStorageAddr = (
+      await EpochStorageContract.getAddress()
+    ).toLowerCase();
+    const activeSinkSum = sumActiveSink(receipt!.logs, epochStorageAddr);
+    const victimSpent = victimBalBefore - (await Token.balanceOf(victim.address));
+
+    expect(victimSpent).to.equal(tokenAmount);
+    // Net-of-treasury distribution funded the pool; it can be ≤ tokenAmount but
+    // must be non-zero and cannot exceed what the victim actually paid.
+    expect(activeSinkSum).to.be.greaterThan(0n);
+    expect(activeSinkSum).to.be.lessThanOrEqual(tokenAmount);
+
+    // KC actually minted to the victim/author.
+    expect(await DKGKnowledgeAssets.ownerOf(reservedKaId)).to.equal(
+      victim.address,
+    );
+    const meta = await DKGKnowledgeAssets.getKnowledgeAssetMetadata(reservedKaId);
+    expect(meta[6]).to.equal(tokenAmount);
+
+    // The malicious association is still present (consent-free registration is
+    // not retroactively removed) but it is now harmless — the victim published.
+    expect(await NFT.agentToAccountId(victim.address)).to.equal(
+      attackerAccountId,
+    );
+  });
+
+  it('unexpected (non-payment) reverts from the conviction branch still propagate', async () => {
+    // Sanity guard for the selector filter: a victim with NO TRAC and NO
+    // approval who falls through to direct spend must still revert
+    // (TooLowAllowance / TooLowBalance) rather than silently succeeding — the
+    // fall-through is not a free pass, it just removes the PCA-side brick.
+    const publishingNode = getDefaultPublishingNode(accounts);
+    const receivingNodes = getDefaultReceivingNodes(accounts);
+    const { identityId: publisherIdentityId } = await createProfile(
+      ProfileContract,
+      publishingNode,
+    );
+    const receiverProfiles = await createProfiles(ProfileContract, receivingNodes);
+    const receiverIdentityIds = receiverProfiles.map((p) => p.identityId);
+
+    await stakeV10(publishingNode.operational, publisherIdentityId, MIN_STAKE);
+    for (let i = 0; i < receivingNodes.length; i++) {
+      await stakeV10(
+        receivingNodes[i].operational,
+        receiverProfiles[i].identityId,
+        MIN_STAKE,
+      );
+    }
+
+    const attacker = accounts[8];
+    const victim = getDefaultKCCreator(accounts);
+    await Token.mint(attacker.address, 1n);
+    await Token.connect(attacker).approve(await NFT.getAddress(), 1n);
+    await NFT.connect(attacker).createAccount(1n);
+    const attackerAccountId = await NFT.totalSupply();
+    await NFT.connect(attacker).registerAgent(attackerAccountId, victim.address);
+    const lockDurationEpochs = Number((await NFT.accounts(attackerAccountId))[5]);
+
+    await CGFacade.connect(victim).createContextGraph(
+      [],
+      0,
+      0,
+      1,
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroHash,
+    );
+    const cgId = await CGS.getLatestContextGraphId();
+
+    const tokenAmount = ethers.parseEther('1000');
+    // NOTE: victim is intentionally NOT funded / NOT approved here.
+    const merkleRoot = ethers.keccak256(ethers.toUtf8Bytes('pca-dos-nofund'));
+    const reservedKaId = packReservedKaId(victim.address, 1);
+    const p = await buildPublishParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes,
+      publisherIdentityId,
+      receiverIdentityIds,
+      author: victim,
+      contextGraphId: cgId,
+      merkleRoot,
+      knowledgeAssetsAmount: 1,
+      byteSize: 1000,
+      epochs: lockDurationEpochs,
+      tokenAmount,
+      isImmutable: false,
+      publishOperationId: 'pca-dos-nofund-op',
+      reservedKaId,
+    });
+
+    // Falls through to direct spend, which reverts on the missing allowance —
+    // the publisher pays via direct spend or not at all; it is never bricked
+    // by the PCA, but it also isn't handed a free publish.
+    await expect(KAV10.connect(victim).publish(p)).to.be.revertedWithCustomError(
+      KAV10,
+      'TooLowAllowance',
+    );
+  });
+});

--- a/packages/evm-module/test/v10-pca-agent-dos.test.ts
+++ b/packages/evm-module/test/v10-pca-agent-dos.test.ts
@@ -3,31 +3,35 @@
 // =============================================================================
 //
 // Agent registration on a publishing-conviction account (PCA) is
-// permissionless and requires NO consent from the agent (RFC-001 §3.6). The
-// publish/update entrypoints auto-route a registered agent into the discount
-// branch based only on (registered, not-expired, epoch-match) — NOT on whether
-// the account can actually fund the cost.
+// permissionless and requires NO consent from the agent (RFC-001 §3.6).
+// `registerAgent` only checks that the caller owns the PCA being registered
+// against — the `agent` address is an arbitrary value the caller types in,
+// and `agentToAccountId` is a single GLOBAL reverse map. So any unprivileged
+// party can:
 //
-// Pre-fix, an attacker could:
-//   1. createAccount(1 wei)            -> active PCA, baseAllowance = 1/12 = 0
-//   2. registerAgent(accountId, victim) (no consent needed)
-// and any victim publish with `epochs == lockDurationEpochs` (or any paid
-// victim update) would route into `coverPublishingCost`, hit
-// `InsufficientAllowance`, and REVERT — bricking the victim's paid publishes
-// and updates indefinitely. The victim cannot self-deregister and cannot
-// register their own address (the global reverse map is taken).
+//   1. createAccount(1 wei)             -> active PCA, baseAllowance = 1/12 = 0
+//   2. registerAgent(theirAccountId, victim)   (no victim consent needed)
+//
+// and thereby point `agentToAccountId[victim]` at their own deliberately
+// underfunded account. Pre-fix, the victim's publish (with
+// `epochs == lockDurationEpochs`) and EVERY paid update routed into
+// `coverPublishingCost`, hit `InsufficientAllowance`, and REVERTED — a
+// near-permanent brick for ~1 wei + gas. The victim cannot self-deregister
+// (owner-gated) nor re-route the global slot.
 //
 // The fix makes the conviction branch FALL THROUGH to direct spend on the
 // PCA-side payment errors (`InsufficientAllowance` / `AccountExpired`) instead
-// of reverting — so a consent-free registration can never block a publisher;
+// of reverting, so a consent-free registration can never block a publisher;
 // it just loses the (non-existent) discount and the victim pays full price.
 //
-// This suite proves: with the attacker's underfunded registration in place and
-// the conviction gate ACTIVE (epochs == lockDurationEpochs), the victim's
-// publish still succeeds via direct spend (victim's own TRAC moves, KC minted).
+// Coverage in this suite:
+//   - publish()  under an attacker-registered, underfunded PCA  -> direct spend
+//   - update()   under an attacker-registered, underfunded PCA  -> direct spend
+//   - publish()  under an attacker-registered, EXPIRED PCA      -> direct spend
+//   - the fall-through is not a free pass (unfunded victim still reverts)
 
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 import hre from 'hardhat';
@@ -54,12 +58,12 @@ import {
 } from './helpers/setup-helpers';
 import {
   buildPublishParams,
+  buildUpdateParams,
   packReservedKaId,
   DEFAULT_CHAIN_ID,
 } from './helpers/v10-kc-helpers';
 
 const MIN_STAKE = ethers.parseEther('50000');
-const STAKER_SHARD_ID = 1n;
 
 type Fixture = {
   accounts: SignerWithAddress[];
@@ -171,31 +175,8 @@ describe('@integration V10 PCA — consent-free agent DoS (audit fix)', function
     await StakingNFT.connect(staker).createConviction(identityId, amount, 1);
   };
 
-  const sumActiveSink = (
-    logs: readonly { address: string; topics: readonly string[]; data: string }[],
-    epochStorageAddr: string,
-  ): bigint => {
-    let sum = 0n;
-    for (const log of logs) {
-      if (log.address.toLowerCase() !== epochStorageAddr) continue;
-      try {
-        const parsed = EpochStorageContract.interface.parseLog({
-          topics: [...log.topics],
-          data: log.data,
-        });
-        if (parsed?.name === 'TokensAddedToEpochRange') {
-          expect(BigInt(parsed.args.shardId)).to.equal(STAKER_SHARD_ID);
-          sum += BigInt(parsed.args.tokenAmount);
-        }
-      } catch {
-        // not our event
-      }
-    }
-    return sum;
-  };
-
-  it('attacker-registered, underfunded PCA no longer bricks a victim publish (falls through to direct spend)', async () => {
-    // ---- Nodes (V10-staked for the ACK signer gate) ----
+  // Publisher + 3 receiver profiles, all V10-staked above the ACK signer gate.
+  const standUpNodes = async () => {
     const publishingNode = getDefaultPublishingNode(accounts);
     const receivingNodes = getDefaultReceivingNodes(accounts);
     const { identityId: publisherIdentityId } = await createProfile(
@@ -213,29 +194,29 @@ describe('@integration V10 PCA — consent-free agent DoS (audit fix)', function
         MIN_STAKE,
       );
     }
+    return { receivingNodes, publisherIdentityId, receiverIdentityIds };
+  };
 
-    // ---- Attack: 1-wei PCA, register the victim as a paying agent ----
-    const attacker = accounts[8];
-    const victim = getDefaultKCCreator(accounts); // accounts[9]
-
+  // Attacker mints a 1-wei PCA (baseAllowance = 1/lockDurationEpochs = 0) and
+  // registers the victim as a paying agent — no victim consent involved.
+  const attackerSquats = async (
+    attacker: SignerWithAddress,
+    victim: SignerWithAddress,
+  ) => {
     await Token.mint(attacker.address, 1n);
     await Token.connect(attacker).approve(await NFT.getAddress(), 1n);
     await NFT.connect(attacker).createAccount(1n);
-    const attackerAccountId = await NFT.totalSupply();
+    const accountId = await NFT.totalSupply();
+    await NFT.connect(attacker).registerAgent(accountId, victim.address);
+    expect(await NFT.agentToAccountId(victim.address)).to.equal(accountId);
+    const lockDurationEpochs = Number((await NFT.accounts(accountId))[5]);
+    return { accountId, lockDurationEpochs };
+  };
 
-    await NFT.connect(attacker).registerAgent(attackerAccountId, victim.address);
-    // The victim is now globally routed to the attacker's underfunded account.
-    expect(await NFT.agentToAccountId(victim.address)).to.equal(
-      attackerAccountId,
-    );
-
-    // The conviction branch is ACTIVE for this publish: the account is fresh
-    // (not expired) and we publish with epochs == lockDurationEpochs. So the
-    // publish MUST enter `coverPublishingCost` and rely on the fall-through.
-    const lockDurationEpochs = Number((await NFT.accounts(attackerAccountId))[5]);
-
-    // ---- Victim's own context graph (open publish policy) ----
-    await CGFacade.connect(victim).createContextGraph(
+  // Open-publish-policy context graph owned by `owner` (authorizes any
+  // non-zero publisher, including the victim).
+  const openContextGraphFor = async (owner: SignerWithAddress) => {
+    await CGFacade.connect(owner).createContextGraph(
       [],
       0,
       0,
@@ -245,128 +226,261 @@ describe('@integration V10 PCA — consent-free agent DoS (audit fix)', function
       ethers.ZeroHash,
     );
     const cgId = await CGS.getLatestContextGraphId();
-    expect(await CGFacade.isAuthorizedPublisher(cgId, victim.address)).to.be
-      .true;
+    expect(await CGFacade.isAuthorizedPublisher(cgId, owner.address)).to.be.true;
+    return cgId;
+  };
 
-    // ---- Victim funds a DIRECT spend (full price) — what they fall back to ----
+  // Fund + execute a victim-authored publish that pays via DIRECT spend.
+  const victimPublish = async (args: {
+    victim: SignerWithAddress;
+    cgId: bigint;
+    epochs: number;
+    tokenAmount: bigint;
+    kaNumber: number;
+    nodes: Awaited<ReturnType<typeof standUpNodes>>;
+    opId: string;
+  }) => {
+    await Token.mint(args.victim.address, args.tokenAmount);
+    await Token.connect(args.victim).approve(
+      await KAV10.getAddress(),
+      args.tokenAmount,
+    );
+    const reservedKaId = packReservedKaId(args.victim.address, args.kaNumber);
+    const p = await buildPublishParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: args.nodes.receivingNodes,
+      publisherIdentityId: args.nodes.publisherIdentityId,
+      receiverIdentityIds: args.nodes.receiverIdentityIds,
+      author: args.victim,
+      contextGraphId: args.cgId,
+      merkleRoot: ethers.keccak256(ethers.toUtf8Bytes(args.opId)),
+      knowledgeAssetsAmount: 1,
+      byteSize: 1000,
+      epochs: args.epochs,
+      tokenAmount: args.tokenAmount,
+      isImmutable: false,
+      publishOperationId: args.opId,
+      reservedKaId,
+    });
+    await (await KAV10.connect(args.victim).publish(p)).wait();
+    return reservedKaId;
+  };
+
+  // --------------------------------------------------------------------------
+  // publish() fall-through under an underfunded squatted PCA
+  // --------------------------------------------------------------------------
+  it('publish: attacker-registered underfunded PCA no longer bricks the victim (falls through to direct spend)', async () => {
+    const nodes = await standUpNodes();
+    const attacker = accounts[8];
+    const victim = getDefaultKCCreator(accounts); // accounts[9]
+
+    const { accountId, lockDurationEpochs } = await attackerSquats(
+      attacker,
+      victim,
+    );
+    const cgId = await openContextGraphFor(victim);
+
+    // epochs == lockDurationEpochs ⇒ conviction gate ACTIVE ⇒ the publish MUST
+    // enter coverPublishingCost and rely on the fall-through (not skip the gate).
     const tokenAmount = ethers.parseEther('1000');
     await Token.mint(victim.address, tokenAmount);
     await Token.connect(victim).approve(await KAV10.getAddress(), tokenAmount);
 
-    const currentEpoch = await Chronos.getCurrentEpoch();
-    const merkleRoot = ethers.keccak256(ethers.toUtf8Bytes('pca-dos-regression'));
     const reservedKaId = packReservedKaId(victim.address, 1);
     const p = await buildPublishParams({
       chainId: DEFAULT_CHAIN_ID,
       kav10Address: await KAV10.getAddress(),
-      receivingNodes,
-      publisherIdentityId,
-      receiverIdentityIds,
+      receivingNodes: nodes.receivingNodes,
+      publisherIdentityId: nodes.publisherIdentityId,
+      receiverIdentityIds: nodes.receiverIdentityIds,
       author: victim,
       contextGraphId: cgId,
-      merkleRoot,
+      merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('pca-dos-publish')),
       knowledgeAssetsAmount: 1,
       byteSize: 1000,
       epochs: lockDurationEpochs,
       tokenAmount,
       isImmutable: false,
-      publishOperationId: 'pca-dos-op',
+      publishOperationId: 'pca-dos-publish-op',
       reservedKaId,
     });
 
-    const victimBalBefore = await Token.balanceOf(victim.address);
+    const balBefore = await Token.balanceOf(victim.address);
+    const tx = await KAV10.connect(victim).publish(p); // pre-fix: reverts
+    expect((await tx.wait())!.status).to.equal(1);
 
-    // Pre-fix this reverted InsufficientAllowance and minted no KC.
-    const tx = await KAV10.connect(victim).publish(p);
-    const receipt = await tx.wait();
-    expect(receipt!.status).to.equal(1);
-
-    // Proof it took the DIRECT-spend fall-through, not the discount branch:
-    // the victim's own TRAC funded the staker pool (conviction branch would
-    // have drawn from the PCA escrow and left the victim's balance intact —
-    // and could not have succeeded anyway since the PCA holds 1 wei).
-    const epochStorageAddr = (
-      await EpochStorageContract.getAddress()
-    ).toLowerCase();
-    const activeSinkSum = sumActiveSink(receipt!.logs, epochStorageAddr);
-    const victimSpent = victimBalBefore - (await Token.balanceOf(victim.address));
-
-    expect(victimSpent).to.equal(tokenAmount);
-    // Net-of-treasury distribution funded the pool; it can be ≤ tokenAmount but
-    // must be non-zero and cannot exceed what the victim actually paid.
-    expect(activeSinkSum).to.be.greaterThan(0n);
-    expect(activeSinkSum).to.be.lessThanOrEqual(tokenAmount);
-
-    // KC actually minted to the victim/author.
+    // Direct-spend proof: the victim's OWN TRAC funded the publish (a discount
+    // branch would have drawn from the PCA escrow — and couldn't succeed on a
+    // 1-wei account anyway).
+    expect(balBefore - (await Token.balanceOf(victim.address))).to.equal(
+      tokenAmount,
+    );
     expect(await DKGKnowledgeAssets.ownerOf(reservedKaId)).to.equal(
       victim.address,
     );
-    const meta = await DKGKnowledgeAssets.getKnowledgeAssetMetadata(reservedKaId);
-    expect(meta[6]).to.equal(tokenAmount);
-
-    // The malicious association is still present (consent-free registration is
-    // not retroactively removed) but it is now harmless — the victim published.
-    expect(await NFT.agentToAccountId(victim.address)).to.equal(
-      attackerAccountId,
-    );
+    // Squat survives (consent-free registration is not auto-removed) but is now
+    // harmless — the victim published.
+    expect(await NFT.agentToAccountId(victim.address)).to.equal(accountId);
   });
 
-  it('unexpected (non-payment) reverts from the conviction branch still propagate', async () => {
-    // Sanity guard for the selector filter: a victim with NO TRAC and NO
-    // approval who falls through to direct spend must still revert
-    // (TooLowAllowance / TooLowBalance) rather than silently succeeding — the
-    // fall-through is not a free pass, it just removes the PCA-side brick.
-    const publishingNode = getDefaultPublishingNode(accounts);
-    const receivingNodes = getDefaultReceivingNodes(accounts);
-    const { identityId: publisherIdentityId } = await createProfile(
-      ProfileContract,
-      publishingNode,
-    );
-    const receiverProfiles = await createProfiles(ProfileContract, receivingNodes);
-    const receiverIdentityIds = receiverProfiles.map((p) => p.identityId);
-
-    await stakeV10(publishingNode.operational, publisherIdentityId, MIN_STAKE);
-    for (let i = 0; i < receivingNodes.length; i++) {
-      await stakeV10(
-        receivingNodes[i].operational,
-        receiverProfiles[i].identityId,
-        MIN_STAKE,
-      );
-    }
-
+  // --------------------------------------------------------------------------
+  // update() fall-through under an underfunded squatted PCA
+  // --------------------------------------------------------------------------
+  //
+  // The update gate has NO epoch-match escape (`remainingEpochs <=
+  // lockDurationEpochs`), so EVERY paid update on a squatted address routed
+  // into coverPublishingCost pre-fix. This pins the update() branch.
+  it('update: attacker-registered underfunded PCA no longer bricks a paid victim update', async () => {
+    const nodes = await standUpNodes();
     const attacker = accounts[8];
     const victim = getDefaultKCCreator(accounts);
+
+    const cgId = await openContextGraphFor(victim);
+    const initialTokenAmount = ethers.parseEther('1000');
+
+    // Create the attacker's 1-wei PCA but DON'T register the victim yet, so the
+    // victim's initial publish is an ordinary direct spend. We read the global
+    // lock duration off this account so the publish/update epoch counts keep
+    // the conviction gate active once the victim IS registered.
     await Token.mint(attacker.address, 1n);
     await Token.connect(attacker).approve(await NFT.getAddress(), 1n);
     await NFT.connect(attacker).createAccount(1n);
     const attackerAccountId = await NFT.totalSupply();
-    await NFT.connect(attacker).registerAgent(attackerAccountId, victim.address);
-    const lockDurationEpochs = Number((await NFT.accounts(attackerAccountId))[5]);
+    const lockEpochs = Number((await NFT.accounts(attackerAccountId))[5]);
 
-    await CGFacade.connect(victim).createContextGraph(
-      [],
-      0,
-      0,
-      1,
-      ethers.ZeroAddress,
-      0,
-      ethers.ZeroHash,
+    const kaId = await victimPublish({
+      victim,
+      cgId,
+      epochs: lockEpochs,
+      tokenAmount: initialTokenAmount,
+      kaNumber: 5,
+      nodes,
+      opId: 'pca-dos-update-base',
+    });
+
+    // Now spring the trap: register the victim against the 1-wei PCA.
+    await NFT.connect(attacker).registerAgent(attackerAccountId, victim.address);
+    expect(await NFT.agentToAccountId(victim.address)).to.equal(
+      attackerAccountId,
     );
-    const cgId = await CGS.getLatestContextGraphId();
+
+    // A paid update (grow tokenAmount). remainingEpochs == lockEpochs ⇒ gate
+    // ACTIVE ⇒ enters coverPublishingCost and relies on the fall-through.
+    const delta = ethers.parseEther('250');
+    const newTokenAmount = initialTokenAmount + delta;
+    await Token.mint(victim.address, delta);
+    await Token.connect(victim).approve(await KAV10.getAddress(), delta);
+
+    const up = await buildUpdateParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: nodes.receivingNodes,
+      publisherIdentityId: nodes.publisherIdentityId,
+      receiverIdentityIds: nodes.receiverIdentityIds,
+      contextGraphId: cgId,
+      id: kaId,
+      preUpdateMerkleRootCount: 1n,
+      newMerkleRoot: ethers.keccak256(ethers.toUtf8Bytes('pca-dos-update-new')),
+      newByteSize: 1000n,
+      newTokenAmount,
+      mintKnowledgeAssetsAmount: 0n,
+      knowledgeAssetsToBurn: [],
+      updateOperationId: 'pca-dos-update-op',
+      author: victim,
+    });
+
+    const balBefore = await Token.balanceOf(victim.address);
+    const tx = await KAV10.connect(victim).update(up); // pre-fix: reverts
+    expect((await tx.wait())!.status).to.equal(1);
+
+    // The delta was paid from the victim's OWN TRAC (direct-spend fall-through).
+    expect(balBefore - (await Token.balanceOf(victim.address))).to.equal(delta);
+    const meta = await DKGKnowledgeAssets.getKnowledgeAssetMetadata(kaId);
+    expect(meta[6]).to.equal(newTokenAmount);
+  });
+
+  // --------------------------------------------------------------------------
+  // expired squatted PCA: publish still falls through (gate-level)
+  // --------------------------------------------------------------------------
+  //
+  // The `AccountExpired` catch arm in `_coverViaConvictionOrFallThrough` is
+  // defensive: the gate already drops the conviction branch once
+  // `block.timestamp >= expiresAtTimestamp` (the SAME field
+  // `coverPublishingCost` checks), so an expired squat falls through BEFORE
+  // the external call. This test pins that partner protection — an expired
+  // squatted registration must not brick the victim either.
+  it('publish: expired squatted PCA falls through at the gate (expiry can never brick the victim)', async () => {
+    const nodes = await standUpNodes();
+    const attacker = accounts[8];
+    const victim = getDefaultKCCreator(accounts);
+
+    const { lockDurationEpochs } = await attackerSquats(attacker, victim);
+    const cgId = await openContextGraphFor(victim);
+
+    // Advance past the PCA's expiry (lockDurationEpochs + 1 to clear the
+    // expiry window plus chain-epoch drift).
+    const epochLength = await Chronos.epochLength();
+    await time.increase(Number(epochLength) * (lockDurationEpochs + 1));
 
     const tokenAmount = ethers.parseEther('1000');
-    // NOTE: victim is intentionally NOT funded / NOT approved here.
-    const merkleRoot = ethers.keccak256(ethers.toUtf8Bytes('pca-dos-nofund'));
-    const reservedKaId = packReservedKaId(victim.address, 1);
+    await Token.mint(victim.address, tokenAmount);
+    await Token.connect(victim).approve(await KAV10.getAddress(), tokenAmount);
+
+    const reservedKaId = packReservedKaId(victim.address, 9);
     const p = await buildPublishParams({
       chainId: DEFAULT_CHAIN_ID,
       kav10Address: await KAV10.getAddress(),
-      receivingNodes,
-      publisherIdentityId,
-      receiverIdentityIds,
+      receivingNodes: nodes.receivingNodes,
+      publisherIdentityId: nodes.publisherIdentityId,
+      receiverIdentityIds: nodes.receiverIdentityIds,
       author: victim,
       contextGraphId: cgId,
-      merkleRoot,
+      merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('pca-dos-expired')),
+      knowledgeAssetsAmount: 1,
+      byteSize: 1000,
+      epochs: lockDurationEpochs,
+      tokenAmount,
+      isImmutable: false,
+      publishOperationId: 'pca-dos-expired-op',
+      reservedKaId,
+    });
+
+    const balBefore = await Token.balanceOf(victim.address);
+    expect((await (await KAV10.connect(victim).publish(p)).wait())!.status).to.equal(
+      1,
+    );
+    expect(balBefore - (await Token.balanceOf(victim.address))).to.equal(
+      tokenAmount,
+    );
+    expect(await DKGKnowledgeAssets.ownerOf(reservedKaId)).to.equal(
+      victim.address,
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // the fall-through is not a free pass
+  // --------------------------------------------------------------------------
+  it('publish: fall-through still reverts for an unfunded victim (not a free publish)', async () => {
+    const nodes = await standUpNodes();
+    const attacker = accounts[8];
+    const victim = getDefaultKCCreator(accounts);
+
+    const { lockDurationEpochs } = await attackerSquats(attacker, victim);
+    const cgId = await openContextGraphFor(victim);
+
+    const tokenAmount = ethers.parseEther('1000');
+    // Victim intentionally NOT funded / NOT approved.
+    const reservedKaId = packReservedKaId(victim.address, 13);
+    const p = await buildPublishParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes: nodes.receivingNodes,
+      publisherIdentityId: nodes.publisherIdentityId,
+      receiverIdentityIds: nodes.receiverIdentityIds,
+      author: victim,
+      contextGraphId: cgId,
+      merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('pca-dos-nofund')),
       knowledgeAssetsAmount: 1,
       byteSize: 1000,
       epochs: lockDurationEpochs,
@@ -376,9 +490,6 @@ describe('@integration V10 PCA — consent-free agent DoS (audit fix)', function
       reservedKaId,
     });
 
-    // Falls through to direct spend, which reverts on the missing allowance —
-    // the publisher pays via direct spend or not at all; it is never bricked
-    // by the PCA, but it also isn't handed a free publish.
     await expect(KAV10.connect(victim).publish(p)).to.be.revertedWithCustomError(
       KAV10,
       'TooLowAllowance',

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2026,17 +2026,27 @@ export class DKGPublisher implements Publisher {
             // probe keep the legacy unconditional coercion.
             let canFundDiscount = true;
             if (typeof this.chain.convictionAccountCanCover === 'function') {
-              let prospectiveBaseCost = BigInt(lockEpochs);
-              if (typeof this.chain.getRequiredPublishTokenAmount === 'function') {
+              // The coverage probe is only meaningful against the REAL
+              // publish price. If we cannot price the prospective
+              // lock-lifetime publish — adapter lacks the quote, or the
+              // quote call reverts — treat the publish as "funding
+              // unverifiable" and do NOT coerce. Falling back to the
+              // protocol minimum (`lockEpochs` wei) would let a partial or
+              // squatted PCA pass the probe against that lower bound and
+              // then fall through to full-price direct spend at the wrong
+              // lifetime — the exact regression this gate exists to prevent.
+              if (typeof this.chain.getRequiredPublishTokenAmount !== 'function') {
+                canFundDiscount = false;
+              } else {
                 try {
                   const quoted = await this.chain.getRequiredPublishTokenAmount(effectiveByteSize, lockEpochs);
                   // Mirror the min-clamp applied to the real tx below.
-                  prospectiveBaseCost = quoted > BigInt(lockEpochs) ? quoted : BigInt(lockEpochs);
+                  const prospectiveBaseCost = quoted > BigInt(lockEpochs) ? quoted : BigInt(lockEpochs);
+                  canFundDiscount = await this.chain.convictionAccountCanCover(accountId, prospectiveBaseCost);
                 } catch {
-                  // Keep the conservative per-epoch minimum on a quote hiccup.
+                  canFundDiscount = false;
                 }
               }
-              canFundDiscount = await this.chain.convictionAccountCanCover(accountId, prospectiveBaseCost);
             }
             if (canFundDiscount) {
               publishEpochs = lockEpochs;
@@ -2047,7 +2057,7 @@ export class DKGPublisher implements Publisher {
             } else {
               this.log.info(
                 ctx,
-                `Signer ${publisherSigner.address} is a registered PCA agent (accountId=${accountId}) but the account cannot cover this publish's discounted cost — NOT coercing publishEpochs; publishing at requested lifetime=${publishEpochs} via direct spend`,
+                `Signer ${publisherSigner.address} is a registered PCA agent (accountId=${accountId}) but funding for this publish's discounted cost could not be confirmed — NOT coercing publishEpochs; publishing at requested lifetime=${publishEpochs} via direct spend`,
               );
             }
           }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1990,6 +1990,13 @@ export class DKGPublisher implements Publisher {
     // `lockDurationEpochs` when one is found AND the caller did not
     // explicitly override the publish lifetime. Wallets without a PCA
     // (direct-spend branch) use the ordinary default lifetime.
+    // LU-5: pricing follows the byteSize that gets signed into the V10
+    // digest. For curated (encrypted-inline) publishes that's the
+    // ciphertext byte count; for public publishes it stays as plaintext
+    // bytes. Single source of truth so ACK pricing == chain tx pricing.
+    // Resolved BEFORE the PCA coercion below so the fundability probe can
+    // price the prospective lock-lifetime publish.
+    const effectiveByteSize = useEncryptedInline ? stagingByteSize : publicByteSize;
     let publishEpochs = explicitPublishEpochs ?? DEFAULT_PUBLISH_EPOCHS;
     if (
       explicitPublishEpochs === undefined &&
@@ -2001,36 +2008,48 @@ export class DKGPublisher implements Publisher {
       try {
         const accountId = await this.chain.getConvictionAgentAccountId(publisherSigner.address);
         if (accountId > 0n) {
-          // Only snap the lifetime to the PCA lock if the account can
-          // actually fund a discounted publish right now. Agent
-          // registration is consent-free (RFC-001 §3.6), so a third party
-          // can squat this signer against a deliberately-underfunded PCA;
-          // since the contract's conviction branch now falls through to
-          // direct spend instead of reverting, an unconditional coercion
-          // would publish at the PCA-lock lifetime AND full price rather
-          // than the caller's intended default. Gating on spendable
-          // allowance keeps the discount path for genuinely funded accounts
-          // while leaving squatted/exhausted/expired ones at the requested
-          // lifetime. Adapters without the probe keep the legacy coercion.
-          let canFundDiscount = true;
-          if (typeof this.chain.getConvictionAccountSpendableAllowance === 'function') {
-            const spendable = await this.chain.getConvictionAccountSpendableAllowance(accountId);
-            canFundDiscount = spendable > 0n;
-          }
-          if (canFundDiscount) {
-            const lockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(accountId);
-            if (lockEpochs > 0) {
+          const lockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(accountId);
+          if (lockEpochs > 0) {
+            // Only snap the lifetime to the PCA lock if the account can
+            // actually cover THIS publish's discounted cost right now. Agent
+            // registration is consent-free (RFC-001 §3.6), so a third party
+            // can squat this signer against an underfunded PCA; since the
+            // contract's conviction branch now falls through to direct spend
+            // instead of reverting, coercing an unfundable account would
+            // publish at the PCA-lock lifetime AND full price rather than the
+            // caller's default. Price the prospective lock-lifetime publish
+            // (the exact base cost the coerced tx would carry) and ask the
+            // chain whether the PCA covers its discounted cost — a coarse
+            // "balance > 0" gate is not enough, since a nonzero-but-short
+            // account (or a few-wei squat) would still be coerced and then
+            // fall through to full-price direct spend. Adapters without the
+            // probe keep the legacy unconditional coercion.
+            let canFundDiscount = true;
+            if (typeof this.chain.convictionAccountCanCover === 'function') {
+              let prospectiveBaseCost = BigInt(lockEpochs);
+              if (typeof this.chain.getRequiredPublishTokenAmount === 'function') {
+                try {
+                  const quoted = await this.chain.getRequiredPublishTokenAmount(effectiveByteSize, lockEpochs);
+                  // Mirror the min-clamp applied to the real tx below.
+                  prospectiveBaseCost = quoted > BigInt(lockEpochs) ? quoted : BigInt(lockEpochs);
+                } catch {
+                  // Keep the conservative per-epoch minimum on a quote hiccup.
+                }
+              }
+              canFundDiscount = await this.chain.convictionAccountCanCover(accountId, prospectiveBaseCost);
+            }
+            if (canFundDiscount) {
               publishEpochs = lockEpochs;
               this.log.info(
                 ctx,
                 `PCA-funded publish detected (signer=${publisherSigner.address}, accountId=${accountId}) — coercing publishEpochs to lockDurationEpochs=${lockEpochs}`,
               );
+            } else {
+              this.log.info(
+                ctx,
+                `Signer ${publisherSigner.address} is a registered PCA agent (accountId=${accountId}) but the account cannot cover this publish's discounted cost — NOT coercing publishEpochs; publishing at requested lifetime=${publishEpochs} via direct spend`,
+              );
             }
-          } else {
-            this.log.info(
-              ctx,
-              `Signer ${publisherSigner.address} is a registered PCA agent (accountId=${accountId}) but the account has no spendable allowance — NOT coercing publishEpochs; publishing at requested lifetime=${publishEpochs} via direct spend`,
-            );
           }
         }
       } catch (err) {
@@ -2049,11 +2068,6 @@ export class DKGPublisher implements Publisher {
         );
       }
     }
-    // LU-5: pricing follows the byteSize that gets signed into the V10
-    // digest. For curated (encrypted-inline) publishes that's the
-    // ciphertext byte count; for public publishes it stays as plaintext
-    // bytes. Single source of truth so ACK pricing == chain tx pricing.
-    const effectiveByteSize = useEncryptedInline ? stagingByteSize : publicByteSize;
     let precomputedTokenAmount = canAttemptOnChainPublish ? BigInt(publishEpochs) : 0n;
     if (canAttemptOnChainPublish && typeof this.chain.getRequiredPublishTokenAmount === 'function') {
       try {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2001,12 +2001,35 @@ export class DKGPublisher implements Publisher {
       try {
         const accountId = await this.chain.getConvictionAgentAccountId(publisherSigner.address);
         if (accountId > 0n) {
-          const lockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(accountId);
-          if (lockEpochs > 0) {
-            publishEpochs = lockEpochs;
+          // Only snap the lifetime to the PCA lock if the account can
+          // actually fund a discounted publish right now. Agent
+          // registration is consent-free (RFC-001 §3.6), so a third party
+          // can squat this signer against a deliberately-underfunded PCA;
+          // since the contract's conviction branch now falls through to
+          // direct spend instead of reverting, an unconditional coercion
+          // would publish at the PCA-lock lifetime AND full price rather
+          // than the caller's intended default. Gating on spendable
+          // allowance keeps the discount path for genuinely funded accounts
+          // while leaving squatted/exhausted/expired ones at the requested
+          // lifetime. Adapters without the probe keep the legacy coercion.
+          let canFundDiscount = true;
+          if (typeof this.chain.getConvictionAccountSpendableAllowance === 'function') {
+            const spendable = await this.chain.getConvictionAccountSpendableAllowance(accountId);
+            canFundDiscount = spendable > 0n;
+          }
+          if (canFundDiscount) {
+            const lockEpochs = await this.chain.getConvictionAccountLockDurationEpochs(accountId);
+            if (lockEpochs > 0) {
+              publishEpochs = lockEpochs;
+              this.log.info(
+                ctx,
+                `PCA-funded publish detected (signer=${publisherSigner.address}, accountId=${accountId}) — coercing publishEpochs to lockDurationEpochs=${lockEpochs}`,
+              );
+            }
+          } else {
             this.log.info(
               ctx,
-              `PCA-funded publish detected (signer=${publisherSigner.address}, accountId=${accountId}) — coercing publishEpochs to lockDurationEpochs=${lockEpochs}`,
+              `Signer ${publisherSigner.address} is a registered PCA agent (accountId=${accountId}) but the account has no spendable allowance — NOT coercing publishEpochs; publishing at requested lifetime=${publishEpochs} via direct spend`,
             );
           }
         }

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -991,7 +991,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     // the contract's conviction branch now falls through to direct spend
     // (instead of reverting), an unconditional coercion would publish at the
     // PCA-lock lifetime AND full price. The SDK must instead detect the
-    // account can't fund a discount (spendable allowance 0) and keep the
+    // account can't cover this publish's discounted cost and keep the
     // caller's requested/default lifetime.
     const wallet = new ethers.Wallet(TEST_KEY);
     const chain = new EpochCapturingChain(wallet);
@@ -999,7 +999,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     // 1-wei commit → baseEpochAllowance = 1 / lockDurationEpochs = 0 → unfundable.
     const { accountId } = await chain.createPublishingConvictionAccount(1n);
     await chain.registerPublishingConvictionAgent(accountId, wallet.address);
-    expect(await chain.getConvictionAccountSpendableAllowance(accountId)).toBe(0n);
+    expect(await chain.convictionAccountCanCover(accountId, 1n)).toBe(false);
 
     const publisher = await makeEpochPublisher(chain, wallet);
     const ack: AckEpochCapture = {};
@@ -1016,6 +1016,39 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(ack.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
     expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
     expect(chain.capturedCreateParams?.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
+  });
+
+  it('does NOT coerce when a nonzero-but-insufficient PCA cannot cover this publish (Codex follow-up)', async () => {
+    // The earlier `spendable > 0` gate let a partially-funded (or few-wei
+    // squat) account slip through: it would coerce to the lock lifetime and
+    // then fall through to full-price direct spend anyway. The cost-aware
+    // gate must reject an account whose remaining allowance is > 0 but
+    // smaller than THIS publish's discounted cost.
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    // committedTRAC = 24 wei → baseEpochAllowance = 24/24 = 1 wei (nonzero!),
+    // discountBps = 0 (below the lowest tier) → can cover a 1-wei cost but
+    // nothing larger. The real publish costs far more than 1 wei.
+    const { accountId } = await chain.createPublishingConvictionAccount(24n);
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    // Nonzero floor, but cannot cover a realistic publish cost.
+    expect(await chain.convictionAccountCanCover(accountId, 1n)).toBe(true);
+    expect(await chain.convictionAccountCanCover(accountId, ethers.parseEther('1'))).toBe(false);
+
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('pca-underfunded-no-coercion'),
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    // Cost at lock lifetime (24) exceeds the 1-wei allowance → no coercion.
+    expect(ack.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
   });
 
   it('initializes V10 readiness before resolving adapter-backed signer addresses', async () => {

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -985,6 +985,39 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(chain.capturedCreateParams?.tokenAmount).toBe(5n);
   });
 
+  it('does NOT coerce the lifetime when the signer is registered against an unfundable PCA (consent-free squat)', async () => {
+    // Audit regression: agent registration is consent-free (RFC-001 §3.6),
+    // so a third party can register this signer against a 1-wei PCA. Since
+    // the contract's conviction branch now falls through to direct spend
+    // (instead of reverting), an unconditional coercion would publish at the
+    // PCA-lock lifetime AND full price. The SDK must instead detect the
+    // account can't fund a discount (spendable allowance 0) and keep the
+    // caller's requested/default lifetime.
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    chain.pcaLockDurationEpochs = 24; // would be the coerced lifetime if it fired
+    // 1-wei commit → baseEpochAllowance = 1 / lockDurationEpochs = 0 → unfundable.
+    const { accountId } = await chain.createPublishingConvictionAccount(1n);
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    expect(await chain.getConvictionAccountSpendableAllowance(accountId)).toBe(0n);
+
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('pca-squat-no-coercion'),
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    // Lifetime stays at the default — NOT snapped to the PCA lock (24).
+    expect(ack.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(ack.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
+    expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(chain.capturedCreateParams?.tokenAmount).toBe(BigInt(DEFAULT_PUBLISH_EPOCHS));
+  });
+
   it('initializes V10 readiness before resolving adapter-backed signer addresses', async () => {
     const keypair = await generateEd25519Keypair();
     const wallet = new ethers.Wallet(TEST_KEY);

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -1051,6 +1051,40 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
   });
 
+  it('does NOT coerce when the publish cannot be priced (unverifiable funding)', async () => {
+    // Codex follow-up: if the prospective publish cost cannot be quoted, the
+    // coverage probe has no real price to check against. Falling back to the
+    // protocol minimum (lockEpochs wei) would let an underfunded/squatted PCA
+    // pass against that lower bound and coerce, then fall through to
+    // full-price direct spend. An unpriceable publish must be treated as
+    // "funding unverifiable" → keep the caller's requested lifetime.
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new EpochCapturingChain(wallet);
+    chain.pcaLockDurationEpochs = 24;
+    // Fully funded — coercion WOULD fire if the gate fell back to the minimum.
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
+    await chain.registerPublishingConvictionAgent(accountId, wallet.address);
+    // Pricing oracle is down for this publish.
+    (chain as unknown as { getRequiredPublishTokenAmount: () => Promise<bigint> }).getRequiredPublishTokenAmount =
+      async () => {
+        throw new Error('pricing oracle unavailable');
+      };
+
+    const publisher = await makeEpochPublisher(chain, wallet);
+    const ack: AckEpochCapture = {};
+
+    const result = await publisher.publish({
+      contextGraphId: '1',
+      quads: epochTestQuads('pca-unpriceable-no-coercion'),
+      v10ACKProvider: captureACKInputs(ack),
+    });
+
+    expect(result.status).toBe('confirmed');
+    // Funded, but unpriceable → no coercion; caller's default lifetime stands.
+    expect(ack.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+    expect(chain.capturedCreateParams?.epochs).toBe(DEFAULT_PUBLISH_EPOCHS);
+  });
+
   it('initializes V10 readiness before resolving adapter-backed signer addresses', async () => {
     const keypair = await generateEd25519Keypair();
     const wallet = new ethers.Wallet(TEST_KEY);


### PR DESCRIPTION
## Summary

Fixes audit finding **"Permissionless agent registration enables a cheap, near-permanent publish/update DoS on any address"** (High).

**The attack (pre-fix):**

1. Attacker calls `DKGPublishingConvictionNFT.createAccount(1 wei)` → active PCA with `baseAllowance = committedTRAC / lockDurationEpochs = 1/12 = 0`.
2. Attacker calls `registerAgent(accountId, victim)` — registration is permissionless and requires **no consent** from the victim (RFC-001 §3.6).
3. Every victim `publish()` with `epochs == lockDurationEpochs` (and **every** paid `update()`, which has no epoch-match escape) is auto-routed into `coverPublishingCost`, hits `InsufficientAllowance`, and **reverts**.
4. The victim cannot self-deregister (`deregisterAgent` is owner-gated), cannot re-route the global `agentToAccountId` reverse map, and the account stays "active" for the full lock duration — a near-permanent brick for ~1 wei + gas, repeatable on expiry.

**The fix** (`KnowledgeAssetsLifecycle` 10.0.4 → 10.0.5):

- `publish()` and `update()` now call `coverPublishingCost` through a new internal `_coverViaConvictionOrFallThrough` helper.
- On the PCA-side payment errors — `InsufficientAllowance` / `AccountExpired` (matched by selector) — the call **falls through to the direct-spend branch** instead of reverting. The victim pays full price from their own TRAC, exactly as if no registration existed.
- **Any other revert is re-thrown verbatim** so genuine faults are never masked and there is no silent downgrade on unexpected state.
- This extends the gate's existing "stale registration must not brick the publisher" intent (already applied to the expired / epoch-mismatch cases) to the underfunded-active case. `coverPublishingCost` is an external call, so a revert rolls back all PCA-side state atomically — the fall-through starts clean.

**Semantics note for legit agents:** an honest-but-underfunded agent no longer gets a hard revert; their publish succeeds at full price via direct spend (requires their own TRAC approval/balance, otherwise it still reverts `TooLowAllowance`). Off-chain tooling that wants "discount or fail" can pre-check the account allowance before publishing.

**Root-cause follow-up (out of scope here):** requiring agent consent on registration (two-step accept or EIP-712 signature) would prevent the unwanted association itself. With this fall-through in place the association is harmless, so that change can be designed without release pressure.

## Regression tests (`test/v10-pca-agent-dos.test.ts`)

Red/green verified — both tests **fail on unpatched code** with `InsufficientAllowance(1, 1, 1000e18, 0)`:

1. **Victim publish succeeds despite attacker registration**: attacker creates a 1-wei PCA and registers the victim; victim publishes with `epochs == lockDurationEpochs` (conviction gate active). Asserts the publish succeeds, the victim's own TRAC funds the staker pool (proving the direct-spend fall-through, not the discount branch), and the KC is minted.
2. **Fall-through is not a free pass**: an unfunded/unapproved victim still reverts `TooLowAllowance` from the direct-spend branch.

## Test plan

- [x] `npx hardhat compile`
- [x] `test/v10-pca-agent-dos.test.ts` (new, 2 passing; verified failing pre-fix)
- [x] `test/v10-pca-lifecycle.test.ts` + `test/v10-e2e-conviction.test.ts` (24 passing)
- [x] `test/unit/DKGPublishingConvictionNFT*.test.ts` + `test/v10-ka-number-getter.test.ts` (83 passing)
