### PR TITLE
chore(evm): rc.17 version bumps + mark 8 changed contracts for redeploy

### DIFF
--- a/packages/evm-module/contracts/ShardingTable.sol
+++ b/packages/evm-module/contracts/ShardingTable.sol
@@ -24,7 +24,7 @@ contract ShardingTable is INamed, IVersioned, ContractStatus, IInitializable {
     // `019_deploy_sharding_table.ts` that referenced `migrateOldShardingTable`
     // is removed in the same PR (the function it called no longer exists,
     // so the branch was already unreachable on V10 deploys).
-    string private constant _VERSION = "10.0.2";
+    string private constant _VERSION = "10.0.3";
 
     ProfileStorage public profileStorage;
     ShardingTableStorage public shardingTableStorage;

--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -9,7 +9,7 @@ import {IVersioned} from "../interfaces/IVersioned.sol";
 
 contract EpochStorage is INamed, IVersioned, HubDependent {
     string private constant _NAME = "EpochStorage";
-    string private constant _VERSION = "10.0.2";
+    string private constant _VERSION = "10.0.3";
 
     event EpochProducedKnowledgeValueAdded(uint72 indexed identityId, uint256 indexed epoch, uint96 knowledgeValue);
     event TokensAddedToEpochRange(

--- a/packages/evm-module/contracts/storage/ParametersStorage.sol
+++ b/packages/evm-module/contracts/storage/ParametersStorage.sol
@@ -21,7 +21,7 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
     // protocol treasury fee (`protocolTreasuryFee`, `protocolTreasury`,
     // `MAX_PROTOCOL_TREASURY_FEE`) skimmed from the staker-bound TRAC on
     // every paid publish / update / lifetime-extension.
-    string private constant _VERSION = "10.0.2";
+    string private constant _VERSION = "10.0.3";
 
     uint96 public minimumStake;
     uint96 public maximumStake;

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -25,7 +25,7 @@
             "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
             "deploymentBlock": 42265715,
             "deploymentTimestamp": 1780299720090,
-            "deployed": true
+            "deployed": false
         },
         "WhitelistStorage": {
             "evmAddress": "0x0a3020BA9BF8E853c306dFE4d3C8AB0449d99c99",
@@ -88,7 +88,7 @@
             "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
             "deploymentBlock": 42265734,
             "deploymentTimestamp": 1780299758505,
-            "deployed": true
+            "deployed": false
         },
         "PaymasterManager": {
             "evmAddress": "0x073aFC5cDf6e81d2Ccfb66d39E1F1224B39b8F15",
@@ -124,7 +124,7 @@
             "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
             "deploymentBlock": 42265746,
             "deploymentTimestamp": 1780299782398,
-            "deployed": true
+            "deployed": false
         },
         "Ask": {
             "evmAddress": "0x3BDF5293DB9D65Bde8A74706530E206bC74eFE77",
@@ -196,7 +196,7 @@
             "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
             "deploymentBlock": 42413915,
             "deploymentTimestamp": 1780596121051,
-            "deployed": true
+            "deployed": false
         },
         "KnowledgeAssetsStorage": {
             "evmAddress": "0x45E0e14c695681c8c93d6A489a314ea1EC28ba59",
@@ -232,7 +232,7 @@
             "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
             "deploymentBlock": 42265743,
             "deploymentTimestamp": 1780299777585,
-            "deployed": true
+            "deployed": false
         },
         "ContextGraphStorage": {
             "evmAddress": "0x9B70896bd3Fc116e413199A198206d0dA8Cd6602",
@@ -295,7 +295,7 @@
             "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
             "deploymentBlock": 42265778,
             "deploymentTimestamp": 1780299846566,
-            "deployed": true
+            "deployed": false
         },
         "DKGStakingConvictionNFT": {
             "evmAddress": "0x44DC019876ce9CF961186Fc4657f71f6786e705C",
@@ -331,7 +331,7 @@
             "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
             "deploymentBlock": 42413912,
             "deploymentTimestamp": 1780596115673,
-            "deployed": true
+            "deployed": false
         },
         "KnowledgeAssetsLifecycle": {
             "evmAddress": "0x63Aa3D0D305e66fB9797802A0E0a00CDD0e5224b",
@@ -340,7 +340,7 @@
             "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
             "deploymentBlock": 42413918,
             "deploymentTimestamp": 1780596126512,
-            "deployed": true
+            "deployed": false
         },
         "V8MigrationEligibility": {
             "evmAddress": "0xF00FA3d29a2d45Fce44324C67C7Eb9C645F3DA1C",


### PR DESCRIPTION
## Summary
Prepares the **Base Sepolia V10** contract deploy for rc.17.

`hre.helpers.deploy()` gates purely on the `deployed` boolean in the network JSON — it does **not** compare the recorded `version` to the Solidity `_VERSION` (see `scripts/KA_HIGH_WATER_GETTER_ROLLOUT_RUNBOOK.md`). So a changed contract left at `deployed:true` is **silently skipped** and the old bytecode stays live. This PR flags the 8 contracts that changed since rc.15 for redeploy and gives 3 of them proper version identity.

## Changes
**`base_sepolia_v10_contracts.json` — 8 contracts → `deployed:false`:**
| Contract | Version | Note |
|---|---|---|
| KnowledgeAssetsLifecycle | 10.0.5 | #1072 ciphertext gate, #1092 DoS fix |
| DKGKnowledgeAssets | 10.0.4 | #1082 getter · **storage** |
| RandomSampling | 10.0.4 | #1090 challenge seed |
| StakingV10 | 10.0.3 | |
| ConvictionStakingStorage | 10.0.3 | **storage** |
| ShardingTable | 10.0.2→**10.0.3** | new `ShardingTableIsFull` revert |
| ParametersStorage | 10.0.2→**10.0.3** | **storage**; new zero-size guard |
| EpochStorage (V8) | 10.0.2→**10.0.3** | **storage**; `firstOpenEpoch` clamp |

**`_VERSION` bumps (3):** ShardingTable, ParametersStorage, EpochStorage had real logic changes but had not bumped `_VERSION`. Bumped `10.0.2 → 10.0.3` so the deployed version identifies the bytecode. `_VERSION` is a constant → ABI unchanged (abi-freshness passes; 14 files compile clean).

## Excluded (deliberate)
- **PublishingConviction** — only moved error declarations into `IPublishingConvictionErrors` (identical selectors) → bytecode-neutral, no redeploy needed.
- **EpochStorageV6** — legacy deployment of the same contract; left as-is.

## ⚠️ Before deploying
- **4 storage contracts** (`DKGKnowledgeAssets`, `ConvictionStakingStorage`, `EpochStorageV8`, `ParametersStorage`) — each redeploy repoints a Hub storage slot; confirm migrate-vs-accept-fresh on Base Sepolia. `DKGKnowledgeAssets` follows the high-water runbook.
- **8 pre-existing `deployed:false`** entries (`PaymasterManager`, `DelegatorsInfo`, `Staking`, `KnowledgeCollection`, `KnowledgeAssetsStorage`, `KnowledgeAssets`, `ContextGraphNameRegistry`, `PublishingConvictionAccount`) will also deploy — confirm intentional.
- Post-deploy, `deployed:true` + the new addresses get committed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
