### PR TITLE
chore(evm): record rc.17 Base Sepolia post-deploy addresses

### DIFF
--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -19,13 +19,13 @@
             "deployed": true
         },
         "ParametersStorage": {
-            "evmAddress": "0xd73D9D2ac659d79aED2B8e4CEa169758c8E1a2F6",
-            "version": "10.0.2",
+            "evmAddress": "0x643451952B91132556B142cA7a0Fdf343575C5Cf",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265715,
-            "deploymentTimestamp": 1780299720090,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661855,
+            "deploymentTimestamp": 1781092000235,
+            "deployed": true
         },
         "WhitelistStorage": {
             "evmAddress": "0x0a3020BA9BF8E853c306dFE4d3C8AB0449d99c99",
@@ -82,13 +82,13 @@
             "deployed": true
         },
         "EpochStorageV8": {
-            "evmAddress": "0x93a8e3e4E42B5B41f4AB336568779A0deDdaCC45",
-            "version": "10.0.2",
+            "evmAddress": "0xdF34Be8665640494640a5f0FDe454e43356C14e9",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265734,
-            "deploymentTimestamp": 1780299758505,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661857,
+            "deploymentTimestamp": 1781092005671,
+            "deployed": true
         },
         "PaymasterManager": {
             "evmAddress": "0x073aFC5cDf6e81d2Ccfb66d39E1F1224B39b8F15",
@@ -118,13 +118,13 @@
             "deployed": true
         },
         "ShardingTable": {
-            "evmAddress": "0xEd480B9e6B3485eFC5583fA4485D1FB3507f278E",
-            "version": "10.0.2",
+            "evmAddress": "0x136bC31B4E26C38bfc2b70EfcB3075AAa2DE9Bc9",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265746,
-            "deploymentTimestamp": 1780299782398,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661865,
+            "deploymentTimestamp": 1781092021004,
+            "deployed": true
         },
         "Ask": {
             "evmAddress": "0x3BDF5293DB9D65Bde8A74706530E206bC74eFE77",
@@ -190,13 +190,13 @@
             "deployed": false
         },
         "RandomSampling": {
-            "evmAddress": "0xC069C93D3A779fE7671A3650029fe4D425629AD7",
-            "version": "10.0.3",
+            "evmAddress": "0x88daA6C2985AF0a5F879AD805F6F92f5079FaC6B",
+            "version": "10.0.4",
             "gitBranch": "main",
-            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
-            "deploymentBlock": 42413915,
-            "deploymentTimestamp": 1780596121051,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661867,
+            "deploymentTimestamp": 1781092026015,
+            "deployed": true
         },
         "KnowledgeAssetsStorage": {
             "evmAddress": "0x45E0e14c695681c8c93d6A489a314ea1EC28ba59",
@@ -226,13 +226,13 @@
             "deployed": true
         },
         "ConvictionStakingStorage": {
-            "evmAddress": "0x60301ac1C95a4dDbDab502e52CE2E23dFb54d13e",
-            "version": "10.0.2",
+            "evmAddress": "0x2B7519CF23dAa2aE4AAfaA0e7ee639d996306CF7",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265743,
-            "deploymentTimestamp": 1780299777585,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661862,
+            "deploymentTimestamp": 1781092016073,
+            "deployed": true
         },
         "ContextGraphStorage": {
             "evmAddress": "0x9B70896bd3Fc116e413199A198206d0dA8Cd6602",
@@ -289,13 +289,13 @@
             "deployed": true
         },
         "StakingV10": {
-            "evmAddress": "0xD8e0daF736e082F779e7BA62B28e8d7A38A82E7c",
-            "version": "10.0.2",
+            "evmAddress": "0x6150B4A2d3661941780cc8905B96c99E5D6b4D35",
+            "version": "10.0.3",
             "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265778,
-            "deploymentTimestamp": 1780299846566,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661872,
+            "deploymentTimestamp": 1781092035828,
+            "deployed": true
         },
         "DKGStakingConvictionNFT": {
             "evmAddress": "0x44DC019876ce9CF961186Fc4657f71f6786e705C",
@@ -325,22 +325,22 @@
             "deployed": true
         },
         "DKGKnowledgeAssets": {
-            "evmAddress": "0xB049694500233300369F69E5c8C3AC9418880008",
-            "version": "10.0.3",
+            "evmAddress": "0xe0890228c6D0FA9fd2bB8F563fD9C2DA08F4F43E",
+            "version": "10.0.4",
             "gitBranch": "main",
-            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
-            "deploymentBlock": 42413912,
-            "deploymentTimestamp": 1780596115673,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661860,
+            "deploymentTimestamp": 1781092011081,
+            "deployed": true
         },
         "KnowledgeAssetsLifecycle": {
-            "evmAddress": "0x63Aa3D0D305e66fB9797802A0E0a00CDD0e5224b",
-            "version": "10.0.3",
+            "evmAddress": "0xaC5cCEF95Fd6fCC1A2302bC4c5b770C7bCaB1577",
+            "version": "10.0.5",
             "gitBranch": "main",
-            "gitCommitHash": "778d6b8e01adeba357824d19893f8c28c10e6305",
-            "deploymentBlock": 42413918,
-            "deploymentTimestamp": 1780596126512,
-            "deployed": false
+            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
+            "deploymentBlock": 42661870,
+            "deploymentTimestamp": 1781092030935,
+            "deployed": true
         },
         "V8MigrationEligibility": {
             "evmAddress": "0xF00FA3d29a2d45Fce44324C67C7Eb9C645F3DA1C",


### PR DESCRIPTION
## Summary
Records the **post-deploy** metadata for the 8 contracts that #1109 flagged and the Base Sepolia V10 deploy run redeployed. Each entry now carries the new address, bumped version, and `deployed:true`.

| Contract | Address | version |
|---|---|---|
| KnowledgeAssetsLifecycle | `0xaC5cCEF…1577` | 10.0.5 |
| DKGKnowledgeAssets | `0xe0890228…F43E` | 10.0.4 |
| RandomSampling | `0x88daA6C2…aC6B` | 10.0.4 |
| StakingV10 | `0x6150B4A2…4D35` | 10.0.3 |
| ConvictionStakingStorage | `0x2B7519CF…06CF7` | 10.0.3 |
| ShardingTable | `0x136bC31B…9Bc9` | 10.0.3 |
| ParametersStorage | `0x64345195…C5Cf` | 10.0.3 |
| EpochStorageV8 | `0xdF34Be86…14e9` | 10.0.3 |

Diff is exactly 8 entries `deployed:false → true` (+ new address / version / block), nothing else.

## Verification
- All 8 redeploy txs confirmed (deploy console receipts).
- Independent `version()` over Base Sepolia RPC returns the expected version for **all 8**.
- `DKGKnowledgeAssets` = **10.0.4** → the #1082 `getMaxKaNumberForAuthor` getter is live; Hub asset-storage pointer repointed to the new address.

Follow-up to #1109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
