### PR TITLE
A1 — sync responder: bound-graph page serving (the ~95% win)

### DIFF
--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -636,7 +636,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       // is gap-safe only when it comes from a CONTIGUOUS watermark, so it is
       // supplied explicitly by callers, never auto-derived from local MAX().
       sinceBatchId: phase === 'data' && !includeSharedMemory ? sinceBatchId : undefined,
-      syncSessionId: phase === 'data' && !includeSharedMemory ? syncSessionId : undefined,
+      syncSessionId: phase === 'snapshot' ? undefined : syncSessionId,
       needsAuth,
       computeSyncDigest: this.computeSyncDigest.bind(this),
       getIdentityId: () => this.chain.getIdentityId(),

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -489,6 +489,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         requesterAgentAddress: parsed.requesterAgentAddress,
         requesterSignatureR: parsed.requesterSignatureR,
         requesterSignatureVS: parsed.requesterSignatureVS,
+        syncSessionId: typeof parsed.syncSessionId === 'string' ? parsed.syncSessionId : undefined,
         // Phase C: unsigned delta hint. Validated/normalised in the responder.
         sinceBatchId: typeof parsed.sinceBatchId === 'string' ? parsed.sinceBatchId : undefined,
       };
@@ -503,19 +504,27 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const includeSharedMemory = ctxGraphPart.startsWith('workspace:');
     const contextGraphId = includeSharedMemory ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const phase = normalizeSyncPhase(parts[3]);
-    // Phase C: the `|since|<n>` keyed token is ALWAYS the final two segments
-    // emitted by `buildSyncRequestEnvelope` (after the optional phase/snapshot
-    // suffix). Match only that trailing position — scanning every segment would
-    // misparse an ordinary segment literally equal to "since" (e.g. a CG or
-    // snapshotRef named "since") as a delta marker and turn a full sync into a
-    // partial response. Old encoders never emit the suffix.
+    // Phase C: parse only the trailing keyed tokens emitted by
+    // `buildSyncRequestEnvelope` (after the optional phase/snapshot suffix).
+    // Scanning every segment would misparse ordinary values literally equal to
+    // "since" or "session" as control tokens. Old encoders never emit them.
     let sinceBatchId: string | undefined;
+    let syncSessionId: string | undefined;
+    let tail = parts.length;
     if (
-      parts.length >= 2 &&
-      parts[parts.length - 2] === 'since' &&
-      /^\d+$/.test(parts[parts.length - 1])
+      tail >= 2 &&
+      parts[tail - 2] === 'since' &&
+      /^\d+$/.test(parts[tail - 1])
     ) {
-      sinceBatchId = parts[parts.length - 1];
+      sinceBatchId = parts[tail - 1];
+      tail -= 2;
+    }
+    if (
+      tail >= 2 &&
+      parts[tail - 2] === 'session' &&
+      parts[tail - 1].length > 0
+    ) {
+      syncSessionId = parts[tail - 1];
     }
     return {
       contextGraphId,
@@ -524,6 +533,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       includeSharedMemory,
       phase,
       snapshotRef: phase === 'snapshot' ? parts[4] : undefined,
+      syncSessionId,
       sinceBatchId,
     };
   }
@@ -600,6 +610,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     phase: SyncPhase = 'data',
     snapshotRef?: string,
     sinceBatchId?: string,
+    syncSessionId?: string,
   ): Promise<Uint8Array> {
     const isPrivate = await this.isPrivateContextGraph(contextGraphId);
 
@@ -625,6 +636,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       // is gap-safe only when it comes from a CONTIGUOUS watermark, so it is
       // supplied explicitly by callers, never auto-derived from local MAX().
       sinceBatchId: phase === 'data' && !includeSharedMemory ? sinceBatchId : undefined,
+      syncSessionId: phase === 'data' && !includeSharedMemory ? syncSessionId : undefined,
       needsAuth,
       computeSyncDigest: this.computeSyncDigest.bind(this),
       getIdentityId: () => this.chain.getIdentityId(),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2856,21 +2856,32 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         deniedPhases: 0,
       };
     }
+    const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
+    const getSubGraphAdmission = (contextGraphId: string) => {
+      let admission = subGraphAdmissionByContextGraph.get(contextGraphId);
+      if (!admission) {
+        admission = getSharedMemorySubGraphAdmission(this.store, contextGraphId, this.listSubGraphs(contextGraphId));
+        subGraphAdmissionByContextGraph.set(contextGraphId, admission);
+      }
+      return admission;
+    };
+
     return runSharedMemorySync({
       ctx,
       remotePeerId,
       contextGraphIds: allowedContextGraphIds,
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
-      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames) =>
+      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
         this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(
           wsDataQuads,
           wsMetaQuads,
           contextGraphId,
           registeredSubGraphNames,
+          excludedSubGraphNames,
         ),
-      getRegisteredSubGraphNames: async (contextGraphId) =>
-        (await this.listSubGraphs(contextGraphId)).map((subGraph) => subGraph.name),
+      getRegisteredSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).registered,
+      getExcludedSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).excluded,
       ensureContextGraph: async (contextGraphId) => {
         const graphManager = new GraphManager(this.store);
         await graphManager.ensureContextGraph(contextGraphId);
@@ -3851,4 +3862,38 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return totalDeleted;
   }
 
+}
+
+async function getSharedMemorySubGraphAdmission(
+  store: TripleStore,
+  contextGraphId: string,
+  subGraphsPromise: Promise<Array<{ name: string }>>,
+): Promise<{ registered: string[]; excluded: string[] }> {
+  const registered: string[] = [];
+  const excluded: string[] = [];
+  for (const subGraph of await subGraphsPromise) {
+    const childContextGraphUri = `${contextGraphDataGraphUri(contextGraphId)}/${subGraph.name}`;
+    if (await isKnownContextGraphUri(store, childContextGraphUri)) {
+      excluded.push(subGraph.name);
+    } else {
+      registered.push(subGraph.name);
+    }
+  }
+  return { registered, excluded };
+}
+
+async function isKnownContextGraphUri(store: TripleStore, contextGraphUri: string): Promise<boolean> {
+  const metaGraph = `${contextGraphUri}/_meta`;
+  const result = await store.query(`
+    ASK {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        {
+          <${assertSafeIri(contextGraphUri)}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+        } UNION {
+          <${assertSafeIri(contextGraphUri)}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?status .
+        }
+      }
+    }
+  `);
+  return result.type === 'boolean' && result.value;
 }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2862,7 +2862,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphIds: allowedContextGraphIds,
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
-      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads) => this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(wsDataQuads, wsMetaQuads),
+      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
+        this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
       ensureContextGraph: async (contextGraphId) => {
         const graphManager = new GraphManager(this.store);
         await graphManager.ensureContextGraph(contextGraphId);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3867,12 +3867,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 async function getSharedMemorySubGraphAdmission(
   store: TripleStore,
   contextGraphId: string,
-  subGraphsPromise: Promise<Array<{ name: string }>>,
+  subGraphsPromise: Promise<Array<{ name: string; uri?: string }>>,
 ): Promise<{ registered: string[]; excluded: string[] }> {
   const registered: string[] = [];
   const excluded: string[] = [];
   for (const subGraph of await subGraphsPromise) {
     const childContextGraphUri = `${contextGraphDataGraphUri(contextGraphId)}/${subGraph.name}`;
+    if (subGraph.uri && subGraph.uri !== childContextGraphUri) continue;
     if (await isKnownContextGraphUri(store, childContextGraphUri)) {
       excluded.push(subGraph.name);
     } else {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2862,8 +2862,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphIds: allowedContextGraphIds,
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
-      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
-        this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+      processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames) =>
+        this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(
+          wsDataQuads,
+          wsMetaQuads,
+          contextGraphId,
+          registeredSubGraphNames,
+        ),
+      getRegisteredSubGraphNames: async (contextGraphId) =>
+        (await this.listSubGraphs(contextGraphId)).map((subGraph) => subGraph.name),
       ensureContextGraph: async (contextGraphId) => {
         const graphManager = new GraphManager(this.store);
         await graphManager.ensureContextGraph(contextGraphId);

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -148,6 +148,7 @@ export interface SyncRequestEnvelope {
   requesterPeerId?: string;
   requestId?: string;
   issuedAtMs?: number;
+  syncSessionId?: string;
   requesterIdentityId?: string;
   requesterAgentAddress?: string;
   requesterSignatureR?: string;

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -204,9 +204,10 @@ function verifySyncedData(
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const quads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const unpagedPreludeKeys = swmRegistrationPreludeKeys(quads, graphUri, contextGraphId);
   return {
     quads: quads.filter((q) => q.graph === graphUri || q.graph.startsWith(cgUriPrefix)),
-    totalQuads: quads.length,
+    totalQuads: quads.filter((q) => !unpagedPreludeKeys.has(quadKey(q))).length,
   };
 }
 
@@ -424,10 +425,64 @@ function replicatedRegisteredSubGraphNames(
   const out = new Set<string>();
   for (const subject of typedSubjects) {
     for (const name of namesBySubject.get(subject) ?? []) {
+      if (subject !== canonicalSubGraphUri(contextGraphId, name)) continue;
       out.add(name);
     }
   }
   return [...out];
+}
+
+function swmRegistrationPreludeKeys(
+  quads: readonly Quad[],
+  graphUri: string,
+  contextGraphId: string,
+): Set<string> {
+  const rootSwmMetaGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+  const rootMetaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  if (graphUri !== rootSwmMetaGraph) return new Set();
+
+  const typedSubjects = new Set<string>();
+  const namesBySubject = new Map<string, Set<string>>();
+  for (const q of quads) {
+    if (q.graph !== rootMetaGraph) continue;
+    if (q.predicate === RDF_TYPE && q.object === DKG_SUB_GRAPH) {
+      typedSubjects.add(q.subject);
+    } else if (q.predicate === SCHEMA_NAME) {
+      const name = stripLiteral(q.object);
+      if (!validateSubGraphName(name).valid) continue;
+      let names = namesBySubject.get(q.subject);
+      if (!names) {
+        names = new Set<string>();
+        namesBySubject.set(q.subject, names);
+      }
+      names.add(name);
+    }
+  }
+
+  const registrationSubjects = new Set<string>();
+  for (const subject of typedSubjects) {
+    for (const name of namesBySubject.get(subject) ?? []) {
+      if (subject === canonicalSubGraphUri(contextGraphId, name)) {
+        registrationSubjects.add(subject);
+      }
+    }
+  }
+
+  const keys = new Set<string>();
+  for (const q of quads) {
+    if (q.graph === rootMetaGraph && registrationSubjects.has(q.subject)) {
+      keys.add(quadKey(q));
+    }
+  }
+  return keys;
+}
+
+function canonicalSubGraphUri(contextGraphId: string, name: string): string {
+  return `did:dkg:context-graph:${contextGraphId}/${name}`;
+}
+
+function quadKey(q: Quad): string {
+  return `${q.graph}\0${q.subject}\0${q.predicate}\0${q.object}`;
 }
 
 function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -6,8 +6,6 @@ import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemor
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const DKG_SUB_GRAPH = `${DKG_NS}SubGraph`;
-const SCHEMA_NAME = 'http://schema.org/name';
 
 parentPort!.on('message', async (message: { id: number; method: string; args: unknown[] }) => {
   try {
@@ -204,10 +202,9 @@ function verifySyncedData(
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const quads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
-  const unpagedPreludeKeys = swmRegistrationPreludeKeys(quads, graphUri, contextGraphId);
   return {
     quads: quads.filter((q) => q.graph === graphUri || q.graph.startsWith(cgUriPrefix)),
-    totalQuads: quads.filter((q) => !unpagedPreludeKeys.has(quadKey(q))).length,
+    totalQuads: quads.length,
   };
 }
 
@@ -230,9 +227,10 @@ function processSharedMemory(
   //   <cgPrefix>/<sub>/_shared_memory <-> <cgPrefix>/<sub>/_shared_memory_meta
   // Stripping the suffix yields the matching data graph URI.
   const META_SUFFIX = '_meta';
-  const effectiveRegisteredSubGraphNames = contextGraphId === undefined
-    ? registeredSubGraphNames
-    : combineRegisteredSubGraphNames(contextGraphId, registeredSubGraphNames, excludedSubGraphNames, wsMetaQuads);
+  const effectiveRegisteredSubGraphNames = combineRegisteredSubGraphNames(
+    registeredSubGraphNames,
+    excludedSubGraphNames,
+  );
 
   // Codex review on #885 — keep validity scoped per (meta graph, op
   // subject). Pre-fix the Sets were global, so an op subject that
@@ -381,108 +379,15 @@ function allowedRootsForSwmDataGraph(
 }
 
 function combineRegisteredSubGraphNames(
-  contextGraphId: string,
   localNames: readonly string[] | undefined,
   excludedNames: readonly string[] | undefined,
-  wsMetaQuads: readonly Quad[],
 ): string[] {
   const out = new Set<string>();
   const excluded = new Set((excludedNames ?? []).filter((name) => validateSubGraphName(name).valid));
   for (const name of localNames ?? []) {
     if (validateSubGraphName(name).valid && !excluded.has(name)) out.add(name);
   }
-  for (const name of replicatedRegisteredSubGraphNames(contextGraphId, wsMetaQuads)) {
-    if (excluded.has(name)) continue;
-    out.add(name);
-  }
   return [...out];
-}
-
-function replicatedRegisteredSubGraphNames(
-  contextGraphId: string,
-  wsMetaQuads: readonly Quad[],
-): string[] {
-  const rootMetaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-  const typedSubjects = new Set<string>();
-  const namesBySubject = new Map<string, Set<string>>();
-
-  for (const q of wsMetaQuads) {
-    if (q.graph !== rootMetaGraph) continue;
-    if (q.predicate === RDF_TYPE && q.object === DKG_SUB_GRAPH) {
-      typedSubjects.add(q.subject);
-    } else if (q.predicate === SCHEMA_NAME) {
-      const name = stripLiteral(q.object);
-      if (!validateSubGraphName(name).valid) continue;
-      let names = namesBySubject.get(q.subject);
-      if (!names) {
-        names = new Set<string>();
-        namesBySubject.set(q.subject, names);
-      }
-      names.add(name);
-    }
-  }
-
-  const out = new Set<string>();
-  for (const subject of typedSubjects) {
-    for (const name of namesBySubject.get(subject) ?? []) {
-      if (subject !== canonicalSubGraphUri(contextGraphId, name)) continue;
-      out.add(name);
-    }
-  }
-  return [...out];
-}
-
-function swmRegistrationPreludeKeys(
-  quads: readonly Quad[],
-  graphUri: string,
-  contextGraphId: string,
-): Set<string> {
-  const rootSwmMetaGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
-  const rootMetaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
-  if (graphUri !== rootSwmMetaGraph) return new Set();
-
-  const typedSubjects = new Set<string>();
-  const namesBySubject = new Map<string, Set<string>>();
-  for (const q of quads) {
-    if (q.graph !== rootMetaGraph) continue;
-    if (q.predicate === RDF_TYPE && q.object === DKG_SUB_GRAPH) {
-      typedSubjects.add(q.subject);
-    } else if (q.predicate === SCHEMA_NAME) {
-      const name = stripLiteral(q.object);
-      if (!validateSubGraphName(name).valid) continue;
-      let names = namesBySubject.get(q.subject);
-      if (!names) {
-        names = new Set<string>();
-        namesBySubject.set(q.subject, names);
-      }
-      names.add(name);
-    }
-  }
-
-  const registrationSubjects = new Set<string>();
-  for (const subject of typedSubjects) {
-    for (const name of namesBySubject.get(subject) ?? []) {
-      if (subject === canonicalSubGraphUri(contextGraphId, name)) {
-        registrationSubjects.add(subject);
-      }
-    }
-  }
-
-  const keys = new Set<string>();
-  for (const q of quads) {
-    if (q.graph === rootMetaGraph && registrationSubjects.has(q.subject)) {
-      keys.add(quadKey(q));
-    }
-  }
-  return keys;
-}
-
-function canonicalSubGraphUri(contextGraphId: string, name: string): string {
-  return `did:dkg:context-graph:${contextGraphId}/${name}`;
-}
-
-function quadKey(q: Quad): string {
-  return `${q.graph}\0${q.subject}\0${q.predicate}\0${q.object}`;
 }
 
 function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
@@ -584,15 +489,29 @@ function processSharedMemoryBatch(
     registeredSubGraphNames,
     excludedSubGraphNames,
   );
+  const effectiveRegisteredSubGraphNames = combineRegisteredSubGraphNames(
+    registeredSubGraphNames,
+    excludedSubGraphNames,
+  );
   return {
     verifiedData: processed.validQuads,
-    verifiedMeta: wsMetaQuads,
+    verifiedMeta: filterSharedMemoryMetaQuads(wsMetaQuads, contextGraphId, effectiveRegisteredSubGraphNames),
     totalFetchedDataQuads,
     totalFetchedMetaQuads,
     droppedDataTriples: processed.dropped,
     emptyResponses: 0,
     entityCreators: processed.entityCreators,
   };
+}
+
+function filterSharedMemoryMetaQuads(
+  wsMetaQuads: readonly Quad[],
+  contextGraphId: string | undefined,
+  registeredSubGraphNames: readonly string[],
+): Quad[] {
+  return wsMetaQuads.filter((q) =>
+    swmDataGraphFromMetaGraph(q.graph, contextGraphId, '_meta', registeredSubGraphNames) !== undefined,
+  );
 }
 
 function parseNQuads(text: string): Quad[] {

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -36,9 +36,15 @@ parentPort!.on('message', async (message: { id: number; method: string; args: un
       return;
     }
     if (message.method === 'processSharedMemoryBatch') {
-      const [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames] =
-        message.args as [Quad[], Quad[], string, readonly string[] | undefined];
-      const result = processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames);
+      const [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames] =
+        message.args as [Quad[], Quad[], string, readonly string[] | undefined, readonly string[] | undefined];
+      const result = processSharedMemoryBatch(
+        wsDataQuads,
+        wsMetaQuads,
+        contextGraphId,
+        registeredSubGraphNames,
+        excludedSubGraphNames,
+      );
       parentPort!.postMessage({ id: message.id, result });
       return;
     }
@@ -209,6 +215,7 @@ function processSharedMemory(
   wsMetaQuads: Quad[],
   contextGraphId?: string,
   registeredSubGraphNames?: readonly string[],
+  excludedSubGraphNames?: readonly string[],
 ): SharedMemoryProcessResult {
   const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
   const DKG_WORKSPACE_OP = 'http://dkg.io/ontology/WorkspaceOperation';
@@ -224,7 +231,7 @@ function processSharedMemory(
   const META_SUFFIX = '_meta';
   const effectiveRegisteredSubGraphNames = contextGraphId === undefined
     ? registeredSubGraphNames
-    : combineRegisteredSubGraphNames(contextGraphId, registeredSubGraphNames, wsMetaQuads);
+    : combineRegisteredSubGraphNames(contextGraphId, registeredSubGraphNames, excludedSubGraphNames, wsMetaQuads);
 
   // Codex review on #885 — keep validity scoped per (meta graph, op
   // subject). Pre-fix the Sets were global, so an op subject that
@@ -375,13 +382,16 @@ function allowedRootsForSwmDataGraph(
 function combineRegisteredSubGraphNames(
   contextGraphId: string,
   localNames: readonly string[] | undefined,
+  excludedNames: readonly string[] | undefined,
   wsMetaQuads: readonly Quad[],
 ): string[] {
   const out = new Set<string>();
+  const excluded = new Set((excludedNames ?? []).filter((name) => validateSubGraphName(name).valid));
   for (const name of localNames ?? []) {
-    if (validateSubGraphName(name).valid) out.add(name);
+    if (validateSubGraphName(name).valid && !excluded.has(name)) out.add(name);
   }
   for (const name of replicatedRegisteredSubGraphNames(contextGraphId, wsMetaQuads)) {
+    if (excluded.has(name)) continue;
     out.add(name);
   }
   return [...out];
@@ -496,6 +506,7 @@ function processSharedMemoryBatch(
   wsMetaQuads: Quad[],
   contextGraphId?: string,
   registeredSubGraphNames?: readonly string[],
+  excludedSubGraphNames?: readonly string[],
 ): SharedMemoryBatchProcessResult {
   const totalFetchedDataQuads = wsDataQuads.length;
   const totalFetchedMetaQuads = wsMetaQuads.length;
@@ -511,7 +522,13 @@ function processSharedMemoryBatch(
     };
   }
 
-  const processed = processSharedMemory(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames);
+  const processed = processSharedMemory(
+    wsDataQuads,
+    wsMetaQuads,
+    contextGraphId,
+    registeredSubGraphNames,
+    excludedSubGraphNames,
+  );
   return {
     verifiedData: processed.validQuads,
     verifiedMeta: wsMetaQuads,

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -33,8 +33,9 @@ parentPort!.on('message', async (message: { id: number; method: string; args: un
       return;
     }
     if (message.method === 'processSharedMemoryBatch') {
-      const [wsDataQuads, wsMetaQuads, contextGraphId] = message.args as [Quad[], Quad[], string];
-      const result = processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId);
+      const [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames] =
+        message.args as [Quad[], Quad[], string, readonly string[] | undefined];
+      const result = processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames);
       parentPort!.postMessage({ id: message.id, result });
       return;
     }
@@ -204,6 +205,7 @@ function processSharedMemory(
   wsDataQuads: Quad[],
   wsMetaQuads: Quad[],
   contextGraphId?: string,
+  registeredSubGraphNames?: readonly string[],
 ): SharedMemoryProcessResult {
   const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -268,7 +270,7 @@ function processSharedMemory(
     if (q.predicate !== DKG_ROOT_ENTITY) continue;
     const validForGraph = validOpsByMeta.get(q.graph);
     if (!validForGraph || !validForGraph.has(q.subject)) continue;
-    const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX);
+    const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, registeredSubGraphNames);
     if (!dataGraph) continue;
     const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
     let s = allowedRootsByDataGraph.get(dataGraph);
@@ -313,7 +315,7 @@ function processSharedMemory(
   for (const q of wsMetaQuads) {
     const validForGraph = validOpsByMeta.get(q.graph);
     if (q.predicate === DKG_ROOT_ENTITY && validForGraph?.has(q.subject)) {
-      const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX);
+      const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, registeredSubGraphNames);
       if (!dataGraph) continue;
       const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
       const creator = opCreators.get(q.subject);
@@ -335,6 +337,7 @@ function swmDataGraphFromMetaGraph(
   metaGraph: string,
   contextGraphId: string | undefined,
   metaSuffix: string,
+  registeredSubGraphNames?: readonly string[],
 ): string | undefined {
   if (!metaGraph.endsWith('/_shared_memory_meta')) return undefined;
   if (contextGraphId === undefined) return metaGraph.slice(0, -metaSuffix.length);
@@ -346,6 +349,7 @@ function swmDataGraphFromMetaGraph(
   if (!metaGraph.startsWith(prefix) || !metaGraph.endsWith(suffix)) return undefined;
   const subGraphName = metaGraph.slice(prefix.length, -suffix.length);
   if (!validateSubGraphName(subGraphName).valid) return undefined;
+  if (!registeredSubGraphNames?.includes(subGraphName)) return undefined;
   return metaGraph.slice(0, -metaSuffix.length);
 }
 
@@ -430,6 +434,7 @@ function processSharedMemoryBatch(
   wsDataQuads: Quad[],
   wsMetaQuads: Quad[],
   contextGraphId?: string,
+  registeredSubGraphNames?: readonly string[],
 ): SharedMemoryBatchProcessResult {
   const totalFetchedDataQuads = wsDataQuads.length;
   const totalFetchedMetaQuads = wsMetaQuads.length;
@@ -445,7 +450,7 @@ function processSharedMemoryBatch(
     };
   }
 
-  const processed = processSharedMemory(wsDataQuads, wsMetaQuads, contextGraphId);
+  const processed = processSharedMemory(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames);
   return {
     verifiedData: processed.validQuads,
     verifiedMeta: wsMetaQuads,

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -3,6 +3,7 @@ import { validateSubGraphName } from '@origintrail-official/dkg-core';
 import { computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
+import { isSharedMemoryBucketDescendantDataGraph } from './sync/shared-memory-graphs.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -388,14 +389,6 @@ function combineRegisteredSubGraphNames(
     if (validateSubGraphName(name).valid && !excluded.has(name)) out.add(name);
   }
   return [...out];
-}
-
-function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
-  if (!graph.startsWith(`${bucketGraph}/`)) return false;
-  const tail = graph.slice(bucketGraph.length + 1);
-  if (tail.startsWith('staging/')) return false;
-  const parts = tail.split('/');
-  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 function processDurableBatch(

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -1,4 +1,5 @@
 import { parentPort } from 'node:worker_threads';
+import { validateSubGraphName } from '@origintrail-official/dkg-core';
 import { computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
@@ -32,8 +33,8 @@ parentPort!.on('message', async (message: { id: number; method: string; args: un
       return;
     }
     if (message.method === 'processSharedMemoryBatch') {
-      const [wsDataQuads, wsMetaQuads] = message.args as [Quad[], Quad[]];
-      const result = processSharedMemoryBatch(wsDataQuads, wsMetaQuads);
+      const [wsDataQuads, wsMetaQuads, contextGraphId] = message.args as [Quad[], Quad[], string];
+      const result = processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId);
       parentPort!.postMessage({ id: message.id, result });
       return;
     }
@@ -199,7 +200,11 @@ function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: st
   };
 }
 
-function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMemoryProcessResult {
+function processSharedMemory(
+  wsDataQuads: Quad[],
+  wsMetaQuads: Quad[],
+  contextGraphId?: string,
+): SharedMemoryProcessResult {
   const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const DKG_WORKSPACE_OP = 'http://dkg.io/ontology/WorkspaceOperation';
@@ -263,8 +268,8 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
     if (q.predicate !== DKG_ROOT_ENTITY) continue;
     const validForGraph = validOpsByMeta.get(q.graph);
     if (!validForGraph || !validForGraph.has(q.subject)) continue;
-    if (!q.graph.endsWith(META_SUFFIX)) continue;
-    const dataGraph = q.graph.slice(0, -META_SUFFIX.length);
+    const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX);
+    if (!dataGraph) continue;
     const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
     let s = allowedRootsByDataGraph.get(dataGraph);
     if (!s) { s = new Set(); allowedRootsByDataGraph.set(dataGraph, s); }
@@ -272,7 +277,7 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   }
 
   const validQuads = wsDataQuads.filter((q) => {
-    const allowed = allowedRootsByDataGraph.get(q.graph);
+    const allowed = allowedRootsForSwmDataGraph(allowedRootsByDataGraph, q.graph);
     if (!allowed) return false;
     if (allowed.has(q.subject)) return true;
     for (const root of allowed) {
@@ -308,8 +313,8 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
   for (const q of wsMetaQuads) {
     const validForGraph = validOpsByMeta.get(q.graph);
     if (q.predicate === DKG_ROOT_ENTITY && validForGraph?.has(q.subject)) {
-      if (!q.graph.endsWith(META_SUFFIX)) continue;
-      const dataGraph = q.graph.slice(0, -META_SUFFIX.length);
+      const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX);
+      if (!dataGraph) continue;
       const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
       const creator = opCreators.get(q.subject);
       const key = `${dataGraph}\0${entity}`;
@@ -324,6 +329,38 @@ function processSharedMemory(wsDataQuads: Quad[], wsMetaQuads: Quad[]): SharedMe
     dropped: wsDataQuads.length - validQuads.length,
     entityCreators: [...entityCreators.values()],
   };
+}
+
+function swmDataGraphFromMetaGraph(
+  metaGraph: string,
+  contextGraphId: string | undefined,
+  metaSuffix: string,
+): string | undefined {
+  if (!metaGraph.endsWith('/_shared_memory_meta')) return undefined;
+  if (contextGraphId === undefined) return metaGraph.slice(0, -metaSuffix.length);
+  const rootMetaGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+  if (metaGraph === rootMetaGraph) return metaGraph.slice(0, -metaSuffix.length);
+
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const suffix = '/_shared_memory_meta';
+  if (!metaGraph.startsWith(prefix) || !metaGraph.endsWith(suffix)) return undefined;
+  const subGraphName = metaGraph.slice(prefix.length, -suffix.length);
+  if (!validateSubGraphName(subGraphName).valid) return undefined;
+  return metaGraph.slice(0, -metaSuffix.length);
+}
+
+function allowedRootsForSwmDataGraph(
+  allowedRootsByDataGraph: Map<string, Set<string>>,
+  graph: string,
+): Set<string> | undefined {
+  const exact = allowedRootsByDataGraph.get(graph);
+  if (exact) return exact;
+  for (const [bucketGraph, allowed] of allowedRootsByDataGraph) {
+    if (graph.startsWith(`${bucketGraph}/`) && !graph.startsWith(`${bucketGraph}/staging/`)) {
+      return allowed;
+    }
+  }
+  return undefined;
 }
 
 function processDurableBatch(
@@ -392,6 +429,7 @@ function processDurableBatch(
 function processSharedMemoryBatch(
   wsDataQuads: Quad[],
   wsMetaQuads: Quad[],
+  contextGraphId?: string,
 ): SharedMemoryBatchProcessResult {
   const totalFetchedDataQuads = wsDataQuads.length;
   const totalFetchedMetaQuads = wsMetaQuads.length;
@@ -407,7 +445,7 @@ function processSharedMemoryBatch(
     };
   }
 
-  const processed = processSharedMemory(wsDataQuads, wsMetaQuads);
+  const processed = processSharedMemory(wsDataQuads, wsMetaQuads, contextGraphId);
   return {
     verifiedData: processed.validQuads,
     verifiedMeta: wsMetaQuads,

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -5,6 +5,9 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DKG_SUB_GRAPH = `${DKG_NS}SubGraph`;
+const SCHEMA_NAME = 'http://schema.org/name';
 
 parentPort!.on('message', async (message: { id: number; method: string; args: unknown[] }) => {
   try {
@@ -208,7 +211,6 @@ function processSharedMemory(
   registeredSubGraphNames?: readonly string[],
 ): SharedMemoryProcessResult {
   const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
-  const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const DKG_WORKSPACE_OP = 'http://dkg.io/ontology/WorkspaceOperation';
   const DKG_PUBLISHED_AT = 'http://dkg.io/ontology/publishedAt';
   const DKG_PUBLISHER_PEER_ID = 'http://dkg.io/ontology/publisherPeerId';
@@ -220,6 +222,9 @@ function processSharedMemory(
   //   <cgPrefix>/<sub>/_shared_memory <-> <cgPrefix>/<sub>/_shared_memory_meta
   // Stripping the suffix yields the matching data graph URI.
   const META_SUFFIX = '_meta';
+  const effectiveRegisteredSubGraphNames = contextGraphId === undefined
+    ? registeredSubGraphNames
+    : combineRegisteredSubGraphNames(contextGraphId, registeredSubGraphNames, wsMetaQuads);
 
   // Codex review on #885 — keep validity scoped per (meta graph, op
   // subject). Pre-fix the Sets were global, so an op subject that
@@ -270,7 +275,7 @@ function processSharedMemory(
     if (q.predicate !== DKG_ROOT_ENTITY) continue;
     const validForGraph = validOpsByMeta.get(q.graph);
     if (!validForGraph || !validForGraph.has(q.subject)) continue;
-    const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, registeredSubGraphNames);
+    const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, effectiveRegisteredSubGraphNames);
     if (!dataGraph) continue;
     const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
     let s = allowedRootsByDataGraph.get(dataGraph);
@@ -315,7 +320,7 @@ function processSharedMemory(
   for (const q of wsMetaQuads) {
     const validForGraph = validOpsByMeta.get(q.graph);
     if (q.predicate === DKG_ROOT_ENTITY && validForGraph?.has(q.subject)) {
-      const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, registeredSubGraphNames);
+      const dataGraph = swmDataGraphFromMetaGraph(q.graph, contextGraphId, META_SUFFIX, effectiveRegisteredSubGraphNames);
       if (!dataGraph) continue;
       const entity = q.object.startsWith('"') ? stripLiteral(q.object) : q.object;
       const creator = opCreators.get(q.subject);
@@ -360,11 +365,67 @@ function allowedRootsForSwmDataGraph(
   const exact = allowedRootsByDataGraph.get(graph);
   if (exact) return exact;
   for (const [bucketGraph, allowed] of allowedRootsByDataGraph) {
-    if (graph.startsWith(`${bucketGraph}/`) && !graph.startsWith(`${bucketGraph}/staging/`)) {
+    if (isSharedMemoryBucketDescendantDataGraph(graph, bucketGraph)) {
       return allowed;
     }
   }
   return undefined;
+}
+
+function combineRegisteredSubGraphNames(
+  contextGraphId: string,
+  localNames: readonly string[] | undefined,
+  wsMetaQuads: readonly Quad[],
+): string[] {
+  const out = new Set<string>();
+  for (const name of localNames ?? []) {
+    if (validateSubGraphName(name).valid) out.add(name);
+  }
+  for (const name of replicatedRegisteredSubGraphNames(contextGraphId, wsMetaQuads)) {
+    out.add(name);
+  }
+  return [...out];
+}
+
+function replicatedRegisteredSubGraphNames(
+  contextGraphId: string,
+  wsMetaQuads: readonly Quad[],
+): string[] {
+  const rootMetaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  const typedSubjects = new Set<string>();
+  const namesBySubject = new Map<string, Set<string>>();
+
+  for (const q of wsMetaQuads) {
+    if (q.graph !== rootMetaGraph) continue;
+    if (q.predicate === RDF_TYPE && q.object === DKG_SUB_GRAPH) {
+      typedSubjects.add(q.subject);
+    } else if (q.predicate === SCHEMA_NAME) {
+      const name = stripLiteral(q.object);
+      if (!validateSubGraphName(name).valid) continue;
+      let names = namesBySubject.get(q.subject);
+      if (!names) {
+        names = new Set<string>();
+        namesBySubject.set(q.subject, names);
+      }
+      names.add(name);
+    }
+  }
+
+  const out = new Set<string>();
+  for (const subject of typedSubjects) {
+    for (const name of namesBySubject.get(subject) ?? []) {
+      out.add(name);
+    }
+  }
+  return [...out];
+}
+
+function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
+  if (!graph.startsWith(`${bucketGraph}/`)) return false;
+  const tail = graph.slice(bucketGraph.length + 1);
+  if (tail.startsWith('staging/')) return false;
+  const parts = tail.split('/');
+  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 function processDurableBatch(

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -203,11 +203,12 @@ export class SyncVerifyWorker {
     wsDataQuads: Quad[],
     wsMetaQuads: Quad[],
     contextGraphId: string,
+    registeredSubGraphNames?: readonly string[],
   ): Promise<SharedMemoryBatchProcessResult> {
     const id = this.nextId++;
     return new Promise<SharedMemoryBatchProcessResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.worker.postMessage({ id, method: 'processSharedMemoryBatch', args: [wsDataQuads, wsMetaQuads, contextGraphId] });
+      this.worker.postMessage({ id, method: 'processSharedMemoryBatch', args: [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames] });
     });
   }
 

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -204,11 +204,16 @@ export class SyncVerifyWorker {
     wsMetaQuads: Quad[],
     contextGraphId: string,
     registeredSubGraphNames?: readonly string[],
+    excludedSubGraphNames?: readonly string[],
   ): Promise<SharedMemoryBatchProcessResult> {
     const id = this.nextId++;
     return new Promise<SharedMemoryBatchProcessResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.worker.postMessage({ id, method: 'processSharedMemoryBatch', args: [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames] });
+      this.worker.postMessage({
+        id,
+        method: 'processSharedMemoryBatch',
+        args: [wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames],
+      });
     });
   }
 

--- a/packages/agent/src/sync-verify-worker.ts
+++ b/packages/agent/src/sync-verify-worker.ts
@@ -202,11 +202,12 @@ export class SyncVerifyWorker {
   processSharedMemoryBatch(
     wsDataQuads: Quad[],
     wsMetaQuads: Quad[],
+    contextGraphId: string,
   ): Promise<SharedMemoryBatchProcessResult> {
     const id = this.nextId++;
     return new Promise<SharedMemoryBatchProcessResult>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.worker.postMessage({ id, method: 'processSharedMemoryBatch', args: [wsDataQuads, wsMetaQuads] });
+      this.worker.postMessage({ id, method: 'processSharedMemoryBatch', args: [wsDataQuads, wsMetaQuads, contextGraphId] });
     });
   }
 

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -11,6 +11,7 @@ export interface SyncRequestEnvelope {
   requesterPeerId?: string;
   requestId?: string;
   issuedAtMs?: number;
+  syncSessionId?: string;
   requesterIdentityId?: string;
   requesterAgentAddress?: string;
   requesterSignatureR?: string;
@@ -42,6 +43,7 @@ interface BuildSyncRequestParams {
   phase?: SyncPhase;
   snapshotRef?: string;
   sinceBatchId?: string;
+  syncSessionId?: string;
   needsAuth: boolean;
   computeSyncDigest: (
     contextGraphId: string,
@@ -79,6 +81,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     phase,
     snapshotRef,
     sinceBatchId,
+    syncSessionId,
     needsAuth,
     computeSyncDigest,
     getIdentityId,
@@ -94,9 +97,10 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
       : phase === 'snapshot'
         ? `|snapshot|${snapshotRef ?? ''}`
         : '';
-    // Phase C: trailing keyed token; old responders ignore the extra parts.
+    // Trailing keyed tokens are additive; old responders ignore the extra parts.
+    const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
     const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
-    return new TextEncoder().encode(`${prefix}|${offset}|${limit}${phaseSuffix}${sinceSuffix}`);
+    return new TextEncoder().encode(`${prefix}|${offset}|${limit}${phaseSuffix}${sessionSuffix}${sinceSuffix}`);
   }
 
   const request: SyncRequestEnvelope = {
@@ -136,6 +140,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
 
   // Phase C: ride the envelope unsigned, after the digest (cannot influence
   // authorization; only narrows the responder's result set).
+  if (syncSessionId) request.syncSessionId = syncSessionId;
   if (sinceBatchId) request.sinceBatchId = sinceBatchId;
 
   const identityId = await getIdentityId();

--- a/packages/agent/src/sync/durable-session.ts
+++ b/packages/agent/src/sync/durable-session.ts
@@ -1,25 +1,7 @@
-import { createHash } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 
-export const DURABLE_DATA_SYNC_SESSION_BUCKET_MS = 10 * 60_000;
+export const DURABLE_DATA_SYNC_SESSION_TTL_MS = 10 * 60_000;
 
-export function durableDataSyncSessionId(params: {
-  remotePeerId: string;
-  contextGraphId: string;
-  sinceBatchId?: string;
-}): string {
-  const sinceScope = params.sinceBatchId?.trim() || 'full';
-  const bucket = Math.floor(Date.now() / DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
-  const digest = createHash('sha256')
-    .update('dkg-sync-durable-data-session')
-    .update('\0')
-    .update(params.remotePeerId)
-    .update('\0')
-    .update(params.contextGraphId)
-    .update('\0')
-    .update(sinceScope)
-    .update('\0')
-    .update(String(bucket))
-    .digest('hex')
-    .slice(0, 32);
-  return `durable-data:${digest}`;
+export function createDurableDataSyncSessionId(): string {
+  return `durable-data:${randomUUID()}`;
 }

--- a/packages/agent/src/sync/durable-session.ts
+++ b/packages/agent/src/sync/durable-session.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 
 export const DURABLE_DATA_SYNC_SESSION_TTL_MS = 10 * 60_000;
 
+export function createSyncResponderSessionId(scope = 'sync'): string {
+  return `${scope}:${randomUUID()}`;
+}
+
 export function createDurableDataSyncSessionId(): string {
-  return `durable-data:${randomUUID()}`;
+  return createSyncResponderSessionId('durable-data');
 }

--- a/packages/agent/src/sync/durable-session.ts
+++ b/packages/agent/src/sync/durable-session.ts
@@ -1,0 +1,25 @@
+import { createHash } from 'node:crypto';
+
+export const DURABLE_DATA_SYNC_SESSION_BUCKET_MS = 10 * 60_000;
+
+export function durableDataSyncSessionId(params: {
+  remotePeerId: string;
+  contextGraphId: string;
+  sinceBatchId?: string;
+}): string {
+  const sinceScope = params.sinceBatchId?.trim() || 'full';
+  const bucket = Math.floor(Date.now() / DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
+  const digest = createHash('sha256')
+    .update('dkg-sync-durable-data-session')
+    .update('\0')
+    .update(params.remotePeerId)
+    .update('\0')
+    .update(params.contextGraphId)
+    .update('\0')
+    .update(sinceScope)
+    .update('\0')
+    .update(String(bucket))
+    .digest('hex')
+    .slice(0, 32);
+  return `durable-data:${digest}`;
+}

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -164,7 +164,6 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     const parseStartedAt = Date.now();
     const parsed = await parseAndFilter(nquadsText, graphUri, contextGraphId);
     const parseDurationMs = Date.now() - parseStartedAt;
-    if (parsed.totalQuads === 0) break;
 
     const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;
     if (stepDurationMs > 100) {
@@ -172,6 +171,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         ctx,
         `Sync page timing for "${contextGraphId}" offset=${curOffset} phase=${phase}: transport=${transportDurationMs}ms decode=${decodeDurationMs}ms parse=${parseDurationMs}ms`,
       );
+    }
+
+    if (parsed.totalQuads === 0) {
+      if (parsed.quads.length > 0) allQuads.push(...parsed.quads);
+      break;
     }
 
     allQuads.push(...parsed.quads);

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -120,7 +120,10 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
   const usesDurableDataSession = !includeSharedMemory && phase === 'data';
-  if (usesDurableDataSession && offset > 0) {
+  const savedDurableDataSessionId = usesDurableDataSession
+    ? unfinishedDurableDataSessions.get(checkpointKey)
+    : undefined;
+  if (usesDurableDataSession && offset > 0 && !savedDurableDataSessionId) {
     checkpointStore.delete(checkpointKey);
     offset = 0;
   }
@@ -128,7 +131,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   let bytesReceived = 0;
   let timedOut = false;
   const syncSessionId = usesDurableDataSession
-    ? (unfinishedDurableDataSessions.get(checkpointKey) ?? createDurableDataSyncSessionId())
+    ? (savedDurableDataSessionId ?? createDurableDataSyncSessionId())
     : undefined;
 
   try {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -108,10 +108,15 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const allQuads: Quad[] = [];
   const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
+  const usesDurableDataSession = !includeSharedMemory && phase === 'data';
+  if (usesDurableDataSession && offset > 0) {
+    checkpointStore.delete(checkpointKey);
+    offset = 0;
+  }
   const resumedFromOffset = offset;
   let bytesReceived = 0;
   let timedOut = false;
-  const syncSessionId = offset === 0 && !includeSharedMemory && phase === 'data' && !sinceBatchId
+  const syncSessionId = usesDurableDataSession
     ? randomUUID()
     : undefined;
 

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -3,7 +3,18 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
-import { durableDataSyncSessionId } from '../durable-session.js';
+import { createDurableDataSyncSessionId } from '../durable-session.js';
+
+const MAX_UNFINISHED_DURABLE_DATA_SESSIONS = 4096;
+const unfinishedDurableDataSessions = new Map<string, string>();
+
+function rememberUnfinishedDurableDataSession(checkpointKey: string, syncSessionId: string): void {
+  if (!unfinishedDurableDataSessions.has(checkpointKey) && unfinishedDurableDataSessions.size >= MAX_UNFINISHED_DURABLE_DATA_SESSIONS) {
+    const oldest = unfinishedDurableDataSessions.keys().next().value;
+    if (oldest) unfinishedDurableDataSessions.delete(oldest);
+  }
+  unfinishedDurableDataSessions.set(checkpointKey, syncSessionId);
+}
 
 export interface SyncPageResult {
   quads: Quad[];
@@ -117,86 +128,98 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   let bytesReceived = 0;
   let timedOut = false;
   const syncSessionId = usesDurableDataSession
-    ? durableDataSyncSessionId({ remotePeerId, contextGraphId, sinceBatchId })
+    ? (unfinishedDurableDataSessions.get(checkpointKey) ?? createDurableDataSyncSessionId())
     : undefined;
 
-  while (true) {
-    if (Date.now() > deadline) {
-      timedOut = true;
-      break;
-    }
+  try {
+    while (true) {
+      if (Date.now() > deadline) {
+        timedOut = true;
+        break;
+      }
 
-    const remainingMs = Math.max(0, deadline - Date.now());
-    const timeoutMs = Math.min(
-      syncPageTimeoutMs,
-      Math.max(2000, Math.floor(remainingMs / syncRouterAttempts)),
-    );
-
-    const curOffset = offset;
-    const transportStartedAt = Date.now();
-    const responseBytes = await sendSyncRequest({
-      remotePeerId,
-      timeoutMs,
-      retryAttempts: syncPageRetryAttempts,
-      contextGraphId,
-      offset,
-      protocolId: protocolSync,
-      // `requestFactory` runs per-attempt so each retry carries a
-      // fresh `issuedAtMs`/`requestId`. Required for sync's auth
-      // gate (`SYNC_AUTH_MAX_AGE_MS` freshness TTL +
-      // `seenRequestIds` replay protection). The matching
-      // fresh-messageId-per-attempt is generated inside
-      // `sendSyncRequest`. See `sendSyncRequest`'s jsdoc for the
-      // full rationale (codex review on #569 follow-ups #1, #4-#8).
-      requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
-      send,
-      onRetry: (attempt, delay, err) => {
-        logWarn(ctx, `Sync page retry ${attempt}/${syncPageRetryAttempts} for offset ${offset} (delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`);
-      },
-    });
-    const transportDurationMs = Date.now() - transportStartedAt;
-
-    const decodeStartedAt = Date.now();
-    const nquadsText = new TextDecoder().decode(responseBytes).trim();
-    const decodeDurationMs = Date.now() - decodeStartedAt;
-    bytesReceived += responseBytes.byteLength;
-    if (
-      nquadsText === syncDeniedResponse ||
-      (extraDeniedResponses && extraDeniedResponses.includes(nquadsText))
-    ) {
-      const error = new Error(`Sync denied by ${remotePeerId} for "${contextGraphId}" (${phase})`);
-      (error as Error & { syncDenied?: boolean }).syncDenied = true;
-      throw error;
-    }
-    if (!nquadsText) break;
-
-    const parseStartedAt = Date.now();
-    const parsed = await parseAndFilter(nquadsText, graphUri, contextGraphId);
-    const parseDurationMs = Date.now() - parseStartedAt;
-
-    const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;
-    if (stepDurationMs > 100) {
-      logDebug(
-        ctx,
-        `Sync page timing for "${contextGraphId}" offset=${curOffset} phase=${phase}: transport=${transportDurationMs}ms decode=${decodeDurationMs}ms parse=${parseDurationMs}ms`,
+      const remainingMs = Math.max(0, deadline - Date.now());
+      const timeoutMs = Math.min(
+        syncPageTimeoutMs,
+        Math.max(2000, Math.floor(remainingMs / syncRouterAttempts)),
       );
-    }
 
-    if (parsed.totalQuads === 0) {
-      if (parsed.quads.length > 0) allQuads.push(...parsed.quads);
-      break;
-    }
+      const curOffset = offset;
+      const transportStartedAt = Date.now();
+      const responseBytes = await sendSyncRequest({
+        remotePeerId,
+        timeoutMs,
+        retryAttempts: syncPageRetryAttempts,
+        contextGraphId,
+        offset,
+        protocolId: protocolSync,
+        // `requestFactory` runs per-attempt so each retry carries a
+        // fresh `issuedAtMs`/`requestId`. Required for sync's auth
+        // gate (`SYNC_AUTH_MAX_AGE_MS` freshness TTL +
+        // `seenRequestIds` replay protection). The matching
+        // fresh-messageId-per-attempt is generated inside
+        // `sendSyncRequest`. See `sendSyncRequest`'s jsdoc for the
+        // full rationale (codex review on #569 follow-ups #1, #4-#8).
+        requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
+        send,
+        onRetry: (attempt, delay, err) => {
+          logWarn(ctx, `Sync page retry ${attempt}/${syncPageRetryAttempts} for offset ${offset} (delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`);
+        },
+      });
+      const transportDurationMs = Date.now() - transportStartedAt;
 
-    allQuads.push(...parsed.quads);
-    offset += parsed.totalQuads;
+      const decodeStartedAt = Date.now();
+      const nquadsText = new TextDecoder().decode(responseBytes).trim();
+      const decodeDurationMs = Date.now() - decodeStartedAt;
+      bytesReceived += responseBytes.byteLength;
+      if (
+        nquadsText === syncDeniedResponse ||
+        (extraDeniedResponses && extraDeniedResponses.includes(nquadsText))
+      ) {
+        const error = new Error(`Sync denied by ${remotePeerId} for "${contextGraphId}" (${phase})`);
+        (error as Error & { syncDenied?: boolean }).syncDenied = true;
+        throw error;
+      }
+      if (!nquadsText) break;
 
-    if (debugSyncProgress) {
-      logInfo(
-        ctx,
-        `Sync progress for "${contextGraphId}" ${includeSharedMemory ? 'shared-memory' : 'durable'} ${phase}: transferred=${allQuads.length} bytes=${bytesReceived} offset=${offset}`,
-      );
+      const parseStartedAt = Date.now();
+      const parsed = await parseAndFilter(nquadsText, graphUri, contextGraphId);
+      const parseDurationMs = Date.now() - parseStartedAt;
+
+      const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;
+      if (stepDurationMs > 100) {
+        logDebug(
+          ctx,
+          `Sync page timing for "${contextGraphId}" offset=${curOffset} phase=${phase}: transport=${transportDurationMs}ms decode=${decodeDurationMs}ms parse=${parseDurationMs}ms`,
+        );
+      }
+
+      if (parsed.totalQuads === 0) {
+        if (parsed.quads.length > 0) allQuads.push(...parsed.quads);
+        break;
+      }
+
+      allQuads.push(...parsed.quads);
+      offset += parsed.totalQuads;
+
+      if (debugSyncProgress) {
+        logInfo(
+          ctx,
+          `Sync progress for "${contextGraphId}" ${includeSharedMemory ? 'shared-memory' : 'durable'} ${phase}: transferred=${allQuads.length} bytes=${bytesReceived} offset=${offset}`,
+        );
+      }
+      if (parsed.totalQuads < syncPageSize) break;
     }
-    if (parsed.totalQuads < syncPageSize) break;
+  } catch (err) {
+    if (usesDurableDataSession && syncSessionId && !(err as Error & { syncDenied?: boolean }).syncDenied) {
+      rememberUnfinishedDurableDataSession(checkpointKey, syncSessionId);
+    }
+    throw err;
+  }
+
+  if (usesDurableDataSession && syncSessionId) {
+    if (timedOut) rememberUnfinishedDurableDataSession(checkpointKey, syncSessionId);
+    else unfinishedDurableDataSessions.delete(checkpointKey);
   }
 
   if (timedOut) {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,9 +1,9 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import { randomUUID } from 'node:crypto';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
+import { durableDataSyncSessionId } from '../durable-session.js';
 
 export interface SyncPageResult {
   quads: Quad[];
@@ -117,7 +117,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   let bytesReceived = 0;
   let timedOut = false;
   const syncSessionId = usesDurableDataSession
-    ? randomUUID()
+    ? durableDataSyncSessionId({ remotePeerId, contextGraphId, sinceBatchId })
     : undefined;
 
   while (true) {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -5,39 +5,50 @@ import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 import {
   createDurableDataSyncSessionId,
+  createSyncResponderSessionId,
   DURABLE_DATA_SYNC_SESSION_TTL_MS,
 } from '../durable-session.js';
 
-const MAX_UNFINISHED_DURABLE_DATA_SESSIONS = 4096;
-type UnfinishedDurableDataSession = {
+const MAX_UNFINISHED_SYNC_RESPONDER_SESSIONS = 4096;
+type UnfinishedSyncResponderSession = {
   syncSessionId: string;
   expiresAt: number;
 };
 
-const unfinishedDurableDataSessions = new Map<string, UnfinishedDurableDataSession>();
+const unfinishedSyncResponderSessions = new Map<string, UnfinishedSyncResponderSession>();
 
-function getUnfinishedDurableDataSession(checkpointKey: string, now = Date.now()): UnfinishedDurableDataSession | undefined {
-  const session = unfinishedDurableDataSessions.get(checkpointKey);
+function getUnfinishedSyncResponderSession(checkpointKey: string, now = Date.now()): UnfinishedSyncResponderSession | undefined {
+  const session = unfinishedSyncResponderSessions.get(checkpointKey);
   if (!session) return undefined;
   if (session.expiresAt > now) return session;
-  unfinishedDurableDataSessions.delete(checkpointKey);
+  unfinishedSyncResponderSessions.delete(checkpointKey);
   return undefined;
 }
 
-function rememberUnfinishedDurableDataSession(checkpointKey: string, session: UnfinishedDurableDataSession, now = Date.now()): void {
+function rememberUnfinishedSyncResponderSession(checkpointKey: string, session: UnfinishedSyncResponderSession, now = Date.now()): void {
   if (session.expiresAt <= now) {
-    unfinishedDurableDataSessions.delete(checkpointKey);
+    unfinishedSyncResponderSessions.delete(checkpointKey);
     return;
   }
-  if (!unfinishedDurableDataSessions.has(checkpointKey) && unfinishedDurableDataSessions.size >= MAX_UNFINISHED_DURABLE_DATA_SESSIONS) {
-    const oldest = unfinishedDurableDataSessions.keys().next().value;
-    if (oldest) unfinishedDurableDataSessions.delete(oldest);
+  if (!unfinishedSyncResponderSessions.has(checkpointKey) && unfinishedSyncResponderSessions.size >= MAX_UNFINISHED_SYNC_RESPONDER_SESSIONS) {
+    const oldest = unfinishedSyncResponderSessions.keys().next().value;
+    if (oldest) unfinishedSyncResponderSessions.delete(oldest);
   }
-  unfinishedDurableDataSessions.set(checkpointKey, session);
+  unfinishedSyncResponderSessions.set(checkpointKey, session);
 }
 
-function isDurableDataSessionSupersededError(err: unknown): boolean {
-  return err instanceof Error && err.message.includes('Durable data sync session was superseded');
+function isSyncResponderSessionSupersededError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('sync session was superseded');
+}
+
+function usesResponderSession(includeSharedMemory: boolean, phase: SyncPhase): boolean {
+  void includeSharedMemory;
+  return phase !== 'snapshot';
+}
+
+function createResponderSessionId(includeSharedMemory: boolean, phase: SyncPhase): string {
+  if (!includeSharedMemory && phase === 'data') return createDurableDataSyncSessionId();
+  return createSyncResponderSessionId(`${includeSharedMemory ? 'swm' : 'durable'}-${phase}`);
 }
 
 export interface SyncPageResult {
@@ -143,25 +154,25 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const allQuads: Quad[] = [];
   const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
-  const usesDurableDataSession = !includeSharedMemory && phase === 'data';
-  const durableSessionStartedAt = Date.now();
-  const savedDurableDataSession = usesDurableDataSession
-    ? getUnfinishedDurableDataSession(checkpointKey, durableSessionStartedAt)
+  const usesPageSession = usesResponderSession(includeSharedMemory, phase);
+  const sessionStartedAt = Date.now();
+  const savedResponderSession = usesPageSession
+    ? getUnfinishedSyncResponderSession(checkpointKey, sessionStartedAt)
     : undefined;
-  if (usesDurableDataSession && offset > 0 && !savedDurableDataSession) {
+  if (usesPageSession && offset > 0 && !savedResponderSession) {
     checkpointStore.delete(checkpointKey);
     offset = 0;
   }
   const resumedFromOffset = offset;
   let bytesReceived = 0;
   let timedOut = false;
-  const syncSessionId = usesDurableDataSession
-    ? (savedDurableDataSession?.syncSessionId ?? createDurableDataSyncSessionId())
+  const syncSessionId = usesPageSession
+    ? (savedResponderSession?.syncSessionId ?? createResponderSessionId(includeSharedMemory, phase))
     : undefined;
-  const durableDataSession = usesDurableDataSession && syncSessionId
+  const responderSession = usesPageSession && syncSessionId
     ? {
       syncSessionId,
-      expiresAt: savedDurableDataSession?.expiresAt ?? durableSessionStartedAt + DURABLE_DATA_SYNC_SESSION_TTL_MS,
+      expiresAt: savedResponderSession?.expiresAt ?? sessionStartedAt + DURABLE_DATA_SYNC_SESSION_TTL_MS,
     }
     : undefined;
 
@@ -245,18 +256,18 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       if (parsed.totalQuads < syncPageSize) break;
     }
   } catch (err) {
-    if (usesDurableDataSession && isDurableDataSessionSupersededError(err)) {
-      unfinishedDurableDataSessions.delete(checkpointKey);
+    if (usesPageSession && isSyncResponderSessionSupersededError(err)) {
+      unfinishedSyncResponderSessions.delete(checkpointKey);
       checkpointStore.delete(checkpointKey);
-    } else if (usesDurableDataSession && durableDataSession && !(err as Error & { syncDenied?: boolean }).syncDenied) {
-      rememberUnfinishedDurableDataSession(checkpointKey, durableDataSession);
+    } else if (usesPageSession && responderSession && !(err as Error & { syncDenied?: boolean }).syncDenied) {
+      rememberUnfinishedSyncResponderSession(checkpointKey, responderSession);
     }
     throw err;
   }
 
-  if (usesDurableDataSession && durableDataSession) {
-    if (timedOut) rememberUnfinishedDurableDataSession(checkpointKey, durableDataSession);
-    else unfinishedDurableDataSessions.delete(checkpointKey);
+  if (usesPageSession && responderSession) {
+    if (timedOut) rememberUnfinishedSyncResponderSession(checkpointKey, responderSession);
+    else unfinishedSyncResponderSessions.delete(checkpointKey);
   }
 
   if (timedOut) {

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -3,17 +3,41 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
-import { createDurableDataSyncSessionId } from '../durable-session.js';
+import {
+  createDurableDataSyncSessionId,
+  DURABLE_DATA_SYNC_SESSION_TTL_MS,
+} from '../durable-session.js';
 
 const MAX_UNFINISHED_DURABLE_DATA_SESSIONS = 4096;
-const unfinishedDurableDataSessions = new Map<string, string>();
+type UnfinishedDurableDataSession = {
+  syncSessionId: string;
+  expiresAt: number;
+};
 
-function rememberUnfinishedDurableDataSession(checkpointKey: string, syncSessionId: string): void {
+const unfinishedDurableDataSessions = new Map<string, UnfinishedDurableDataSession>();
+
+function getUnfinishedDurableDataSession(checkpointKey: string, now = Date.now()): UnfinishedDurableDataSession | undefined {
+  const session = unfinishedDurableDataSessions.get(checkpointKey);
+  if (!session) return undefined;
+  if (session.expiresAt > now) return session;
+  unfinishedDurableDataSessions.delete(checkpointKey);
+  return undefined;
+}
+
+function rememberUnfinishedDurableDataSession(checkpointKey: string, session: UnfinishedDurableDataSession, now = Date.now()): void {
+  if (session.expiresAt <= now) {
+    unfinishedDurableDataSessions.delete(checkpointKey);
+    return;
+  }
   if (!unfinishedDurableDataSessions.has(checkpointKey) && unfinishedDurableDataSessions.size >= MAX_UNFINISHED_DURABLE_DATA_SESSIONS) {
     const oldest = unfinishedDurableDataSessions.keys().next().value;
     if (oldest) unfinishedDurableDataSessions.delete(oldest);
   }
-  unfinishedDurableDataSessions.set(checkpointKey, syncSessionId);
+  unfinishedDurableDataSessions.set(checkpointKey, session);
+}
+
+function isDurableDataSessionSupersededError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('Durable data sync session was superseded');
 }
 
 export interface SyncPageResult {
@@ -120,10 +144,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
   const usesDurableDataSession = !includeSharedMemory && phase === 'data';
-  const savedDurableDataSessionId = usesDurableDataSession
-    ? unfinishedDurableDataSessions.get(checkpointKey)
+  const durableSessionStartedAt = Date.now();
+  const savedDurableDataSession = usesDurableDataSession
+    ? getUnfinishedDurableDataSession(checkpointKey, durableSessionStartedAt)
     : undefined;
-  if (usesDurableDataSession && offset > 0 && !savedDurableDataSessionId) {
+  if (usesDurableDataSession && offset > 0 && !savedDurableDataSession) {
     checkpointStore.delete(checkpointKey);
     offset = 0;
   }
@@ -131,7 +156,13 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   let bytesReceived = 0;
   let timedOut = false;
   const syncSessionId = usesDurableDataSession
-    ? (savedDurableDataSessionId ?? createDurableDataSyncSessionId())
+    ? (savedDurableDataSession?.syncSessionId ?? createDurableDataSyncSessionId())
+    : undefined;
+  const durableDataSession = usesDurableDataSession && syncSessionId
+    ? {
+      syncSessionId,
+      expiresAt: savedDurableDataSession?.expiresAt ?? durableSessionStartedAt + DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    }
     : undefined;
 
   try {
@@ -214,14 +245,17 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       if (parsed.totalQuads < syncPageSize) break;
     }
   } catch (err) {
-    if (usesDurableDataSession && syncSessionId && !(err as Error & { syncDenied?: boolean }).syncDenied) {
-      rememberUnfinishedDurableDataSession(checkpointKey, syncSessionId);
+    if (usesDurableDataSession && isDurableDataSessionSupersededError(err)) {
+      unfinishedDurableDataSessions.delete(checkpointKey);
+      checkpointStore.delete(checkpointKey);
+    } else if (usesDurableDataSession && durableDataSession && !(err as Error & { syncDenied?: boolean }).syncDenied) {
+      rememberUnfinishedDurableDataSession(checkpointKey, durableDataSession);
     }
     throw err;
   }
 
-  if (usesDurableDataSession && syncSessionId) {
-    if (timedOut) rememberUnfinishedDurableDataSession(checkpointKey, syncSessionId);
+  if (usesDurableDataSession && durableDataSession) {
+    if (timedOut) rememberUnfinishedDurableDataSession(checkpointKey, durableDataSession);
     else unfinishedDurableDataSessions.delete(checkpointKey);
   }
 

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,5 +1,6 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { randomUUID } from 'node:crypto';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
@@ -41,7 +42,7 @@ interface FetchSyncPagesParams {
   debugSyncProgress: boolean;
   protocolSync: string;
   checkpointStore: SyncCheckpointStore;
-  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string) => Promise<Uint8Array>;
+  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string) => Promise<Uint8Array>;
   /**
    * Phase C — optional, gap-safe delta-sync high-water mark. Forwarded to the
    * responder for the durable DATA phase so it returns only KAs with
@@ -110,6 +111,9 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   const resumedFromOffset = offset;
   let bytesReceived = 0;
   let timedOut = false;
+  const syncSessionId = offset === 0 && !includeSharedMemory && phase === 'data' && !sinceBatchId
+    ? randomUUID()
+    : undefined;
 
   while (true) {
     if (Date.now() > deadline) {
@@ -139,7 +143,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       // fresh-messageId-per-attempt is generated inside
       // `sendSyncRequest`. See `sendSyncRequest`'s jsdoc for the
       // full rationale (codex review on #569 follow-ups #1, #4-#8).
-      requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId),
+      requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
       send,
       onRetry: (attempt, delay, err) => {
         logWarn(ctx, `Sync page retry ${attempt}/${syncPageRetryAttempts} for offset ${offset} (delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -36,7 +36,7 @@ interface SharedMemorySyncContext {
     deadline: number,
     snapshotRef?: string,
   ) => Promise<SyncPageResult>;
-  processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[]) => Promise<{
+  processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[], contextGraphId: string) => Promise<{
     verifiedData: Quad[];
     verifiedMeta: Quad[];
     totalFetchedDataQuads: number;
@@ -103,7 +103,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const fetchDurationMs = Date.now() - fetchStartedAt;
 
       const verifyStartedAt = Date.now();
-      const processed = await processSharedMemoryBatch(wsDataResult.quads, wsMetaResult.quads);
+      const processed = await processSharedMemoryBatch(wsDataResult.quads, wsMetaResult.quads, pid);
       const verifyDurationMs = Date.now() - verifyStartedAt;
       logInfo(ctx, `  shared memory: ${processed.totalFetchedDataQuads} data + ${processed.totalFetchedMetaQuads} meta triples fetched`);
       summary.bytesReceived += wsMetaResult.bytesReceived + wsDataResult.bytesReceived;
@@ -194,17 +194,29 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
 
 function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGraph: string): string | undefined {
   const rootGraph = contextGraphWorkspaceGraphUri(contextGraphId);
-  if (dataGraph === rootGraph) return contextGraphId;
+  if (isSharedMemoryBucketOrDescendant(dataGraph, rootGraph)) return contextGraphId;
 
   const prefix = `did:dkg:context-graph:${contextGraphId}/`;
   const suffix = '/_shared_memory';
-  if (!dataGraph.startsWith(prefix) || !dataGraph.endsWith(suffix)) return undefined;
+  if (!dataGraph.startsWith(prefix)) return undefined;
 
-  const subGraphName = dataGraph.slice(prefix.length, -suffix.length);
+  const remainder = dataGraph.slice(prefix.length);
+  const suffixAt = remainder.indexOf(suffix);
+  if (suffixAt <= 0) return undefined;
+  const subGraphName = remainder.slice(0, suffixAt);
+  const tail = remainder.slice(suffixAt + suffix.length);
+  if (tail && (!tail.startsWith('/') || tail.startsWith('/staging/'))) return undefined;
   if (!subGraphName || subGraphName.includes('/')) return undefined;
   if (!validateSubGraphName(subGraphName).valid) return undefined;
 
   return `${contextGraphId}\0${subGraphName}`;
+}
+
+function isSharedMemoryBucketOrDescendant(dataGraph: string, bucketGraph: string): boolean {
+  return dataGraph === bucketGraph || (
+    dataGraph.startsWith(`${bucketGraph}/`) &&
+    !dataGraph.startsWith(`${bucketGraph}/staging/`)
+  );
 }
 
 interface PublicSnapshotMetadata {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -36,7 +36,13 @@ interface SharedMemorySyncContext {
     deadline: number,
     snapshotRef?: string,
   ) => Promise<SyncPageResult>;
-  processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[], contextGraphId: string, registeredSubGraphNames?: readonly string[]) => Promise<{
+  processSharedMemoryBatch: (
+    wsDataQuads: Quad[],
+    wsMetaQuads: Quad[],
+    contextGraphId: string,
+    registeredSubGraphNames?: readonly string[],
+    excludedSubGraphNames?: readonly string[],
+  ) => Promise<{
     verifiedData: Quad[];
     verifiedMeta: Quad[];
     totalFetchedDataQuads: number;
@@ -49,6 +55,7 @@ interface SharedMemorySyncContext {
   storeInsert: (quads: Quad[]) => Promise<void>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   getRegisteredSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
+  getExcludedSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -69,6 +76,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     storeInsert,
     publicSnapshotStore,
     getRegisteredSubGraphNames,
+    getExcludedSubGraphNames,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -108,7 +116,16 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const registeredSubGraphNames = getRegisteredSubGraphNames
         ? await getRegisteredSubGraphNames(pid)
         : undefined;
-      const processed = await processSharedMemoryBatch(wsDataResult.quads, wsMetaResult.quads, pid, registeredSubGraphNames);
+      const excludedSubGraphNames = getExcludedSubGraphNames
+        ? await getExcludedSubGraphNames(pid)
+        : undefined;
+      const processed = await processSharedMemoryBatch(
+        wsDataResult.quads,
+        wsMetaResult.quads,
+        pid,
+        registeredSubGraphNames,
+        excludedSubGraphNames,
+      );
       const verifyDurationMs = Date.now() - verifyStartedAt;
       logInfo(ctx, `  shared memory: ${processed.totalFetchedDataQuads} data + ${processed.totalFetchedMetaQuads} meta triples fetched`);
       summary.bytesReceived += wsMetaResult.bytesReceived + wsDataResult.bytesReceived;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -199,7 +199,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
 
 function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGraph: string): string | undefined {
   const rootGraph = contextGraphWorkspaceGraphUri(contextGraphId);
-  if (isSharedMemoryBucketOrDescendant(dataGraph, rootGraph)) return contextGraphId;
+  if (dataGraph === rootGraph || isSharedMemoryBucketDescendantDataGraph(dataGraph, rootGraph)) return contextGraphId;
 
   const prefix = `did:dkg:context-graph:${contextGraphId}/`;
   const suffix = '/_shared_memory';
@@ -208,20 +208,24 @@ function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGraph: st
   const remainder = dataGraph.slice(prefix.length);
   const suffixAt = remainder.indexOf(suffix);
   if (suffixAt <= 0) return undefined;
+  const bucketGraph = dataGraph.slice(0, prefix.length + suffixAt + suffix.length);
   const subGraphName = remainder.slice(0, suffixAt);
   const tail = remainder.slice(suffixAt + suffix.length);
-  if (tail && (!tail.startsWith('/') || tail.startsWith('/staging/'))) return undefined;
+  if (tail && (!tail.startsWith('/') || !isSharedMemoryBucketDescendantDataGraph(dataGraph, bucketGraph))) {
+    return undefined;
+  }
   if (!subGraphName || subGraphName.includes('/')) return undefined;
   if (!validateSubGraphName(subGraphName).valid) return undefined;
 
   return `${contextGraphId}\0${subGraphName}`;
 }
 
-function isSharedMemoryBucketOrDescendant(dataGraph: string, bucketGraph: string): boolean {
-  return dataGraph === bucketGraph || (
-    dataGraph.startsWith(`${bucketGraph}/`) &&
-    !dataGraph.startsWith(`${bucketGraph}/staging/`)
-  );
+function isSharedMemoryBucketDescendantDataGraph(dataGraph: string, bucketGraph: string): boolean {
+  if (!dataGraph.startsWith(`${bucketGraph}/`)) return false;
+  const tail = dataGraph.slice(bucketGraph.length + 1);
+  if (tail.startsWith('staging/')) return false;
+  const parts = tail.split('/');
+  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 interface PublicSnapshotMetadata {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -3,6 +3,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
+import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncPageResult } from './page-fetch.js';
 
 const DKG = 'http://dkg.io/ontology/';
@@ -235,14 +236,6 @@ function sharedMemoryOwnershipKeyFromGraph(contextGraphId: string, dataGraph: st
   if (!validateSubGraphName(subGraphName).valid) return undefined;
 
   return `${contextGraphId}\0${subGraphName}`;
-}
-
-function isSharedMemoryBucketDescendantDataGraph(dataGraph: string, bucketGraph: string): boolean {
-  if (!dataGraph.startsWith(`${bucketGraph}/`)) return false;
-  const tail = dataGraph.slice(bucketGraph.length + 1);
-  if (tail.startsWith('staging/')) return false;
-  const parts = tail.split('/');
-  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 interface PublicSnapshotMetadata {

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -36,7 +36,7 @@ interface SharedMemorySyncContext {
     deadline: number,
     snapshotRef?: string,
   ) => Promise<SyncPageResult>;
-  processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[], contextGraphId: string) => Promise<{
+  processSharedMemoryBatch: (wsDataQuads: Quad[], wsMetaQuads: Quad[], contextGraphId: string, registeredSubGraphNames?: readonly string[]) => Promise<{
     verifiedData: Quad[];
     verifiedMeta: Quad[];
     totalFetchedDataQuads: number;
@@ -48,6 +48,7 @@ interface SharedMemorySyncContext {
   ensureContextGraph: (contextGraphId: string) => Promise<void>;
   storeInsert: (quads: Quad[]) => Promise<void>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
+  getRegisteredSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -67,6 +68,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     ensureContextGraph,
     storeInsert,
     publicSnapshotStore,
+    getRegisteredSubGraphNames,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -103,7 +105,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const fetchDurationMs = Date.now() - fetchStartedAt;
 
       const verifyStartedAt = Date.now();
-      const processed = await processSharedMemoryBatch(wsDataResult.quads, wsMetaResult.quads, pid);
+      const registeredSubGraphNames = getRegisteredSubGraphNames
+        ? await getRegisteredSubGraphNames(pid)
+        : undefined;
+      const processed = await processSharedMemoryBatch(wsDataResult.quads, wsMetaResult.quads, pid, registeredSubGraphNames);
       const verifyDurationMs = Date.now() - verifyStartedAt;
       logInfo(ctx, `  shared memory: ${processed.totalFetchedDataQuads} data + ${processed.totalFetchedMetaQuads} meta triples fetched`);
       summary.bytesReceived += wsMetaResult.bytesReceived + wsDataResult.bytesReceived;

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -22,7 +22,7 @@ const DKG_BATCH_ID = `${DKG}batchId`;
 const SCHEMA_NAME = 'http://schema.org/name';
 
 export interface GraphListMemo {
-  get(): Promise<readonly string[]>;
+  get(options?: { refresh?: boolean }): Promise<readonly string[]>;
 }
 
 export function createResponderGraphListMemo(
@@ -33,10 +33,10 @@ export function createResponderGraphListMemo(
   let cachedAt = 0;
   let inflight: Promise<readonly string[]> | null = null;
   return {
-    async get() {
+    async get(options?: { refresh?: boolean }) {
       const now = Date.now();
-      if (cached && now - cachedAt < ttlMs) return [...cached];
       if (inflight) return [...(await inflight)];
+      if (!options?.refresh && cached && now - cachedAt < ttlMs) return [...cached];
       inflight = store.listGraphs()
         .then((graphs) => {
           const sorted = [...new Set(graphs)].sort(compareCodePoint);
@@ -88,17 +88,30 @@ export async function readSwmMetaPage(params: {
 }): Promise<SyncRow[]> {
   const graphs = await planSwmGraphs(params.store, params.contextGraphId, true);
   const graphSet = new Set(params.graphList);
-  const rows: SyncRow[] = [];
-  for (const graph of graphs.filter((graph) => graphSet.has(graph))) {
-    const subjects = params.cutoffIso
-      ? await readFreshWorkspaceSubjects(params.store, graph, params.cutoffIso)
-      : null;
-    rows.push(...await readGraphRows(params.store, graph, (row) =>
-      !subjects || subjects.has(row.s),
-    ));
+  const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
+  if (!params.cutoffIso) {
+    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, async () => true);
   }
-  rows.sort(compareRows);
-  return rows.slice(params.offset, params.offset + params.limit);
+
+  const rows: SyncRow[] = [];
+  let skip = params.offset;
+  let remaining = params.limit;
+  for (const graph of candidateGraphs) {
+    if (skip > 0) {
+      const count = await countFreshSwmMetaGraphRows(params.store, graph, params.cutoffIso);
+      if (skip >= count) {
+        skip -= count;
+        continue;
+      }
+    }
+
+    const page = await readFreshSwmMetaGraphRowsPage(params.store, graph, params.cutoffIso, skip, remaining);
+    rows.push(...page);
+    remaining -= page.length;
+    skip = 0;
+    if (remaining <= 0) break;
+  }
+  return rows;
 }
 
 export async function readSwmDataPage(params: {
@@ -379,42 +392,6 @@ async function readAdmittedAssertionGraphs(
   return new Set(res.bindings.map((row) => row['g']).filter(Boolean));
 }
 
-async function readFreshWorkspaceSubjects(
-  store: TripleStore,
-  metaGraph: string,
-  cutoffIso: string,
-): Promise<Set<string>> {
-  const res = await store.query(`
-    SELECT DISTINCT ?subject WHERE {
-      GRAPH <${assertSafeIri(metaGraph)}> {
-        ?subject <${DKG_PUBLISHED_AT}> ?ts .
-        FILTER(?ts >= "${cutoffIso}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-      }
-    }
-  `);
-  return new Set(res.type === 'bindings' ? res.bindings.map((row) => row['subject']).filter(Boolean) : []);
-}
-
-async function readGraphRows(
-  store: TripleStore,
-  graph: string,
-  predicate?: (row: SyncRow) => boolean | Promise<boolean>,
-): Promise<SyncRow[]> {
-  const res = await store.query(`
-    SELECT ?s ?p ?o WHERE {
-      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
-    }
-  `);
-  if (res.type !== 'bindings') return [];
-  const rows: SyncRow[] = [];
-  for (const row of res.bindings) {
-    const syncRow = { s: row['s'], p: row['p'], o: row['o'], g: graph };
-    if (!syncRow.s || !syncRow.p || !syncRow.o) continue;
-    if (!predicate || await predicate(syncRow)) rows.push(syncRow);
-  }
-  return rows;
-}
-
 async function countGraphRows(store: TripleStore, graph: string): Promise<number> {
   const res = await store.query(`
     SELECT (COUNT(*) AS ?count) WHERE {
@@ -439,6 +416,54 @@ async function readGraphRowsPage(
   const res = await store.query(`
     SELECT ?s ?p ?o WHERE {
       GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    }
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
+    .filter((row) => row.s && row.p && row.o);
+}
+
+async function countFreshSwmMetaGraphRows(
+  store: TripleStore,
+  graph: string,
+  cutoffIso: string,
+): Promise<number> {
+  const res = await store.query(`
+    SELECT (COUNT(*) AS ?count) WHERE {
+      GRAPH <${assertSafeIri(graph)}> {
+        ?s ?p ?o .
+        ?s <${DKG_PUBLISHED_AT}> ?ts .
+        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return 0;
+  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
+  if (value == null || value < 0n) return 0;
+  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
+}
+
+async function readFreshSwmMetaGraphRowsPage(
+  store: TripleStore,
+  graph: string,
+  cutoffIso: string,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const res = await store.query(`
+    SELECT ?s ?p ?o WHERE {
+      GRAPH <${assertSafeIri(graph)}> {
+        ?s ?p ?o .
+        ?s <${DKG_PUBLISHED_AT}> ?ts .
+        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+      }
     }
     ORDER BY ?s ?p ?o
     OFFSET ${safeOffset}

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -89,29 +89,15 @@ export async function readSwmMetaPage(params: {
   const graphs = await planSwmGraphs(params.store, params.contextGraphId, true);
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
-  if (!params.cutoffIso) {
-    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, async () => true);
-  }
-
-  const rows: SyncRow[] = [];
-  let skip = params.offset;
-  let remaining = params.limit;
-  for (const graph of candidateGraphs) {
-    if (skip > 0) {
-      const count = await countFreshSwmMetaGraphRows(params.store, graph, params.cutoffIso);
-      if (skip >= count) {
-        skip -= count;
-        continue;
-      }
-    }
-
-    const page = await readFreshSwmMetaGraphRowsPage(params.store, graph, params.cutoffIso, skip, remaining);
-    rows.push(...page);
-    remaining -= page.length;
-    skip = 0;
-    if (remaining <= 0) break;
-  }
-  return rows;
+  const registrationGraph = contextGraphMetaGraphUri(params.contextGraphId);
+  return readSwmMetaRowsPage(
+    params.store,
+    candidateGraphs,
+    graphSet.has(registrationGraph) ? registrationGraph : null,
+    params.cutoffIso,
+    params.offset,
+    params.limit,
+  );
 }
 
 export async function readSwmDataPage(params: {
@@ -125,7 +111,7 @@ export async function readSwmDataPage(params: {
   const dataGraphs = await planSwmGraphs(params.store, params.contextGraphId, false);
   const graphSet = new Set(params.graphList);
   const candidateGraphsFor = (graph: string) => params.graphList
-    .filter((candidate) => candidate === graph || candidate.startsWith(`${graph}/`))
+    .filter((candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph))
     .sort(compareCodePoint);
 
   if (!params.cutoffIso) {
@@ -423,52 +409,57 @@ async function readRowsPageAcrossGraphs(
     .filter((row) => row.s && row.p && row.o && row.g);
 }
 
-async function countFreshSwmMetaGraphRows(
+async function readSwmMetaRowsPage(
   store: TripleStore,
-  graph: string,
-  cutoffIso: string,
-): Promise<number> {
-  const res = await store.query(`
-    SELECT (COUNT(*) AS ?count) WHERE {
-      GRAPH <${assertSafeIri(graph)}> {
-        ?s ?p ?o .
-        ?s <${DKG_PUBLISHED_AT}> ?ts .
-        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-      }
-    }
-  `);
-  if (res.type !== 'bindings') return 0;
-  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
-  if (value == null || value < 0n) return 0;
-  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
-}
-
-async function readFreshSwmMetaGraphRowsPage(
-  store: TripleStore,
-  graph: string,
-  cutoffIso: string,
+  swmMetaGraphs: readonly string[],
+  registrationGraph: string | null,
+  cutoffIso: string | null,
   offset: number,
   limit: number,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
   if (safeLimit === 0) return [];
+  const swmMetaValues = graphValues(swmMetaGraphs);
+  const swmMetaClause = swmMetaValues
+    ? `
+      {
+        VALUES ?g { ${swmMetaValues} }
+        GRAPH ?g {
+          ?s ?p ?o .
+          ${cutoffIso
+            ? `
+          ?s <${DKG_PUBLISHED_AT}> ?ts .
+          FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`
+            : ''}
+        }
+      }`
+    : '';
+  const registrationClause = registrationGraph
+    ? `
+      {
+        GRAPH <${assertSafeIri(registrationGraph)}> {
+          ?s <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
+             <${SCHEMA_NAME}> ?subGraphName ;
+             ?p ?o .
+        }
+        BIND(<${assertSafeIri(registrationGraph)}> AS ?g)
+      }`
+    : '';
+  if (!swmMetaClause && !registrationClause) return [];
+  const union = [registrationClause, swmMetaClause].filter(Boolean).join(' UNION ');
   const res = await store.query(`
-    SELECT ?s ?p ?o WHERE {
-      GRAPH <${assertSafeIri(graph)}> {
-        ?s ?p ?o .
-        ?s <${DKG_PUBLISHED_AT}> ?ts .
-        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-      }
+    SELECT DISTINCT ?g ?s ?p ?o WHERE {
+      ${union}
     }
-    ORDER BY ?s ?p ?o
+    ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
     LIMIT ${safeLimit}
   `);
   if (res.type !== 'bindings') return [];
   return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
-    .filter((row) => row.s && row.p && row.o);
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g);
 }
 
 async function countFreshSwmDataGraphRows(
@@ -664,6 +655,14 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
+}
+
+function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
+  if (!graph.startsWith(`${bucketGraph}/`)) return false;
+  const tail = graph.slice(bucketGraph.length + 1);
+  if (tail.startsWith('staging/')) return false;
+  const parts = tail.split('/');
+  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -205,7 +205,8 @@ export async function readDurableDataPage(params: {
   const isAdmitted = async (graph: string): Promise<boolean> => {
     if (graph.includes('/assertion/')) {
       assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId);
-      if (!assertionGraphs.has(graph)) return false;
+      const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
+      if (!assertionGraphs.has(assertionGraph)) return false;
     }
     return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph));
   };
@@ -354,11 +355,11 @@ function isDurableContextPartitionGraphSegments(segments: readonly string[]): bo
 
 function isAssertionGraphSegments(segments: readonly string[]): boolean {
   return (
-    segments.length === 3 &&
     segments[0] === 'assertion' &&
     segments[1].startsWith('0x') &&
     segments[1].length > 2 &&
-    segments[2].length > 0
+    segments[2].length > 0 &&
+    (segments.length === 3 || (segments.length === 4 && segments[3] === '_meta'))
   );
 }
 

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -111,32 +111,39 @@ export async function readSwmDataPage(params: {
 }): Promise<SyncRow[]> {
   const dataGraphs = await planSwmGraphs(params.store, params.contextGraphId, false);
   const graphSet = new Set(params.graphList);
+  const candidateGraphsFor = (graph: string) => params.graphList
+    .filter((candidate) => candidate === graph || candidate.startsWith(`${graph}/`))
+    .sort(compareCodePoint);
+
   if (!params.cutoffIso) {
-    const rows = (await Promise.all(dataGraphs
-      .filter((graph) => graphSet.has(graph) || params.graphList.some((candidate) => candidate.startsWith(`${graph}/`)))
-      .flatMap((graph) => params.graphList.filter((candidate) => candidate === graph || candidate.startsWith(`${graph}/`)))
-      .map((graph) => readGraphRows(params.store, graph))))
-      .flat()
-      .sort(compareRows);
-    return rows.slice(params.offset, params.offset + params.limit);
+    const candidateGraphs = dedupeStrings(dataGraphs.flatMap(candidateGraphsFor)).sort(compareCodePoint);
+    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, async () => true);
   }
 
   const rows: SyncRow[] = [];
+  let skip = params.offset;
+  let remaining = params.limit;
   for (const graph of dataGraphs) {
     const metaGraph = `${graph}_meta`;
     if (!graphSet.has(metaGraph)) continue;
-    const roots = await readFreshWorkspaceRoots(params.store, metaGraph, params.cutoffIso);
-    if (roots.size === 0) continue;
-    const rootList = [...roots];
-    for (const candidate of params.graphList) {
-      if (candidate !== graph && !candidate.startsWith(`${graph}/`)) continue;
-      rows.push(...await readGraphRows(params.store, candidate, (row) =>
-        roots.has(row.s) || rootList.some((root) => row.s.startsWith(`${root}/.well-known/genid/`)),
-      ));
+    for (const candidate of candidateGraphsFor(graph)) {
+      if (skip > 0) {
+        const count = await countFreshSwmDataGraphRows(params.store, candidate, metaGraph, params.cutoffIso);
+        if (skip >= count) {
+          skip -= count;
+          continue;
+        }
+      }
+
+      const page = await readFreshSwmDataGraphRowsPage(params.store, candidate, metaGraph, params.cutoffIso, skip, remaining);
+      rows.push(...page);
+      remaining -= page.length;
+      skip = 0;
+      if (remaining <= 0) break;
     }
+    if (remaining <= 0) break;
   }
-  rows.sort(compareRows);
-  return dedupeRows(rows).slice(params.offset, params.offset + params.limit);
+  return rows;
 }
 
 export async function readDurableMetaPage(params: {
@@ -145,13 +152,12 @@ export async function readDurableMetaPage(params: {
   offset: number;
   limit: number;
 }): Promise<SyncRow[]> {
-  const metaGraph = contextGraphMetaGraphUri(params.contextGraphId);
-  const metaRows = await readGraphRows(params.store, metaGraph);
-  const allowedSubjects = collectDurableMetaSubjects(metaRows, params.contextGraphId);
-  if (allowedSubjects.size === 0) return [];
-  const rows = metaRows.filter((row) => allowedSubjects.has(row.s));
-  rows.sort(compareRows);
-  return rows.slice(params.offset, params.offset + params.limit);
+  return readDurableMetaRowsPage(
+    params.store,
+    params.contextGraphId,
+    params.offset,
+    params.limit,
+  );
 }
 
 export async function readDurableCanonicalDataPage(params: {
@@ -373,51 +379,6 @@ async function readAdmittedAssertionGraphs(
   return new Set(res.bindings.map((row) => row['g']).filter(Boolean));
 }
 
-function collectDurableMetaSubjects(
-  rows: readonly SyncRow[],
-  contextGraphId: string,
-): Set<string> {
-  const cgEntity = contextGraphDataGraphUri(contextGraphId);
-  const allowed = new Set<string>([cgEntity]);
-  const nonWorkingLifecycle = new Set<string>();
-  const assertionNames: string[] = [];
-  const assertionSubjects = new Set<string>();
-
-  for (const row of rows) {
-    if (row.s.startsWith('did:dkg:activity:') || row.s.startsWith('did:dkg:join-request:')) {
-      allowed.add(row.s);
-    }
-    if (row.s.includes('/assertion/')) {
-      assertionSubjects.add(row.s);
-    }
-    if (row.p === DKG_MEMORY_LAYER && stripLiteral(row.o) !== MemoryLayer.WorkingMemory) {
-      nonWorkingLifecycle.add(row.s);
-    }
-  }
-
-  for (const row of rows) {
-    if (nonWorkingLifecycle.has(row.s)) {
-      allowed.add(row.s);
-      if (row.p === DKG_ASSERTION_GRAPH) allowed.add(row.o);
-      if (row.p === DKG_ASSERTION_NAME) assertionNames.push(stripLiteral(row.o));
-    }
-    if (
-      (row.p === 'http://www.w3.org/ns/prov#generated' || row.p === 'http://www.w3.org/ns/prov#used') &&
-      nonWorkingLifecycle.has(row.o)
-    ) {
-      allowed.add(row.s);
-    }
-  }
-
-  for (const assertionName of assertionNames) {
-    const suffix = `/${assertionName}`;
-    for (const subject of assertionSubjects) {
-      if (subject.endsWith(suffix)) allowed.add(subject);
-    }
-  }
-  return allowed;
-}
-
 async function readFreshWorkspaceSubjects(
   store: TripleStore,
   metaGraph: string,
@@ -432,24 +393,6 @@ async function readFreshWorkspaceSubjects(
     }
   `);
   return new Set(res.type === 'bindings' ? res.bindings.map((row) => row['subject']).filter(Boolean) : []);
-}
-
-async function readFreshWorkspaceRoots(
-  store: TripleStore,
-  metaGraph: string,
-  cutoffIso: string,
-): Promise<Set<string>> {
-  const res = await store.query(`
-    SELECT DISTINCT ?root WHERE {
-      GRAPH <${assertSafeIri(metaGraph)}> {
-        ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
-            <${DKG_PUBLISHED_AT}> ?ts ;
-            <${DKG_ROOT_ENTITY}> ?root .
-        FILTER(?ts >= "${cutoffIso}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-      }
-    }
-  `);
-  return new Set(res.type === 'bindings' ? res.bindings.map((row) => row['root']).filter(Boolean) : []);
 }
 
 async function readGraphRows(
@@ -504,6 +447,123 @@ async function readGraphRowsPage(
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
+    .filter((row) => row.s && row.p && row.o);
+}
+
+async function countFreshSwmDataGraphRows(
+  store: TripleStore,
+  graph: string,
+  metaGraph: string,
+  cutoffIso: string,
+): Promise<number> {
+  const res = await store.query(`
+    SELECT (COUNT(*) AS ?count) WHERE {
+      {
+        SELECT DISTINCT ?s ?p ?o WHERE {
+          ${freshSwmDataWhereClause(graph, metaGraph, cutoffIso)}
+        }
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return 0;
+  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
+  if (value == null || value < 0n) return 0;
+  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
+}
+
+async function readFreshSwmDataGraphRowsPage(
+  store: TripleStore,
+  graph: string,
+  metaGraph: string,
+  cutoffIso: string,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const res = await store.query(`
+    SELECT DISTINCT ?s ?p ?o WHERE {
+      ${freshSwmDataWhereClause(graph, metaGraph, cutoffIso)}
+    }
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
+    .filter((row) => row.s && row.p && row.o);
+}
+
+function freshSwmDataWhereClause(graph: string, metaGraph: string, cutoffIso: string): string {
+  return `
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+            <${DKG_PUBLISHED_AT}> ?ts ;
+            <${DKG_ROOT_ENTITY}> ?root .
+        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+      }
+      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+      FILTER(sameTerm(?s, ?root) || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+  `;
+}
+
+async function readDurableMetaRowsPage(
+  store: TripleStore,
+  contextGraphId: string,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const cgEntity = contextGraphDataGraphUri(contextGraphId);
+  const workingMemory = sparqlString(MemoryLayer.WorkingMemory);
+  const res = await store.query(`
+    SELECT ?s ?p ?o WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
+      FILTER(
+        STR(?s) = ${sparqlString(cgEntity)} ||
+        STRSTARTS(STR(?s), "did:dkg:activity:") ||
+        STRSTARTS(STR(?s), "did:dkg:join-request:") ||
+        EXISTS {
+          GRAPH <${assertSafeIri(metaGraph)}> {
+            ?lc <${DKG_MEMORY_LAYER}> ?layer .
+            FILTER(STR(?layer) != ${workingMemory})
+            {
+              FILTER(sameTerm(?lc, ?s))
+            } UNION {
+              ?lc <${DKG_ASSERTION_GRAPH}> ?s .
+            } UNION {
+              ?lc <${DKG_ASSERTION_NAME}> ?aname .
+              FILTER(
+                CONTAINS(STR(?s), "/assertion/") &&
+                STRENDS(STR(?s), CONCAT("/", STR(?aname)))
+              )
+            }
+          }
+        } ||
+        EXISTS {
+          GRAPH <${assertSafeIri(metaGraph)}> {
+            { ?evt <http://www.w3.org/ns/prov#generated> ?parent }
+            UNION
+            { ?evt <http://www.w3.org/ns/prov#used> ?parent }
+            FILTER(sameTerm(?evt, ?s))
+            ?parent <${DKG_MEMORY_LAYER}> ?eventLayer .
+            FILTER(STR(?eventLayer) != ${workingMemory})
+          }
+        }
+      )
+    }
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: metaGraph }))
     .filter((row) => row.s && row.p && row.o);
 }
 
@@ -600,14 +660,13 @@ function durableDeltaGroupClause(
   `;
 }
 
-function dedupeRows(rows: readonly SyncRow[]): SyncRow[] {
+function dedupeStrings(values: readonly string[]): string[] {
   const seen = new Set<string>();
-  const out: SyncRow[] = [];
-  for (const row of rows) {
-    const key = `${row.g}\u0000${row.s}\u0000${row.p}\u0000${row.o}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(row);
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
   }
   return out;
 }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -90,9 +90,6 @@ export async function readSwmMetaPage(params: {
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
   const registrationGraph = contextGraphMetaGraphUri(params.contextGraphId);
-  const registrationNames = candidateGraphs
-    .map((graph) => subGraphNameFromSwmMetaGraph(params.contextGraphId, graph))
-    .filter((name): name is string => name !== undefined);
   const swmRows = await readSwmMetaRowsPage(
     params.store,
     candidateGraphs,
@@ -100,7 +97,11 @@ export async function readSwmMetaPage(params: {
     params.offset,
     params.limit,
   );
-  if (params.offset !== 0 || !graphSet.has(registrationGraph) || registrationNames.length === 0) {
+  const registrationNames = dedupeStrings(swmRows
+    .map((row) => subGraphNameFromSwmMetaGraph(params.contextGraphId, row.g))
+    .filter((name): name is string => name !== undefined))
+    .sort(compareCodePoint);
+  if (!graphSet.has(registrationGraph) || registrationNames.length === 0) {
     return swmRows;
   }
   const registrationRows = await readSwmRegistrationRows(
@@ -354,12 +355,14 @@ function isDurableContextPartitionGraphSegments(segments: readonly string[]): bo
 }
 
 function isAssertionGraphSegments(segments: readonly string[]): boolean {
+  if (segments.length !== 3 && !(segments.length === 4 && segments[3] === '_meta')) {
+    return false;
+  }
   return (
     segments[0] === 'assertion' &&
     segments[1].startsWith('0x') &&
     segments[1].length > 2 &&
-    segments[2].length > 0 &&
-    (segments.length === 3 || (segments.length === 4 && segments[3] === '_meta'))
+    segments[2].length > 0
   );
 }
 

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -364,13 +364,26 @@ async function isDescendantOfKnownChildContextGraph(
   graph: string,
 ): Promise<boolean> {
   if (graph === cgPrefix || !graph.startsWith(`${cgPrefix}/`)) return false;
+  if (await isKnownContextGraph(store, graph)) return true;
+  if (graph.endsWith('/_meta')) {
+    const graphOwner = graph.slice(0, -'/_meta'.length);
+    if (await isKnownContextGraph(store, graphOwner)) return true;
+  }
   const remainder = graph.slice(cgPrefix.length + 1);
   const segments = remainder.split('/').filter(Boolean);
+  if (isDurableContextPartitionGraphSegments(segments)) return false;
   let childUri = cgPrefix;
   for (const segment of segments) {
     childUri = `${childUri}/${segment}`;
     if (await isKnownContextGraph(store, childUri)) return true;
   }
+  return false;
+}
+
+function isDurableContextPartitionGraphSegments(segments: readonly string[]): boolean {
+  if (segments[0] !== 'context') return false;
+  if (segments.length === 2) return /^[0-9]+$/.test(segments[1]);
+  if (segments.length === 3) return /^[0-9]+$/.test(segments[1]) && segments[2] === '_meta';
   return false;
 }
 

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -6,6 +6,7 @@ import {
   validateSubGraphName,
 } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 
 export type SyncRow = { s: string; p: string; o: string; g: string };
 
@@ -669,14 +670,6 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
-}
-
-function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
-  if (!graph.startsWith(`${bucketGraph}/`)) return false;
-  const tail = graph.slice(bucketGraph.length + 1);
-  if (tail.startsWith('staging/')) return false;
-  const parts = tail.split('/');
-  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -90,10 +90,14 @@ export async function readSwmMetaPage(params: {
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
   const registrationGraph = contextGraphMetaGraphUri(params.contextGraphId);
+  const registrationNames = candidateGraphs
+    .map((graph) => subGraphNameFromSwmMetaGraph(params.contextGraphId, graph))
+    .filter((name): name is string => name !== undefined);
   return readSwmMetaRowsPage(
     params.store,
     candidateGraphs,
-    graphSet.has(registrationGraph) ? registrationGraph : null,
+    graphSet.has(registrationGraph) && registrationNames.length > 0 ? registrationGraph : null,
+    registrationNames,
     params.cutoffIso,
     params.offset,
     params.limit,
@@ -315,7 +319,7 @@ async function isDescendantOfKnownChildContextGraph(
   }
   const remainder = graph.slice(cgPrefix.length + 1);
   const segments = remainder.split('/').filter(Boolean);
-  if (isDurableContextPartitionGraphSegments(segments)) return false;
+  if (isParentOwnedReservedGraphSegments(segments)) return false;
   let childUri = cgPrefix;
   for (const segment of segments) {
     childUri = `${childUri}/${segment}`;
@@ -324,11 +328,25 @@ async function isDescendantOfKnownChildContextGraph(
   return false;
 }
 
+function isParentOwnedReservedGraphSegments(segments: readonly string[]): boolean {
+  return isDurableContextPartitionGraphSegments(segments) || isAssertionGraphSegments(segments);
+}
+
 function isDurableContextPartitionGraphSegments(segments: readonly string[]): boolean {
-  if (segments[0] !== 'context') return false;
-  if (segments.length === 2) return /^[0-9]+$/.test(segments[1]);
-  if (segments.length === 3) return /^[0-9]+$/.test(segments[1]) && segments[2] === '_meta';
-  return false;
+  return segments[0] === 'context' && (
+    (segments.length === 2 && /^[0-9]+$/.test(segments[1])) ||
+    (segments.length === 3 && /^[0-9]+$/.test(segments[1]) && segments[2] === '_meta')
+  );
+}
+
+function isAssertionGraphSegments(segments: readonly string[]): boolean {
+  return (
+    segments.length === 3 &&
+    segments[0] === 'assertion' &&
+    segments[1].startsWith('0x') &&
+    segments[1].length > 2 &&
+    segments[2].length > 0
+  );
 }
 
 async function readAdmittedAssertionGraphs(
@@ -413,6 +431,7 @@ async function readSwmMetaRowsPage(
   store: TripleStore,
   swmMetaGraphs: readonly string[],
   registrationGraph: string | null,
+  registrationNames: readonly string[],
   cutoffIso: string | null,
   offset: number,
   limit: number,
@@ -439,6 +458,7 @@ async function readSwmMetaRowsPage(
     ? `
       {
         GRAPH <${assertSafeIri(registrationGraph)}> {
+          VALUES ?subGraphName { ${registrationNames.map(sparqlString).join(' ')} }
           ?s <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
              <${SCHEMA_NAME}> ?subGraphName ;
              ?p ?o .
@@ -655,6 +675,16 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
+}
+
+function subGraphNameFromSwmMetaGraph(contextGraphId: string, graph: string): string | undefined {
+  const rootGraph = `${contextGraphDataGraphUri(contextGraphId)}/_shared_memory_meta`;
+  if (graph === rootGraph) return undefined;
+  const prefix = `${contextGraphDataGraphUri(contextGraphId)}/`;
+  const suffix = '/_shared_memory_meta';
+  if (!graph.startsWith(prefix) || !graph.endsWith(suffix)) return undefined;
+  const name = graph.slice(prefix.length, -suffix.length);
+  return validateSubGraphName(name).valid ? name : undefined;
 }
 
 function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -244,28 +244,13 @@ async function readPagedRowsAcrossGraphs(
   limit: number,
   isAdmitted: (graph: string) => Promise<boolean>,
 ): Promise<SyncRow[]> {
-  let skip = offset;
-  let remaining = limit;
-  const rows: SyncRow[] = [];
-
+  const admittedGraphs: string[] = [];
   for (const graph of graphs) {
     if (!(await isAdmitted(graph))) continue;
-    if (skip > 0) {
-      const count = await countGraphRows(store, graph);
-      if (skip >= count) {
-        skip -= count;
-        continue;
-      }
-    }
-
-    const page = await readGraphRowsPage(store, graph, skip, remaining);
-    rows.push(...page);
-    remaining -= page.length;
-    skip = 0;
-    if (remaining <= 0) break;
+    admittedGraphs.push(graph);
   }
 
-  return rows;
+  return readRowsPageAcrossGraphs(store, admittedGraphs, offset, limit);
 }
 
 async function readPagedDurableDeltaRowsAcrossGraphs(
@@ -276,34 +261,7 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   offset: number,
   limit: number,
 ): Promise<SyncRow[]> {
-  let skip = offset;
-  let remaining = limit;
-  const rows: SyncRow[] = [];
-
-  for (const graph of graphs) {
-    if (skip > 0) {
-      const count = await countDurableDeltaGraphRows(store, graph, metaGraphs, sinceBatchId);
-      if (skip >= count) {
-        skip -= count;
-        continue;
-      }
-    }
-
-    const page = await readDurableDeltaGraphRowsPage(
-      store,
-      graph,
-      metaGraphs,
-      sinceBatchId,
-      skip,
-      remaining,
-    );
-    rows.push(...page);
-    remaining -= page.length;
-    skip = 0;
-    if (remaining <= 0) break;
-  }
-
-  return rows;
+  return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
 }
 
 async function planSwmGraphs(
@@ -438,6 +396,31 @@ async function readGraphRowsPage(
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
     .filter((row) => row.s && row.p && row.o);
+}
+
+async function readRowsPageAcrossGraphs(
+  store: TripleStore,
+  graphs: readonly string[],
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  const values = graphValues(graphs);
+  if (safeLimit === 0 || !values) return [];
+  const res = await store.query(`
+    SELECT ?g ?s ?p ?o WHERE {
+      VALUES ?g { ${values} }
+      GRAPH ?g { ?s ?p ?o }
+    }
+    ORDER BY ?g ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g);
 }
 
 async function countFreshSwmMetaGraphRows(
@@ -605,32 +588,9 @@ async function readDurableMetaRowsPage(
     .filter((row) => row.s && row.p && row.o);
 }
 
-async function countDurableDeltaGraphRows(
+async function readDurableDeltaRowsPageAcrossGraphs(
   store: TripleStore,
-  graph: string,
-  metaGraphs: readonly string[],
-  sinceBatchId: bigint,
-): Promise<number> {
-  const res = await store.query(`
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-    SELECT (COUNT(*) AS ?count) WHERE {
-      {
-        SELECT ?s ?p ?o WHERE {
-          ${durableDeltaWhereClause(graph, metaGraphs)}
-        }
-        ${durableDeltaGroupClause(metaGraphs, sinceBatchId)}
-      }
-    }
-  `);
-  if (res.type !== 'bindings') return 0;
-  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
-  if (value == null || value < 0n) return 0;
-  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
-}
-
-async function readDurableDeltaGraphRowsPage(
-  store: TripleStore,
-  graph: string,
+  graphs: readonly string[],
   metaGraphs: readonly string[],
   sinceBatchId: bigint,
   offset: number,
@@ -638,35 +598,38 @@ async function readDurableDeltaGraphRowsPage(
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
-  if (safeLimit === 0) return [];
+  const values = graphValues(graphs);
+  if (safeLimit === 0 || !values) return [];
   const res = await store.query(`
     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-    SELECT ?s ?p ?o WHERE {
-      ${durableDeltaWhereClause(graph, metaGraphs)}
+    SELECT ?g ?s ?p ?o WHERE {
+      ${durableDeltaWhereClauseForGraphs(values, metaGraphs)}
     }
-    ${durableDeltaGroupClause(metaGraphs, sinceBatchId)}
-    ORDER BY ?s ?p ?o
+    ${durableDeltaGroupClause(metaGraphs, sinceBatchId, true)}
+    ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
     LIMIT ${safeLimit}
   `);
   if (res.type !== 'bindings') return [];
   return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
-    .filter((row) => row.s && row.p && row.o);
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g);
 }
 
-function durableDeltaWhereClause(
-  graph: string,
+function durableDeltaWhereClauseForGraphs(
+  graphValuesClause: string,
   metaGraphs: readonly string[],
 ): string {
   const values = metaGraphs.map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
   if (!values) {
     return `
-          GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+      VALUES ?g { ${graphValuesClause} }
+      GRAPH ?g { ?s ?p ?o }
     `;
   }
   return `
-      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+      VALUES ?g { ${graphValuesClause} }
+      GRAPH ?g { ?s ?p ?o }
       OPTIONAL {
         {
           SELECT ?deltaRoot ?deltaBid WHERE {
@@ -690,12 +653,17 @@ function durableDeltaWhereClause(
 function durableDeltaGroupClause(
   metaGraphs: readonly string[],
   sinceBatchId: bigint,
+  includeGraph: boolean = false,
 ): string {
   if (metaGraphs.length === 0) return '';
   return `
-    GROUP BY ?s ?p ?o
+    GROUP BY ${includeGraph ? '?g ' : ''}?s ?p ?o
     HAVING(COUNT(?deltaBatch) = 0 || MAX(?deltaBatch) > ${sinceBatchId.toString()})
   `;
+}
+
+function graphValues(graphs: readonly string[]): string {
+  return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -26,7 +26,7 @@ export interface GraphListMemo {
   get(options?: { refresh?: boolean }): Promise<readonly string[]>;
 }
 
-export interface SwmAdmissionMemo {
+export interface SubGraphNameMemo {
   get(contextGraphId: string, options?: { refresh?: boolean }): Promise<readonly string[]>;
 }
 
@@ -60,7 +60,21 @@ export function createResponderGraphListMemo(
 export function createResponderSwmAdmissionMemo(
   store: TripleStore,
   ttlMs = 10_000,
-): SwmAdmissionMemo {
+): SubGraphNameMemo {
+  return createSubGraphNameMemo((contextGraphId) => readAdmittedSwmSubGraphNames(store, contextGraphId), ttlMs);
+}
+
+export function createResponderSubGraphRegistrationMemo(
+  store: TripleStore,
+  ttlMs = 10_000,
+): SubGraphNameMemo {
+  return createSubGraphNameMemo((contextGraphId) => readRegisteredSubGraphNames(store, contextGraphId), ttlMs);
+}
+
+function createSubGraphNameMemo(
+  loadNames: (contextGraphId: string) => Promise<string[]>,
+  ttlMs: number,
+): SubGraphNameMemo {
   const cached = new Map<string, { value: readonly string[]; cachedAt: number }>();
   const inflight = new Map<string, Promise<readonly string[]>>();
   return {
@@ -70,7 +84,7 @@ export function createResponderSwmAdmissionMemo(
       if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) return [...existing.value];
       const pending = inflight.get(contextGraphId);
       if (pending) return [...(await pending)];
-      const load = readAdmittedSwmSubGraphNames(store, contextGraphId)
+      const load = loadNames(contextGraphId)
         .then((names) => {
           cached.set(contextGraphId, { value: names, cachedAt: Date.now() });
           return names;
@@ -361,14 +375,14 @@ async function isDescendantOfKnownChildContextGraph(
   graph: string,
 ): Promise<boolean> {
   if (graph === cgPrefix || !graph.startsWith(`${cgPrefix}/`)) return false;
+  const remainder = graph.slice(cgPrefix.length + 1);
+  const segments = remainder.split('/').filter(Boolean);
+  if (isParentOwnedReservedGraphSegments(segments)) return false;
   if (await isKnownContextGraph(store, graph)) return true;
   if (graph.endsWith('/_meta')) {
     const graphOwner = graph.slice(0, -'/_meta'.length);
     if (await isKnownContextGraph(store, graphOwner)) return true;
   }
-  const remainder = graph.slice(cgPrefix.length + 1);
-  const segments = remainder.split('/').filter(Boolean);
-  if (isParentOwnedReservedGraphSegments(segments)) return false;
   let childUri = cgPrefix;
   for (const segment of segments) {
     childUri = `${childUri}/${segment}`;

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1,0 +1,643 @@
+import {
+  DKG_ONTOLOGY,
+  MemoryLayer,
+  assertSafeIri,
+  sparqlString,
+  validateSubGraphName,
+} from '@origintrail-official/dkg-core';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+
+export type SyncRow = { s: string; p: string; o: string; g: string };
+
+const DKG = 'http://dkg.io/ontology/';
+const DKG_SUB_GRAPH = `${DKG}SubGraph`;
+const DKG_WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
+const DKG_PUBLISHED_AT = `${DKG}publishedAt`;
+const DKG_ROOT_ENTITY = `${DKG}rootEntity`;
+const DKG_ASSERTION_GRAPH = `${DKG}assertionGraph`;
+const DKG_ASSERTION_NAME = `${DKG}assertionName`;
+const DKG_MEMORY_LAYER = `${DKG}memoryLayer`;
+const DKG_PART_OF = `${DKG}partOf`;
+const DKG_BATCH_ID = `${DKG}batchId`;
+const SCHEMA_NAME = 'http://schema.org/name';
+
+export interface GraphListMemo {
+  get(): Promise<readonly string[]>;
+}
+
+export function createResponderGraphListMemo(
+  store: TripleStore,
+  ttlMs = 10_000,
+): GraphListMemo {
+  let cached: readonly string[] | null = null;
+  let cachedAt = 0;
+  let inflight: Promise<readonly string[]> | null = null;
+  return {
+    async get() {
+      const now = Date.now();
+      if (cached && now - cachedAt < ttlMs) return [...cached];
+      if (inflight) return [...(await inflight)];
+      inflight = store.listGraphs()
+        .then((graphs) => {
+          const sorted = [...new Set(graphs)].sort(compareCodePoint);
+          cached = sorted;
+          cachedAt = Date.now();
+          return sorted;
+        })
+        .finally(() => {
+          inflight = null;
+        });
+      return [...(await inflight)];
+    },
+  };
+}
+
+export function compareCodePoint(a: string, b: string): number {
+  const left = Array.from(a);
+  const right = Array.from(b);
+  const len = Math.min(left.length, right.length);
+  for (let i = 0; i < len; i++) {
+    const delta = left[i].codePointAt(0)! - right[i].codePointAt(0)!;
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+export function compareRows(a: SyncRow, b: SyncRow): number {
+  return (
+    compareCodePoint(a.g, b.g) ||
+    compareCodePoint(a.s, b.s) ||
+    compareCodePoint(a.p, b.p) ||
+    compareCodePoint(a.o, b.o)
+  );
+}
+
+export function serializeResponderRows(rows: readonly SyncRow[]): string {
+  return rows.map((row) =>
+    `${formatTerm(row.s)} <${assertSafeIri(row.p)}> ${formatTerm(row.o)} <${assertSafeIri(row.g)}> .`,
+  ).join('\n');
+}
+
+export async function readSwmMetaPage(params: {
+  store: TripleStore;
+  graphList: readonly string[];
+  contextGraphId: string;
+  cutoffIso: string | null;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const graphs = await planSwmGraphs(params.store, params.contextGraphId, true);
+  const graphSet = new Set(params.graphList);
+  const rows: SyncRow[] = [];
+  for (const graph of graphs.filter((graph) => graphSet.has(graph))) {
+    const subjects = params.cutoffIso
+      ? await readFreshWorkspaceSubjects(params.store, graph, params.cutoffIso)
+      : null;
+    rows.push(...await readGraphRows(params.store, graph, (row) =>
+      !subjects || subjects.has(row.s),
+    ));
+  }
+  rows.sort(compareRows);
+  return rows.slice(params.offset, params.offset + params.limit);
+}
+
+export async function readSwmDataPage(params: {
+  store: TripleStore;
+  graphList: readonly string[];
+  contextGraphId: string;
+  cutoffIso: string | null;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const dataGraphs = await planSwmGraphs(params.store, params.contextGraphId, false);
+  const graphSet = new Set(params.graphList);
+  if (!params.cutoffIso) {
+    const rows = (await Promise.all(dataGraphs
+      .filter((graph) => graphSet.has(graph) || params.graphList.some((candidate) => candidate.startsWith(`${graph}/`)))
+      .flatMap((graph) => params.graphList.filter((candidate) => candidate === graph || candidate.startsWith(`${graph}/`)))
+      .map((graph) => readGraphRows(params.store, graph))))
+      .flat()
+      .sort(compareRows);
+    return rows.slice(params.offset, params.offset + params.limit);
+  }
+
+  const rows: SyncRow[] = [];
+  for (const graph of dataGraphs) {
+    const metaGraph = `${graph}_meta`;
+    if (!graphSet.has(metaGraph)) continue;
+    const roots = await readFreshWorkspaceRoots(params.store, metaGraph, params.cutoffIso);
+    if (roots.size === 0) continue;
+    const rootList = [...roots];
+    for (const candidate of params.graphList) {
+      if (candidate !== graph && !candidate.startsWith(`${graph}/`)) continue;
+      rows.push(...await readGraphRows(params.store, candidate, (row) =>
+        roots.has(row.s) || rootList.some((root) => row.s.startsWith(`${root}/.well-known/genid/`)),
+      ));
+    }
+  }
+  rows.sort(compareRows);
+  return dedupeRows(rows).slice(params.offset, params.offset + params.limit);
+}
+
+export async function readDurableMetaPage(params: {
+  store: TripleStore;
+  contextGraphId: string;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const metaGraph = contextGraphMetaGraphUri(params.contextGraphId);
+  const metaRows = await readGraphRows(params.store, metaGraph);
+  const allowedSubjects = collectDurableMetaSubjects(metaRows, params.contextGraphId);
+  if (allowedSubjects.size === 0) return [];
+  const rows = metaRows.filter((row) => allowedSubjects.has(row.s));
+  rows.sort(compareRows);
+  return rows.slice(params.offset, params.offset + params.limit);
+}
+
+export async function readDurableCanonicalDataPage(params: {
+  store: TripleStore;
+  contextGraphId: string;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  return readGraphRowsPage(
+    params.store,
+    contextGraphDataGraphUri(params.contextGraphId),
+    params.offset,
+    params.limit,
+  );
+}
+
+export async function readDurableDataPage(params: {
+  store: TripleStore;
+  graphList: readonly string[];
+  contextGraphId: string;
+  sinceBatchId: bigint | null;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const cgPrefix = contextGraphDataGraphUri(params.contextGraphId);
+  const topMetaGraph = contextGraphMetaGraphUri(params.contextGraphId);
+  const candidateGraphs = params.graphList.filter((graph) => {
+    if (graph !== cgPrefix && !graph.startsWith(`${cgPrefix}/`)) return false;
+    if (graph === topMetaGraph) return false;
+    return !graph.includes('/_private');
+  }).sort(compareCodePoint);
+
+  let assertionGraphs: Set<string> | null = null;
+  const isAdmitted = async (graph: string): Promise<boolean> => {
+    if (graph.includes('/assertion/')) {
+      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId);
+      if (!assertionGraphs.has(graph)) return false;
+    }
+    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph));
+  };
+
+  if (params.sinceBatchId == null) {
+    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, isAdmitted);
+  }
+
+  const graphs: string[] = [];
+  for (const graph of candidateGraphs) {
+    if (await isAdmitted(graph)) graphs.push(graph);
+  }
+
+  const metaGraphs = [
+    topMetaGraph,
+    ...graphs.filter((graph) =>
+      graph.startsWith(`${cgPrefix}/`) && graph.endsWith('/_meta'),
+    ),
+  ];
+  return readPagedDurableDeltaRowsAcrossGraphs(
+    params.store,
+    graphs,
+    metaGraphs,
+    params.sinceBatchId,
+    params.offset,
+    params.limit,
+  );
+}
+
+async function readPagedRowsAcrossGraphs(
+  store: TripleStore,
+  graphs: readonly string[],
+  offset: number,
+  limit: number,
+  isAdmitted: (graph: string) => Promise<boolean>,
+): Promise<SyncRow[]> {
+  let skip = offset;
+  let remaining = limit;
+  const rows: SyncRow[] = [];
+
+  for (const graph of graphs) {
+    if (!(await isAdmitted(graph))) continue;
+    if (skip > 0) {
+      const count = await countGraphRows(store, graph);
+      if (skip >= count) {
+        skip -= count;
+        continue;
+      }
+    }
+
+    const page = await readGraphRowsPage(store, graph, skip, remaining);
+    rows.push(...page);
+    remaining -= page.length;
+    skip = 0;
+    if (remaining <= 0) break;
+  }
+
+  return rows;
+}
+
+async function readPagedDurableDeltaRowsAcrossGraphs(
+  store: TripleStore,
+  graphs: readonly string[],
+  metaGraphs: readonly string[],
+  sinceBatchId: bigint,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  let skip = offset;
+  let remaining = limit;
+  const rows: SyncRow[] = [];
+
+  for (const graph of graphs) {
+    if (skip > 0) {
+      const count = await countDurableDeltaGraphRows(store, graph, metaGraphs, sinceBatchId);
+      if (skip >= count) {
+        skip -= count;
+        continue;
+      }
+    }
+
+    const page = await readDurableDeltaGraphRowsPage(
+      store,
+      graph,
+      metaGraphs,
+      sinceBatchId,
+      skip,
+      remaining,
+    );
+    rows.push(...page);
+    remaining -= page.length;
+    skip = 0;
+    if (remaining <= 0) break;
+  }
+
+  return rows;
+}
+
+async function planSwmGraphs(
+  store: TripleStore,
+  contextGraphId: string,
+  meta: boolean,
+): Promise<string[]> {
+  const cgPrefix = contextGraphDataGraphUri(contextGraphId);
+  const suffix = meta ? '/_shared_memory_meta' : '/_shared_memory';
+  const graphs = [`${cgPrefix}${suffix}`];
+  for (const name of await readRegisteredSubGraphNames(store, contextGraphId)) {
+    const childCgUri = `${cgPrefix}/${name}`;
+    if (await isKnownContextGraph(store, childCgUri)) continue;
+    graphs.push(`${childCgUri}${suffix}`);
+  }
+  return graphs.sort(compareCodePoint);
+}
+
+async function readRegisteredSubGraphNames(
+  store: TripleStore,
+  contextGraphId: string,
+): Promise<string[]> {
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const res = await store.query(`
+    SELECT DISTINCT ?name WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?sg <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
+            <${SCHEMA_NAME}> ?name .
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => stripLiteral(row['name']))
+    .filter((name) => name && validateSubGraphName(name).valid)
+    .sort(compareCodePoint);
+}
+
+async function isKnownContextGraph(store: TripleStore, contextGraphUri: string): Promise<boolean> {
+  const metaGraph = `${contextGraphUri}/_meta`;
+  const res = await store.query(`
+    ASK {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        {
+          <${assertSafeIri(contextGraphUri)}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+        } UNION {
+          <${assertSafeIri(contextGraphUri)}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?status .
+        }
+      }
+    }
+  `);
+  return res.type === 'boolean' && res.value;
+}
+
+async function isDescendantOfKnownChildContextGraph(
+  store: TripleStore,
+  cgPrefix: string,
+  graph: string,
+): Promise<boolean> {
+  if (graph === cgPrefix || !graph.startsWith(`${cgPrefix}/`)) return false;
+  const remainder = graph.slice(cgPrefix.length + 1);
+  const segments = remainder.split('/').filter(Boolean);
+  let childUri = cgPrefix;
+  for (const segment of segments) {
+    childUri = `${childUri}/${segment}`;
+    if (await isKnownContextGraph(store, childUri)) return true;
+  }
+  return false;
+}
+
+async function readAdmittedAssertionGraphs(
+  store: TripleStore,
+  contextGraphId: string,
+): Promise<Set<string>> {
+  const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+  const res = await store.query(`
+    SELECT DISTINCT ?g WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?lifecycle <${DKG_ASSERTION_GRAPH}> ?g ;
+                   <${DKG_MEMORY_LAYER}> ?layer .
+        FILTER(?layer != ${sparqlString(MemoryLayer.WorkingMemory)})
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return new Set();
+  return new Set(res.bindings.map((row) => row['g']).filter(Boolean));
+}
+
+function collectDurableMetaSubjects(
+  rows: readonly SyncRow[],
+  contextGraphId: string,
+): Set<string> {
+  const cgEntity = contextGraphDataGraphUri(contextGraphId);
+  const allowed = new Set<string>([cgEntity]);
+  const nonWorkingLifecycle = new Set<string>();
+  const assertionNames: string[] = [];
+  const assertionSubjects = new Set<string>();
+
+  for (const row of rows) {
+    if (row.s.startsWith('did:dkg:activity:') || row.s.startsWith('did:dkg:join-request:')) {
+      allowed.add(row.s);
+    }
+    if (row.s.includes('/assertion/')) {
+      assertionSubjects.add(row.s);
+    }
+    if (row.p === DKG_MEMORY_LAYER && stripLiteral(row.o) !== MemoryLayer.WorkingMemory) {
+      nonWorkingLifecycle.add(row.s);
+    }
+  }
+
+  for (const row of rows) {
+    if (nonWorkingLifecycle.has(row.s)) {
+      allowed.add(row.s);
+      if (row.p === DKG_ASSERTION_GRAPH) allowed.add(row.o);
+      if (row.p === DKG_ASSERTION_NAME) assertionNames.push(stripLiteral(row.o));
+    }
+    if (
+      (row.p === 'http://www.w3.org/ns/prov#generated' || row.p === 'http://www.w3.org/ns/prov#used') &&
+      nonWorkingLifecycle.has(row.o)
+    ) {
+      allowed.add(row.s);
+    }
+  }
+
+  for (const assertionName of assertionNames) {
+    const suffix = `/${assertionName}`;
+    for (const subject of assertionSubjects) {
+      if (subject.endsWith(suffix)) allowed.add(subject);
+    }
+  }
+  return allowed;
+}
+
+async function readFreshWorkspaceSubjects(
+  store: TripleStore,
+  metaGraph: string,
+  cutoffIso: string,
+): Promise<Set<string>> {
+  const res = await store.query(`
+    SELECT DISTINCT ?subject WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?subject <${DKG_PUBLISHED_AT}> ?ts .
+        FILTER(?ts >= "${cutoffIso}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+      }
+    }
+  `);
+  return new Set(res.type === 'bindings' ? res.bindings.map((row) => row['subject']).filter(Boolean) : []);
+}
+
+async function readFreshWorkspaceRoots(
+  store: TripleStore,
+  metaGraph: string,
+  cutoffIso: string,
+): Promise<Set<string>> {
+  const res = await store.query(`
+    SELECT DISTINCT ?root WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+            <${DKG_PUBLISHED_AT}> ?ts ;
+            <${DKG_ROOT_ENTITY}> ?root .
+        FILTER(?ts >= "${cutoffIso}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+      }
+    }
+  `);
+  return new Set(res.type === 'bindings' ? res.bindings.map((row) => row['root']).filter(Boolean) : []);
+}
+
+async function readGraphRows(
+  store: TripleStore,
+  graph: string,
+  predicate?: (row: SyncRow) => boolean | Promise<boolean>,
+): Promise<SyncRow[]> {
+  const res = await store.query(`
+    SELECT ?s ?p ?o WHERE {
+      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    }
+  `);
+  if (res.type !== 'bindings') return [];
+  const rows: SyncRow[] = [];
+  for (const row of res.bindings) {
+    const syncRow = { s: row['s'], p: row['p'], o: row['o'], g: graph };
+    if (!syncRow.s || !syncRow.p || !syncRow.o) continue;
+    if (!predicate || await predicate(syncRow)) rows.push(syncRow);
+  }
+  return rows;
+}
+
+async function countGraphRows(store: TripleStore, graph: string): Promise<number> {
+  const res = await store.query(`
+    SELECT (COUNT(*) AS ?count) WHERE {
+      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    }
+  `);
+  if (res.type !== 'bindings') return 0;
+  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
+  if (value == null || value < 0n) return 0;
+  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
+}
+
+async function readGraphRowsPage(
+  store: TripleStore,
+  graph: string,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const res = await store.query(`
+    SELECT ?s ?p ?o WHERE {
+      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    }
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
+    .filter((row) => row.s && row.p && row.o);
+}
+
+async function countDurableDeltaGraphRows(
+  store: TripleStore,
+  graph: string,
+  metaGraphs: readonly string[],
+  sinceBatchId: bigint,
+): Promise<number> {
+  const res = await store.query(`
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT (COUNT(*) AS ?count) WHERE {
+      {
+        SELECT ?s ?p ?o WHERE {
+          ${durableDeltaWhereClause(graph, metaGraphs)}
+        }
+        ${durableDeltaGroupClause(metaGraphs, sinceBatchId)}
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return 0;
+  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
+  if (value == null || value < 0n) return 0;
+  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
+}
+
+async function readDurableDeltaGraphRowsPage(
+  store: TripleStore,
+  graph: string,
+  metaGraphs: readonly string[],
+  sinceBatchId: bigint,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const res = await store.query(`
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT ?s ?p ?o WHERE {
+      ${durableDeltaWhereClause(graph, metaGraphs)}
+    }
+    ${durableDeltaGroupClause(metaGraphs, sinceBatchId)}
+    ORDER BY ?s ?p ?o
+    OFFSET ${safeOffset}
+    LIMIT ${safeLimit}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
+    .filter((row) => row.s && row.p && row.o);
+}
+
+function durableDeltaWhereClause(
+  graph: string,
+  metaGraphs: readonly string[],
+): string {
+  const values = metaGraphs.map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
+  if (!values) {
+    return `
+          GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    `;
+  }
+  return `
+      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+      OPTIONAL {
+        {
+          SELECT ?deltaRoot ?deltaBid WHERE {
+            VALUES ?deltaMg { ${values} }
+            GRAPH ?deltaMg {
+              ?deltaKa <${DKG_PART_OF}> ?deltaUal ;
+                       <${DKG_ROOT_ENTITY}> ?deltaRoot .
+              { ?deltaUal <${DKG_BATCH_ID}> ?deltaBid }
+              UNION
+              { ?deltaKa <${DKG_BATCH_ID}> ?deltaBid }
+              FILTER(REGEX(STR(?deltaBid), "^-?\\\\d+$"))
+            }
+          }
+        }
+        FILTER(sameTerm(?s, ?deltaRoot) || STRSTARTS(STR(?s), CONCAT(STR(?deltaRoot), "/.well-known/genid/")))
+        BIND(xsd:integer(STR(?deltaBid)) AS ?deltaBatch)
+      }
+    `;
+}
+
+function durableDeltaGroupClause(
+  metaGraphs: readonly string[],
+  sinceBatchId: bigint,
+): string {
+  if (metaGraphs.length === 0) return '';
+  return `
+    GROUP BY ?s ?p ?o
+    HAVING(COUNT(?deltaBatch) = 0 || MAX(?deltaBatch) > ${sinceBatchId.toString()})
+  `;
+}
+
+function dedupeRows(rows: readonly SyncRow[]): SyncRow[] {
+  const seen = new Set<string>();
+  const out: SyncRow[] = [];
+  for (const row of rows) {
+    const key = `${row.g}\u0000${row.s}\u0000${row.p}\u0000${row.o}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(row);
+  }
+  return out;
+}
+
+function contextGraphDataGraphUri(contextGraphId: string): string {
+  return `did:dkg:context-graph:${contextGraphId}`;
+}
+
+function contextGraphMetaGraphUri(contextGraphId: string): string {
+  return `${contextGraphDataGraphUri(contextGraphId)}/_meta`;
+}
+
+function stripLiteral(value: string | undefined): string {
+  if (!value) return '';
+  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[\w-]+|\^\^<[^>]+>)?$/);
+  return match ? match[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\') : value;
+}
+
+function parseIntegerLiteral(value: string | undefined): bigint | null {
+  const stripped = stripLiteral(value);
+  if (!/^-?\d+$/.test(stripped)) return null;
+  try {
+    return BigInt(stripped);
+  } catch {
+    return null;
+  }
+}
+
+function formatTerm(term: string): string {
+  if (term.startsWith('"') || term.startsWith('_:')) return term;
+  if (term.startsWith('<') && term.endsWith('>')) return term;
+  return `<${assertSafeIri(term)}>`;
+}

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -26,6 +26,10 @@ export interface GraphListMemo {
   get(options?: { refresh?: boolean }): Promise<readonly string[]>;
 }
 
+export interface SwmAdmissionMemo {
+  get(contextGraphId: string, options?: { refresh?: boolean }): Promise<readonly string[]>;
+}
+
 export function createResponderGraphListMemo(
   store: TripleStore,
   ttlMs = 10_000,
@@ -49,6 +53,33 @@ export function createResponderGraphListMemo(
           inflight = null;
         });
       return [...(await inflight)];
+    },
+  };
+}
+
+export function createResponderSwmAdmissionMemo(
+  store: TripleStore,
+  ttlMs = 10_000,
+): SwmAdmissionMemo {
+  const cached = new Map<string, { value: readonly string[]; cachedAt: number }>();
+  const inflight = new Map<string, Promise<readonly string[]>>();
+  return {
+    async get(contextGraphId: string, options?: { refresh?: boolean }) {
+      const now = Date.now();
+      const existing = cached.get(contextGraphId);
+      if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) return [...existing.value];
+      const pending = inflight.get(contextGraphId);
+      if (pending) return [...(await pending)];
+      const load = readAdmittedSwmSubGraphNames(store, contextGraphId)
+        .then((names) => {
+          cached.set(contextGraphId, { value: names, cachedAt: Date.now() });
+          return names;
+        })
+        .finally(() => {
+          inflight.delete(contextGraphId);
+        });
+      inflight.set(contextGraphId, load);
+      return [...(await load)];
     },
   };
 }
@@ -82,12 +113,13 @@ export function serializeResponderRows(rows: readonly SyncRow[]): string {
 export async function readSwmMetaPage(params: {
   store: TripleStore;
   graphList: readonly string[];
+  registeredSubGraphNames: readonly string[];
   contextGraphId: string;
   cutoffIso: string | null;
   offset: number;
   limit: number;
 }): Promise<SyncRow[]> {
-  const graphs = await planSwmGraphs(params.store, params.contextGraphId, true);
+  const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
   return readSwmMetaRowsPage(
@@ -102,12 +134,13 @@ export async function readSwmMetaPage(params: {
 export async function readSwmDataPage(params: {
   store: TripleStore;
   graphList: readonly string[];
+  registeredSubGraphNames: readonly string[];
   contextGraphId: string;
   cutoffIso: string | null;
   offset: number;
   limit: number;
 }): Promise<SyncRow[]> {
-  const dataGraphs = await planSwmGraphs(params.store, params.contextGraphId, false);
+  const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
   const graphSet = new Set(params.graphList);
   const candidateGraphsFor = (graph: string) => params.graphList
     .filter((candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph))
@@ -147,12 +180,14 @@ export async function readSwmDataPage(params: {
 export async function readDurableMetaPage(params: {
   store: TripleStore;
   contextGraphId: string;
+  registeredSubGraphNames: readonly string[];
   offset: number;
   limit: number;
 }): Promise<SyncRow[]> {
   return readDurableMetaRowsPage(
     params.store,
     params.contextGraphId,
+    params.registeredSubGraphNames,
     params.offset,
     params.limit,
   );
@@ -250,20 +285,33 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
 }
 
-async function planSwmGraphs(
+async function readAdmittedSwmSubGraphNames(
   store: TripleStore,
   contextGraphId: string,
-  meta: boolean,
 ): Promise<string[]> {
   const cgPrefix = contextGraphDataGraphUri(contextGraphId);
-  const suffix = meta ? '/_shared_memory_meta' : '/_shared_memory';
-  const graphs = [`${cgPrefix}${suffix}`];
+  const names: string[] = [];
   for (const name of await readRegisteredSubGraphNames(store, contextGraphId)) {
     const childCgUri = `${cgPrefix}/${name}`;
     if (await isKnownContextGraph(store, childCgUri)) continue;
-    graphs.push(`${childCgUri}${suffix}`);
+    names.push(name);
   }
-  return graphs.sort(compareCodePoint);
+  return names.sort(compareCodePoint);
+}
+
+function swmGraphsForRegisteredSubGraphs(
+  contextGraphId: string,
+  registeredSubGraphNames: readonly string[],
+  meta: boolean,
+): string[] {
+  const cgPrefix = contextGraphDataGraphUri(contextGraphId);
+  const suffix = meta ? '/_shared_memory_meta' : '/_shared_memory';
+  return [
+    `${cgPrefix}${suffix}`,
+    ...dedupeStrings(registeredSubGraphNames)
+      .filter((name) => validateSubGraphName(name).valid)
+      .map((name) => `${cgPrefix}/${name}${suffix}`),
+  ].sort(compareCodePoint);
 }
 
 async function readRegisteredSubGraphNames(
@@ -531,6 +579,7 @@ function freshSwmDataWhereClause(graph: string, metaGraph: string, cutoffIso: st
 async function readDurableMetaRowsPage(
   store: TripleStore,
   contextGraphId: string,
+  registeredSubGraphNames: readonly string[],
   offset: number,
   limit: number,
 ): Promise<SyncRow[]> {
@@ -539,7 +588,8 @@ async function readDurableMetaRowsPage(
   if (safeLimit === 0) return [];
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const cgEntity = contextGraphDataGraphUri(contextGraphId);
-  const registeredSubGraphSubjects = (await readRegisteredSubGraphNames(store, contextGraphId))
+  const registeredSubGraphSubjects = dedupeStrings(registeredSubGraphNames)
+    .filter((name) => validateSubGraphName(name).valid)
     .map((name) => `<${assertSafeIri(`${cgEntity}/${name}`)}>`);
   const registeredSubGraphSubjectClause = registeredSubGraphSubjects.length === 0
     ? ''

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -66,14 +66,15 @@ export function createResponderGraphListMemo(
 }
 
 export function createResponderSyncRowListMemo(
-  ttlMs = 10_000,
-  maxEntries = 8,
+  ttlMs = 120_000,
+  maxEntries = 32,
 ): SyncRowListMemo {
   const cached = new Map<string, {
     value: readonly SyncRow[];
     cachedAt: number;
     cleanupTimer: ReturnType<typeof setTimeout>;
   }>();
+  const expired = new Map<string, ReturnType<typeof setTimeout>>();
   const inflight = new Map<string, Promise<readonly SyncRow[]>>();
 
   const deleteCached = (key: string) => {
@@ -82,9 +83,25 @@ export function createResponderSyncRowListMemo(
     cached.delete(key);
   };
 
+  const deleteExpired = (key: string) => {
+    const timer = expired.get(key);
+    if (timer) clearTimeout(timer);
+    expired.delete(key);
+  };
+
+  const markExpired = (key: string) => {
+    deleteCached(key);
+    deleteExpired(key);
+    const timer = setTimeout(() => {
+      expired.delete(key);
+    }, ttlMs);
+    (timer as { unref?: () => void }).unref?.();
+    expired.set(key, timer);
+  };
+
   const pruneExpired = (now = Date.now()) => {
     for (const [key, entry] of cached) {
-      if (now - entry.cachedAt >= ttlMs) deleteCached(key);
+      if (now - entry.cachedAt >= ttlMs) markExpired(key);
     }
   };
 
@@ -100,6 +117,8 @@ export function createResponderSyncRowListMemo(
   const storeCached = (key: string, value: readonly SyncRow[]) => {
     const now = Date.now();
     pruneExpired(now);
+    deleteExpired(key);
+    if (value.length === 0) return;
     const replacingExisting = cached.has(key);
     if (!replacingExisting && cached.size >= maxEntries) {
       throw new Error('Too many active durable data sync session snapshots');
@@ -118,6 +137,9 @@ export function createResponderSyncRowListMemo(
       pruneExpired(now);
       const pending = inflight.get(key);
       if (pending) return [...(await pending)];
+      if (expired.has(key)) {
+        throw new Error('Durable data sync session snapshot expired before page completion');
+      }
 
       const existing = cached.get(key);
       if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) {
@@ -339,7 +361,7 @@ export async function readDurableDataPage(params: {
       params.rowListMemo
         ? {
           memo: params.rowListMemo,
-          key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId),
+          key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId, params.sinceBatchId),
           refresh: params.refreshRowList,
         }
         : undefined,
@@ -364,6 +386,13 @@ export async function readDurableDataPage(params: {
     params.sinceBatchId,
     params.offset,
     params.limit,
+    params.rowListMemo
+      ? {
+        memo: params.rowListMemo,
+        key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId, params.sinceBatchId),
+        refresh: params.refreshRowList,
+      }
+      : undefined,
   );
 }
 
@@ -425,8 +454,28 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   sinceBatchId: bigint,
   offset: number,
   limit: number,
+  cache?: { memo: SyncRowListMemo; key: string; refresh?: boolean },
 ): Promise<SyncRow[]> {
-  return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
+  if (!cache) {
+    return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
+  }
+
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+
+  const rows = await cache.memo.get(
+    cache.key,
+    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId),
+    {
+      refresh: cache.refresh,
+      requireExisting: safeOffset > 0,
+    },
+  );
+  if (rows == null) {
+    throw new Error('Durable data sync session snapshot expired before page completion');
+  }
+  return [...rows].slice(safeOffset, safeOffset + safeLimit);
 }
 
 async function readAdmittedSwmSubGraphNames(
@@ -812,6 +861,28 @@ async function readDurableDeltaRowsPageAcrossGraphs(
     .filter((row) => row.s && row.p && row.o && row.g);
 }
 
+async function readDurableDeltaRowsAcrossGraphs(
+  store: TripleStore,
+  graphs: readonly string[],
+  metaGraphs: readonly string[],
+  sinceBatchId: bigint,
+): Promise<SyncRow[]> {
+  const values = graphValues(graphs);
+  if (!values) return [];
+  const res = await store.query(`
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT ?g ?s ?p ?o WHERE {
+      ${durableDeltaWhereClauseForGraphs(values, metaGraphs)}
+    }
+    ${durableDeltaGroupClause(metaGraphs, sinceBatchId, true)}
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g)
+    .sort(compareRows);
+}
+
 function durableDeltaWhereClauseForGraphs(
   graphValuesClause: string,
   metaGraphs: readonly string[],
@@ -869,8 +940,8 @@ function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
 }
 
-function durableDataRowListCacheKey(scope: string, contextGraphId: string): string {
-  return `durable-data:${scope}:${contextGraphId}`;
+function durableDataRowListCacheKey(scope: string, contextGraphId: string, sinceBatchId: bigint | null): string {
+  return `durable-data:${scope}:${contextGraphId}:${sinceBatchId == null ? 'full' : `since:${sinceBatchId.toString()}`}`;
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -89,28 +89,13 @@ export async function readSwmMetaPage(params: {
   const graphs = await planSwmGraphs(params.store, params.contextGraphId, true);
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
-  const registrationGraph = contextGraphMetaGraphUri(params.contextGraphId);
-  const swmRows = await readSwmMetaRowsPage(
+  return readSwmMetaRowsPage(
     params.store,
     candidateGraphs,
     params.cutoffIso,
     params.offset,
     params.limit,
   );
-  const registrationNames = dedupeStrings(swmRows
-    .map((row) => subGraphNameFromSwmMetaGraph(params.contextGraphId, row.g))
-    .filter((name): name is string => name !== undefined))
-    .sort(compareCodePoint);
-  if (!graphSet.has(registrationGraph) || registrationNames.length === 0) {
-    return swmRows;
-  }
-  const registrationRows = await readSwmRegistrationRows(
-    params.store,
-    registrationGraph,
-    params.contextGraphId,
-    registrationNames,
-  );
-  return [...registrationRows, ...swmRows].sort(compareRows);
 }
 
 export async function readSwmDataPage(params: {
@@ -483,33 +468,6 @@ async function readSwmMetaRowsPage(
     .filter((row) => row.s && row.p && row.o && row.g);
 }
 
-async function readSwmRegistrationRows(
-  store: TripleStore,
-  registrationGraph: string,
-  contextGraphId: string,
-  registrationNames: readonly string[],
-): Promise<SyncRow[]> {
-  const values = registrationNames
-    .map((name) => `(<${assertSafeIri(`${contextGraphDataGraphUri(contextGraphId)}/${name}`)}> ${sparqlString(name)})`)
-    .join(' ');
-  if (!values) return [];
-  const res = await store.query(`
-    SELECT DISTINCT ?s ?p ?o WHERE {
-      VALUES (?s ?subGraphName) { ${values} }
-      GRAPH <${assertSafeIri(registrationGraph)}> {
-        ?s <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
-           <${SCHEMA_NAME}> ?subGraphName ;
-           ?p ?o .
-      }
-    }
-    ORDER BY ?s ?p ?o
-  `);
-  if (res.type !== 'bindings') return [];
-  return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: registrationGraph }))
-    .filter((row) => row.s && row.p && row.o);
-}
-
 async function countFreshSwmDataGraphRows(
   store: TripleStore,
   graph: string,
@@ -703,16 +661,6 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
-}
-
-function subGraphNameFromSwmMetaGraph(contextGraphId: string, graph: string): string | undefined {
-  const rootGraph = `${contextGraphDataGraphUri(contextGraphId)}/_shared_memory_meta`;
-  if (graph === rootGraph) return undefined;
-  const prefix = `${contextGraphDataGraphUri(contextGraphId)}/`;
-  const suffix = '/_shared_memory_meta';
-  if (!graph.startsWith(prefix) || !graph.endsWith(suffix)) return undefined;
-  const name = graph.slice(prefix.length, -suffix.length);
-  return validateSubGraphName(name).valid ? name : undefined;
 }
 
 function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -138,7 +138,11 @@ export function createResponderSyncRowListMemo(
       const pending = inflight.get(key);
       if (pending) return [...(await pending)];
       if (expired.has(key)) {
-        throw new Error('Durable data sync session snapshot expired before page completion');
+        if (options?.refresh) {
+          deleteExpired(key);
+        } else {
+          throw new Error('Durable data sync session snapshot expired before page completion');
+        }
       }
 
       const existing = cached.get(key);

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -538,12 +538,20 @@ async function readDurableMetaRowsPage(
   if (safeLimit === 0) return [];
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const cgEntity = contextGraphDataGraphUri(contextGraphId);
+  const registeredSubGraphSubjects = (await readRegisteredSubGraphNames(store, contextGraphId))
+    .map((name) => `<${assertSafeIri(`${cgEntity}/${name}`)}>`);
+  const registeredSubGraphSubjectClause = registeredSubGraphSubjects.length === 0
+    ? ''
+    : `${registeredSubGraphSubjects.length === 1
+      ? `sameTerm(?s, ${registeredSubGraphSubjects[0]})`
+      : `?s IN (${registeredSubGraphSubjects.join(', ')})`} ||`;
   const workingMemory = sparqlString(MemoryLayer.WorkingMemory);
   const res = await store.query(`
     SELECT ?s ?p ?o WHERE {
       GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
       FILTER(
         STR(?s) = ${sparqlString(cgEntity)} ||
+        ${registeredSubGraphSubjectClause}
         STRSTARTS(STR(?s), "did:dkg:activity:") ||
         STRSTARTS(STR(?s), "did:dkg:join-request:") ||
         EXISTS {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -30,6 +30,14 @@ export interface SubGraphNameMemo {
   get(contextGraphId: string, options?: { refresh?: boolean }): Promise<readonly string[]>;
 }
 
+export interface SyncRowListMemo {
+  get(
+    key: string,
+    loadRows: () => Promise<readonly SyncRow[]>,
+    options?: { refresh?: boolean; requireExisting?: boolean },
+  ): Promise<readonly SyncRow[] | null>;
+}
+
 export function createResponderGraphListMemo(
   store: TripleStore,
   ttlMs = 10_000,
@@ -53,6 +61,91 @@ export function createResponderGraphListMemo(
           inflight = null;
         });
       return [...(await inflight)];
+    },
+  };
+}
+
+export function createResponderSyncRowListMemo(
+  ttlMs = 10_000,
+  maxEntries = 8,
+): SyncRowListMemo {
+  const cached = new Map<string, {
+    value: readonly SyncRow[];
+    cachedAt: number;
+    cleanupTimer: ReturnType<typeof setTimeout>;
+  }>();
+  const inflight = new Map<string, Promise<readonly SyncRow[]>>();
+
+  const deleteCached = (key: string) => {
+    const existing = cached.get(key);
+    if (existing) clearTimeout(existing.cleanupTimer);
+    cached.delete(key);
+  };
+
+  const pruneExpired = (now = Date.now()) => {
+    for (const [key, entry] of cached) {
+      if (now - entry.cachedAt >= ttlMs) deleteCached(key);
+    }
+  };
+
+  const scheduleCleanup = (key: string, cachedAt: number) => {
+    const timer = setTimeout(() => {
+      const existing = cached.get(key);
+      if (existing?.cachedAt === cachedAt) cached.delete(key);
+    }, ttlMs);
+    (timer as { unref?: () => void }).unref?.();
+    return timer;
+  };
+
+  const storeCached = (key: string, value: readonly SyncRow[]) => {
+    const now = Date.now();
+    pruneExpired(now);
+    const replacingExisting = cached.has(key);
+    if (!replacingExisting && cached.size >= maxEntries) {
+      throw new Error('Too many active durable data sync session snapshots');
+    }
+    deleteCached(key);
+    cached.set(key, {
+      value,
+      cachedAt: now,
+      cleanupTimer: scheduleCleanup(key, now),
+    });
+  };
+
+  return {
+    async get(key, loadRows, options?: { refresh?: boolean; requireExisting?: boolean }) {
+      const now = Date.now();
+      pruneExpired(now);
+      const pending = inflight.get(key);
+      if (pending) return [...(await pending)];
+
+      const existing = cached.get(key);
+      if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) {
+        const refreshed = {
+          value: existing.value,
+          cachedAt: now,
+          cleanupTimer: scheduleCleanup(key, now),
+        };
+        deleteCached(key);
+        cached.set(key, refreshed);
+        return [...existing.value];
+      }
+      if (options?.requireExisting) return null;
+      if (!cached.has(key) && cached.size + inflight.size >= maxEntries) {
+        throw new Error('Too many active durable data sync session snapshots');
+      }
+
+      const load = loadRows()
+        .then((rows) => {
+          const value = [...rows];
+          storeCached(key, value);
+          return value;
+        })
+        .finally(() => {
+          if (inflight.get(key) === load) inflight.delete(key);
+        });
+      inflight.set(key, load);
+      return [...(await load)];
     },
   };
 }
@@ -162,7 +255,7 @@ export async function readSwmDataPage(params: {
 
   if (!params.cutoffIso) {
     const candidateGraphs = dedupeStrings(dataGraphs.flatMap(candidateGraphsFor)).sort(compareCodePoint);
-    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, async () => true);
+    return readPagedRowsAcrossGraphsStoreBounded(params.store, candidateGraphs, params.offset, params.limit, async () => true);
   }
 
   const rows: SyncRow[] = [];
@@ -207,20 +300,6 @@ export async function readDurableMetaPage(params: {
   );
 }
 
-export async function readDurableCanonicalDataPage(params: {
-  store: TripleStore;
-  contextGraphId: string;
-  offset: number;
-  limit: number;
-}): Promise<SyncRow[]> {
-  return readGraphRowsPage(
-    params.store,
-    contextGraphDataGraphUri(params.contextGraphId),
-    params.offset,
-    params.limit,
-  );
-}
-
 export async function readDurableDataPage(params: {
   store: TripleStore;
   graphList: readonly string[];
@@ -228,6 +307,9 @@ export async function readDurableDataPage(params: {
   sinceBatchId: bigint | null;
   offset: number;
   limit: number;
+  rowListMemo?: SyncRowListMemo;
+  rowListCacheScope?: string;
+  refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
   const cgPrefix = contextGraphDataGraphUri(params.contextGraphId);
   const topMetaGraph = contextGraphMetaGraphUri(params.contextGraphId);
@@ -248,7 +330,20 @@ export async function readDurableDataPage(params: {
   };
 
   if (params.sinceBatchId == null) {
-    return readPagedRowsAcrossGraphs(params.store, candidateGraphs, params.offset, params.limit, isAdmitted);
+    return readPagedRowsAcrossGraphs(
+      params.store,
+      candidateGraphs,
+      params.offset,
+      params.limit,
+      isAdmitted,
+      params.rowListMemo
+        ? {
+          memo: params.rowListMemo,
+          key: durableDataRowListCacheKey(params.rowListCacheScope ?? 'default', params.contextGraphId),
+          refresh: params.refreshRowList,
+        }
+        : undefined,
+    );
   }
 
   const graphs: string[] = [];
@@ -273,6 +368,41 @@ export async function readDurableDataPage(params: {
 }
 
 async function readPagedRowsAcrossGraphs(
+  store: TripleStore,
+  graphs: readonly string[],
+  offset: number,
+  limit: number,
+  isAdmitted: (graph: string) => Promise<boolean>,
+  cache?: { memo: SyncRowListMemo; key: string; refresh?: boolean },
+): Promise<SyncRow[]> {
+  if (!cache) {
+    return readPagedRowsAcrossGraphsStoreBounded(store, graphs, offset, limit, isAdmitted);
+  }
+
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+
+  const loadRows = async (): Promise<SyncRow[]> => {
+    const admittedGraphs: string[] = [];
+    for (const graph of graphs) {
+      if (!(await isAdmitted(graph))) continue;
+      admittedGraphs.push(graph);
+    }
+    return readRowsAcrossGraphs(store, admittedGraphs);
+  };
+
+  const rows = await cache.memo.get(cache.key, loadRows, {
+    refresh: cache.refresh,
+    requireExisting: safeOffset > 0,
+  });
+  if (rows == null) {
+    throw new Error('Durable data sync session snapshot expired before page completion');
+  }
+  return [...rows].slice(safeOffset, safeOffset + safeLimit);
+}
+
+async function readPagedRowsAcrossGraphsStoreBounded(
   store: TripleStore,
   graphs: readonly string[],
   offset: number,
@@ -444,27 +574,23 @@ async function countGraphRows(store: TripleStore, graph: string): Promise<number
   return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
 }
 
-async function readGraphRowsPage(
+async function readRowsAcrossGraphs(
   store: TripleStore,
-  graph: string,
-  offset: number,
-  limit: number,
+  graphs: readonly string[],
 ): Promise<SyncRow[]> {
-  const safeOffset = Math.max(0, Math.floor(offset));
-  const safeLimit = Math.max(0, Math.floor(limit));
-  if (safeLimit === 0) return [];
+  const values = graphValues(graphs);
+  if (!values) return [];
   const res = await store.query(`
-    SELECT ?s ?p ?o WHERE {
-      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+    SELECT ?g ?s ?p ?o WHERE {
+      VALUES ?g { ${values} }
+      GRAPH ?g { ?s ?p ?o }
     }
-    ORDER BY ?s ?p ?o
-    OFFSET ${safeOffset}
-    LIMIT ${safeLimit}
   `);
   if (res.type !== 'bindings') return [];
   return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
-    .filter((row) => row.s && row.p && row.o);
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g)
+    .sort(compareRows);
 }
 
 async function readRowsPageAcrossGraphs(
@@ -705,11 +831,18 @@ function durableDeltaWhereClauseForGraphs(
           SELECT ?deltaRoot ?deltaBid WHERE {
             VALUES ?deltaMg { ${values} }
             GRAPH ?deltaMg {
-              ?deltaKa <${DKG_PART_OF}> ?deltaUal ;
-                       <${DKG_ROOT_ENTITY}> ?deltaRoot .
-              { ?deltaUal <${DKG_BATCH_ID}> ?deltaBid }
+              {
+                ?deltaKa <${DKG_PART_OF}> ?deltaUal ;
+                         <${DKG_ROOT_ENTITY}> ?deltaRoot .
+                { ?deltaUal <${DKG_BATCH_ID}> ?deltaBid }
+                UNION
+                { ?deltaKa <${DKG_BATCH_ID}> ?deltaBid }
+              }
               UNION
-              { ?deltaKa <${DKG_BATCH_ID}> ?deltaBid }
+              {
+                ?deltaKa <${DKG_ROOT_ENTITY}> ?deltaRoot ;
+                         <${DKG_BATCH_ID}> ?deltaBid .
+              }
               FILTER(REGEX(STR(?deltaBid), "^-?\\\\d+$"))
             }
           }
@@ -734,6 +867,10 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
+}
+
+function durableDataRowListCacheKey(scope: string, contextGraphId: string): string {
+  return `durable-data:${scope}:${contextGraphId}`;
 }
 
 function dedupeStrings(values: readonly string[]): string[] {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -21,6 +21,8 @@ const DKG_MEMORY_LAYER = `${DKG}memoryLayer`;
 const DKG_PART_OF = `${DKG}partOf`;
 const DKG_BATCH_ID = `${DKG}batchId`;
 const SCHEMA_NAME = 'http://schema.org/name';
+const PROV_GENERATED = 'http://www.w3.org/ns/prov#generated';
+const PROV_USED = 'http://www.w3.org/ns/prov#used';
 
 export interface GraphListMemo {
   get(options?: { refresh?: boolean }): Promise<readonly string[]>;
@@ -36,6 +38,13 @@ export interface SyncRowListMemo {
     loadRows: () => Promise<readonly SyncRow[]>,
     options?: { refresh?: boolean; requireExisting?: boolean },
   ): Promise<readonly SyncRow[] | null>;
+}
+
+interface RowListCache {
+  memo: SyncRowListMemo;
+  key: string;
+  refresh?: boolean;
+  expiredMessage?: string;
 }
 
 export function createResponderGraphListMemo(
@@ -251,10 +260,26 @@ export async function readSwmMetaPage(params: {
   cutoffIso: string | null;
   offset: number;
   limit: number;
+  rowListMemo?: SyncRowListMemo;
+  rowListCacheKey?: string;
+  refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
   const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
   const graphSet = new Set(params.graphList);
   const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
+  if (params.rowListMemo && params.rowListCacheKey) {
+    return readCachedRowsPage(
+      {
+        memo: params.rowListMemo,
+        key: params.rowListCacheKey,
+        refresh: params.refreshRowList,
+        expiredMessage: 'Shared-memory meta sync session snapshot expired before page completion',
+      },
+      () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso),
+      params.offset,
+      params.limit,
+    );
+  }
   return readSwmMetaRowsPage(
     params.store,
     candidateGraphs,
@@ -272,42 +297,48 @@ export async function readSwmDataPage(params: {
   cutoffIso: string | null;
   offset: number;
   limit: number;
+  rowListMemo?: SyncRowListMemo;
+  rowListCacheKey?: string;
+  refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
   const graphSet = new Set(params.graphList);
   const candidateGraphsFor = (graph: string) => params.graphList
     .filter((candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph))
     .sort(compareCodePoint);
+  const cache = params.rowListMemo && params.rowListCacheKey
+    ? {
+      memo: params.rowListMemo,
+      key: params.rowListCacheKey,
+      refresh: params.refreshRowList,
+      expiredMessage: 'Shared-memory data sync session snapshot expired before page completion',
+    }
+    : undefined;
 
   if (!params.cutoffIso) {
     const candidateGraphs = dedupeStrings(dataGraphs.flatMap(candidateGraphsFor)).sort(compareCodePoint);
-    return readPagedRowsAcrossGraphsStoreBounded(params.store, candidateGraphs, params.offset, params.limit, async () => true);
+    return readPagedRowsAcrossGraphs(
+      params.store,
+      candidateGraphs,
+      params.offset,
+      params.limit,
+      async () => true,
+      cache,
+    );
   }
 
-  const rows: SyncRow[] = [];
-  let skip = params.offset;
-  let remaining = params.limit;
-  for (const graph of dataGraphs) {
-    const metaGraph = `${graph}_meta`;
-    if (!graphSet.has(metaGraph)) continue;
-    for (const candidate of candidateGraphsFor(graph)) {
-      if (skip > 0) {
-        const count = await countFreshSwmDataGraphRows(params.store, candidate, metaGraph, params.cutoffIso);
-        if (skip >= count) {
-          skip -= count;
-          continue;
-        }
-      }
-
-      const page = await readFreshSwmDataGraphRowsPage(params.store, candidate, metaGraph, params.cutoffIso, skip, remaining);
-      rows.push(...page);
-      remaining -= page.length;
-      skip = 0;
-      if (remaining <= 0) break;
-    }
-    if (remaining <= 0) break;
+  const loadRows = () => readFreshSwmDataRows(
+    params.store,
+    dataGraphs,
+    graphSet,
+    candidateGraphsFor,
+    params.cutoffIso!,
+  );
+  if (cache) {
+    return readCachedRowsPage(cache, loadRows, params.offset, params.limit);
   }
-  return rows;
+  const rows = await loadRows();
+  return rows.slice(Math.max(0, Math.floor(params.offset)), Math.max(0, Math.floor(params.offset)) + Math.max(0, Math.floor(params.limit)));
 }
 
 export async function readDurableMetaPage(params: {
@@ -316,14 +347,28 @@ export async function readDurableMetaPage(params: {
   registeredSubGraphNames: readonly string[];
   offset: number;
   limit: number;
+  rowListMemo?: SyncRowListMemo;
+  rowListCacheKey?: string;
+  refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
-  return readDurableMetaRowsPage(
-    params.store,
-    params.contextGraphId,
-    params.registeredSubGraphNames,
-    params.offset,
-    params.limit,
-  );
+  const loadRows = () => readDurableMetaRows(params.store, params.contextGraphId, params.registeredSubGraphNames);
+  if (params.rowListMemo && params.rowListCacheKey) {
+    return readCachedRowsPage(
+      {
+        memo: params.rowListMemo,
+        key: params.rowListCacheKey,
+        refresh: params.refreshRowList,
+        expiredMessage: 'Durable meta sync session snapshot expired before page completion',
+      },
+      loadRows,
+      params.offset,
+      params.limit,
+    );
+  }
+  const rows = await loadRows();
+  const safeOffset = Math.max(0, Math.floor(params.offset));
+  const safeLimit = Math.max(0, Math.floor(params.limit));
+  return rows.slice(safeOffset, safeOffset + safeLimit);
 }
 
 export async function readDurableDataPage(params: {
@@ -406,7 +451,7 @@ async function readPagedRowsAcrossGraphs(
   offset: number,
   limit: number,
   isAdmitted: (graph: string) => Promise<boolean>,
-  cache?: { memo: SyncRowListMemo; key: string; refresh?: boolean },
+  cache?: RowListCache,
 ): Promise<SyncRow[]> {
   if (!cache) {
     return readPagedRowsAcrossGraphsStoreBounded(store, graphs, offset, limit, isAdmitted);
@@ -425,14 +470,15 @@ async function readPagedRowsAcrossGraphs(
     return readRowsAcrossGraphs(store, admittedGraphs);
   };
 
-  const rows = await cache.memo.get(cache.key, loadRows, {
-    refresh: cache.refresh,
-    requireExisting: safeOffset > 0,
-  });
-  if (rows == null) {
-    throw new Error('Durable data sync session snapshot expired before page completion');
-  }
-  return [...rows].slice(safeOffset, safeOffset + safeLimit);
+  return readCachedRowsPage(
+    {
+      ...cache,
+      expiredMessage: cache.expiredMessage ?? 'Durable data sync session snapshot expired before page completion',
+    },
+    loadRows,
+    safeOffset,
+    safeLimit,
+  );
 }
 
 async function readPagedRowsAcrossGraphsStoreBounded(
@@ -458,7 +504,7 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   sinceBatchId: bigint,
   offset: number,
   limit: number,
-  cache?: { memo: SyncRowListMemo; key: string; refresh?: boolean },
+  cache?: RowListCache,
 ): Promise<SyncRow[]> {
   if (!cache) {
     return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
@@ -468,16 +514,32 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   const safeLimit = Math.max(0, Math.floor(limit));
   if (safeLimit === 0) return [];
 
-  const rows = await cache.memo.get(
-    cache.key,
-    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId),
+  return readCachedRowsPage(
     {
-      refresh: cache.refresh,
-      requireExisting: safeOffset > 0,
+      ...cache,
+      expiredMessage: cache.expiredMessage ?? 'Durable data sync session snapshot expired before page completion',
     },
+    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId),
+    safeOffset,
+    safeLimit,
   );
+}
+
+async function readCachedRowsPage(
+  cache: RowListCache,
+  loadRows: () => Promise<readonly SyncRow[]>,
+  offset: number,
+  limit: number,
+): Promise<SyncRow[]> {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit = Math.max(0, Math.floor(limit));
+  if (safeLimit === 0) return [];
+  const rows = await cache.memo.get(cache.key, loadRows, {
+    refresh: cache.refresh,
+    requireExisting: safeOffset > 0,
+  });
   if (rows == null) {
-    throw new Error('Durable data sync session snapshot expired before page completion');
+    throw new Error(cache.expiredMessage ?? 'Sync session snapshot expired before page completion');
   }
   return [...rows].slice(safeOffset, safeOffset + safeLimit);
 }
@@ -615,18 +677,6 @@ async function readAdmittedAssertionGraphs(
   return new Set(res.bindings.map((row) => row['g']).filter(Boolean));
 }
 
-async function countGraphRows(store: TripleStore, graph: string): Promise<number> {
-  const res = await store.query(`
-    SELECT (COUNT(*) AS ?count) WHERE {
-      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
-    }
-  `);
-  if (res.type !== 'bindings') return 0;
-  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
-  if (value == null || value < 0n) return 0;
-  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
-}
-
 async function readRowsAcrossGraphs(
   store: TripleStore,
   graphs: readonly string[],
@@ -671,6 +721,33 @@ async function readRowsPageAcrossGraphs(
     .filter((row) => row.s && row.p && row.o && row.g);
 }
 
+async function readSwmMetaRows(
+  store: TripleStore,
+  swmMetaGraphs: readonly string[],
+  cutoffIso: string | null,
+): Promise<SyncRow[]> {
+  const swmMetaValues = graphValues(swmMetaGraphs);
+  if (!swmMetaValues) return [];
+  const res = await store.query(`
+    SELECT DISTINCT ?g ?s ?p ?o WHERE {
+      VALUES ?g { ${swmMetaValues} }
+      GRAPH ?g {
+        ?s ?p ?o .
+        ${cutoffIso
+    ? `
+        ?s <${DKG_PUBLISHED_AT}> ?ts .
+        FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`
+    : ''}
+      }
+    }
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
+    .filter((row) => row.s && row.p && row.o && row.g)
+    .sort(compareRows);
+}
+
 async function readSwmMetaRowsPage(
   store: TripleStore,
   swmMetaGraphs: readonly string[],
@@ -710,131 +787,94 @@ async function readSwmMetaRowsPage(
     .filter((row) => row.s && row.p && row.o && row.g);
 }
 
-async function countFreshSwmDataGraphRows(
+async function readFreshSwmDataRows(
   store: TripleStore,
-  graph: string,
-  metaGraph: string,
+  dataGraphs: readonly string[],
+  graphSet: ReadonlySet<string>,
+  candidateGraphsFor: (graph: string) => string[],
   cutoffIso: string,
-): Promise<number> {
-  const res = await store.query(`
-    SELECT (COUNT(*) AS ?count) WHERE {
-      {
-        SELECT DISTINCT ?s ?p ?o WHERE {
-          ${freshSwmDataWhereClause(graph, metaGraph, cutoffIso)}
-        }
-      }
-    }
-  `);
-  if (res.type !== 'bindings') return 0;
-  const value = parseIntegerLiteral(res.bindings[0]?.['count']);
-  if (value == null || value < 0n) return 0;
-  return Number(value > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : value);
-}
-
-async function readFreshSwmDataGraphRowsPage(
-  store: TripleStore,
-  graph: string,
-  metaGraph: string,
-  cutoffIso: string,
-  offset: number,
-  limit: number,
 ): Promise<SyncRow[]> {
-  const safeOffset = Math.max(0, Math.floor(offset));
-  const safeLimit = Math.max(0, Math.floor(limit));
-  if (safeLimit === 0) return [];
-  const res = await store.query(`
-    SELECT DISTINCT ?s ?p ?o WHERE {
-      ${freshSwmDataWhereClause(graph, metaGraph, cutoffIso)}
-    }
-    ORDER BY ?s ?p ?o
-    OFFSET ${safeOffset}
-    LIMIT ${safeLimit}
-  `);
-  if (res.type !== 'bindings') return [];
-  return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: graph }))
-    .filter((row) => row.s && row.p && row.o);
+  const rows: SyncRow[] = [];
+  for (const graph of dataGraphs) {
+    const metaGraph = `${graph}_meta`;
+    if (!graphSet.has(metaGraph)) continue;
+    const roots = await readFreshSwmRoots(store, metaGraph, cutoffIso);
+    if (roots.size === 0) continue;
+    const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
+    const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph));
+    rows.push(...graphRows.filter((row) =>
+      roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix)),
+    ));
+  }
+  return rows.sort(compareRows);
 }
 
-function freshSwmDataWhereClause(graph: string, metaGraph: string, cutoffIso: string): string {
-  return `
+async function readFreshSwmRoots(
+  store: TripleStore,
+  metaGraph: string,
+  cutoffIso: string,
+): Promise<Set<string>> {
+  const res = await store.query(`
+    SELECT DISTINCT ?root WHERE {
       GRAPH <${assertSafeIri(metaGraph)}> {
         ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
             <${DKG_PUBLISHED_AT}> ?ts ;
             <${DKG_ROOT_ENTITY}> ?root .
         FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
       }
-      GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
-      FILTER(sameTerm(?s, ?root) || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
-  `;
+    }
+  `);
+  if (res.type !== 'bindings') return new Set();
+  return new Set(res.bindings.map((row) => row['root']).filter(Boolean));
 }
 
-async function readDurableMetaRowsPage(
+async function readDurableMetaRows(
   store: TripleStore,
   contextGraphId: string,
   registeredSubGraphNames: readonly string[],
-  offset: number,
-  limit: number,
 ): Promise<SyncRow[]> {
-  const safeOffset = Math.max(0, Math.floor(offset));
-  const safeLimit = Math.max(0, Math.floor(limit));
-  if (safeLimit === 0) return [];
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const cgEntity = contextGraphDataGraphUri(contextGraphId);
-  const registeredSubGraphSubjects = dedupeStrings(registeredSubGraphNames)
+  const registeredSubGraphSubjects = new Set(dedupeStrings(registeredSubGraphNames)
     .filter((name) => validateSubGraphName(name).valid)
-    .map((name) => `<${assertSafeIri(`${cgEntity}/${name}`)}>`);
-  const registeredSubGraphSubjectClause = registeredSubGraphSubjects.length === 0
-    ? ''
-    : `${registeredSubGraphSubjects.length === 1
-      ? `sameTerm(?s, ${registeredSubGraphSubjects[0]})`
-      : `?s IN (${registeredSubGraphSubjects.join(', ')})`} ||`;
-  const workingMemory = sparqlString(MemoryLayer.WorkingMemory);
-  const res = await store.query(`
-    SELECT ?s ?p ?o WHERE {
-      GRAPH <${assertSafeIri(metaGraph)}> { ?s ?p ?o }
-      FILTER(
-        STR(?s) = ${sparqlString(cgEntity)} ||
-        ${registeredSubGraphSubjectClause}
-        STRSTARTS(STR(?s), "did:dkg:activity:") ||
-        STRSTARTS(STR(?s), "did:dkg:join-request:") ||
-        EXISTS {
-          GRAPH <${assertSafeIri(metaGraph)}> {
-            ?lc <${DKG_MEMORY_LAYER}> ?layer .
-            FILTER(STR(?layer) != ${workingMemory})
-            {
-              FILTER(sameTerm(?lc, ?s))
-            } UNION {
-              ?lc <${DKG_ASSERTION_GRAPH}> ?s .
-            } UNION {
-              ?lc <${DKG_ASSERTION_NAME}> ?aname .
-              FILTER(
-                CONTAINS(STR(?s), "/assertion/") &&
-                STRENDS(STR(?s), CONCAT("/", STR(?aname)))
-              )
-            }
-          }
-        } ||
-        EXISTS {
-          GRAPH <${assertSafeIri(metaGraph)}> {
-            { ?evt <http://www.w3.org/ns/prov#generated> ?parent }
-            UNION
-            { ?evt <http://www.w3.org/ns/prov#used> ?parent }
-            FILTER(sameTerm(?evt, ?s))
-            ?parent <${DKG_MEMORY_LAYER}> ?eventLayer .
-            FILTER(STR(?eventLayer) != ${workingMemory})
-          }
-        }
-      )
+    .map((name) => `${cgEntity}/${name}`));
+  const rows = await readRowsAcrossGraphs(store, [metaGraph]);
+  const nonWorkingLifecycles = new Set<string>();
+  for (const row of rows) {
+    if (row.p === DKG_MEMORY_LAYER && stripLiteral(row.o) !== MemoryLayer.WorkingMemory) {
+      nonWorkingLifecycles.add(row.s);
     }
-    ORDER BY ?s ?p ?o
-    OFFSET ${safeOffset}
-    LIMIT ${safeLimit}
-  `);
-  if (res.type !== 'bindings') return [];
-  return res.bindings
-    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: metaGraph }))
-    .filter((row) => row.s && row.p && row.o);
+  }
+
+  const assertionGraphs = new Set<string>();
+  const assertionNames = new Set<string>();
+  const eventSubjects = new Set<string>();
+  for (const row of rows) {
+    if (nonWorkingLifecycles.has(row.s) && row.p === DKG_ASSERTION_GRAPH) {
+      assertionGraphs.add(row.o);
+    }
+    if (nonWorkingLifecycles.has(row.s) && row.p === DKG_ASSERTION_NAME) {
+      const name = stripLiteral(row.o);
+      if (name) assertionNames.add(name);
+    }
+    if ((row.p === PROV_GENERATED || row.p === PROV_USED) && nonWorkingLifecycles.has(row.o)) {
+      eventSubjects.add(row.s);
+    }
+  }
+
+  return rows.filter((row) =>
+    row.s === cgEntity ||
+    registeredSubGraphSubjects.has(row.s) ||
+    row.s.startsWith('did:dkg:activity:') ||
+    row.s.startsWith('did:dkg:join-request:') ||
+    nonWorkingLifecycles.has(row.s) ||
+    assertionGraphs.has(row.s) ||
+    eventSubjects.has(row.s) ||
+    (
+      row.s.includes('/assertion/') &&
+      [...assertionNames].some((name) => row.s.endsWith(`/${name}`))
+    ),
+  );
 }
 
 async function readDurableDeltaRowsPageAcrossGraphs(
@@ -971,16 +1011,6 @@ function stripLiteral(value: string | undefined): string {
   if (!value) return '';
   const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[\w-]+|\^\^<[^>]+>)?$/);
   return match ? match[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\') : value;
-}
-
-function parseIntegerLiteral(value: string | undefined): bigint | null {
-  const stripped = stripLiteral(value);
-  if (!/^-?\d+$/.test(stripped)) return null;
-  try {
-    return BigInt(stripped);
-  } catch {
-    return null;
-  }
 }
 
 function formatTerm(term: string): string {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -93,15 +93,23 @@ export async function readSwmMetaPage(params: {
   const registrationNames = candidateGraphs
     .map((graph) => subGraphNameFromSwmMetaGraph(params.contextGraphId, graph))
     .filter((name): name is string => name !== undefined);
-  return readSwmMetaRowsPage(
+  const swmRows = await readSwmMetaRowsPage(
     params.store,
     candidateGraphs,
-    graphSet.has(registrationGraph) && registrationNames.length > 0 ? registrationGraph : null,
-    registrationNames,
     params.cutoffIso,
     params.offset,
     params.limit,
   );
+  if (params.offset !== 0 || !graphSet.has(registrationGraph) || registrationNames.length === 0) {
+    return swmRows;
+  }
+  const registrationRows = await readSwmRegistrationRows(
+    params.store,
+    registrationGraph,
+    params.contextGraphId,
+    registrationNames,
+  );
+  return [...registrationRows, ...swmRows].sort(compareRows);
 }
 
 export async function readSwmDataPage(params: {
@@ -276,7 +284,7 @@ async function readRegisteredSubGraphNames(
 ): Promise<string[]> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const res = await store.query(`
-    SELECT DISTINCT ?name WHERE {
+    SELECT DISTINCT ?sg ?name WHERE {
       GRAPH <${assertSafeIri(metaGraph)}> {
         ?sg <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
             <${SCHEMA_NAME}> ?name .
@@ -285,8 +293,13 @@ async function readRegisteredSubGraphNames(
   `);
   if (res.type !== 'bindings') return [];
   return res.bindings
-    .map((row) => stripLiteral(row['name']))
-    .filter((name) => name && validateSubGraphName(name).valid)
+    .map((row) => ({ subject: row['sg'], name: stripLiteral(row['name']) }))
+    .filter(({ subject, name }) =>
+      name &&
+      validateSubGraphName(name).valid &&
+      subject === `${contextGraphDataGraphUri(contextGraphId)}/${name}`,
+    )
+    .map(({ name }) => name)
     .sort(compareCodePoint);
 }
 
@@ -430,8 +443,6 @@ async function readRowsPageAcrossGraphs(
 async function readSwmMetaRowsPage(
   store: TripleStore,
   swmMetaGraphs: readonly string[],
-  registrationGraph: string | null,
-  registrationNames: readonly string[],
   cutoffIso: string | null,
   offset: number,
   limit: number,
@@ -442,7 +453,6 @@ async function readSwmMetaRowsPage(
   const swmMetaValues = graphValues(swmMetaGraphs);
   const swmMetaClause = swmMetaValues
     ? `
-      {
         VALUES ?g { ${swmMetaValues} }
         GRAPH ?g {
           ?s ?p ?o .
@@ -452,25 +462,12 @@ async function readSwmMetaRowsPage(
           FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`
             : ''}
         }
-      }`
+      `
     : '';
-  const registrationClause = registrationGraph
-    ? `
-      {
-        GRAPH <${assertSafeIri(registrationGraph)}> {
-          VALUES ?subGraphName { ${registrationNames.map(sparqlString).join(' ')} }
-          ?s <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
-             <${SCHEMA_NAME}> ?subGraphName ;
-             ?p ?o .
-        }
-        BIND(<${assertSafeIri(registrationGraph)}> AS ?g)
-      }`
-    : '';
-  if (!swmMetaClause && !registrationClause) return [];
-  const union = [registrationClause, swmMetaClause].filter(Boolean).join(' UNION ');
+  if (!swmMetaClause) return [];
   const res = await store.query(`
     SELECT DISTINCT ?g ?s ?p ?o WHERE {
-      ${union}
+      ${swmMetaClause}
     }
     ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
@@ -480,6 +477,33 @@ async function readSwmMetaRowsPage(
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
     .filter((row) => row.s && row.p && row.o && row.g);
+}
+
+async function readSwmRegistrationRows(
+  store: TripleStore,
+  registrationGraph: string,
+  contextGraphId: string,
+  registrationNames: readonly string[],
+): Promise<SyncRow[]> {
+  const values = registrationNames
+    .map((name) => `(<${assertSafeIri(`${contextGraphDataGraphUri(contextGraphId)}/${name}`)}> ${sparqlString(name)})`)
+    .join(' ');
+  if (!values) return [];
+  const res = await store.query(`
+    SELECT DISTINCT ?s ?p ?o WHERE {
+      VALUES (?s ?subGraphName) { ${values} }
+      GRAPH <${assertSafeIri(registrationGraph)}> {
+        ?s <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_SUB_GRAPH}> ;
+           <${SCHEMA_NAME}> ?subGraphName ;
+           ?p ?o .
+      }
+    }
+    ORDER BY ?s ?p ?o
+  `);
+  if (res.type !== 'bindings') return [];
+  return res.bindings
+    .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: registrationGraph }))
+    .filter((row) => row.s && row.p && row.o);
 }
 
 async function countFreshSwmDataGraphRows(

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -7,9 +7,9 @@ import {
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
 import {
   createResponderGraphListMemo,
+  createResponderSyncRowListMemo,
   createResponderSubGraphRegistrationMemo,
   createResponderSwmAdmissionMemo,
-  readDurableCanonicalDataPage,
   readDurableDataPage,
   readDurableMetaPage,
   readSwmDataPage,
@@ -59,6 +59,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
+  const durableDataRowsMemo = createResponderSyncRowListMemo();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 
@@ -167,24 +168,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     } else {
       const queryStartedAt = Date.now();
       const rows = sinceBatchId == null
-        ? await (async () => {
-          const graphList = await graphListMemo.get({ refresh: offset === 0 });
-          const canonicalRows = await readDurableCanonicalDataPage({
-            store,
-            contextGraphId,
-            offset,
-            limit,
-          });
-          if (canonicalRows.length === limit) return canonicalRows;
-          return readDurableDataPage({
-            store,
-            graphList,
-            contextGraphId,
-            sinceBatchId,
-            offset,
-            limit,
-          });
-        })()
+        ? await readDurableDataPage({
+          store,
+          graphList: await graphListMemo.get({ refresh: offset === 0 }),
+          contextGraphId,
+          sinceBatchId,
+          offset,
+          limit,
+          rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
+          rowListCacheScope: request.syncSessionId ? `${peerId}:${request.syncSessionId}` : undefined,
+          refreshRowList: offset === 0,
+        })
         : await readDurableDataPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -5,7 +5,7 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
-import { DURABLE_DATA_SYNC_SESSION_BUCKET_MS } from '../durable-session.js';
+import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
   createResponderSyncRowListMemo,
@@ -60,7 +60,8 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
-  const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
+  const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
+  const durableDataSessionTokens = new Map<string, string>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 
@@ -168,6 +169,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
     } else {
       const queryStartedAt = Date.now();
+      const durableSessionTokenKey = request.syncSessionId
+        ? `${peerId}:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`
+        : undefined;
+      const refreshDurableSessionRows = Boolean(
+        durableSessionTokenKey &&
+        offset === 0 &&
+        durableDataSessionTokens.get(durableSessionTokenKey) !== request.syncSessionId,
+      );
+      if (durableSessionTokenKey && offset === 0) {
+        durableDataSessionTokens.set(durableSessionTokenKey, request.syncSessionId!);
+      }
       const rows = sinceBatchId == null
         ? await readDurableDataPage({
           store,
@@ -177,8 +189,8 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           offset,
           limit,
           rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
-          rowListCacheScope: request.syncSessionId ? `${peerId}:${request.syncSessionId}` : undefined,
-          refreshRowList: false,
+          rowListCacheScope: request.syncSessionId ? peerId : undefined,
+          refreshRowList: refreshDurableSessionRows,
         })
         : await readDurableDataPage({
           store,
@@ -188,8 +200,8 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           offset,
           limit,
           rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
-          rowListCacheScope: request.syncSessionId ? `${peerId}:${request.syncSessionId}` : undefined,
-          refreshRowList: false,
+          rowListCacheScope: request.syncSessionId ? peerId : undefined,
+          refreshRowList: refreshDurableSessionRows,
         });
       const queryDurationMs = Date.now() - queryStartedAt;
       const serializeStartedAt = Date.now();

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -6,6 +6,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
 import {
+  createResponderGraphListMemo,
   readDurableCanonicalDataPage,
   readDurableDataPage,
   readDurableMetaPage,
@@ -55,6 +56,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logWarn,
     logDebug,
   } = params;
+  const graphListMemo = createResponderGraphListMemo(store);
 
   register(protocolSync, async (data, peerId) => {
     const handlerStartedAt = Date.now();
@@ -110,7 +112,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const queryStartedAt = Date.now();
         const rows = await readSwmMetaPage({
           store,
-          graphList: await store.listGraphs(),
+          graphList: await graphListMemo.get({ refresh: offset === 0 }),
           contextGraphId,
           cutoffIso: cutoff,
           offset,
@@ -126,7 +128,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const queryStartedAt = Date.now();
         const rows = await readSwmDataPage({
           store,
-          graphList: await store.listGraphs(),
+          graphList: await graphListMemo.get({ refresh: offset === 0 }),
           contextGraphId,
           cutoffIso: cutoff,
           offset,
@@ -163,7 +165,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           if (canonicalRows.length === limit) return canonicalRows;
           return readDurableDataPage({
             store,
-            graphList: await store.listGraphs(),
+            graphList: await graphListMemo.get({ refresh: offset === 0 }),
             contextGraphId,
             sinceBatchId,
             offset,
@@ -172,7 +174,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         })()
         : await readDurableDataPage({
           store,
-          graphList: await store.listGraphs(),
+          graphList: await graphListMemo.get({ refresh: offset === 0 }),
           contextGraphId,
           sinceBatchId,
           offset,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -18,11 +18,16 @@ import {
   serializeResponderRows,
 } from './graph-plan.js';
 
-const MAX_DURABLE_DATA_SESSION_TOKENS = 64;
+const MAX_SYNC_SESSION_TOKENS = 256;
 
-type DurableDataSessionTokenEntry = {
+type SyncSessionTokenEntry = {
   token: string;
   expiresAt: number;
+};
+
+type PreparedResponderSession = {
+  rowListCacheKey: string;
+  refreshRowList: boolean;
 };
 
 interface RegisterSyncHandlerParams {
@@ -68,31 +73,54 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
   const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
-  const durableDataSessionTokens = new Map<string, DurableDataSessionTokenEntry>();
+  const durableMetaRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
+  const swmRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
+  const syncSessionTokens = new Map<string, SyncSessionTokenEntry>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 
-  const pruneDurableDataSessionTokens = (now = Date.now()) => {
-    for (const [key, entry] of durableDataSessionTokens) {
-      if (entry.expiresAt <= now) durableDataSessionTokens.delete(key);
+  const pruneSyncSessionTokens = (now = Date.now()) => {
+    for (const [key, entry] of syncSessionTokens) {
+      if (entry.expiresAt <= now) syncSessionTokens.delete(key);
     }
-    while (durableDataSessionTokens.size > MAX_DURABLE_DATA_SESSION_TOKENS) {
-      const oldest = durableDataSessionTokens.keys().next().value;
+    while (syncSessionTokens.size > MAX_SYNC_SESSION_TOKENS) {
+      const oldest = syncSessionTokens.keys().next().value;
       if (!oldest) break;
-      durableDataSessionTokens.delete(oldest);
+      syncSessionTokens.delete(oldest);
     }
   };
 
-  const rememberDurableDataSessionToken = (key: string, token: string, now = Date.now()) => {
-    pruneDurableDataSessionTokens(now);
-    if (!durableDataSessionTokens.has(key) && durableDataSessionTokens.size >= MAX_DURABLE_DATA_SESSION_TOKENS) {
-      const oldest = durableDataSessionTokens.keys().next().value;
-      if (oldest) durableDataSessionTokens.delete(oldest);
+  const rememberSyncSessionToken = (key: string, token: string, now = Date.now()) => {
+    pruneSyncSessionTokens(now);
+    if (!syncSessionTokens.has(key) && syncSessionTokens.size >= MAX_SYNC_SESSION_TOKENS) {
+      const oldest = syncSessionTokens.keys().next().value;
+      if (oldest) syncSessionTokens.delete(oldest);
     }
-    durableDataSessionTokens.set(key, {
+    syncSessionTokens.set(key, {
       token,
       expiresAt: now + DURABLE_DATA_SYNC_SESSION_TTL_MS,
     });
+  };
+
+  const prepareResponderSession = (
+    label: string,
+    key: string,
+    token: string | undefined,
+    offset: number,
+    now = Date.now(),
+  ): PreparedResponderSession | undefined => {
+    if (!token) return undefined;
+    pruneSyncSessionTokens(now);
+    const activeToken = syncSessionTokens.get(key)?.token;
+    if (offset > 0 && activeToken !== token) {
+      throw new Error(`${label} sync session was superseded before page completion`);
+    }
+    const refreshRowList = offset === 0 && activeToken !== token;
+    rememberSyncSessionToken(key, token, now);
+    return {
+      rowListCacheKey: key,
+      refreshRowList,
+    };
   };
 
   register(protocolSync, async (data, peerId) => {
@@ -147,6 +175,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
       } else if (phase === 'meta') {
         const queryStartedAt = Date.now();
+        const session = prepareResponderSession(
+          'Shared memory meta',
+          `${peerId}:swm-meta:${contextGraphId}`,
+          request.syncSessionId,
+          offset,
+        );
         const rows = await readSwmMetaPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),
@@ -155,6 +189,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           cutoffIso: cutoff,
           offset,
           limit,
+          rowListMemo: session ? swmRowsMemo : undefined,
+          rowListCacheKey: session?.rowListCacheKey,
+          refreshRowList: session?.refreshRowList,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();
@@ -164,6 +201,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       } else {
         const queryStartedAt = Date.now();
+        const session = prepareResponderSession(
+          'Shared memory data',
+          `${peerId}:swm-data:${contextGraphId}`,
+          request.syncSessionId,
+          offset,
+        );
         const rows = await readSwmDataPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),
@@ -172,6 +215,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           cutoffIso: cutoff,
           offset,
           limit,
+          rowListMemo: session ? swmRowsMemo : undefined,
+          rowListCacheKey: session?.rowListCacheKey,
+          refreshRowList: session?.refreshRowList,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();
@@ -184,12 +230,21 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (nquads.length === 0) return new TextEncoder().encode('');
     } else if (phase === 'meta') {
       const queryStartedAt = Date.now();
+      const session = prepareResponderSession(
+        'Durable meta',
+        `${peerId}:durable-meta:${contextGraphId}`,
+        request.syncSessionId,
+        offset,
+      );
       const rows = await readDurableMetaPage({
         store,
         contextGraphId,
         registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
         offset,
         limit,
+        rowListMemo: session ? durableMetaRowsMemo : undefined,
+        rowListCacheKey: session?.rowListCacheKey,
+        refreshRowList: session?.refreshRowList,
       });
       const queryDurationMs = Date.now() - queryStartedAt;
       const serializeStartedAt = Date.now();
@@ -199,31 +254,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
     } else {
       const queryStartedAt = Date.now();
-      const durableSessionTokenKey = request.syncSessionId
-        ? `${peerId}:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`
-        : undefined;
-      const durableSessionTokenNow = Date.now();
-      if (durableSessionTokenKey) pruneDurableDataSessionTokens(durableSessionTokenNow);
-      const activeDurableSessionToken = durableSessionTokenKey
-        ? durableDataSessionTokens.get(durableSessionTokenKey)?.token
-        : undefined;
-      if (
-        durableSessionTokenKey &&
-        offset > 0 &&
-        activeDurableSessionToken !== request.syncSessionId
-      ) {
-        throw new Error('Durable data sync session was superseded before page completion');
-      }
-      const refreshDurableSessionRows = Boolean(
-        durableSessionTokenKey &&
-        offset === 0 &&
-        activeDurableSessionToken !== request.syncSessionId,
+      const session = prepareResponderSession(
+        'Durable data',
+        `${peerId}:durable-data:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`,
+        request.syncSessionId,
+        offset,
       );
-      if (durableSessionTokenKey && offset === 0) {
-        rememberDurableDataSessionToken(durableSessionTokenKey, request.syncSessionId!, durableSessionTokenNow);
-      } else if (durableSessionTokenKey) {
-        rememberDurableDataSessionToken(durableSessionTokenKey, request.syncSessionId!, durableSessionTokenNow);
-      }
       const rows = sinceBatchId == null
         ? await readDurableDataPage({
           store,
@@ -232,9 +268,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           sinceBatchId,
           offset,
           limit,
-          rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
-          rowListCacheScope: request.syncSessionId ? peerId : undefined,
-          refreshRowList: refreshDurableSessionRows,
+          rowListMemo: session ? durableDataRowsMemo : undefined,
+          rowListCacheScope: session ? peerId : undefined,
+          refreshRowList: session?.refreshRowList,
         })
         : await readDurableDataPage({
           store,
@@ -243,9 +279,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           sinceBatchId,
           offset,
           limit,
-          rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
-          rowListCacheScope: request.syncSessionId ? peerId : undefined,
-          refreshRowList: refreshDurableSessionRows,
+          rowListMemo: session ? durableDataRowsMemo : undefined,
+          rowListCacheScope: session ? peerId : undefined,
+          refreshRowList: session?.refreshRowList,
         });
       const queryDurationMs = Date.now() - queryStartedAt;
       const serializeStartedAt = Date.now();

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -18,6 +18,13 @@ import {
   serializeResponderRows,
 } from './graph-plan.js';
 
+const MAX_DURABLE_DATA_SESSION_TOKENS = 64;
+
+type DurableDataSessionTokenEntry = {
+  token: string;
+  expiresAt: number;
+};
+
 interface RegisterSyncHandlerParams {
   /**
    * `register` callable. In production this is bound to the RAW
@@ -61,9 +68,32 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
   const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
-  const durableDataSessionTokens = new Map<string, string>();
+  const durableDataSessionTokens = new Map<string, DurableDataSessionTokenEntry>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
+
+  const pruneDurableDataSessionTokens = (now = Date.now()) => {
+    for (const [key, entry] of durableDataSessionTokens) {
+      if (entry.expiresAt <= now) durableDataSessionTokens.delete(key);
+    }
+    while (durableDataSessionTokens.size > MAX_DURABLE_DATA_SESSION_TOKENS) {
+      const oldest = durableDataSessionTokens.keys().next().value;
+      if (!oldest) break;
+      durableDataSessionTokens.delete(oldest);
+    }
+  };
+
+  const rememberDurableDataSessionToken = (key: string, token: string, now = Date.now()) => {
+    pruneDurableDataSessionTokens(now);
+    if (!durableDataSessionTokens.has(key) && durableDataSessionTokens.size >= MAX_DURABLE_DATA_SESSION_TOKENS) {
+      const oldest = durableDataSessionTokens.keys().next().value;
+      if (oldest) durableDataSessionTokens.delete(oldest);
+    }
+    durableDataSessionTokens.set(key, {
+      token,
+      expiresAt: now + DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    });
+  };
 
   register(protocolSync, async (data, peerId) => {
     const handlerStartedAt = Date.now();
@@ -172,13 +202,27 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       const durableSessionTokenKey = request.syncSessionId
         ? `${peerId}:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`
         : undefined;
+      const durableSessionTokenNow = Date.now();
+      if (durableSessionTokenKey) pruneDurableDataSessionTokens(durableSessionTokenNow);
+      const activeDurableSessionToken = durableSessionTokenKey
+        ? durableDataSessionTokens.get(durableSessionTokenKey)?.token
+        : undefined;
+      if (
+        durableSessionTokenKey &&
+        offset > 0 &&
+        activeDurableSessionToken !== request.syncSessionId
+      ) {
+        throw new Error('Durable data sync session was superseded before page completion');
+      }
       const refreshDurableSessionRows = Boolean(
         durableSessionTokenKey &&
         offset === 0 &&
-        durableDataSessionTokens.get(durableSessionTokenKey) !== request.syncSessionId,
+        activeDurableSessionToken !== request.syncSessionId,
       );
       if (durableSessionTokenKey && offset === 0) {
-        durableDataSessionTokens.set(durableSessionTokenKey, request.syncSessionId!);
+        rememberDurableDataSessionToken(durableSessionTokenKey, request.syncSessionId!, durableSessionTokenNow);
+      } else if (durableSessionTokenKey) {
+        rememberDurableDataSessionToken(durableSessionTokenKey, request.syncSessionId!, durableSessionTokenNow);
       }
       const rows = sinceBatchId == null
         ? await readDurableDataPage({

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -156,6 +156,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       const queryStartedAt = Date.now();
       const rows = sinceBatchId == null
         ? await (async () => {
+          const graphList = await graphListMemo.get({ refresh: offset === 0 });
           const canonicalRows = await readDurableCanonicalDataPage({
             store,
             contextGraphId,
@@ -165,7 +166,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           if (canonicalRows.length === limit) return canonicalRows;
           return readDurableDataPage({
             store,
-            graphList: await graphListMemo.get({ refresh: offset === 0 }),
+            graphList,
             contextGraphId,
             sinceBatchId,
             offset,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -177,7 +177,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           limit,
           rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
           rowListCacheScope: request.syncSessionId ? `${peerId}:${request.syncSessionId}` : undefined,
-          refreshRowList: offset === 0,
+          refreshRowList: false,
         })
         : await readDurableDataPage({
           store,
@@ -186,6 +186,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           sinceBatchId,
           offset,
           limit,
+          rowListMemo: request.syncSessionId ? durableDataRowsMemo : undefined,
+          rowListCacheScope: request.syncSessionId ? `${peerId}:${request.syncSessionId}` : undefined,
+          refreshRowList: false,
         });
       const queryDurationMs = Date.now() - queryStartedAt;
       const serializeStartedAt = Date.now();

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -5,6 +5,7 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
+import { DURABLE_DATA_SYNC_SESSION_BUCKET_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
   createResponderSyncRowListMemo,
@@ -59,7 +60,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
-  const durableDataRowsMemo = createResponderSyncRowListMemo();
+  const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -7,6 +7,7 @@ import {
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
 import {
   createResponderGraphListMemo,
+  createResponderSubGraphRegistrationMemo,
   createResponderSwmAdmissionMemo,
   readDurableCanonicalDataPage,
   readDurableDataPage,
@@ -58,6 +59,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
+  const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 
   register(protocolSync, async (data, peerId) => {
@@ -152,7 +154,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       const rows = await readDurableMetaPage({
         store,
         contextGraphId,
-        registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+        registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
         offset,
         limit,
       });

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -1,23 +1,28 @@
-import { createOperationContext, DKG_ONTOLOGY, MemoryLayer, type OperationContext } from '@origintrail-official/dkg-core';
-import { contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
-import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
-import { serializeWorkspacePublicSnapshotQuads, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
+import { createOperationContext, type OperationContext } from '@origintrail-official/dkg-core';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  serializeWorkspacePublicSnapshotQuads,
+  type WorkspacePublicSnapshotStore,
+} from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
+import {
+  readDurableCanonicalDataPage,
+  readDurableDataPage,
+  readDurableMetaPage,
+  readSwmDataPage,
+  readSwmMetaPage,
+  serializeResponderRows,
+} from './graph-plan.js';
 
 interface RegisterSyncHandlerParams {
   /**
    * `register` callable. In production this is bound to the RAW
    * ProtocolRouter (via an adapter that re-exposes the string `peerId`),
-   * NOT `Messenger.register`: sync runs outside the Universal Messenger
+   * not `Messenger.register`: sync runs outside the Universal Messenger
    * substrate as raw `/dkg/10.0.2/sync` so its large, never-reused page
-   * responses are not cached in message_idempotency (the node-ui.db
-   * bloat fix). The handler receives the bare payload — exactly the
-   * auth envelope `parseSyncRequest` expects — and returns the response
+   * responses are not cached in message_idempotency. The handler receives
+   * the bare auth envelope `parseSyncRequest` expects and returns response
    * bytes for the router to send.
-   *
-   * In tests this can be any callable matching the signature; the
-   * caller doesn't need to provide a real ProtocolRouter or full
-   * Messenger.
    */
   register: (
     protocolId: string,
@@ -62,12 +67,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     if (!contextGraphId || typeof contextGraphId !== 'string') {
       return new TextEncoder().encode('');
     }
-    // Phase C — validate the optional delta hint into a non-negative bigint.
-    // Anything malformed is ignored (full scan), never an error: the field is
-    // an unsigned, best-effort optimization.
+
+    // Phase C: validate the optional delta hint into a non-negative bigint.
+    // Malformed values are ignored so older or buggy requesters fall back to a
+    // full scan instead of making the responder fail closed.
     let sinceBatchId: bigint | null = null;
     if (request.sinceBatchId != null && /^\d+$/.test(String(request.sinceBatchId))) {
-      try { sinceBatchId = BigInt(String(request.sinceBatchId)); } catch { sinceBatchId = null; }
+      try {
+        sinceBatchId = BigInt(String(request.sinceBatchId));
+      } catch {
+        sinceBatchId = null;
+      }
     }
     const nquads: string[] = [];
 
@@ -81,85 +91,6 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
 
     if (isWorkspace) {
       const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
-      // SWM lives at two URI shapes per CG (see `contextGraphSharedMemoryUri`
-      // / `contextGraphSharedMemoryMetaUri` in dkg-core/constants.ts):
-      //   <cgPrefix>/_shared_memory                  (root SWM)
-      //   <cgPrefix>/<sub>/_shared_memory            (sub-graph SWM)
-      //   <cgPrefix>/_shared_memory_meta             (root SWM meta)
-      //   <cgPrefix>/<sub>/_shared_memory_meta       (sub-graph SWM meta)
-      //
-      // Pre-PR-X this branch only queried the root graphs (via
-      // `contextGraphWorkspaceGraphUri`/`...MetaGraphUri`, which are
-      // hardcoded aliases for the root). A sync requester therefore
-      // received zero bytes of any sub-graph SWM the responder had
-      // locally, so a late joiner who joined AFTER the curator had
-      // published into a sub-graph could not backfill that history
-      // through `PROTOCOL_SYNC` — see the SWM late-joiner backfill
-      // gap (urn:dkg:finding:swm-gap-2-subgraph-blind-spot). Filter
-      // by URI shape under the CG prefix and emit `?g` per binding so
-      // the requester reconstructs the correct graph at write time.
-      // Sub-graph names cannot contain `/` and cannot start with `_`
-      // (`validateSubGraphName` in dkg-core/constants.ts), so the
-      // segment between `<cgPrefix>/` and `/_shared_memory[_meta]` is
-      // always a single path component when it represents a sub-graph.
-      //
-      // Codex review on #885 — URI shape alone is NOT a sufficient CG
-      // boundary because `contextGraphId` itself permits `/` (wallet-
-      // scoped IDs do, e.g. `0xabc/project`, and `validateContextGraphId`
-      // accepts `/`). For a request on CG `cg-A`, the URI
-      // `<cgPrefix>/child/_shared_memory` is structurally
-      // indistinguishable from a sub-graph "child" of cg-A AND from the
-      // root SWM of a different CG `cg-A/child` — even with a tightened
-      // STRBEFORE/STRAFTER segment check that allows exactly one path
-      // segment.
-      //
-      // Disambiguate by registration: the `<cgPrefix>/_meta` graph
-      // carries the SubGraph registration triples (see
-      // `DKGPublisher.isSubGraphRegistered` in dkg-publisher.ts:3828
-      // and the auto-register in
-      // `FinalizationHandler.ensureContextGraphAndSubGraph`,
-      // finalization-handler.ts:540). Admit only the root SWM and the
-      // SWM of registered sub-graphs of THIS CG.
-      //
-      // Codex review round 5: a parent sub-graph and a known child CG can
-      // still collide on the exact same graph URI:
-      //   parent sub-graph "code" => <parent>/code/_shared_memory
-      //   child CG "parent/code"  => <parent>/code/_shared_memory
-      // Match dkg-query-engine's scoped allowlist and reject registered
-      // sub-graph candidates whose `<cgPrefix>/<name>` is also known as a
-      // child context graph via its own `_meta` graph.
-      const cgPrefix = `did:dkg:context-graph:${contextGraphId}`;
-      const cgMetaGraph = `${cgPrefix}/_meta`;
-      const rootSwm = `${cgPrefix}/_shared_memory`;
-      const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
-      // Registered sub-graphs are identified by their schema:name
-      // literal in `<cgPrefix>/_meta`. Reconstruct the canonical
-      // SWM/SWM_meta URI from that name (matching
-      // `contextGraphSharedMemoryUri` in dkg-core/constants.ts) so
-      // sub-graph entities slated under arbitrary `<cgPrefix>/<name>/...`
-      // shapes (e.g. assertion graphs) are not accidentally admitted.
-      const registeredSubGraphSwmFilter = (forMeta: boolean) => {
-        const suffix = forMeta ? '/_shared_memory_meta' : '/_shared_memory';
-        return `EXISTS {
-          GRAPH <${cgMetaGraph}> {
-            ?sg <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/SubGraph> .
-            ?sg <http://schema.org/name> ?subGraphName .
-            FILTER(${forMeta ? `STR(?g) = CONCAT("${cgPrefix}/", STR(?subGraphName), "${suffix}")` : `(STRSTARTS(STR(?g), CONCAT("${cgPrefix}/", STR(?subGraphName), "${suffix}", "/")) || STR(?g) = CONCAT("${cgPrefix}/", STR(?subGraphName), "${suffix}"))`})
-          }
-          FILTER NOT EXISTS {
-            GRAPH ?childMetaGraph {
-              {
-                ?childContextGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://dkg.network/ontology#ContextGraph> .
-              } UNION {
-                ?childContextGraph <https://dkg.network/ontology#registrationStatus> ?childStatus .
-              }
-            }
-            FILTER(STR(?childContextGraph) = CONCAT("${cgPrefix}/", STR(?subGraphName)))
-            FILTER(STR(?childMetaGraph) = CONCAT(STR(?childContextGraph), "/_meta"))
-          }
-        }`;
-      };
-
       if (phase === 'snapshot') {
         const snapshotRef = request.snapshotRef?.trim();
         if (!snapshotRef || !publicSnapshotStore) {
@@ -176,240 +107,83 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
         logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
       } else if (phase === 'meta') {
-        // Codex review on #885 — admit only the root SWM_meta + the
-        // SWM_meta of REGISTERED sub-graphs of this CG. Nested CGs
-        // sharing the prefix have their registration in their own
-        // `_meta`, not this CG's, so they are excluded.
-        const metaBoundaryFilter = `STR(?g) = "${rootSwmMeta}" || ${registeredSubGraphSwmFilter(true)}`;
-        const metaQuery = cutoff != null
-          ? `SELECT ?s ?p ?o ?g WHERE {
-              GRAPH ?g { ?s ?p ?o }
-              FILTER(${metaBoundaryFilter})
-              FILTER EXISTS {
-                GRAPH ?g {
-                  ?s <http://dkg.io/ontology/publishedAt> ?ts .
-                  FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-                }
-              }
-            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
-          : `SELECT ?s ?p ?o ?g WHERE {
-              GRAPH ?g { ?s ?p ?o }
-              FILTER(${metaBoundaryFilter})
-            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
-
         const queryStartedAt = Date.now();
-        const metaResult = await store.query(metaQuery);
+        const rows = await readSwmMetaPage({
+          store,
+          graphList: await store.listGraphs(),
+          contextGraphId,
+          cutoffIso: cutoff,
+          offset,
+          limit,
+        });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();
-        if (metaResult.type === 'bindings') {
-          for (const b of metaResult.bindings) {
-            const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-            nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${b['g']}> .`);
-          }
-        }
+        const serialized = serializeResponderRows(rows);
+        if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
         logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       } else {
-        // The TTL branch joins a WorkspaceOperation entry (in the
-        // matching `_shared_memory_meta` graph) to its root entity
-        // and skolemized children (in the same-prefix `_shared_memory`
-        // graph). Bind the two graphs together by URI structure:
-        //   STR(?gMeta) = CONCAT(STR(?g), "_meta")
-        // so a publish into sub-graph "foo" pairs ops in
-        // `<cgPrefix>/foo/_shared_memory_meta` with entities in
-        // `<cgPrefix>/foo/_shared_memory` only — without bleeding into
-        // a different sub-graph's ops or into root ops.
-        // Codex review on #885 — admit only the root SWM + the SWM of
-        // REGISTERED sub-graphs of this CG. The TTL branch still
-        // pairs `?gMeta = ?g + "_meta"` to scope op→entity matching to
-        // a single sub-graph; the registration check is what rejects
-        // nested-CG SWM that shares the URI prefix.
-        const dataBoundaryFilter = `(STRSTARTS(STR(?g), "${rootSwm}/") || STR(?g) = "${rootSwm}") || ${registeredSubGraphSwmFilter(false)}`;
-        const wsQuery = cutoff != null
-          ? `SELECT DISTINCT ?s ?p ?o ?g WHERE {
-  GRAPH ?gMeta {
-    ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/WorkspaceOperation> .
-    ?op <http://dkg.io/ontology/publishedAt> ?ts .
-    ?op <http://dkg.io/ontology/rootEntity> ?re .
-    FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
-  }
-  GRAPH ?g { ?s ?p ?o }
-  FILTER(
-    (${dataBoundaryFilter}) &&
-    STR(?gMeta) = CONCAT(STR(?g), "_meta")
-  )
-  FILTER(?s = ?re || STRSTARTS(STR(?s), CONCAT(STR(?re), "/.well-known/genid/")))
-} ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
-          : `SELECT ?s ?p ?o ?g WHERE {
-              GRAPH ?g { ?s ?p ?o }
-              FILTER(${dataBoundaryFilter})
-            } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
-
         const queryStartedAt = Date.now();
-        const wsResult = await store.query(wsQuery);
+        const rows = await readSwmDataPage({
+          store,
+          graphList: await store.listGraphs(),
+          contextGraphId,
+          cutoffIso: cutoff,
+          offset,
+          limit,
+        });
         const queryDurationMs = Date.now() - queryStartedAt;
-        if (wsResult.type !== 'bindings' || wsResult.bindings.length === 0) {
-          return new TextEncoder().encode('');
-        }
         const serializeStartedAt = Date.now();
-        for (const b of wsResult.bindings) {
-          const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-          nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${b['g']}> .`);
-        }
+        const serialized = serializeResponderRows(rows);
+        if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
         logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       }
 
       if (nquads.length === 0) return new TextEncoder().encode('');
+    } else if (phase === 'meta') {
+      const queryStartedAt = Date.now();
+      const rows = await readDurableMetaPage({ store, contextGraphId, offset, limit });
+      const queryDurationMs = Date.now() - queryStartedAt;
+      const serializeStartedAt = Date.now();
+      const serialized = serializeResponderRows(rows);
+      if (serialized) nquads.push(serialized);
+      const serializeDurationMs = Date.now() - serializeStartedAt;
+      logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
     } else {
-      const dataGraph = contextGraphDataGraphUri(contextGraphId);
-      const metaGraph = contextGraphMetaGraphUri(contextGraphId);
-
-      if (phase === 'meta') {
-        const DKG_NS = 'http://dkg.io/ontology/';
-        const cgEntity = `did:dkg:context-graph:${contextGraphId}`;
-        const queryStartedAt = Date.now();
-        const metaResult = await store.query(
-          `SELECT ?s ?p ?o WHERE {
-            GRAPH <${metaGraph}> { ?s ?p ?o }
-            FILTER(
-              STR(?s) = "${cgEntity}" ||
-              STRSTARTS(STR(?s), "did:dkg:activity:") ||
-              STRSTARTS(STR(?s), "did:dkg:join-request:") ||
-              EXISTS {
-                GRAPH <${metaGraph}> {
-                  ?lc <${DKG_NS}memoryLayer> ?layer .
-                  FILTER(?layer != "${MemoryLayer.WorkingMemory}")
-                  {
-                    FILTER(?lc = ?s)
-                  } UNION {
-                    ?lc <${DKG_NS}assertionGraph> ?s .
-                  } UNION {
-                    ?lc <${DKG_NS}assertionName> ?aname .
-                    FILTER(
-                      CONTAINS(STR(?s), "/assertion/") &&
-                      STRENDS(STR(?s), CONCAT("/", STR(?aname)))
-                    )
-                  }
-                }
-              } ||
-              EXISTS {
-                GRAPH <${metaGraph}> {
-                  { ?evt_src <http://www.w3.org/ns/prov#generated> ?parent }
-                  UNION
-                  { ?evt_src <http://www.w3.org/ns/prov#used> ?parent }
-                  FILTER(?evt_src = ?s)
-                  ?parent <${DKG_NS}memoryLayer> ?elayer .
-                  FILTER(?elayer != "${MemoryLayer.WorkingMemory}")
-                }
-              }
-            )
-          } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`,
-        );
-        const queryDurationMs = Date.now() - queryStartedAt;
-        const serializeStartedAt = Date.now();
-        if (metaResult.type === 'bindings') {
-          for (const b of metaResult.bindings) {
-            const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-            nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${metaGraph}> .`);
-          }
-        }
-        const serializeDurationMs = Date.now() - serializeStartedAt;
-        logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-      } else {
-        const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}`;
-        const innerMetaGraph = `${cgUriPrefix}/_meta`;
-        const DKG_NS = 'http://dkg.io/ontology/';
-        // Exclude only the TOP-LEVEL `${cgUriPrefix}/_meta` graph (handled by the
-        // 'meta' phase above). Per-cgId meta graphs like
-        // `${cgUriPrefix}/context/<cgId>/_meta` MUST be sent by the data phase —
-        // they carry KC metadata (merkleRoot, batchId, tokenId, partOf,
-        // publication, ...) that the RS prover's kc-extractor.ts queries to
-        // resolve a challenge into a concrete chunk. The previous
-        // `!STRENDS(?g, "/_meta")` filter dropped them on the floor, so
-        // non-publisher peers received the per-cgId data but no per-cgId meta
-        // and emitted `kc-not-synced` for every challenge they were assigned
-        // against KCs they hadn't published themselves.
-        // Phase C delta filter (narrowing-only). When the requester sends a
-        // `sinceBatchId` high-water mark, drop DATA triples whose owning KC has
-        // `dkg:batchId <= sinceBatchId`. Subjects with NO KA→KC→batchId mapping
-        // (KC/KA meta rows, lifecycle, activity) are NEVER hidden — a delta can
-        // only ever return a subset, so re-sending un-keyed rows is correct (and
-        // keeps every responder's behavior a safe superset). Old responders that
-        // predate this field simply ignore it and return the full scan.
-        // Perf note: the EXISTS/NOT-EXISTS join only runs for delta requests,
-        // which are by definition small; full scans skip it entirely.
-        // Scope the KA→KC→batchId join to THIS context graph's meta graphs
-        // only. Without it, any other CG on the node that happens to reuse the
-        // same `rootEntity` IRI could satisfy the EXISTS/NOT-EXISTS checks and
-        // wrongly include/exclude triples. CG meta graphs are `${cgUriPrefix}/…
-        // /_meta` (top-level, per-cgId, and sub-graph); the trailing slash in
-        // the prefix prevents `mfacts` from matching `mfacts-2`.
-        const metaGraphScope = (g: string): string =>
-          `FILTER(STRSTARTS(STR(${g}), "${cgUriPrefix}/") && STRENDS(STR(${g}), "/_meta"))`;
-        // Bind ?bid<sfx> to the batchId of the KC owning subject ?s, tolerant of
-        // the legacy shapes the rest of the agent also falls back on (see
-        // `getBatchMerkleRoot` in dkg-agent.ts): the canonical placement on the
-        // KC (`?kc dkg:batchId`) AND a legacy placement directly on the KA
-        // (`?ka dkg:batchId`). Either typed (`"5"^^xsd:integer`) or untyped
-        // (`"5"`) literals are accepted — the comparison below coerces via
-        // xsd:integer(STR(...)) so an untyped literal isn't silently skipped by
-        // a typed `>` comparison (which would resend stale rows or, in the
-        // NOT-EXISTS arm, hide eligible ones).
-        const batchIdOfSubject = (sfx: string): string => `
-                GRAPH ?mg${sfx} {
-                  ${metaGraphScope('?mg' + sfx)}
-                  ?ka${sfx} <${DKG_NS}partOf> ?ual${sfx} ; <${DKG_NS}rootEntity> ?re${sfx} .
-                  FILTER(?re${sfx} = ?s || STRSTARTS(STR(?s), CONCAT(STR(?re${sfx}), "/.well-known/genid/")))
-                  { ?ual${sfx} <${DKG_NS}batchId> ?bid${sfx} }
-                  UNION
-                  { ?ka${sfx} <${DKG_NS}batchId> ?bid${sfx} }
-                }`;
-        const deltaFilter = sinceBatchId != null
-          ? `
-            FILTER(
-              NOT EXISTS {${batchIdOfSubject('Any')}
-              }
-              ||
-              EXISTS {${batchIdOfSubject('New')}
-                FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(?bidNew)) > ${sinceBatchId.toString()})
-              }
-            )`
-          : '';
-        const queryStartedAt = Date.now();
-        const dataResult = await store.query(
-          `SELECT ?s ?p ?o ?g WHERE {
-            GRAPH ?g { ?s ?p ?o }
-            FILTER(
-              (STR(?g) = "${cgUriPrefix}" || STRSTARTS(STR(?g), "${cgUriPrefix}/")) &&
-              STR(?g) != "${innerMetaGraph}" &&
-              !CONTAINS(STR(?g), "/_private")
-            )
-            FILTER(
-              !CONTAINS(STR(?g), "/assertion/") ||
-              EXISTS {
-                GRAPH <${innerMetaGraph}> {
-                  ?lifecycle <${DKG_NS}assertionGraph> ?g .
-                  ?lifecycle <${DKG_NS}memoryLayer> ?layer .
-                  FILTER(?layer != "${MemoryLayer.WorkingMemory}")
-                }
-              }
-            )${deltaFilter}
-          } ORDER BY ?g ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`,
-        );
-        const queryDurationMs = Date.now() - queryStartedAt;
-        if (dataResult.type !== 'bindings' || dataResult.bindings.length === 0) {
-          return new TextEncoder().encode('');
-        }
-        const serializeStartedAt = Date.now();
-        for (const b of dataResult.bindings) {
-          const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
-          const graph = b['g'] ?? dataGraph;
-          nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${graph}> .`);
-        }
-        const serializeDurationMs = Date.now() - serializeStartedAt;
-        logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-      }
+      const queryStartedAt = Date.now();
+      const rows = sinceBatchId == null
+        ? await (async () => {
+          const canonicalRows = await readDurableCanonicalDataPage({
+            store,
+            contextGraphId,
+            offset,
+            limit,
+          });
+          if (canonicalRows.length === limit) return canonicalRows;
+          return readDurableDataPage({
+            store,
+            graphList: await store.listGraphs(),
+            contextGraphId,
+            sinceBatchId,
+            offset,
+            limit,
+          });
+        })()
+        : await readDurableDataPage({
+          store,
+          graphList: await store.listGraphs(),
+          contextGraphId,
+          sinceBatchId,
+          offset,
+          limit,
+        });
+      const queryDurationMs = Date.now() - queryStartedAt;
+      const serializeStartedAt = Date.now();
+      const serialized = serializeResponderRows(rows);
+      if (serialized) nquads.push(serialized);
+      const serializeDurationMs = Date.now() - serializeStartedAt;
+      logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
     }
 
     const totalDurationMs = Date.now() - handlerStartedAt;

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -7,6 +7,7 @@ import {
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
 import {
   createResponderGraphListMemo,
+  createResponderSwmAdmissionMemo,
   readDurableCanonicalDataPage,
   readDurableDataPage,
   readDurableMetaPage,
@@ -57,6 +58,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
+  const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
 
   register(protocolSync, async (data, peerId) => {
     const handlerStartedAt = Date.now();
@@ -113,6 +115,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const rows = await readSwmMetaPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),
+          registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
           contextGraphId,
           cutoffIso: cutoff,
           offset,
@@ -129,6 +132,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const rows = await readSwmDataPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),
+          registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
           contextGraphId,
           cutoffIso: cutoff,
           offset,
@@ -145,7 +149,13 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (nquads.length === 0) return new TextEncoder().encode('');
     } else if (phase === 'meta') {
       const queryStartedAt = Date.now();
-      const rows = await readDurableMetaPage({ store, contextGraphId, offset, limit });
+      const rows = await readDurableMetaPage({
+        store,
+        contextGraphId,
+        registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+        offset,
+        limit,
+      });
       const queryDurationMs = Date.now() - queryStartedAt;
       const serializeStartedAt = Date.now();
       const serialized = serializeResponderRows(rows);

--- a/packages/agent/src/sync/shared-memory-graphs.ts
+++ b/packages/agent/src/sync/shared-memory-graphs.ts
@@ -1,0 +1,7 @@
+export function isSharedMemoryBucketDescendantDataGraph(graph: string, bucketGraph: string): boolean {
+  if (!graph.startsWith(`${bucketGraph}/`)) return false;
+  const tail = graph.slice(bucketGraph.length + 1);
+  if (tail.startsWith('staging/')) return false;
+  const parts = tail.split('/');
+  return parts.length === 2 && parts[0].length > 0 && /^[0-9]+$/.test(parts[1]);
+}

--- a/packages/agent/test/_helpers/sync-responder.ts
+++ b/packages/agent/test/_helpers/sync-responder.ts
@@ -17,7 +17,7 @@ export interface CapturedSyncHandler {
     proto: string,
     handler: (data: Uint8Array, peerId: string) => Promise<Uint8Array>,
   ) => void;
-  invoke: (envelope: SyncRequestEnvelope) => Promise<string>;
+  invoke: (envelope: SyncRequestEnvelope, remotePeerId?: string) => Promise<string>;
 }
 
 export function captureSyncHandler(): CapturedSyncHandler {
@@ -26,10 +26,10 @@ export function captureSyncHandler(): CapturedSyncHandler {
     register: (_proto, handler) => {
       captured = handler;
     },
-    invoke: async (envelope) => {
+    invoke: async (envelope, remotePeerId = TEST_REMOTE_PEER) => {
       if (!captured) throw new Error('handler not registered');
       const bytes = new TextEncoder().encode(JSON.stringify(envelope));
-      const out = await captured(bytes, TEST_REMOTE_PEER);
+      const out = await captured(bytes, remotePeerId);
       return new TextDecoder().decode(out);
     },
   };

--- a/packages/agent/test/_helpers/sync-responder.ts
+++ b/packages/agent/test/_helpers/sync-responder.ts
@@ -1,0 +1,101 @@
+import type { OperationContext } from '@origintrail-official/dkg-core';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { registerSyncHandler } from '../../src/sync/responder/sync-handler.js';
+import type { SyncRequestEnvelope } from '../../src/sync/auth/request-build.js';
+
+export const TEST_SYNC_PROTOCOL = '/origintrail/dkg/sync/1.0.0';
+export const TEST_SYNC_DENIED = 'sync-denied';
+export const TEST_REMOTE_PEER = '12D3KooWSyncResponderTestRemote';
+export const DKG_NS = 'http://dkg.io/ontology/';
+export const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+export const SCHEMA_NAME = 'http://schema.org/name';
+
+export const noopLog = (_ctx: OperationContext, _msg: string) => {};
+
+export interface CapturedSyncHandler {
+  register: (
+    proto: string,
+    handler: (data: Uint8Array, peerId: string) => Promise<Uint8Array>,
+  ) => void;
+  invoke: (envelope: SyncRequestEnvelope) => Promise<string>;
+}
+
+export function captureSyncHandler(): CapturedSyncHandler {
+  let captured: ((data: Uint8Array, peerId: string) => Promise<Uint8Array>) | null = null;
+  return {
+    register: (_proto, handler) => {
+      captured = handler;
+    },
+    invoke: async (envelope) => {
+      if (!captured) throw new Error('handler not registered');
+      const bytes = new TextEncoder().encode(JSON.stringify(envelope));
+      const out = await captured(bytes, TEST_REMOTE_PEER);
+      return new TextDecoder().decode(out);
+    },
+  };
+}
+
+export function registerTestSyncHandler(
+  store: TripleStore,
+  options: {
+    sharedMemoryTtlMs?: number;
+    syncPageSize?: number;
+    authorize?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+  } = {},
+): CapturedSyncHandler {
+  const cap = captureSyncHandler();
+  registerSyncHandler({
+    register: cap.register,
+    protocolSync: TEST_SYNC_PROTOCOL,
+    syncDeniedResponse: TEST_SYNC_DENIED,
+    syncPageSize: options.syncPageSize ?? 5000,
+    sharedMemoryTtlMs: options.sharedMemoryTtlMs ?? 0,
+    store,
+    peerId: 'self-peer',
+    parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+    authorizeSyncRequest: options.authorize ?? (async () => true),
+    logWarn: noopLog,
+    logDebug: noopLog,
+  });
+  return cap;
+}
+
+export function lineGraphsFromNquads(text: string): Set<string> {
+  const graphs = new Set<string>();
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const match = line.match(/<([^<>]+)>\s*\.\s*$/);
+    if (match) graphs.add(match[1]);
+  }
+  return graphs;
+}
+
+export function linesFromNquads(text: string): string[] {
+  return text.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+export function workspaceOpQuads(
+  cgId: string,
+  opId: string,
+  rootEntity: string,
+  metaGraph: string,
+  publishedAt: string,
+) {
+  const subject = `urn:dkg:share:${cgId}:${opId}`;
+  return [
+    { graph: metaGraph, subject, predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}publishedAt`, object: `"${publishedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}rootEntity`, object: rootEntity },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}contextGraphId`, object: `"${cgId}"` },
+    { graph: metaGraph, subject, predicate: `${DKG_NS}shareOperationId`, object: `"${opId}"` },
+  ];
+}
+export function subGraphRegistrationQuads(cgId: string, subGraphName: string) {
+  const cgMeta = `did:dkg:context-graph:${cgId}/_meta`;
+  const sgUri = `did:dkg:context-graph:${cgId}/${subGraphName}`;
+  return [
+    { graph: cgMeta, subject: sgUri, predicate: RDF_TYPE, object: `${DKG_NS}SubGraph` },
+    { graph: cgMeta, subject: sgUri, predicate: SCHEMA_NAME, object: `"${subGraphName}"` },
+    { graph: cgMeta, subject: sgUri, predicate: `${DKG_NS}createdBy`, object: '"test-creator"' },
+  ];
+}

--- a/packages/agent/test/agent.part-17.test.ts
+++ b/packages/agent/test/agent.part-17.test.ts
@@ -361,6 +361,10 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         const bytes = await (agent as any).buildSyncRequest('public-cg', 5, 100, false, 'peer-remote', 'meta');
         const text = new TextDecoder().decode(bytes);
         expect(text).toBe('public-cg|5|100|meta');
+
+        const sessionBytes = await (agent as any).buildSyncRequest('public-cg', 5, 100, false, 'peer-remote', 'meta', undefined, undefined, 'meta-session');
+        const sessionText = new TextDecoder().decode(sessionBytes);
+        expect(sessionText).toBe('public-cg|5|100|meta|session|meta-session');
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -107,7 +107,7 @@ describe('runSharedMemorySync ownership hydration', () => {
     expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-sub');
   });
 
-  it('accepts sub-graph SWM when the remote registration is replicated in the same meta batch', async () => {
+  it('rejects sub-graph SWM authorized only by a remote registration in the same meta batch', async () => {
     const worker = new SyncVerifyWorker();
     const ownedMaps = new Map<string, Map<string, string>>();
     const inserted: Quad[] = [];
@@ -128,8 +128,14 @@ describe('runSharedMemorySync ownership hydration', () => {
         fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
           phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
         ),
-        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames) =>
-          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
+          worker.processSharedMemoryBatch(
+            wsDataQuads,
+            wsMetaQuads,
+            contextGraphId,
+            registeredSubGraphNames,
+            excludedSubGraphNames,
+          ),
         getRegisteredSubGraphNames: async () => [],
         ensureContextGraph: async () => {},
         storeInsert: async (quads) => {
@@ -151,17 +157,17 @@ describe('runSharedMemorySync ownership hydration', () => {
       });
 
       expect(summary.failedPeers).toBe(0);
-      expect(summary.droppedDataTriples).toBe(0);
-      expect(summary.insertedDataTriples).toBe(1);
-      expect(inserted.some((quad) => quad.graph === ROOT_CG_META_GRAPH && quad.predicate === SCHEMA_NAME)).toBe(true);
-      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(true);
-      expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-remote-sub');
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === ROOT_CG_META_GRAPH && quad.predicate === SCHEMA_NAME)).toBe(false);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(false);
+      expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBeUndefined();
     } finally {
       await worker.close();
     }
   });
 
-  it('does not count SWM registration preludes against the paged meta cursor', async () => {
+  it('counts replicated SWM registration rows against the paged meta cursor', async () => {
     const worker = new SyncVerifyWorker();
     const nquads = [
       `<did:dkg:context-graph:${CG_ID}/${SUB_GRAPH}> <${RDF_TYPE}> <${DKG}SubGraph> <${ROOT_CG_META_GRAPH}> .`,
@@ -174,7 +180,7 @@ describe('runSharedMemorySync ownership hydration', () => {
     try {
       const parsed = await worker.parseAndFilter(nquads, ROOT_META_GRAPH, CG_ID);
       expect(parsed.quads).toHaveLength(5);
-      expect(parsed.totalQuads).toBe(2);
+      expect(parsed.totalQuads).toBe(5);
     } finally {
       await worker.close();
     }

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -13,8 +13,10 @@ const ROOT_GRAPH = contextGraphSharedMemoryUri(CG_ID);
 const SUB_GRAPH_SWM = contextGraphSharedMemoryUri(CG_ID, SUB_GRAPH);
 const ROOT_META_GRAPH = contextGraphSharedMemoryMetaUri(CG_ID);
 const SUB_GRAPH_META = contextGraphSharedMemoryMetaUri(CG_ID, SUB_GRAPH);
+const ROOT_CG_META_GRAPH = `did:dkg:context-graph:${CG_ID}/_meta`;
 const DKG = 'http://dkg.io/ontology/';
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SCHEMA_NAME = 'http://schema.org/name';
 
 function page(quads: Quad[], phase: SyncPhase): SyncPageResult {
   return {
@@ -33,6 +35,15 @@ function workspaceOperationMeta(graph: string, op: string, root: string, publish
     { graph, subject: op, predicate: `${DKG}publishedAt`, object: '"2030-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
     { graph, subject: op, predicate: `${DKG}rootEntity`, object: root },
     { graph, subject: op, predicate: `${DKG}publisherPeerId`, object: `"${publisherPeerId}"` },
+  ];
+}
+
+function subGraphRegistrationMeta(name: string): Quad[] {
+  const subject = `did:dkg:context-graph:${CG_ID}/${name}`;
+  return [
+    { graph: ROOT_CG_META_GRAPH, subject, predicate: RDF_TYPE, object: `${DKG}SubGraph` },
+    { graph: ROOT_CG_META_GRAPH, subject, predicate: SCHEMA_NAME, object: `"${name}"` },
+    { graph: ROOT_CG_META_GRAPH, subject, predicate: `${DKG}createdBy`, object: '"remote-peer"' },
   ];
 }
 
@@ -96,6 +107,60 @@ describe('runSharedMemorySync ownership hydration', () => {
     expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-sub');
   });
 
+  it('accepts sub-graph SWM when the remote registration is replicated in the same meta batch', async () => {
+    const worker = new SyncVerifyWorker();
+    const ownedMaps = new Map<string, Map<string, string>>();
+    const inserted: Quad[] = [];
+    const dataQuads: Quad[] = [
+      { graph: SUB_GRAPH_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"remote-sub"' },
+    ];
+    const metaQuads: Quad[] = [
+      ...subGraphRegistrationMeta(SUB_GRAPH),
+      ...workspaceOperationMeta(SUB_GRAPH_META, 'urn:dkg:share:remote-sub', ROOT_ENTITY, 'peer-remote-sub'),
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterReplicatedRegistration',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames),
+        getRegisteredSubGraphNames: async () => [],
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: (key) => {
+          let map = ownedMaps.get(key);
+          if (!map) {
+            map = new Map<string, string>();
+            ownedMaps.set(key, map);
+          }
+          return map;
+        },
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(0);
+      expect(summary.insertedDataTriples).toBe(1);
+      expect(inserted.some((quad) => quad.graph === ROOT_CG_META_GRAPH && quad.predicate === SCHEMA_NAME)).toBe(true);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(true);
+      expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-remote-sub');
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('accepts descendant SWM data graphs verified by their bucket meta graph', async () => {
     const worker = new SyncVerifyWorker();
     const ownedMaps = new Map<string, Map<string, string>>();
@@ -155,6 +220,47 @@ describe('runSharedMemorySync ownership hydration', () => {
       expect(insertedDataGraphs).toEqual([rootDescendantGraph, subDescendantGraph].sort());
       expect(ownedMaps.get(CG_ID)?.get(ROOT_ENTITY)).toBe('peer-root-descendant');
       expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(subEntity)).toBe('peer-sub-descendant');
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects malformed descendant SWM data graphs under an otherwise valid bucket', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const malformedDescendantGraph = `${ROOT_GRAPH}/0xabc/1/extra`;
+    const metaQuads = workspaceOperationMeta(ROOT_META_GRAPH, 'urn:dkg:share:malformed-descendant', ROOT_ENTITY, 'peer-root');
+    const dataQuads: Quad[] = [
+      { graph: malformedDescendantGraph, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"malformed-descendant"' },
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterMalformedDescendant',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === malformedDescendantGraph)).toBe(false);
     } finally {
       await worker.close();
     }

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { createOperationContext, contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
+import { createOperationContext, contextGraphSharedMemoryMetaUri, contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import { SyncVerifyWorker } from '../src/sync-verify-worker.js';
 
 const CG_ID = 'sync-owned-cg';
 const SUB_GRAPH = 'code';
 const ROOT_ENTITY = 'urn:swm:shared-root';
 const ROOT_GRAPH = contextGraphSharedMemoryUri(CG_ID);
 const SUB_GRAPH_SWM = contextGraphSharedMemoryUri(CG_ID, SUB_GRAPH);
+const ROOT_META_GRAPH = contextGraphSharedMemoryMetaUri(CG_ID);
+const SUB_GRAPH_META = contextGraphSharedMemoryMetaUri(CG_ID, SUB_GRAPH);
+const DKG = 'http://dkg.io/ontology/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 function page(quads: Quad[], phase: SyncPhase): SyncPageResult {
   return {
@@ -20,6 +25,15 @@ function page(quads: Quad[], phase: SyncPhase): SyncPageResult {
     checkpointKey: `${phase}-checkpoint`,
     completed: true,
   };
+}
+
+function workspaceOperationMeta(graph: string, op: string, root: string, publisherPeerId: string): Quad[] {
+  return [
+    { graph, subject: op, predicate: RDF_TYPE, object: `${DKG}WorkspaceOperation` },
+    { graph, subject: op, predicate: `${DKG}publishedAt`, object: '"2030-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
+    { graph, subject: op, predicate: `${DKG}rootEntity`, object: root },
+    { graph, subject: op, predicate: `${DKG}publisherPeerId`, object: `"${publisherPeerId}"` },
+  ];
 }
 
 describe('runSharedMemorySync ownership hydration', () => {
@@ -80,5 +94,152 @@ describe('runSharedMemorySync ownership hydration', () => {
     expect(deletedCheckpoints.sort()).toEqual(['data-checkpoint', 'meta-checkpoint']);
     expect(ownedMaps.get(CG_ID)?.get(ROOT_ENTITY)).toBe('peer-root');
     expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-sub');
+  });
+
+  it('accepts descendant SWM data graphs verified by their bucket meta graph', async () => {
+    const worker = new SyncVerifyWorker();
+    const ownedMaps = new Map<string, Map<string, string>>();
+    const inserted: Quad[] = [];
+
+    const rootDescendantGraph = `${ROOT_GRAPH}/0xabc/1`;
+    const subDescendantGraph = `${SUB_GRAPH_SWM}/0xdef/2`;
+    const rootSubEntity = `${ROOT_ENTITY}/.well-known/genid/root-child`;
+    const subEntity = 'urn:swm:sub-descendant-root';
+    const dataQuads: Quad[] = [
+      { graph: rootDescendantGraph, subject: rootSubEntity, predicate: 'http://schema.org/name', object: '"root-descendant"' },
+      { graph: subDescendantGraph, subject: subEntity, predicate: 'http://schema.org/name', object: '"sub-descendant"' },
+    ];
+    const metaQuads: Quad[] = [
+      ...workspaceOperationMeta(ROOT_META_GRAPH, 'urn:dkg:share:root-descendant', ROOT_ENTITY, 'peer-root-descendant'),
+      ...workspaceOperationMeta(SUB_GRAPH_META, 'urn:dkg:share:sub-descendant', subEntity, 'peer-sub-descendant'),
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterDescendantSwm',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: (key) => {
+          let map = ownedMaps.get(key);
+          if (!map) {
+            map = new Map<string, string>();
+            ownedMaps.set(key, map);
+          }
+          return map;
+        },
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(0);
+      expect(summary.insertedDataTriples).toBe(2);
+      const insertedDataGraphs = inserted
+        .filter((quad) => quad.predicate === 'http://schema.org/name')
+        .map((quad) => quad.graph)
+        .sort();
+      expect(insertedDataGraphs).toEqual([rootDescendantGraph, subDescendantGraph].sort());
+      expect(ownedMaps.get(CG_ID)?.get(ROOT_ENTITY)).toBe('peer-root-descendant');
+      expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(subEntity)).toBe('peer-sub-descendant');
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects descendant data graphs derived from non-SWM _meta graphs', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const fakeMetaGraph = `did:dkg:context-graph:${CG_ID}/foo_meta`;
+    const fakeDataGraph = `did:dkg:context-graph:${CG_ID}/foo/bar`;
+    const metaQuads = workspaceOperationMeta(fakeMetaGraph, 'urn:dkg:share:fake-meta', 'urn:swm:fake', 'peer-fake');
+    const dataQuads: Quad[] = [
+      { graph: fakeDataGraph, subject: 'urn:swm:fake', predicate: 'http://schema.org/name', object: '"fake-descendant"' },
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterFakeMeta',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === fakeDataGraph)).toBe(false);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects descendant data graphs derived from nested fake SWM buckets', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const fakeMetaGraph = `did:dkg:context-graph:${CG_ID}/nested/fake/_shared_memory_meta`;
+    const fakeDataGraph = `did:dkg:context-graph:${CG_ID}/nested/fake/_shared_memory/0xabc/1`;
+    const metaQuads = workspaceOperationMeta(fakeMetaGraph, 'urn:dkg:share:nested-fake', 'urn:swm:nested-fake', 'peer-fake');
+    const dataQuads: Quad[] = [
+      { graph: fakeDataGraph, subject: 'urn:swm:nested-fake', predicate: 'http://schema.org/name', object: '"nested-fake-descendant"' },
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterNestedFake',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === fakeDataGraph)).toBe(false);
+    } finally {
+      await worker.close();
+    }
   });
 });

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createOperationContext, contextGraphSharedMemoryMetaUri, contextGraphSharedMemoryUri } from '@origintrail-official/dkg-core';
-import type { Quad } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPhase } from '../src/sync/auth/request-build.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
@@ -45,6 +45,27 @@ function subGraphRegistrationMeta(name: string): Quad[] {
     { graph: ROOT_CG_META_GRAPH, subject, predicate: SCHEMA_NAME, object: `"${name}"` },
     { graph: ROOT_CG_META_GRAPH, subject, predicate: `${DKG}createdBy`, object: '"remote-peer"' },
   ];
+}
+
+async function registeredSubGraphNamesFromStore(store: OxigraphStore, contextGraphId: string): Promise<string[]> {
+  const metaGraph = `did:dkg:context-graph:${contextGraphId}/_meta`;
+  const prefix = `did:dkg:context-graph:${contextGraphId}/`;
+  const result = await store.query(`
+    SELECT DISTINCT ?sg ?name WHERE {
+      GRAPH <${metaGraph}> {
+        ?sg <${RDF_TYPE}> <${DKG}SubGraph> ;
+            <${SCHEMA_NAME}> ?name .
+      }
+    }
+  `);
+  if (result.type !== 'bindings') return [];
+  return result.bindings
+    .map((row) => {
+      const subject = row['sg'] ?? '';
+      const name = (row['name'] ?? '').replace(/^"|"$/g, '');
+      return subject === `${prefix}${name}` ? name : undefined;
+    })
+    .filter((name): name is string => name !== undefined);
 }
 
 describe('runSharedMemorySync ownership hydration', () => {
@@ -163,6 +184,69 @@ describe('runSharedMemorySync ownership hydration', () => {
       expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(false);
       expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBeUndefined();
     } finally {
+      await worker.close();
+    }
+  });
+
+  it('accepts sub-graph SWM after durable registration rows are local', async () => {
+    const worker = new SyncVerifyWorker();
+    const durableStore = new OxigraphStore();
+    const ownedMaps = new Map<string, Map<string, string>>();
+    const inserted: Quad[] = [];
+    const dataQuads: Quad[] = [
+      { graph: SUB_GRAPH_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"durable-registered-sub"' },
+    ];
+    const metaQuads: Quad[] = [
+      ...workspaceOperationMeta(SUB_GRAPH_META, 'urn:dkg:share:durable-sub', ROOT_ENTITY, 'peer-durable-sub'),
+    ];
+
+    try {
+      await durableStore.insert(subGraphRegistrationMeta(SUB_GRAPH));
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterDurableRegisteredSub',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
+          worker.processSharedMemoryBatch(
+            wsDataQuads,
+            wsMetaQuads,
+            contextGraphId,
+            registeredSubGraphNames,
+            excludedSubGraphNames,
+          ),
+        getRegisteredSubGraphNames: (contextGraphId) => registeredSubGraphNamesFromStore(durableStore, contextGraphId),
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: (key) => {
+          let map = ownedMaps.get(key);
+          if (!map) {
+            map = new Map<string, string>();
+            ownedMaps.set(key, map);
+          }
+          return map;
+        },
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(0);
+      expect(summary.insertedDataTriples).toBe(1);
+      expect(summary.insertedMetaTriples).toBe(metaQuads.length);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(true);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_META)).toBe(true);
+      expect(ownedMaps.get(`${CG_ID}\0${SUB_GRAPH}`)?.get(ROOT_ENTITY)).toBe('peer-durable-sub');
+    } finally {
+      await durableStore.close();
       await worker.close();
     }
   });

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -124,7 +124,8 @@ describe('runSharedMemorySync ownership hydration', () => {
           phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
         ),
         processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId) =>
-          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId),
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, [SUB_GRAPH]),
+        getRegisteredSubGraphNames: async () => [SUB_GRAPH],
         ensureContextGraph: async () => {},
         storeInsert: async (quads) => {
           inserted.push(...quads);
@@ -238,6 +239,49 @@ describe('runSharedMemorySync ownership hydration', () => {
       expect(summary.droppedDataTriples).toBe(1);
       expect(summary.insertedDataTriples).toBe(0);
       expect(inserted.some((quad) => quad.graph === fakeDataGraph)).toBe(false);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects unregistered child-CG-shaped SWM descendants', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const childMetaGraph = contextGraphSharedMemoryMetaUri(CG_ID, 'child');
+    const childDataGraph = `${contextGraphSharedMemoryUri(CG_ID, 'child')}/0xabc/1`;
+    const metaQuads = workspaceOperationMeta(childMetaGraph, 'urn:dkg:share:child-cg', 'urn:swm:child-cg', 'peer-child');
+    const dataQuads: Quad[] = [
+      { graph: childDataGraph, subject: 'urn:swm:child-cg', predicate: 'http://schema.org/name', object: '"child-cg-descendant"' },
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterChildCgFake',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames) =>
+          worker.processSharedMemoryBatch(wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames),
+        getRegisteredSubGraphNames: async () => [],
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === childDataGraph)).toBe(false);
     } finally {
       await worker.close();
     }

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -161,6 +161,76 @@ describe('runSharedMemorySync ownership hydration', () => {
     }
   });
 
+  it('does not count SWM registration preludes against the paged meta cursor', async () => {
+    const worker = new SyncVerifyWorker();
+    const nquads = [
+      `<did:dkg:context-graph:${CG_ID}/${SUB_GRAPH}> <${RDF_TYPE}> <${DKG}SubGraph> <${ROOT_CG_META_GRAPH}> .`,
+      `<did:dkg:context-graph:${CG_ID}/${SUB_GRAPH}> <${SCHEMA_NAME}> "${SUB_GRAPH}" <${ROOT_CG_META_GRAPH}> .`,
+      `<did:dkg:context-graph:${CG_ID}/${SUB_GRAPH}> <${DKG}createdBy> "remote-peer" <${ROOT_CG_META_GRAPH}> .`,
+      `<urn:dkg:share:one> <${RDF_TYPE}> <${DKG}WorkspaceOperation> <${ROOT_META_GRAPH}> .`,
+      `<urn:dkg:share:one> <${DKG}publishedAt> "2030-01-01T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <${ROOT_META_GRAPH}> .`,
+    ].join('\n');
+
+    try {
+      const parsed = await worker.parseAndFilter(nquads, ROOT_META_GRAPH, CG_ID);
+      expect(parsed.quads).toHaveLength(5);
+      expect(parsed.totalQuads).toBe(2);
+    } finally {
+      await worker.close();
+    }
+  });
+
+  it('rejects forged replicated registrations with noncanonical subjects', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const dataQuads: Quad[] = [
+      { graph: SUB_GRAPH_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"forged-sub"' },
+    ];
+    const metaQuads: Quad[] = [
+      { graph: ROOT_CG_META_GRAPH, subject: 'urn:forged-subgraph-registration', predicate: RDF_TYPE, object: `${DKG}SubGraph` },
+      { graph: ROOT_CG_META_GRAPH, subject: 'urn:forged-subgraph-registration', predicate: SCHEMA_NAME, object: `"${SUB_GRAPH}"` },
+      ...workspaceOperationMeta(SUB_GRAPH_META, 'urn:dkg:share:forged-sub', ROOT_ENTITY, 'peer-forged-sub'),
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterForgedRegistration',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
+          worker.processSharedMemoryBatch(
+            wsDataQuads,
+            wsMetaQuads,
+            contextGraphId,
+            registeredSubGraphNames,
+            excludedSubGraphNames,
+          ),
+        getRegisteredSubGraphNames: async () => [],
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(false);
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('rejects replicated sub-graph SWM registrations excluded by local child-CG state', async () => {
     const worker = new SyncVerifyWorker();
     const inserted: Quad[] = [];

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -161,6 +161,57 @@ describe('runSharedMemorySync ownership hydration', () => {
     }
   });
 
+  it('rejects replicated sub-graph SWM registrations excluded by local child-CG state', async () => {
+    const worker = new SyncVerifyWorker();
+    const inserted: Quad[] = [];
+    const dataQuads: Quad[] = [
+      { graph: SUB_GRAPH_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"colliding-sub"' },
+    ];
+    const metaQuads: Quad[] = [
+      ...subGraphRegistrationMeta(SUB_GRAPH),
+      ...workspaceOperationMeta(SUB_GRAPH_META, 'urn:dkg:share:colliding-sub', ROOT_ENTITY, 'peer-colliding-sub'),
+    ];
+
+    try {
+      const summary = await runSharedMemorySync({
+        ctx: createOperationContext('sync'),
+        remotePeerId: '12D3KooWRequesterExcludedRegistration',
+        contextGraphIds: [CG_ID],
+        createContextGraphSyncDeadline: () => Date.now() + 30_000,
+        fetchSyncPages: async (_ctx, _peer, _cg, _includeSwm, phase) => (
+          phase === 'data' ? page(dataQuads, phase) : page(metaQuads, phase)
+        ),
+        processSharedMemoryBatch: (wsDataQuads, wsMetaQuads, contextGraphId, registeredSubGraphNames, excludedSubGraphNames) =>
+          worker.processSharedMemoryBatch(
+            wsDataQuads,
+            wsMetaQuads,
+            contextGraphId,
+            registeredSubGraphNames,
+            excludedSubGraphNames,
+          ),
+        getRegisteredSubGraphNames: async () => [],
+        getExcludedSubGraphNames: async () => [SUB_GRAPH],
+        ensureContextGraph: async () => {},
+        storeInsert: async (quads) => {
+          inserted.push(...quads);
+        },
+        deleteCheckpoint: () => {},
+        setCheckpoint: () => {},
+        ensureOwnedMap: () => new Map<string, string>(),
+        logInfo: () => {},
+        logWarn: () => {},
+        logDebug: () => {},
+      });
+
+      expect(summary.failedPeers).toBe(0);
+      expect(summary.droppedDataTriples).toBe(1);
+      expect(summary.insertedDataTriples).toBe(0);
+      expect(inserted.some((quad) => quad.graph === SUB_GRAPH_SWM)).toBe(false);
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('accepts descendant SWM data graphs verified by their bucket meta graph', async () => {
     const worker = new SyncVerifyWorker();
     const ownedMaps = new Map<string, Map<string, string>>();

--- a/packages/agent/test/sync-envelope-cursor.test.ts
+++ b/packages/agent/test/sync-envelope-cursor.test.ts
@@ -10,7 +10,7 @@ import { buildSyncRequestEnvelope, type SyncRequestEnvelope } from '../src/sync/
  * or negotiation. These tests pin that invariant.
  */
 
-const baseParams = (sinceBatchId?: string) => {
+const baseParams = (sinceBatchId?: string, syncSessionId?: string) => {
   const digestCalls: unknown[][] = [];
   return {
     digestCalls,
@@ -23,6 +23,7 @@ const baseParams = (sinceBatchId?: string) => {
       requesterPeerId: 'peer-requester',
       phase: 'data' as const,
       sinceBatchId,
+      syncSessionId,
       needsAuth: true,
       computeSyncDigest: (...args: unknown[]) => {
         digestCalls.push(args);
@@ -36,9 +37,9 @@ const baseParams = (sinceBatchId?: string) => {
 };
 
 describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
-  it('does not feed sinceBatchId into the signed digest', async () => {
+  it('does not feed sinceBatchId or syncSessionId into the signed digest', async () => {
     const without = baseParams(undefined);
-    const withHint = baseParams('42');
+    const withHint = baseParams('42', 'session-1');
 
     await buildSyncRequestEnvelope(without.params);
     await buildSyncRequestEnvelope(withHint.params);
@@ -55,8 +56,9 @@ describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
     expect(a).toHaveLength(9);
     expect(b).toHaveLength(9);
     for (const idx of [0, 1, 2, 3, 4, 5, 8]) expect(b[idx]).toEqual(a[idx]);
-    // The hint value never appears anywhere in the digest inputs.
+    // The additive hint values never appear anywhere in the digest inputs.
     expect(b.some((arg) => String(arg) === '42')).toBe(false);
+    expect(b.some((arg) => String(arg) === 'session-1')).toBe(false);
   });
 
   it('carries sinceBatchId in the authenticated JSON envelope when set', async () => {
@@ -65,6 +67,14 @@ describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
     const parsed = JSON.parse(new TextDecoder().decode(bytes)) as SyncRequestEnvelope;
     expect(parsed.sinceBatchId).toBe('42');
     // Sanity: it's still a signed envelope.
+    expect(parsed.requesterSignatureR).toBeTruthy();
+  });
+
+  it('carries syncSessionId in the authenticated JSON envelope when set', async () => {
+    const { params } = baseParams(undefined, 'session-1');
+    const bytes = await buildSyncRequestEnvelope(params);
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as SyncRequestEnvelope;
+    expect(parsed.syncSessionId).toBe('session-1');
     expect(parsed.requesterSignatureR).toBeTruthy();
   });
 
@@ -80,6 +90,13 @@ describe('Phase C sync envelope — sinceBatchId is unsigned', () => {
     const bytes = await buildSyncRequestEnvelope({ ...params, needsAuth: false });
     const text = new TextDecoder().decode(bytes);
     expect(text).toBe('mfacts|0|100|since|42');
+  });
+
+  it('appends unauthenticated session and since tokens for the pipe encoding', async () => {
+    const { params } = baseParams('42', 'session-1');
+    const bytes = await buildSyncRequestEnvelope({ ...params, needsAuth: false });
+    const text = new TextDecoder().decode(bytes);
+    expect(text).toBe('mfacts|0|100|session|session-1|since|42');
   });
 
   it('omits the pipe |since| token when the hint is unset', async () => {

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
+import { DURABLE_DATA_SYNC_SESSION_BUCKET_MS } from '../src/sync/durable-session.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 /**
@@ -69,6 +70,58 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
       await vi.runAllTimersAsync();
     }
     return promise;
+  }
+
+  async function captureDurableSyncSessionId(options: {
+    remotePeerId?: string;
+    contextGraphId?: string;
+    sinceBatchId?: string;
+  } = {}): Promise<string | undefined> {
+    let observed: string | undefined;
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: options.remotePeerId ?? REMOTE_PEER_ID,
+        contextGraphId: options.contextGraphId ?? CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        sinceBatchId: options.sinceBatchId,
+        buildSyncRequest: async (
+          _contextGraphId,
+          _offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observed = syncSessionId;
+          return new TextEncoder().encode('request');
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => new TextEncoder().encode(''),
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+    return observed;
   }
 
   it('keeps parsed quads even when they do not advance the page cursor', async () => {
@@ -186,7 +239,28 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(observedBuilds[1].syncSessionId).toBe(observedBuilds[0].syncSessionId);
   });
 
-  it('restarts durable data checkpoints at offset zero with a fresh sync session', async () => {
+  it('reuses durable sync session ids across nearby fetch rounds', async () => {
+    vi.setSystemTime(1_700_000_000_000);
+
+    const first = await captureDurableSyncSessionId();
+    const second = await captureDurableSyncSessionId();
+    const otherPeer = await captureDurableSyncSessionId({ remotePeerId: `${REMOTE_PEER_ID}-other` });
+    const otherGraph = await captureDurableSyncSessionId({ contextGraphId: `${CG_ID}-other` });
+    const delta = await captureDurableSyncSessionId({ sinceBatchId: '42' });
+
+    expect(typeof first).toBe('string');
+    expect(first?.length).toBeGreaterThan(0);
+    expect(second).toBe(first);
+    expect(otherPeer).not.toBe(first);
+    expect(otherGraph).not.toBe(first);
+    expect(delta).not.toBe(first);
+
+    vi.setSystemTime(1_700_000_000_000 + DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
+    const nextBucket = await captureDurableSyncSessionId();
+    expect(nextBucket).not.toBe(first);
+  });
+
+  it('restarts durable data checkpoints at offset zero with a stable sync session', async () => {
     const observedBuilds: Array<{
       offset: number;
       syncSessionId: string | undefined;

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -354,7 +354,7 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     );
 
     expect(observedBuilds[observedBuilds.length - 1]).toEqual({
-      offset: 0,
+      offset: 1,
       syncSessionId: unfinishedSessionId,
     });
   });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -71,8 +71,8 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     return promise;
   }
 
-  it('keeps parsed prelude quads even when they do not advance the page cursor', async () => {
-    const preludeQuad = {
+  it('keeps parsed quads even when they do not advance the page cursor', async () => {
+    const parsedQuad = {
       graph: `${CG_ID}/_meta`,
       subject: `${CG_ID}/registered`,
       predicate: 'http://schema.org/name',
@@ -101,15 +101,15 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
           delete: () => {},
         },
         buildSyncRequest: async () => new TextEncoder().encode('request'),
-        parseAndFilter: async () => ({ quads: [preludeQuad], totalQuads: 0 }),
-        send: async () => new TextEncoder().encode('registration-prelude-only'),
+        parseAndFilter: async () => ({ quads: [parsedQuad], totalQuads: 0 }),
+        send: async () => new TextEncoder().encode('zero-count-page'),
         logWarn: noopLog,
         logInfo: noopLog,
         logDebug: noopLog,
       }),
     );
 
-    expect(result.quads).toEqual([preludeQuad]);
+    expect(result.quads).toEqual([parsedQuad]);
     expect(result.nextOffset).toBe(0);
     expect(result.completed).toBe(true);
   });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -186,11 +186,12 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(observedBuilds[1].syncSessionId).toBe(observedBuilds[0].syncSessionId);
   });
 
-  it('does not mint a new sync session id when resuming a durable data checkpoint', async () => {
+  it('restarts durable data checkpoints at offset zero with a fresh sync session', async () => {
     const observedBuilds: Array<{
       offset: number;
       syncSessionId: string | undefined;
     }> = [];
+    const deletedCheckpoints: string[] = [];
 
     await runFetchWithFakeTimers(
       fetchSyncPages({
@@ -211,7 +212,9 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
         checkpointStore: {
           get: () => 250,
           set: () => {},
-          delete: () => {},
+          delete: (key) => {
+            deletedCheckpoints.push(key);
+          },
         },
         buildSyncRequest: async (
           _contextGraphId,
@@ -235,7 +238,74 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
       }),
     );
 
-    expect(observedBuilds).toEqual([{ offset: 250, syncSessionId: undefined }]);
+    expect(observedBuilds).toHaveLength(1);
+    expect(observedBuilds[0].offset).toBe(0);
+    expect(typeof observedBuilds[0].syncSessionId).toBe('string');
+    expect(observedBuilds[0].syncSessionId?.length).toBeGreaterThan(0);
+    expect(deletedCheckpoints).toEqual([`${REMOTE_PEER_ID}|${CG_ID}|durable|data`]);
+  });
+
+  it('uses one stable sync session id across pages for durable delta sync', async () => {
+    const observedBuilds: Array<{
+      offset: number;
+      sinceBatchId: string | undefined;
+      syncSessionId: string | undefined;
+    }> = [];
+    let sendCalls = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        sinceBatchId: '42',
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, sinceBatchId, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          return new TextEncoder().encode(sendCalls === 1 ? 'one-quad-line' : '');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedBuilds).toHaveLength(2);
+    expect(observedBuilds.map((build) => build.offset)).toEqual([0, 1]);
+    expect(observedBuilds.every((build) => build.sinceBatchId === '42')).toBe(true);
+    expect(typeof observedBuilds[0].syncSessionId).toBe('string');
+    expect(observedBuilds[0].syncSessionId?.length).toBeGreaterThan(0);
+    expect(observedBuilds[1].syncSessionId).toBe(observedBuilds[0].syncSessionId);
   });
 
   /**

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
-import { DURABLE_DATA_SYNC_SESSION_BUCKET_MS } from '../src/sync/durable-session.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 /**
@@ -239,25 +238,125 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(observedBuilds[1].syncSessionId).toBe(observedBuilds[0].syncSessionId);
   });
 
-  it('reuses durable sync session ids across nearby fetch rounds', async () => {
-    vi.setSystemTime(1_700_000_000_000);
-
+  it('uses a fresh durable sync session id for each completed fetch round', async () => {
     const first = await captureDurableSyncSessionId();
     const second = await captureDurableSyncSessionId();
-    const otherPeer = await captureDurableSyncSessionId({ remotePeerId: `${REMOTE_PEER_ID}-other` });
-    const otherGraph = await captureDurableSyncSessionId({ contextGraphId: `${CG_ID}-other` });
-    const delta = await captureDurableSyncSessionId({ sinceBatchId: '42' });
 
     expect(typeof first).toBe('string');
     expect(first?.length).toBeGreaterThan(0);
-    expect(second).toBe(first);
-    expect(otherPeer).not.toBe(first);
-    expect(otherGraph).not.toBe(first);
-    expect(delta).not.toBe(first);
+    expect(second).not.toBe(first);
+  });
 
-    vi.setSystemTime(1_700_000_000_000 + DURABLE_DATA_SYNC_SESSION_BUCKET_MS);
-    const nextBucket = await captureDurableSyncSessionId();
-    expect(nextBucket).not.toBe(first);
+  it('reuses the durable sync session id after an incomplete fetch round', async () => {
+    vi.setSystemTime(1_700_000_000_000);
+    const observedBuilds: Array<{
+      offset: number;
+      syncSessionId: string | undefined;
+    }> = [];
+    let sendCalls = 0;
+
+    const first = await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'incomplete-session-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          if (sendCalls === 1) {
+            vi.setSystemTime(1_700_000_060_001);
+            return new TextEncoder().encode('one-quad-line');
+          }
+          return new TextEncoder().encode('');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(first.completed).toBe(false);
+    expect(first.nextOffset).toBe(1);
+    const unfinishedSessionId = observedBuilds[0].syncSessionId;
+    expect(typeof unfinishedSessionId).toBe('string');
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'incomplete-session-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 1,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => new TextEncoder().encode(''),
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedBuilds[observedBuilds.length - 1]).toEqual({
+      offset: 0,
+      syncSessionId: unfinishedSessionId,
+    });
   });
 
   it('restarts durable data checkpoints at offset zero with a stable sync session', async () => {

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -114,6 +114,130 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(result.completed).toBe(true);
   });
 
+  it('uses one stable sync session id across pages for full durable data sync', async () => {
+    const observedBuilds: Array<{
+      offset: number;
+      includeSharedMemory: boolean;
+      phase: string | undefined;
+      sinceBatchId: string | undefined;
+      syncSessionId: string | undefined;
+    }> = [];
+    let sendCalls = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          includeSharedMemory,
+          _remotePeerId,
+          phase,
+          _snapshotRef,
+          sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({
+            offset,
+            includeSharedMemory,
+            phase,
+            sinceBatchId,
+            syncSessionId,
+          });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          return new TextEncoder().encode(sendCalls === 1 ? 'one-quad-line' : '');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedBuilds).toHaveLength(2);
+    expect(observedBuilds.map((build) => build.offset)).toEqual([0, 1]);
+    expect(observedBuilds.every((build) => build.includeSharedMemory === false)).toBe(true);
+    expect(observedBuilds.every((build) => build.phase === 'data')).toBe(true);
+    expect(observedBuilds.every((build) => build.sinceBatchId === undefined)).toBe(true);
+    expect(typeof observedBuilds[0].syncSessionId).toBe('string');
+    expect(observedBuilds[0].syncSessionId?.length).toBeGreaterThan(0);
+    expect(observedBuilds[1].syncSessionId).toBe(observedBuilds[0].syncSessionId);
+  });
+
+  it('does not mint a new sync session id when resuming a durable data checkpoint', async () => {
+    const observedBuilds: Array<{
+      offset: number;
+      syncSessionId: string | undefined;
+    }> = [];
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 250,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => new TextEncoder().encode(''),
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedBuilds).toEqual([{ offset: 250, syncSessionId: undefined }]);
+  });
+
   /**
    * Codex review #569 follow-up #1: original PR called
    * `sendReliable` without any `messageId` plumbing. Final design

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
+import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 /**
@@ -62,9 +63,14 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
    */
   async function runFetchWithFakeTimers<T>(promise: Promise<T>): Promise<T> {
     let done = false;
-    promise.finally(() => {
-      done = true;
-    });
+    promise.then(
+      () => {
+        done = true;
+      },
+      () => {
+        done = true;
+      },
+    );
     while (!done) {
       await vi.runAllTimersAsync();
     }
@@ -357,6 +363,204 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
       offset: 1,
       syncSessionId: unfinishedSessionId,
     });
+  });
+
+  it('restarts durable data checkpoints when the saved unfinished session expires', async () => {
+    vi.setSystemTime(1_700_000_000_000);
+    const observedBuilds: Array<{
+      contextGraphId: string;
+      offset: number;
+      syncSessionId: string | undefined;
+    }> = [];
+    const deletedCheckpoints: string[] = [];
+    const checkpointKey = `${REMOTE_PEER_ID}|expired-incomplete-session-cg|durable|data`;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'expired-incomplete-session-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async (
+          contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ contextGraphId, offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          vi.setSystemTime(1_700_000_060_001);
+          return new TextEncoder().encode('one-quad-line');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    const expiredSessionId = observedBuilds[0].syncSessionId;
+    vi.setSystemTime(1_700_000_000_000 + DURABLE_DATA_SYNC_SESSION_TTL_MS + 1);
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'expired-incomplete-session-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 1,
+          set: () => {},
+          delete: (key) => {
+            deletedCheckpoints.push(key);
+          },
+        },
+        buildSyncRequest: async (
+          contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ contextGraphId, offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => new TextEncoder().encode(''),
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(observedBuilds[observedBuilds.length - 1]).toMatchObject({
+      contextGraphId: 'expired-incomplete-session-cg',
+      offset: 0,
+    });
+    expect(observedBuilds[observedBuilds.length - 1].syncSessionId).not.toBe(expiredSessionId);
+    expect(deletedCheckpoints).toEqual([checkpointKey]);
+  });
+
+  it('clears durable data checkpoints when the saved unfinished session is superseded', async () => {
+    vi.setSystemTime(1_700_100_000_000);
+    const observedBuilds: Array<{
+      offset: number;
+      syncSessionId: string | undefined;
+    }> = [];
+    const checkpointValues = new Map<string, number>();
+    const deletedCheckpoints: string[] = [];
+    const checkpointKey = `${REMOTE_PEER_ID}|superseded-incomplete-session-cg|durable|data`;
+    let sendMode: 'timeout' | 'superseded' | 'complete' = 'timeout';
+
+    const checkpointStore = {
+      get: (key: string) => checkpointValues.get(key),
+      set: (key: string, value: number) => {
+        checkpointValues.set(key, value);
+      },
+      delete: (key: string) => {
+        deletedCheckpoints.push(key);
+        checkpointValues.delete(key);
+      },
+    };
+
+    const runSupersededFetch = () => runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: 'superseded-incomplete-session-cg',
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 1,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore,
+        buildSyncRequest: async (
+          _contextGraphId,
+          offset,
+          _limit,
+          _includeSharedMemory,
+          _remotePeerId,
+          _phase,
+          _snapshotRef,
+          _sinceBatchId,
+          syncSessionId,
+        ) => {
+          observedBuilds.push({ offset, syncSessionId });
+          return new TextEncoder().encode(`request-${offset}`);
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          if (sendMode === 'timeout') {
+            vi.setSystemTime(1_700_100_060_001);
+            return new TextEncoder().encode('one-quad-line');
+          }
+          if (sendMode === 'superseded') {
+            throw new Error('Durable data sync session was superseded before page completion');
+          }
+          return new TextEncoder().encode('');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    const first = await runSupersededFetch();
+    expect(first.completed).toBe(false);
+    checkpointValues.set(checkpointKey, first.nextOffset);
+    const supersededSessionId = observedBuilds[0].syncSessionId;
+
+    sendMode = 'superseded';
+    await expect(runSupersededFetch()).rejects.toThrow('Durable data sync session was superseded');
+    expect(deletedCheckpoints).toEqual([checkpointKey]);
+
+    sendMode = 'complete';
+    const resumed = await runSupersededFetch();
+    expect(resumed.resumedFromOffset).toBe(0);
+    expect(observedBuilds[observedBuilds.length - 1]).toMatchObject({ offset: 0 });
+    expect(observedBuilds[observedBuilds.length - 1].syncSessionId).not.toBe(supersededSessionId);
   });
 
   it('restarts durable data checkpoints at offset zero with a stable sync session', async () => {

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -71,6 +71,49 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     return promise;
   }
 
+  it('keeps parsed prelude quads even when they do not advance the page cursor', async () => {
+    const preludeQuad = {
+      graph: `${CG_ID}/_meta`,
+      subject: `${CG_ID}/registered`,
+      predicate: 'http://schema.org/name',
+      object: '"registered"',
+    } as never;
+
+    const result = await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'meta',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => new TextEncoder().encode('request'),
+        parseAndFilter: async () => ({ quads: [preludeQuad], totalQuads: 0 }),
+        send: async () => new TextEncoder().encode('registration-prelude-only'),
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(result.quads).toEqual([preludeQuad]);
+    expect(result.nextOffset).toBe(0);
+    expect(result.completed).toBe(true);
+  });
+
   /**
    * Codex review #569 follow-up #1: original PR called
    * `sendReliable` without any `messageId` plumbing. Final design

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -342,15 +342,14 @@ describe('sync responder graph admission planner', () => {
 
     expect(metaGraphs.has(rootSwmMeta)).toBe(true);
     expect(metaGraphs.has(registeredSwmMeta)).toBe(true);
-    expect(metaGraphs.has(cgMeta)).toBe(true);
+    expect(metaGraphs.has(cgMeta)).toBe(false);
     expect(metaGraphs.has(childSwmMeta)).toBe(false);
-    expect(metaOut).toContain(`${DKG_NS}SubGraph`);
-    expect(metaOut).toContain(`did:dkg:context-graph:${cgId}/registered`);
+    expect(metaOut).not.toContain(`${DKG_NS}SubGraph`);
     expect(metaOut).not.toContain(`did:dkg:context-graph:${cgId}/child`);
   });
 
-  it('serves bounded SWM registration preludes for subgraphs present in the current meta page', async () => {
-    const cgId = 'planner-swm-registration-prelude-cg';
+  it('does not append SWM registration rows to paged meta responses', async () => {
+    const cgId = 'planner-swm-registration-page-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
     const alphaSwmMeta = `${cgPrefix}/alpha/_shared_memory_meta`;
     const bravoSwmMeta = `${cgPrefix}/bravo/_shared_memory_meta`;
@@ -379,13 +378,9 @@ describe('sync responder graph admission planner', () => {
       limit: 5,
     });
 
-    expect(first).toContain(`${DKG_NS}SubGraph`);
-    expect(first).toContain(`did:dkg:context-graph:${cgId}/alpha`);
-    expect(first).not.toContain(`did:dkg:context-graph:${cgId}/bravo`);
-    expect(linesFromNquads(first).length).toBeGreaterThan(5);
-    expect(second).toContain(`${DKG_NS}SubGraph`);
-    expect(second).toContain(`did:dkg:context-graph:${cgId}/bravo`);
-    expect(second).not.toContain(`did:dkg:context-graph:${cgId}/alpha`);
+    expect(first).not.toContain(`${DKG_NS}SubGraph`);
+    expect(linesFromNquads(first)).toHaveLength(5);
+    expect(second).not.toContain(`${DKG_NS}SubGraph`);
     expect(lineGraphsFromNquads(second).has(bravoSwmMeta)).toBe(true);
   });
 

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -171,6 +171,8 @@ describe('sync responder graph admission planner', () => {
       q(parentPartition, 'urn:parent:partition', 'http://schema.org/name', '"parent-context-partition"'),
       q(parentAssertion, 'urn:parent:assertion', 'http://schema.org/name', '"parent-assertion"'),
       q(parentAssertionMeta, 'urn:parent:assertion', `${DKG_NS}merkleRoot`, '"parent-assertion-meta"'),
+      q(`${parentPartition}/_meta`, parentPartition, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(`${parentAssertion}/_meta`, parentAssertion, RDF_TYPE, DKG_CONTEXT_GRAPH),
       q(malformedAssertion, 'urn:malformed:assertion', 'http://schema.org/name', '"malformed-assertion-leak"'),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}assertionGraph`, parentAssertion),
@@ -214,10 +216,13 @@ describe('sync responder graph admission planner', () => {
     const vmAssertion = `${cgPrefix}/assertion/0xabc/final`;
     const wmAssertion = `${cgPrefix}/assertion/0xabc/draft`;
     const registeredSubGraph = `${cgPrefix}/registered`;
+    const childCollisionSubGraph = `${cgPrefix}/child`;
 
     await store.insert([
       q(cgMeta, cgPrefix, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'),
       ...subGraphRegistrationQuads(cgId, 'registered'),
+      ...subGraphRegistrationQuads(cgId, 'child'),
+      q(`${childCollisionSubGraph}/_meta`, childCollisionSubGraph, RDF_TYPE, DKG_CONTEXT_GRAPH),
       q(cgMeta, 'urn:forged-subgraph-registration', RDF_TYPE, `${DKG_NS}SubGraph`),
       q(cgMeta, 'urn:forged-subgraph-registration', SCHEMA_NAME, '"forged"'),
       q(cgMeta, `${cgPrefix}/context`, RDF_TYPE, `${DKG_NS}SubGraph`),
@@ -246,6 +251,7 @@ describe('sync responder graph admission planner', () => {
 
     expect(out).toContain(cgPrefix);
     expect(out).toContain(registeredSubGraph);
+    expect(out).toContain(childCollisionSubGraph);
     expect(out).toContain(`${DKG_NS}SubGraph`);
     expect(out).toContain(SCHEMA_NAME);
     expect(out).toContain('did:dkg:activity:1');

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -382,6 +382,9 @@ describe('sync responder graph admission planner', () => {
       offset: 0,
       limit: 5,
     });
+    await store.insert([
+      q(`${cgPrefix}/bravo/_meta`, `${cgPrefix}/bravo`, RDF_TYPE, DKG_CONTEXT_GRAPH),
+    ]);
     const second = await cap.invoke({
       contextGraphId: cgId,
       includeSharedMemory: true,

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -342,6 +342,43 @@ describe('sync responder graph admission planner', () => {
     expect(metaOut).not.toContain(`did:dkg:context-graph:${cgId}/child`);
   });
 
+  it('serves SWM registration rows as an offset-zero meta prelude only', async () => {
+    const cgId = 'planner-swm-registration-prelude-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+    const registeredSwmMeta = `${cgPrefix}/registered/_shared_memory_meta`;
+    const now = '2026-06-01T00:00:00.000Z';
+
+    await store.insert([
+      ...subGraphRegistrationQuads(cgId, 'registered'),
+      ...workspaceOpQuads(cgId, 'root', 'urn:swm:prelude:root', rootSwmMeta, now),
+      ...workspaceOpQuads(cgId, 'registered', 'urn:swm:prelude:registered', registeredSwmMeta, now),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const first = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 1,
+    });
+    const second = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 1,
+      limit: 1,
+    });
+
+    expect(first).toContain(`${DKG_NS}SubGraph`);
+    expect(first).toContain(`did:dkg:context-graph:${cgId}/registered`);
+    expect(linesFromNquads(first).length).toBeGreaterThan(1);
+    expect(second).not.toContain(`${DKG_NS}SubGraph`);
+    expect(second).not.toContain(`did:dkg:context-graph:${cgId}/registered`);
+    expect(lineGraphsFromNquads(second).has(rootSwmMeta)).toBe(true);
+  });
+
   it('does not serve stale SWM rows from a previous request after same-graph writes', async () => {
     const cgId = 'planner-swm-freshness-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -151,6 +151,7 @@ describe('sync responder graph admission planner', () => {
     const parentPartition = `${cgPrefix}/context/1`;
     const parentAssertion = `${cgPrefix}/assertion/0xabc/final`;
     const parentAssertionMeta = `${parentAssertion}/_meta`;
+    const malformedAssertion = `${cgPrefix}/assertion/foo`;
     const reservedNameChildId = `${cgId}/context`;
     const reservedNameChildPrefix = `did:dkg:context-graph:${reservedNameChildId}`;
     const reservedNameChildMeta = `${reservedNameChildPrefix}/_meta`;
@@ -169,6 +170,7 @@ describe('sync responder graph admission planner', () => {
       q(parentPartition, 'urn:parent:partition', 'http://schema.org/name', '"parent-context-partition"'),
       q(parentAssertion, 'urn:parent:assertion', 'http://schema.org/name', '"parent-assertion"'),
       q(parentAssertionMeta, 'urn:parent:assertion', `${DKG_NS}merkleRoot`, '"parent-assertion-meta"'),
+      q(malformedAssertion, 'urn:malformed:assertion', 'http://schema.org/name', '"malformed-assertion-leak"'),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}assertionGraph`, parentAssertion),
       q(reservedNameChildMeta, reservedNameChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
@@ -199,6 +201,7 @@ describe('sync responder graph admission planner', () => {
     expect(out).not.toContain('"reserved-child-leak"');
     expect(out).not.toContain('"reserved-child-swm-leak"');
     expect(out).not.toContain('"assertion-child-partition-leak"');
+    expect(out).not.toContain('"malformed-assertion-leak"');
     expect(out).not.toContain('"regular-child-numeric-leak"');
     expect(out).not.toContain('"regular-child-numeric-meta-leak"');
   });
@@ -346,17 +349,18 @@ describe('sync responder graph admission planner', () => {
     expect(metaOut).not.toContain(`did:dkg:context-graph:${cgId}/child`);
   });
 
-  it('serves SWM registration rows as an offset-zero meta prelude only', async () => {
+  it('serves bounded SWM registration preludes for subgraphs present in the current meta page', async () => {
     const cgId = 'planner-swm-registration-prelude-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
-    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
-    const registeredSwmMeta = `${cgPrefix}/registered/_shared_memory_meta`;
+    const alphaSwmMeta = `${cgPrefix}/alpha/_shared_memory_meta`;
+    const bravoSwmMeta = `${cgPrefix}/bravo/_shared_memory_meta`;
     const now = '2026-06-01T00:00:00.000Z';
 
     await store.insert([
-      ...subGraphRegistrationQuads(cgId, 'registered'),
-      ...workspaceOpQuads(cgId, 'root', 'urn:swm:prelude:root', rootSwmMeta, now),
-      ...workspaceOpQuads(cgId, 'registered', 'urn:swm:prelude:registered', registeredSwmMeta, now),
+      ...subGraphRegistrationQuads(cgId, 'alpha'),
+      ...subGraphRegistrationQuads(cgId, 'bravo'),
+      ...workspaceOpQuads(cgId, 'alpha', 'urn:swm:prelude:alpha', alphaSwmMeta, now),
+      ...workspaceOpQuads(cgId, 'bravo', 'urn:swm:prelude:bravo', bravoSwmMeta, now),
     ]);
 
     const cap = registerTestSyncHandler(store);
@@ -365,22 +369,24 @@ describe('sync responder graph admission planner', () => {
       includeSharedMemory: true,
       phase: 'meta',
       offset: 0,
-      limit: 1,
+      limit: 5,
     });
     const second = await cap.invoke({
       contextGraphId: cgId,
       includeSharedMemory: true,
       phase: 'meta',
-      offset: 1,
-      limit: 1,
+      offset: 5,
+      limit: 5,
     });
 
     expect(first).toContain(`${DKG_NS}SubGraph`);
-    expect(first).toContain(`did:dkg:context-graph:${cgId}/registered`);
-    expect(linesFromNquads(first).length).toBeGreaterThan(1);
-    expect(second).not.toContain(`${DKG_NS}SubGraph`);
-    expect(second).not.toContain(`did:dkg:context-graph:${cgId}/registered`);
-    expect(lineGraphsFromNquads(second).has(rootSwmMeta)).toBe(true);
+    expect(first).toContain(`did:dkg:context-graph:${cgId}/alpha`);
+    expect(first).not.toContain(`did:dkg:context-graph:${cgId}/bravo`);
+    expect(linesFromNquads(first).length).toBeGreaterThan(5);
+    expect(second).toContain(`${DKG_NS}SubGraph`);
+    expect(second).toContain(`did:dkg:context-graph:${cgId}/bravo`);
+    expect(second).not.toContain(`did:dkg:context-graph:${cgId}/alpha`);
+    expect(lineGraphsFromNquads(second).has(bravoSwmMeta)).toBe(true);
   });
 
   it('does not serve stale SWM rows from a previous request after same-graph writes', async () => {

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -145,6 +145,54 @@ describe('sync responder graph admission planner', () => {
     expect(out).not.toContain('"child-leak"');
   });
 
+  it('keeps parent durable partitions when a child CG has a reserved partition name', async () => {
+    const cgId = 'planner-reserved-child-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const parentPartition = `${cgPrefix}/context/1`;
+    const reservedNameChildId = `${cgId}/context`;
+    const reservedNameChildPrefix = `did:dkg:context-graph:${reservedNameChildId}`;
+    const reservedNameChildMeta = `${reservedNameChildPrefix}/_meta`;
+    const reservedNameChildSwm = `${reservedNameChildPrefix}/_shared_memory`;
+    const assertionNameChildId = `${cgId}/assertion`;
+    const assertionNameChildPrefix = `did:dkg:context-graph:${assertionNameChildId}`;
+    const assertionNameChildMeta = `${assertionNameChildPrefix}/_meta`;
+    const assertionNameChildPartition = `${assertionNameChildPrefix}/context/1`;
+    const regularChildId = `${cgId}/team`;
+    const regularChildPrefix = `did:dkg:context-graph:${regularChildId}`;
+    const regularChildMeta = `${regularChildPrefix}/_meta`;
+    const regularChildNumericPartition = `${regularChildPrefix}/1`;
+    const regularChildNumericMeta = `${regularChildPrefix}/1/_meta`;
+
+    await store.insert([
+      q(parentPartition, 'urn:parent:partition', 'http://schema.org/name', '"parent-context-partition"'),
+      q(reservedNameChildMeta, reservedNameChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(reservedNameChildPrefix, 'urn:reserved-child:data', 'http://schema.org/name', '"reserved-child-leak"'),
+      q(reservedNameChildSwm, 'urn:reserved-child:swm', 'http://schema.org/name', '"reserved-child-swm-leak"'),
+      q(assertionNameChildMeta, assertionNameChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(assertionNameChildPartition, 'urn:assertion-child:partition', 'http://schema.org/name', '"assertion-child-partition-leak"'),
+      q(regularChildMeta, regularChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(regularChildNumericPartition, 'urn:regular-child:partition', 'http://schema.org/name', '"regular-child-numeric-leak"'),
+      q(regularChildNumericMeta, 'urn:regular-child:meta', `${DKG_NS}merkleRoot`, '"regular-child-numeric-meta-leak"'),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(lineGraphsFromNquads(out).has(parentPartition)).toBe(true);
+    expect(out).toContain('"parent-context-partition"');
+    expect(out).not.toContain('"reserved-child-leak"');
+    expect(out).not.toContain('"reserved-child-swm-leak"');
+    expect(out).not.toContain('"assertion-child-partition-leak"');
+    expect(out).not.toContain('"regular-child-numeric-leak"');
+    expect(out).not.toContain('"regular-child-numeric-meta-leak"');
+  });
+
   it('preserves durable meta admission without per-row EXISTS filters', async () => {
     const cgId = 'planner-meta-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -150,6 +150,7 @@ describe('sync responder graph admission planner', () => {
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
     const parentPartition = `${cgPrefix}/context/1`;
     const parentAssertion = `${cgPrefix}/assertion/0xabc/final`;
+    const parentAssertionMeta = `${parentAssertion}/_meta`;
     const reservedNameChildId = `${cgId}/context`;
     const reservedNameChildPrefix = `did:dkg:context-graph:${reservedNameChildId}`;
     const reservedNameChildMeta = `${reservedNameChildPrefix}/_meta`;
@@ -167,6 +168,7 @@ describe('sync responder graph admission planner', () => {
     await store.insert([
       q(parentPartition, 'urn:parent:partition', 'http://schema.org/name', '"parent-context-partition"'),
       q(parentAssertion, 'urn:parent:assertion', 'http://schema.org/name', '"parent-assertion"'),
+      q(parentAssertionMeta, 'urn:parent:assertion', `${DKG_NS}merkleRoot`, '"parent-assertion-meta"'),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
       q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}assertionGraph`, parentAssertion),
       q(reservedNameChildMeta, reservedNameChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
@@ -190,8 +192,10 @@ describe('sync responder graph admission planner', () => {
 
     expect(lineGraphsFromNquads(out).has(parentPartition)).toBe(true);
     expect(lineGraphsFromNquads(out).has(parentAssertion)).toBe(true);
+    expect(lineGraphsFromNquads(out).has(parentAssertionMeta)).toBe(true);
     expect(out).toContain('"parent-context-partition"');
     expect(out).toContain('"parent-assertion"');
+    expect(out).toContain('"parent-assertion-meta"');
     expect(out).not.toContain('"reserved-child-leak"');
     expect(out).not.toContain('"reserved-child-swm-leak"');
     expect(out).not.toContain('"assertion-child-partition-leak"');

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryLayer } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKG_NS,
+  RDF_TYPE,
+  lineGraphsFromNquads,
+  linesFromNquads,
+  registerTestSyncHandler,
+  subGraphRegistrationQuads,
+  workspaceOpQuads,
+} from './_helpers/sync-responder.js';
+
+const DKG_CONTEXT_GRAPH = 'https://dkg.network/ontology#ContextGraph';
+
+function compareCodePoint(a: string, b: string): number {
+  const left = Array.from(a);
+  const right = Array.from(b);
+  const len = Math.min(left.length, right.length);
+  for (let i = 0; i < len; i++) {
+    const delta = left[i].codePointAt(0)! - right[i].codePointAt(0)!;
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+function q(graph: string, subject: string, predicate: string, object: string): Quad {
+  return { graph, subject, predicate, object };
+}
+
+describe('sync responder graph admission planner', () => {
+  let store: OxigraphStore;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+  });
+
+  it('D-SEC denies durable data for a curated child requested through a bare public ancestor', async () => {
+    const ancestorId = '0x1111111111111111111111111111111111111111';
+    const childId = `${ancestorId}/medical-evidence`;
+    const childPrefix = `did:dkg:context-graph:${childId}`;
+    const childMeta = `${childPrefix}/_meta`;
+    const childPerCgData = `${childPrefix}/context/1`;
+    const childPerCgMeta = `${childPrefix}/context/1/_meta`;
+    const childSwm = `${childPrefix}/_shared_memory`;
+    const childSwmMeta = `${childPrefix}/_shared_memory_meta`;
+
+    await store.insert([
+      q(childMeta, childPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(childMeta, childPrefix, `${DKG_NS}accessPolicy`, '"private"'),
+      q(childPrefix, 'urn:patient:root', 'http://schema.org/name', '"CHILD-DATA-LEAK"'),
+      q(childPerCgData, 'urn:patient:kc', 'http://schema.org/name', '"CHILD-PER-CG-LEAK"'),
+      q(childPerCgMeta, 'urn:patient:meta', `${DKG_NS}merkleRoot`, '"CHILD-META-LEAK"'),
+      q(childSwm, 'urn:patient:swm', 'http://schema.org/name', '"CHILD-SWM-LEAK"'),
+      ...workspaceOpQuads(childId, 'op-child', 'urn:patient:swm', childSwmMeta, '2026-06-01T00:00:00.000Z'),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const out = await cap.invoke({
+      contextGraphId: ancestorId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(out).toBe('');
+  });
+
+  it('D-SEC denies durable data for slash-bearing descendant CGs even when the first segment is not a CG', async () => {
+    const ancestorId = '0x2222222222222222222222222222222222222222';
+    const childId = `${ancestorId}/team/project`;
+    const childPrefix = `did:dkg:context-graph:${childId}`;
+    const childMeta = `${childPrefix}/_meta`;
+
+    await store.insert([
+      q(childMeta, childPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(childPrefix, 'urn:descendant:root', 'http://schema.org/name', '"DESCENDANT-LEAK"'),
+      q(`${childPrefix}/context/1/_meta`, 'urn:descendant:meta', `${DKG_NS}merkleRoot`, '"DESCENDANT-META-LEAK"'),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const out = await cap.invoke({
+      contextGraphId: ancestorId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(out).toBe('');
+  });
+
+  it('preserves durable data admission while excluding private, top-level meta, WM assertions, and child CGs', async () => {
+    const cgId = 'planner-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const cgMeta = `${cgPrefix}/_meta`;
+    const canonicalData = cgPrefix;
+    const perCgData = `${cgPrefix}/context/1`;
+    const perCgMeta = `${cgPrefix}/context/1/_meta`;
+    const privateGraph = `${cgPrefix}/_private/secret`;
+    const wmAssertion = `${cgPrefix}/assertion/0xabc/wm-draft`;
+    const vmAssertion = `${cgPrefix}/assertion/0xabc/vm-final`;
+    const childId = `${cgId}/child`;
+    const childPrefix = `did:dkg:context-graph:${childId}`;
+    const childMeta = `${childPrefix}/_meta`;
+
+    await store.insert([
+      q(canonicalData, 'urn:durable:root', 'http://schema.org/name', '"canonical"'),
+      q(cgMeta, cgPrefix, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'),
+      q(perCgData, 'urn:per-cg:data', 'http://schema.org/name', '"per-cg-data"'),
+      q(perCgMeta, 'urn:per-cg:meta', `${DKG_NS}merkleRoot`, '"per-cg-meta"'),
+      q(privateGraph, 'urn:private:data', 'http://schema.org/name', '"private-leak"'),
+      q(wmAssertion, 'urn:assertion:wm', 'http://schema.org/name', '"wm-assertion-leak"'),
+      q(vmAssertion, 'urn:assertion:vm', 'http://schema.org/name', '"vm-assertion"'),
+      q(cgMeta, 'urn:lifecycle:wm', `${DKG_NS}assertionGraph`, wmAssertion),
+      q(cgMeta, 'urn:lifecycle:wm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.WorkingMemory}"`),
+      q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}assertionGraph`, vmAssertion),
+      q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
+      q(childMeta, childPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(childPrefix, 'urn:child:data', 'http://schema.org/name', '"child-leak"'),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    const graphs = lineGraphsFromNquads(out);
+
+    expect(graphs.has(canonicalData)).toBe(true);
+    expect(graphs.has(perCgData)).toBe(true);
+    expect(graphs.has(perCgMeta)).toBe(true);
+    expect(graphs.has(vmAssertion)).toBe(true);
+    expect(graphs.has(cgMeta)).toBe(false);
+    expect(graphs.has(privateGraph)).toBe(false);
+    expect(graphs.has(wmAssertion)).toBe(false);
+    expect(graphs.has(childPrefix)).toBe(false);
+    expect(out).toContain('"vm-assertion"');
+    expect(out).not.toContain('"wm-assertion-leak"');
+    expect(out).not.toContain('"private-leak"');
+    expect(out).not.toContain('"child-leak"');
+  });
+
+  it('preserves durable meta admission without per-row EXISTS filters', async () => {
+    const cgId = 'planner-meta-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const cgMeta = `${cgPrefix}/_meta`;
+    const vmAssertion = `${cgPrefix}/assertion/0xabc/final`;
+    const wmAssertion = `${cgPrefix}/assertion/0xabc/draft`;
+
+    await store.insert([
+      q(cgMeta, cgPrefix, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'),
+      q(cgMeta, 'did:dkg:activity:1', 'http://schema.org/name', '"activity"'),
+      q(cgMeta, 'did:dkg:join-request:1', 'http://schema.org/name', '"join"'),
+      q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
+      q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}assertionGraph`, vmAssertion),
+      q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}assertionName`, '"final"'),
+      q(cgMeta, vmAssertion, `${DKG_NS}merkleRoot`, '"vm-assertion-meta"'),
+      q(cgMeta, 'urn:event:vm', 'http://www.w3.org/ns/prov#generated', 'urn:lifecycle:vm'),
+      q(cgMeta, 'urn:lifecycle:wm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.WorkingMemory}"`),
+      q(cgMeta, 'urn:lifecycle:wm', `${DKG_NS}assertionGraph`, wmAssertion),
+      q(cgMeta, wmAssertion, `${DKG_NS}merkleRoot`, '"wm-assertion-meta-leak"'),
+      q(cgMeta, 'urn:noise', 'http://schema.org/name', '"noise-leak"'),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'meta',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(out).toContain(cgPrefix);
+    expect(out).toContain('did:dkg:activity:1');
+    expect(out).toContain('did:dkg:join-request:1');
+    expect(out).toContain('urn:lifecycle:vm');
+    expect(out).toContain(vmAssertion);
+    expect(out).toContain('urn:event:vm');
+    expect(out).not.toContain('urn:lifecycle:wm');
+    expect(out).not.toContain('wm-assertion-meta-leak');
+    expect(out).not.toContain('noise-leak');
+  });
+
+  it('uses true codepoint order for graph-level pagination', async () => {
+    const cgId = 'planner-order-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const graphs = [
+      `${cgPrefix}/alpha`,
+      `${cgPrefix}/\u{10000}-astral`,
+      `${cgPrefix}/\uF900-bmp`,
+      `${cgPrefix}/zeta`,
+    ];
+    await store.insert(graphs.map((graph) =>
+      q(graph, `urn:subject:${graph.slice(cgPrefix.length + 1)}`, 'http://schema.org/name', `"${graph}"`),
+    ));
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 2 });
+    const first = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 2,
+    });
+    const second = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 2,
+      limit: 2,
+    });
+    const actualLines = [...linesFromNquads(first), ...linesFromNquads(second)];
+    const expectedGraphs = [...graphs].sort(compareCodePoint);
+
+    expect(actualLines).toHaveLength(expectedGraphs.length);
+    for (let i = 0; i < expectedGraphs.length; i++) {
+      expect(actualLines[i]).toContain(`<${expectedGraphs[i]}> .`);
+    }
+  });
+
+  it('serves registered SWM subgraphs while denying unregistered and child-CG collisions', async () => {
+    const cgId = 'planner-swm-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const rootSwm = `${cgPrefix}/_shared_memory`;
+    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+    const registeredSwm = `${cgPrefix}/registered/_shared_memory`;
+    const registeredSwmMeta = `${cgPrefix}/registered/_shared_memory_meta`;
+    const unregisteredSwm = `${cgPrefix}/unregistered/_shared_memory`;
+    const childId = `${cgId}/child`;
+    const childPrefix = `did:dkg:context-graph:${childId}`;
+    const childMeta = `${childPrefix}/_meta`;
+    const childSwm = `${childPrefix}/_shared_memory`;
+    const childSwmMeta = `${childPrefix}/_shared_memory_meta`;
+    const now = '2026-06-01T00:00:00.000Z';
+
+    await store.insert([
+      q(rootSwm, 'urn:swm:root', 'http://schema.org/name', '"root-swm"'),
+      ...workspaceOpQuads(cgId, 'root', 'urn:swm:root', rootSwmMeta, now),
+      ...subGraphRegistrationQuads(cgId, 'registered'),
+      q(registeredSwm, 'urn:swm:registered', 'http://schema.org/name', '"registered-swm"'),
+      ...workspaceOpQuads(cgId, 'registered', 'urn:swm:registered', registeredSwmMeta, now),
+      q(unregisteredSwm, 'urn:swm:unregistered', 'http://schema.org/name', '"unregistered-leak"'),
+      ...subGraphRegistrationQuads(cgId, 'child'),
+      q(childMeta, childPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
+      q(childSwm, 'urn:swm:child', 'http://schema.org/name', '"child-swm-leak"'),
+      ...workspaceOpQuads(childId, 'child', 'urn:swm:child', childSwmMeta, now),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const dataOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    const dataGraphs = lineGraphsFromNquads(dataOut);
+
+    expect(dataGraphs.has(rootSwm)).toBe(true);
+    expect(dataGraphs.has(registeredSwm)).toBe(true);
+    expect(dataGraphs.has(unregisteredSwm)).toBe(false);
+    expect(dataGraphs.has(childSwm)).toBe(false);
+    expect(dataOut).not.toContain('"unregistered-leak"');
+    expect(dataOut).not.toContain('"child-swm-leak"');
+
+    const metaOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 5000,
+    });
+    const metaGraphs = lineGraphsFromNquads(metaOut);
+
+    expect(metaGraphs.has(rootSwmMeta)).toBe(true);
+    expect(metaGraphs.has(registeredSwmMeta)).toBe(true);
+    expect(metaGraphs.has(childSwmMeta)).toBe(false);
+  });
+
+  it('does not serve stale SWM rows from a previous request after same-graph writes', async () => {
+    const cgId = 'planner-swm-freshness-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const rootSwm = `${cgPrefix}/_shared_memory`;
+    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+    const now = new Date().toISOString();
+
+    await store.insert([
+      q(rootSwm, 'urn:swm:freshness:first', 'http://schema.org/name', '"first"'),
+      ...workspaceOpQuads(cgId, 'first', 'urn:swm:freshness:first', rootSwmMeta, now),
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000 });
+    const firstOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    expect(firstOut).toContain('"first"');
+    expect(firstOut).not.toContain('"second"');
+
+    await store.insert([
+      q(rootSwm, 'urn:swm:freshness:second', 'http://schema.org/name', '"second"'),
+      ...workspaceOpQuads(cgId, 'second', 'urn:swm:freshness:second', rootSwmMeta, now),
+    ]);
+
+    const secondOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(secondOut).toContain('"first"');
+    expect(secondOut).toContain('"second"');
+  });
+
+  it('discovers newly-created SWM graphs on the next request', async () => {
+    const cgId = 'planner-swm-new-graph-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const rootSwm = `${cgPrefix}/_shared_memory`;
+    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+    const subSwm = `${cgPrefix}/fresh-sub/_shared_memory`;
+    const subSwmMeta = `${cgPrefix}/fresh-sub/_shared_memory_meta`;
+    const now = new Date().toISOString();
+
+    await store.insert([
+      q(rootSwm, 'urn:swm:new-graph:root', 'http://schema.org/name', '"root"'),
+      ...workspaceOpQuads(cgId, 'root', 'urn:swm:new-graph:root', rootSwmMeta, now),
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000 });
+    const firstOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    expect(firstOut).toContain('"root"');
+    expect(firstOut).not.toContain('"new-sub"');
+
+    await store.insert([
+      ...subGraphRegistrationQuads(cgId, 'fresh-sub'),
+      q(subSwm, 'urn:swm:new-graph:sub', 'http://schema.org/name', '"new-sub"'),
+      ...workspaceOpQuads(cgId, 'sub', 'urn:swm:new-graph:sub', subSwmMeta, now),
+    ]);
+
+    const secondOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    const graphs = lineGraphsFromNquads(secondOut);
+    expect(graphs.has(rootSwm)).toBe(true);
+    expect(graphs.has(subSwm)).toBe(true);
+    expect(secondOut).toContain('"new-sub"');
+  });
+
+  it('ignores malformed replicated subgraph names without failing SWM sync', async () => {
+    const cgId = 'planner-swm-malformed-subgraph-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const cgMeta = `${cgPrefix}/_meta`;
+    const rootSwm = `${cgPrefix}/_shared_memory`;
+    const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
+    const malformedSg = `${cgPrefix}/bad-name-record`;
+    const now = new Date().toISOString();
+
+    await store.insert([
+      q(rootSwm, 'urn:swm:malformed:root', 'http://schema.org/name', '"root"'),
+      ...workspaceOpQuads(cgId, 'root', 'urn:swm:malformed:root', rootSwmMeta, now),
+      q(cgMeta, malformedSg, RDF_TYPE, `${DKG_NS}SubGraph`),
+      q(cgMeta, malformedSg, 'http://schema.org/name', '"bad name"'),
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    expect(out).toContain('"root"');
+  });
+
+  it('uses top-level durable meta for sinceBatchId filtering without emitting it as data', async () => {
+    const cgId = 'planner-delta-top-meta-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const cgMeta = `${cgPrefix}/_meta`;
+    const kc = 'did:dkg:evm:31337/0xplannerdelta';
+    const ka = `${kc}/1`;
+    const root = 'urn:delta:top-meta-root';
+
+    await store.insert([
+      q(cgPrefix, root, 'http://schema.org/name', '"stale-data"'),
+      q(cgMeta, kc, `${DKG_NS}batchId`, '"4"'),
+      q(cgMeta, ka, `${DKG_NS}partOf`, kc),
+      q(cgMeta, ka, `${DKG_NS}rootEntity`, root),
+    ]);
+
+    const cap = registerTestSyncHandler(store);
+    const staleOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+      sinceBatchId: '4',
+    });
+    expect(staleOut).not.toContain('"stale-data"');
+    expect(lineGraphsFromNquads(staleOut).has(cgMeta)).toBe(false);
+
+    const freshOut = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+      sinceBatchId: '3',
+    });
+    expect(freshOut).toContain('"stale-data"');
+    expect(lineGraphsFromNquads(freshOut).has(cgMeta)).toBe(false);
+  });
+});

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -275,6 +275,7 @@ describe('sync responder graph admission planner', () => {
   it('serves registered SWM subgraphs while denying unregistered and child-CG collisions', async () => {
     const cgId = 'planner-swm-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const cgMeta = `${cgPrefix}/_meta`;
     const rootSwm = `${cgPrefix}/_shared_memory`;
     const rootSwmMeta = `${cgPrefix}/_shared_memory_meta`;
     const registeredSwm = `${cgPrefix}/registered/_shared_memory`;
@@ -328,7 +329,10 @@ describe('sync responder graph admission planner', () => {
 
     expect(metaGraphs.has(rootSwmMeta)).toBe(true);
     expect(metaGraphs.has(registeredSwmMeta)).toBe(true);
+    expect(metaGraphs.has(cgMeta)).toBe(true);
     expect(metaGraphs.has(childSwmMeta)).toBe(false);
+    expect(metaOut).toContain(`${DKG_NS}SubGraph`);
+    expect(metaOut).toContain(`did:dkg:context-graph:${cgId}/registered`);
   });
 
   it('does not serve stale SWM rows from a previous request after same-graph writes', async () => {

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -149,6 +149,7 @@ describe('sync responder graph admission planner', () => {
     const cgId = 'planner-reserved-child-cg';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
     const parentPartition = `${cgPrefix}/context/1`;
+    const parentAssertion = `${cgPrefix}/assertion/0xabc/final`;
     const reservedNameChildId = `${cgId}/context`;
     const reservedNameChildPrefix = `did:dkg:context-graph:${reservedNameChildId}`;
     const reservedNameChildMeta = `${reservedNameChildPrefix}/_meta`;
@@ -165,6 +166,9 @@ describe('sync responder graph admission planner', () => {
 
     await store.insert([
       q(parentPartition, 'urn:parent:partition', 'http://schema.org/name', '"parent-context-partition"'),
+      q(parentAssertion, 'urn:parent:assertion', 'http://schema.org/name', '"parent-assertion"'),
+      q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
+      q(`${cgPrefix}/_meta`, 'urn:lifecycle:reserved-vm', `${DKG_NS}assertionGraph`, parentAssertion),
       q(reservedNameChildMeta, reservedNameChildPrefix, RDF_TYPE, DKG_CONTEXT_GRAPH),
       q(reservedNameChildPrefix, 'urn:reserved-child:data', 'http://schema.org/name', '"reserved-child-leak"'),
       q(reservedNameChildSwm, 'urn:reserved-child:swm', 'http://schema.org/name', '"reserved-child-swm-leak"'),
@@ -185,7 +189,9 @@ describe('sync responder graph admission planner', () => {
     });
 
     expect(lineGraphsFromNquads(out).has(parentPartition)).toBe(true);
+    expect(lineGraphsFromNquads(out).has(parentAssertion)).toBe(true);
     expect(out).toContain('"parent-context-partition"');
+    expect(out).toContain('"parent-assertion"');
     expect(out).not.toContain('"reserved-child-leak"');
     expect(out).not.toContain('"reserved-child-swm-leak"');
     expect(out).not.toContain('"assertion-child-partition-leak"');
@@ -333,6 +339,7 @@ describe('sync responder graph admission planner', () => {
     expect(metaGraphs.has(childSwmMeta)).toBe(false);
     expect(metaOut).toContain(`${DKG_NS}SubGraph`);
     expect(metaOut).toContain(`did:dkg:context-graph:${cgId}/registered`);
+    expect(metaOut).not.toContain(`did:dkg:context-graph:${cgId}/child`);
   });
 
   it('does not serve stale SWM rows from a previous request after same-graph writes', async () => {

--- a/packages/agent/test/sync-responder-admission-parity.test.ts
+++ b/packages/agent/test/sync-responder-admission-parity.test.ts
@@ -4,6 +4,7 @@ import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   DKG_NS,
   RDF_TYPE,
+  SCHEMA_NAME,
   lineGraphsFromNquads,
   linesFromNquads,
   registerTestSyncHandler,
@@ -212,9 +213,15 @@ describe('sync responder graph admission planner', () => {
     const cgMeta = `${cgPrefix}/_meta`;
     const vmAssertion = `${cgPrefix}/assertion/0xabc/final`;
     const wmAssertion = `${cgPrefix}/assertion/0xabc/draft`;
+    const registeredSubGraph = `${cgPrefix}/registered`;
 
     await store.insert([
       q(cgMeta, cgPrefix, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'),
+      ...subGraphRegistrationQuads(cgId, 'registered'),
+      q(cgMeta, 'urn:forged-subgraph-registration', RDF_TYPE, `${DKG_NS}SubGraph`),
+      q(cgMeta, 'urn:forged-subgraph-registration', SCHEMA_NAME, '"forged"'),
+      q(cgMeta, `${cgPrefix}/context`, RDF_TYPE, `${DKG_NS}SubGraph`),
+      q(cgMeta, `${cgPrefix}/context`, SCHEMA_NAME, '"context"'),
       q(cgMeta, 'did:dkg:activity:1', 'http://schema.org/name', '"activity"'),
       q(cgMeta, 'did:dkg:join-request:1', 'http://schema.org/name', '"join"'),
       q(cgMeta, 'urn:lifecycle:vm', `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`),
@@ -238,11 +245,16 @@ describe('sync responder graph admission planner', () => {
     });
 
     expect(out).toContain(cgPrefix);
+    expect(out).toContain(registeredSubGraph);
+    expect(out).toContain(`${DKG_NS}SubGraph`);
+    expect(out).toContain(SCHEMA_NAME);
     expect(out).toContain('did:dkg:activity:1');
     expect(out).toContain('did:dkg:join-request:1');
     expect(out).toContain('urn:lifecycle:vm');
     expect(out).toContain(vmAssertion);
     expect(out).toContain('urn:event:vm');
+    expect(out).not.toContain('urn:forged-subgraph-registration');
+    expect(out).not.toContain(`${cgPrefix}/context`);
     expect(out).not.toContain('urn:lifecycle:wm');
     expect(out).not.toContain('wm-assertion-meta-leak');
     expect(out).not.toContain('noise-leak');

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -423,15 +423,14 @@ describe('sync responder pagination interleaving', () => {
     }, 'peer-a');
     expect(secondSessionPage).toContain('"row-000"');
 
-    const oldSessionNextPage = await cap.invoke({
+    await expect(cap.invoke({
       contextGraphId: cgId,
       includeSharedMemory: false,
       phase: 'data',
       offset: 1,
       limit: 1,
       syncSessionId: 'session-old',
-    }, 'peer-a');
-    expect(oldSessionNextPage).toContain('"row-001"');
+    }, 'peer-a')).rejects.toThrow('Durable data sync session was superseded before page completion');
   });
 
   it('derives durable-data cache keys server-side instead of from arbitrary session ids', async () => {

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -5,6 +5,7 @@ import {
   lineGraphsFromNquads,
   linesFromNquads,
   registerTestSyncHandler,
+  workspaceOpQuads,
 } from './_helpers/sync-responder.js';
 
 function q(graph: string, index: number): Quad {
@@ -13,6 +14,38 @@ function q(graph: string, index: number): Quad {
     subject: `urn:interleave:${index.toString().padStart(3, '0')}`,
     predicate: `${DKG_NS}label`,
     object: `"row-${index.toString().padStart(3, '0')}"`,
+  };
+}
+
+function watchBoundedPageQuery(
+  store: OxigraphStore,
+  graph: string,
+  expectedOffset: number,
+  expectedLimit: number,
+) {
+  const originalQuery = store.query.bind(store);
+  let observedPageQueries = 0;
+  store.query = (async (sparql: string) => {
+    const normalized = sparql.replace(/\s+/g, ' ').trim();
+    const isTargetPageQuery = /^SELECT (?:DISTINCT )?\?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`GRAPH <${graph}>`);
+    if (isTargetPageQuery) {
+      observedPageQueries++;
+      expect(normalized).toContain('ORDER BY ?s ?p ?o');
+      expect(normalized).toContain(`OFFSET ${expectedOffset}`);
+      expect(normalized).toContain(`LIMIT ${expectedLimit}`);
+    }
+    const result = await originalQuery(sparql);
+    if (isTargetPageQuery && result.type === 'bindings') {
+      expect(result.bindings.length).toBeLessThanOrEqual(expectedLimit);
+    }
+    return result;
+  }) as OxigraphStore['query'];
+
+  return {
+    assertObserved() {
+      expect(observedPageQueries).toBeGreaterThan(0);
+    },
   };
 }
 
@@ -57,5 +90,106 @@ describe('sync responder pagination interleaving', () => {
     }
     const graphs = new Set(outputs.flatMap((out) => [...lineGraphsFromNquads(out)]));
     expect(graphs).toEqual(new Set([graphA, graphB, graphC]));
+  });
+
+  it('uses bounded store-side paging for deep SWM data pages without TTL', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'bounded-swm';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    await store.insert(Array.from({ length: 100 }, (_, index) => q(swmGraph, index)));
+
+    const probe = watchBoundedPageQuery(store, swmGraph, 90, 5);
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 0, syncPageSize: 5 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 90,
+      limit: 5,
+    });
+
+    probe.assertObserved();
+    const lines = linesFromNquads(out);
+    expect(lines).toHaveLength(5);
+    expect(out).toContain('"row-090"');
+    expect(out).toContain('"row-094"');
+    expect(out).not.toContain('"row-089"');
+    expect(out).not.toContain('"row-095"');
+  });
+
+  it('uses bounded store-side paging for deep SWM data pages with TTL filtering', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'bounded-swm-ttl';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const swmMetaGraph = `${swmGraph}_meta`;
+    const now = new Date().toISOString();
+    const rows: Quad[] = [];
+    for (let index = 0; index < 100; index++) {
+      const root = `urn:interleave:${index.toString().padStart(3, '0')}`;
+      rows.push(q(swmGraph, index));
+      rows.push(...workspaceOpQuads(cgId, `op-${index}`, root, swmMetaGraph, now));
+    }
+    await store.insert(rows);
+
+    const probe = watchBoundedPageQuery(store, swmGraph, 90, 5);
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 90,
+      limit: 5,
+    });
+
+    probe.assertObserved();
+    const lines = linesFromNquads(out);
+    expect(lines).toHaveLength(5);
+    expect(out).toContain('"row-090"');
+    expect(out).toContain('"row-094"');
+    expect(out).not.toContain('"row-089"');
+    expect(out).not.toContain('"row-095"');
+  });
+
+  it('uses bounded store-side paging for deep durable meta pages', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'bounded-meta';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const metaGraph = `${cgPrefix}/_meta`;
+    const rows: Quad[] = [];
+    for (let index = 0; index < 100; index++) {
+      const padded = index.toString().padStart(3, '0');
+      rows.push({
+        graph: metaGraph,
+        subject: cgPrefix,
+        predicate: `http://schema.org/p${padded}`,
+        object: `"meta-${padded}"`,
+      });
+    }
+    rows.push({
+      graph: metaGraph,
+      subject: 'urn:noise',
+      predicate: 'http://schema.org/p000',
+      object: '"noise-leak"',
+    });
+    await store.insert(rows);
+
+    const probe = watchBoundedPageQuery(store, metaGraph, 90, 5);
+    const cap = registerTestSyncHandler(store, { syncPageSize: 5 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'meta',
+      offset: 90,
+      limit: 5,
+    });
+
+    probe.assertObserved();
+    const lines = linesFromNquads(out);
+    expect(lines).toHaveLength(5);
+    expect(out).toContain('"meta-090"');
+    expect(out).toContain('"meta-094"');
+    expect(out).not.toContain('"meta-089"');
+    expect(out).not.toContain('"meta-095"');
+    expect(out).not.toContain('"noise-leak"');
   });
 });

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { createResponderGraphListMemo } from '../src/sync/responder/graph-plan.js';
 import {
   DKG_NS,
   lineGraphsFromNquads,
   linesFromNquads,
   registerTestSyncHandler,
+  subGraphRegistrationQuads,
   workspaceOpQuads,
 } from './_helpers/sync-responder.js';
 
@@ -15,6 +17,16 @@ function q(graph: string, index: number): Quad {
     predicate: `${DKG_NS}label`,
     object: `"row-${index.toString().padStart(3, '0')}"`,
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function watchBoundedPageQuery(
@@ -117,21 +129,47 @@ describe('sync responder pagination interleaving', () => {
     expect(out).not.toContain('"row-095"');
   });
 
+  it('uses bounded store-side paging for deep SWM meta pages', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'bounded-swm-meta';
+    const swmMetaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
+    await store.insert(Array.from({ length: 100 }, (_, index) => q(swmMetaGraph, index)));
+
+    const probe = watchBoundedPageQuery(store, swmMetaGraph, 90, 5);
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 0, syncPageSize: 5 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 90,
+      limit: 5,
+    });
+
+    probe.assertObserved();
+    const lines = linesFromNquads(out);
+    expect(lines).toHaveLength(5);
+    expect(out).toContain('"row-090"');
+    expect(out).toContain('"row-094"');
+    expect(out).not.toContain('"row-089"');
+    expect(out).not.toContain('"row-095"');
+  });
+
   it('uses bounded store-side paging for deep SWM data pages with TTL filtering', async () => {
     const store = new OxigraphStore();
     const cgId = 'bounded-swm-ttl';
     const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const dataGraph = `${swmGraph}/0xabc/1`;
     const swmMetaGraph = `${swmGraph}_meta`;
     const now = new Date().toISOString();
     const rows: Quad[] = [];
     for (let index = 0; index < 100; index++) {
       const root = `urn:interleave:${index.toString().padStart(3, '0')}`;
-      rows.push(q(swmGraph, index));
+      rows.push(q(dataGraph, index));
       rows.push(...workspaceOpQuads(cgId, `op-${index}`, root, swmMetaGraph, now));
     }
     await store.insert(rows);
 
-    const probe = watchBoundedPageQuery(store, swmGraph, 90, 5);
+    const probe = watchBoundedPageQuery(store, dataGraph, 90, 5);
     const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5 });
     const out = await cap.invoke({
       contextGraphId: cgId,
@@ -144,6 +182,7 @@ describe('sync responder pagination interleaving', () => {
     probe.assertObserved();
     const lines = linesFromNquads(out);
     expect(lines).toHaveLength(5);
+    expect(lineGraphsFromNquads(out)).toEqual(new Set([dataGraph]));
     expect(out).toContain('"row-090"');
     expect(out).toContain('"row-094"');
     expect(out).not.toContain('"row-089"');
@@ -191,5 +230,105 @@ describe('sync responder pagination interleaving', () => {
     expect(out).not.toContain('"meta-089"');
     expect(out).not.toContain('"meta-095"');
     expect(out).not.toContain('"noise-leak"');
+  });
+
+  it('reuses the responder graph-list memo across nearby page requests', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'memo-swm';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    await store.insert(Array.from({ length: 2 }, (_, index) => q(swmGraph, index)));
+    const originalListGraphs = store.listGraphs.bind(store);
+    let listGraphCalls = 0;
+    store.listGraphs = async () => {
+      listGraphCalls++;
+      return originalListGraphs();
+    };
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 0, syncPageSize: 1 });
+    await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+    });
+    await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 1,
+      limit: 1,
+    });
+
+    expect(listGraphCalls).toBe(1);
+  });
+
+  it('keeps SWM data pagination stable when a subgraph appears after page zero', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'memo-stable-swm';
+    const rootSwm = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const subSwm = `did:dkg:context-graph:${cgId}/later/_shared_memory`;
+    await store.insert([
+      q(rootSwm, 0),
+      q(rootSwm, 1),
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 0, syncPageSize: 1 });
+    const first = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+    });
+
+    await store.insert([
+      ...subGraphRegistrationQuads(cgId, 'later'),
+      {
+        graph: subSwm,
+        subject: 'urn:interleave:000',
+        predicate: `${DKG_NS}label`,
+        object: '"new-subgraph-row"',
+      },
+    ]);
+
+    const second = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 1,
+      limit: 1,
+    });
+
+    expect(first).toContain('"row-000"');
+    expect(second).toContain('"row-001"');
+    expect(second).not.toContain('"new-subgraph-row"');
+  });
+
+  it('joins an in-flight graph-list refresh before serving cached pages', async () => {
+    const firstRefresh = deferred<string[]>();
+    const secondRefresh = deferred<string[]>();
+    let calls = 0;
+    const store = {
+      listGraphs: async () => {
+        calls++;
+        return calls === 1 ? firstRefresh.promise : secondRefresh.promise;
+      },
+    } as unknown as OxigraphStore;
+    const memo = createResponderGraphListMemo(store);
+
+    const initial = memo.get({ refresh: true });
+    firstRefresh.resolve(['old']);
+    await expect(initial).resolves.toEqual(['old']);
+
+    const refreshing = memo.get({ refresh: true });
+    const overlappingRefresh = memo.get({ refresh: true });
+    const deepPage = memo.get();
+    secondRefresh.resolve(['new']);
+
+    await expect(refreshing).resolves.toEqual(['new']);
+    await expect(overlappingRefresh).resolves.toEqual(['new']);
+    await expect(deepPage).resolves.toEqual(['new']);
+    expect(calls).toBe(2);
   });
 });

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -41,14 +41,16 @@ function watchBoundedPageQuery(
     const normalized = sparql.replace(/\s+/g, ' ').trim();
     const isTargetPageQuery = /^SELECT (?:DISTINCT )?\?s \?p \?o WHERE \{/.test(normalized) &&
       normalized.includes(`GRAPH <${graph}>`);
-    if (isTargetPageQuery) {
+    const isTargetMultiGraphPageQuery = /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`VALUES ?g { <${graph}>`);
+    if (isTargetPageQuery || isTargetMultiGraphPageQuery) {
       observedPageQueries++;
-      expect(normalized).toContain('ORDER BY ?s ?p ?o');
+      expect(normalized).toMatch(/ORDER BY \?g \?s \?p \?o|ORDER BY \?s \?p \?o/);
       expect(normalized).toContain(`OFFSET ${expectedOffset}`);
       expect(normalized).toContain(`LIMIT ${expectedLimit}`);
     }
     const result = await originalQuery(sparql);
-    if (isTargetPageQuery && result.type === 'bindings') {
+    if ((isTargetPageQuery || isTargetMultiGraphPageQuery) && result.type === 'bindings') {
       expect(result.bindings.length).toBeLessThanOrEqual(expectedLimit);
     }
     return result;
@@ -230,6 +232,79 @@ describe('sync responder pagination interleaving', () => {
     expect(out).not.toContain('"meta-089"');
     expect(out).not.toContain('"meta-095"');
     expect(out).not.toContain('"noise-leak"');
+  });
+
+  it('refreshes the graph list before canonical page-zero durable fallback', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'memo-refresh-before-canonical-fallback';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const fallbackGraph = `${cgPrefix}/context/1`;
+    await store.insert([
+      q(cgPrefix, 0),
+      q(fallbackGraph, 1),
+    ]);
+
+    const originalListGraphs = store.listGraphs.bind(store);
+    let listGraphCalls = 0;
+    store.listGraphs = async () => {
+      listGraphCalls++;
+      return originalListGraphs();
+    };
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 2 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 2,
+    });
+
+    expect(listGraphCalls).toBe(1);
+    expect(out).toContain('"row-000"');
+    expect(out).toContain('"row-001"');
+    expect(lineGraphsFromNquads(out)).toEqual(new Set([cgPrefix, fallbackGraph]));
+  });
+
+  it('durable fallback pages admitted graphs with one global store query', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'single-query-durable-fallback';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const fallbackGraph = `${cgPrefix}/context/1`;
+    await store.insert([
+      q(cgPrefix, 0),
+      q(fallbackGraph, 1),
+    ]);
+
+    const originalQuery = store.query.bind(store);
+    let globalPageQueries = 0;
+    store.query = (async (sparql: string) => {
+      const normalized = sparql.replace(/\s+/g, ' ').trim();
+      if (normalized.includes('COUNT(*)')) {
+        throw new Error(`durable fallback should not count per graph: ${normalized}`);
+      }
+      if (
+        /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+        normalized.includes(`VALUES ?g { <${cgPrefix}> <${fallbackGraph}>`) &&
+        normalized.includes('ORDER BY ?g ?s ?p ?o')
+      ) {
+        globalPageQueries++;
+      }
+      return originalQuery(sparql);
+    }) as OxigraphStore['query'];
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 1,
+      limit: 1,
+    });
+
+    expect(globalPageQueries).toBe(1);
+    expect(out).toContain('"row-001"');
+    expect(out).not.toContain('"row-000"');
   });
 
   it('reuses the responder graph-list memo across nearby page requests', async () => {

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -434,6 +434,36 @@ describe('sync responder pagination interleaving', () => {
     expect(firstSessionNextPage).toBe('');
   });
 
+  it('reuses a durable-data session snapshot on page-zero retry', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'retry-session-durable';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    await store.insert([q(cgPrefix, 1)]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const firstAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session',
+    }, 'peer-a');
+    expect(firstAttempt).toContain('"row-001"');
+
+    await store.insert([q(cgPrefix, 0)]);
+    const retryAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session',
+    }, 'peer-a');
+    expect(retryAttempt).toBe(firstAttempt);
+    expect(retryAttempt).not.toContain('"row-000"');
+  });
+
   it('reuses the responder graph-list memo across nearby page requests', async () => {
     const store = new OxigraphStore();
     const cgId = 'memo-swm';
@@ -566,7 +596,7 @@ describe('sync responder pagination interleaving', () => {
     expect(loads).toBe(1);
   });
 
-  it('does not rebuild an expired durable row snapshot for deep session pages', async () => {
+  it('does not rebuild an expired durable row snapshot for the same session', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
 
@@ -585,8 +615,34 @@ describe('sync responder pagination interleaving', () => {
     await expect(memo.get('durable', loadRows)).resolves.toHaveLength(1);
 
     vi.setSystemTime(11);
-    await expect(memo.get('durable', loadRows, { requireExisting: true })).resolves.toBeNull();
+    await expect(memo.get('durable', loadRows)).rejects.toThrow(
+      'Durable data sync session snapshot expired before page completion',
+    );
     expect(loads).toBe(1);
+  });
+
+  it('does not retain empty durable row snapshots against the active cap', async () => {
+    const memo = createResponderSyncRowListMemo(10_000, 1);
+    let emptyLoads = 0;
+    let nonEmptyLoads = 0;
+
+    await expect(memo.get('durable:empty', async () => {
+      emptyLoads++;
+      return [];
+    })).resolves.toHaveLength(0);
+
+    await expect(memo.get('durable:non-empty', async () => {
+      nonEmptyLoads++;
+      return [{
+        s: 'urn:memo:row',
+        p: `${DKG_NS}label`,
+        o: '"snapshot"',
+        g: 'urn:memo:graph',
+      }];
+    })).resolves.toHaveLength(1);
+
+    expect(emptyLoads).toBe(1);
+    expect(nonEmptyLoads).toBe(1);
   });
 
   it('rejects new durable row snapshots at the active cap without evicting existing sessions', async () => {

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -395,9 +395,9 @@ describe('sync responder pagination interleaving', () => {
     expect(peerASecond).toBe('');
   });
 
-  it('isolates overlapping durable-data row snapshots from the same peer by sync session', async () => {
+  it('refreshes same-peer durable-data snapshots when the page-zero session token changes', async () => {
     const store = new OxigraphStore();
-    const cgId = 'session-isolated-durable';
+    const cgId = 'session-refresh-durable';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
     await store.insert([q(cgPrefix, 1)]);
 
@@ -423,7 +423,7 @@ describe('sync responder pagination interleaving', () => {
     }, 'peer-a');
     expect(secondSessionPage).toContain('"row-000"');
 
-    const firstSessionNextPage = await cap.invoke({
+    const oldSessionNextPage = await cap.invoke({
       contextGraphId: cgId,
       includeSharedMemory: false,
       phase: 'data',
@@ -431,7 +431,27 @@ describe('sync responder pagination interleaving', () => {
       limit: 1,
       syncSessionId: 'session-old',
     }, 'peer-a');
-    expect(firstSessionNextPage).toBe('');
+    expect(oldSessionNextPage).toContain('"row-001"');
+  });
+
+  it('derives durable-data cache keys server-side instead of from arbitrary session ids', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'server-keyed-session-durable';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    await store.insert([q(cgPrefix, 1)]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    for (let i = 0; i < 40; i++) {
+      const page = await cap.invoke({
+        contextGraphId: cgId,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset: 0,
+        limit: 1,
+        syncSessionId: `attacker-controlled-${i}`,
+      }, 'peer-a');
+      expect(page).toContain('"row-001"');
+    }
   });
 
   it('reuses a durable-data session snapshot on page-zero retry', async () => {

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { createResponderGraphListMemo } from '../src/sync/responder/graph-plan.js';
+import {
+  createResponderGraphListMemo,
+  createResponderSyncRowListMemo,
+} from '../src/sync/responder/graph-plan.js';
 import {
   DKG_NS,
   lineGraphsFromNquads,
@@ -29,6 +32,10 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 function watchBoundedPageQuery(
   store: OxigraphStore,
   graph: string,
@@ -41,7 +48,7 @@ function watchBoundedPageQuery(
     const normalized = sparql.replace(/\s+/g, ' ').trim();
     const isTargetPageQuery = /^SELECT (?:DISTINCT )?\?s \?p \?o WHERE \{/.test(normalized) &&
       normalized.includes(`GRAPH <${graph}>`);
-    const isTargetMultiGraphPageQuery = /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+    const isTargetMultiGraphPageQuery = /^SELECT (?:DISTINCT )?\?g \?s \?p \?o WHERE \{/.test(normalized) &&
       normalized.includes(`VALUES ?g { <${graph}>`);
     if (isTargetPageQuery || isTargetMultiGraphPageQuery) {
       observedPageQueries++;
@@ -266,7 +273,7 @@ describe('sync responder pagination interleaving', () => {
     expect(lineGraphsFromNquads(out)).toEqual(new Set([cgPrefix, fallbackGraph]));
   });
 
-  it('durable fallback pages admitted graphs with one global store query', async () => {
+  it('caches sorted durable-data rows instead of issuing ordered offset page queries', async () => {
     const store = new OxigraphStore();
     const cgId = 'single-query-durable-fallback';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
@@ -277,7 +284,7 @@ describe('sync responder pagination interleaving', () => {
     ]);
 
     const originalQuery = store.query.bind(store);
-    let globalPageQueries = 0;
+    let globalRowLoads = 0;
     store.query = (async (sparql: string) => {
       const normalized = sparql.replace(/\s+/g, ' ').trim();
       if (normalized.includes('COUNT(*)')) {
@@ -285,26 +292,146 @@ describe('sync responder pagination interleaving', () => {
       }
       if (
         /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
-        normalized.includes(`VALUES ?g { <${cgPrefix}> <${fallbackGraph}>`) &&
-        normalized.includes('ORDER BY ?g ?s ?p ?o')
+        normalized.includes(`VALUES ?g { <${cgPrefix}> <${fallbackGraph}>`)
       ) {
-        globalPageQueries++;
+        globalRowLoads++;
+        expect(normalized).not.toContain('ORDER BY');
+        expect(normalized).not.toContain('OFFSET');
+        expect(normalized).not.toContain('LIMIT');
       }
       return originalQuery(sparql);
     }) as OxigraphStore['query'];
 
     const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
-    const out = await cap.invoke({
+    const first = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'cache-session',
+    });
+    const second = await cap.invoke({
       contextGraphId: cgId,
       includeSharedMemory: false,
       phase: 'data',
       offset: 1,
       limit: 1,
+      syncSessionId: 'cache-session',
     });
 
-    expect(globalPageQueries).toBe(1);
-    expect(out).toContain('"row-001"');
-    expect(out).not.toContain('"row-000"');
+    expect(globalRowLoads).toBe(1);
+    expect(first).toContain('"row-000"');
+    expect(first).not.toContain('"row-001"');
+    expect(second).toContain('"row-001"');
+    expect(second).not.toContain('"row-000"');
+  });
+
+  it('refreshes full durable-data snapshots on page zero for the same peer', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'fresh-page-zero-durable';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    await store.insert([q(cgPrefix, 1)]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const first = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+    }, 'peer-a');
+    expect(first).toContain('"row-001"');
+
+    await store.insert([q(cgPrefix, 0)]);
+    const refreshed = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+    }, 'peer-a');
+
+    expect(refreshed).toContain('"row-000"');
+    expect(refreshed).not.toContain('"row-001"');
+  });
+
+  it('isolates active durable-data row snapshots per remote peer', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'peer-isolated-durable';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    await store.insert([q(cgPrefix, 1)]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const peerAFirst = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'peer-a-session',
+    }, 'peer-a');
+    expect(peerAFirst).toContain('"row-001"');
+
+    await store.insert([q(cgPrefix, 0)]);
+    const peerBFresh = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'peer-b-session',
+    }, 'peer-b');
+    expect(peerBFresh).toContain('"row-000"');
+
+    const peerASecond = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 1,
+      limit: 1,
+      syncSessionId: 'peer-a-session',
+    }, 'peer-a');
+    expect(peerASecond).toBe('');
+  });
+
+  it('isolates overlapping durable-data row snapshots from the same peer by sync session', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'session-isolated-durable';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    await store.insert([q(cgPrefix, 1)]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const firstSessionPage = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'session-old',
+    }, 'peer-a');
+    expect(firstSessionPage).toContain('"row-001"');
+
+    await store.insert([q(cgPrefix, 0)]);
+    const secondSessionPage = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'session-new',
+    }, 'peer-a');
+    expect(secondSessionPage).toContain('"row-000"');
+
+    const firstSessionNextPage = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 1,
+      limit: 1,
+      syncSessionId: 'session-old',
+    }, 'peer-a');
+    expect(firstSessionNextPage).toBe('');
   });
 
   it('reuses the responder graph-list memo across nearby page requests', async () => {
@@ -405,5 +532,113 @@ describe('sync responder pagination interleaving', () => {
     await expect(overlappingRefresh).resolves.toEqual(['new']);
     await expect(deepPage).resolves.toEqual(['new']);
     expect(calls).toBe(2);
+  });
+
+  it('keeps active durable row snapshots alive while pages are still being read', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const memo = createResponderSyncRowListMemo(10);
+    let loads = 0;
+    const loadRows = async () => {
+      loads++;
+      return [{
+        s: 'urn:memo:row',
+        p: `${DKG_NS}label`,
+        o: `"snapshot-${loads}"`,
+        g: 'urn:memo:graph',
+      }];
+    };
+
+    await expect(memo.get('durable', loadRows)).resolves.toMatchObject([
+      { o: '"snapshot-1"' },
+    ]);
+
+    vi.setSystemTime(9);
+    await expect(memo.get('durable', loadRows)).resolves.toMatchObject([
+      { o: '"snapshot-1"' },
+    ]);
+
+    vi.setSystemTime(18);
+    await expect(memo.get('durable', loadRows)).resolves.toMatchObject([
+      { o: '"snapshot-1"' },
+    ]);
+    expect(loads).toBe(1);
+  });
+
+  it('does not rebuild an expired durable row snapshot for deep session pages', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const memo = createResponderSyncRowListMemo(10);
+    let loads = 0;
+    const loadRows = async () => {
+      loads++;
+      return [{
+        s: 'urn:memo:row',
+        p: `${DKG_NS}label`,
+        o: `"snapshot-${loads}"`,
+        g: 'urn:memo:graph',
+      }];
+    };
+
+    await expect(memo.get('durable', loadRows)).resolves.toHaveLength(1);
+
+    vi.setSystemTime(11);
+    await expect(memo.get('durable', loadRows, { requireExisting: true })).resolves.toBeNull();
+    expect(loads).toBe(1);
+  });
+
+  it('rejects new durable row snapshots at the active cap without evicting existing sessions', async () => {
+    const memo = createResponderSyncRowListMemo(10_000, 2);
+    let loads = 0;
+    const loadRows = async () => {
+      loads++;
+      return [{
+        s: 'urn:memo:row',
+        p: `${DKG_NS}label`,
+        o: `"snapshot-${loads}"`,
+        g: 'urn:memo:graph',
+      }];
+    };
+
+    await expect(memo.get('durable:session-1', loadRows)).resolves.toHaveLength(1);
+    await expect(memo.get('durable:session-2', loadRows)).resolves.toHaveLength(1);
+    await expect(memo.get('durable:session-3', loadRows)).rejects.toThrow(
+      'Too many active durable data sync session snapshots',
+    );
+
+    await expect(
+      memo.get('durable:session-1', loadRows, { requireExisting: true }),
+    ).resolves.toMatchObject([{ o: '"snapshot-1"' }]);
+    expect(loads).toBe(2);
+  });
+
+  it('coalesces concurrent durable row snapshot refreshes', async () => {
+    const memo = createResponderSyncRowListMemo();
+    const snapshot = deferred<readonly {
+      s: string;
+      p: string;
+      o: string;
+      g: string;
+    }[]>();
+    let loads = 0;
+    const loadRows = () => {
+      loads++;
+      return snapshot.promise;
+    };
+
+    const first = memo.get('durable', loadRows, { refresh: true });
+    const second = memo.get('durable', loadRows, { refresh: true });
+    snapshot.resolve([{
+      s: 'urn:memo:row',
+      p: `${DKG_NS}label`,
+      o: '"snapshot"',
+      g: 'urn:memo:graph',
+    }]);
+
+    await expect(first).resolves.toHaveLength(1);
+    await expect(second).resolves.toHaveLength(1);
+    expect(loads).toBe(1);
   });
 });

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKG_NS,
+  lineGraphsFromNquads,
+  linesFromNquads,
+  registerTestSyncHandler,
+} from './_helpers/sync-responder.js';
+
+function q(graph: string, index: number): Quad {
+  return {
+    graph,
+    subject: `urn:interleave:${index.toString().padStart(3, '0')}`,
+    predicate: `${DKG_NS}label`,
+    object: `"row-${index.toString().padStart(3, '0')}"`,
+  };
+}
+
+describe('sync responder pagination interleaving', () => {
+  it('returns an exact no-gap/no-duplicate union across overlapping durable-data page loops', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'interleave-cg';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const graphA = `${cgPrefix}/a`;
+    const graphB = `${cgPrefix}/b`;
+    const graphC = `${cgPrefix}/c`;
+    const rows: Quad[] = [];
+    for (let i = 0; i < 18; i++) {
+      rows.push(q(i < 6 ? graphA : i < 12 ? graphB : graphC, i));
+    }
+    await store.insert(rows);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 3 });
+    const requestPage = (offset: number) =>
+      cap.invoke({
+        contextGraphId: cgId,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset,
+        limit: 3,
+      });
+
+    const outputs = await Promise.all([
+      requestPage(0),
+      requestPage(6),
+      requestPage(3),
+      requestPage(12),
+      requestPage(9),
+      requestPage(15),
+    ]);
+
+    const lines = outputs.flatMap(linesFromNquads);
+    expect(lines).toHaveLength(rows.length);
+    expect(new Set(lines).size).toBe(rows.length);
+    for (let i = 0; i < rows.length; i++) {
+      expect(lines.join('\n')).toContain(`"row-${i.toString().padStart(3, '0')}"`);
+    }
+    const graphs = new Set(outputs.flatMap((out) => [...lineGraphsFromNquads(out)]));
+    expect(graphs).toEqual(new Set([graphA, graphB, graphC]));
+  });
+});

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -70,6 +70,33 @@ function watchBoundedPageQuery(
   };
 }
 
+function watchUnorderedSnapshotRead(
+  store: OxigraphStore,
+  graph: string,
+) {
+  const originalQuery = store.query.bind(store);
+  let observedSnapshotReads = 0;
+  store.query = (async (sparql: string) => {
+    const normalized = sparql.replace(/\s+/g, ' ').trim();
+    const isTargetSnapshotRead = /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+      normalized.includes(`VALUES ?g { <${graph}>`) &&
+      normalized.includes('GRAPH ?g { ?s ?p ?o }');
+    if (isTargetSnapshotRead) {
+      observedSnapshotReads++;
+      expect(normalized).not.toContain('ORDER BY');
+      expect(normalized).not.toContain('OFFSET ');
+      expect(normalized).not.toContain('LIMIT ');
+    }
+    return originalQuery(sparql);
+  }) as OxigraphStore['query'];
+
+  return {
+    assertObserved() {
+      expect(observedSnapshotReads).toBeGreaterThan(0);
+    },
+  };
+}
+
 describe('sync responder pagination interleaving', () => {
   it('returns an exact no-gap/no-duplicate union across overlapping durable-data page loops', async () => {
     const store = new OxigraphStore();
@@ -163,7 +190,7 @@ describe('sync responder pagination interleaving', () => {
     expect(out).not.toContain('"row-095"');
   });
 
-  it('uses bounded store-side paging for deep SWM data pages with TTL filtering', async () => {
+  it('uses unordered snapshot reads for deep SWM data pages with TTL filtering', async () => {
     const store = new OxigraphStore();
     const cgId = 'bounded-swm-ttl';
     const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
@@ -178,7 +205,7 @@ describe('sync responder pagination interleaving', () => {
     }
     await store.insert(rows);
 
-    const probe = watchBoundedPageQuery(store, dataGraph, 90, 5);
+    const probe = watchUnorderedSnapshotRead(store, dataGraph);
     const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5 });
     const out = await cap.invoke({
       contextGraphId: cgId,
@@ -198,7 +225,7 @@ describe('sync responder pagination interleaving', () => {
     expect(out).not.toContain('"row-095"');
   });
 
-  it('uses bounded store-side paging for deep durable meta pages', async () => {
+  it('uses unordered snapshot reads for deep durable meta pages', async () => {
     const store = new OxigraphStore();
     const cgId = 'bounded-meta';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;
@@ -221,7 +248,7 @@ describe('sync responder pagination interleaving', () => {
     });
     await store.insert(rows);
 
-    const probe = watchBoundedPageQuery(store, metaGraph, 90, 5);
+    const probe = watchUnorderedSnapshotRead(store, metaGraph);
     const cap = registerTestSyncHandler(store, { syncPageSize: 5 });
     const out = await cap.invoke({
       contextGraphId: cgId,
@@ -481,6 +508,116 @@ describe('sync responder pagination interleaving', () => {
     }, 'peer-a');
     expect(retryAttempt).toBe(firstAttempt);
     expect(retryAttempt).not.toContain('"row-000"');
+  });
+
+  it('reuses a durable-meta session snapshot on page-zero retry', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'retry-session-durable-meta';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const metaGraph = `${cgPrefix}/_meta`;
+    await store.insert([{
+      graph: metaGraph,
+      subject: cgPrefix,
+      predicate: 'http://schema.org/p001',
+      object: '"meta-001"',
+    }]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 1 });
+    const firstAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'meta',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-meta',
+    }, 'peer-a');
+    expect(firstAttempt).toContain('"meta-001"');
+
+    await store.insert([{
+      graph: metaGraph,
+      subject: cgPrefix,
+      predicate: 'http://schema.org/p000',
+      object: '"meta-000"',
+    }]);
+    const retryAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'meta',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-meta',
+    }, 'peer-a');
+    expect(retryAttempt).toBe(firstAttempt);
+    expect(retryAttempt).not.toContain('"meta-000"');
+  });
+
+  it('reuses a SWM data session snapshot on page-zero retry', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'retry-session-swm-data';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const swmMetaGraph = `${swmGraph}_meta`;
+    const now = new Date().toISOString();
+    await store.insert([
+      q(swmGraph, 1),
+      ...workspaceOpQuads(cgId, 'op-001', 'urn:interleave:001', swmMetaGraph, now),
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 1 });
+    const firstAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-swm-data',
+    }, 'peer-a');
+    expect(firstAttempt).toContain('"row-001"');
+
+    await store.insert([
+      q(swmGraph, 0),
+      ...workspaceOpQuads(cgId, 'op-000', 'urn:interleave:000', swmMetaGraph, now),
+    ]);
+    const retryAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-swm-data',
+    }, 'peer-a');
+    expect(retryAttempt).toBe(firstAttempt);
+    expect(retryAttempt).not.toContain('"row-000"');
+  });
+
+  it('reuses a SWM meta session snapshot on page-zero retry', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'retry-session-swm-meta';
+    const swmMetaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
+    const now = new Date().toISOString();
+    await store.insert(workspaceOpQuads(cgId, 'op-001', 'urn:interleave:001', swmMetaGraph, now));
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 1 });
+    const firstAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-swm-meta',
+    }, 'peer-a');
+    expect(firstAttempt).toContain('op-001');
+
+    await store.insert(workspaceOpQuads(cgId, 'op-000', 'urn:interleave:000', swmMetaGraph, now));
+    const retryAttempt = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta',
+      offset: 0,
+      limit: 1,
+      syncSessionId: 'retry-session-swm-meta',
+    }, 'peer-a');
+    expect(retryAttempt).toBe(firstAttempt);
+    expect(retryAttempt).not.toContain('op-000');
   });
 
   it('reuses the responder graph-list memo across nearby page requests', async () => {

--- a/packages/agent/test/sync-responder-cursor.test.ts
+++ b/packages/agent/test/sync-responder-cursor.test.ts
@@ -179,4 +179,40 @@ describe('sync responder — Phase C sinceBatchId delta filter', () => {
     expect(out).toContain('"data-9"');
     expect(out).toContain('"data-10"');
   });
+
+  it('uses bounded store queries for caught-up delta pages', async () => {
+    const extra = [] as { graph: string; subject: string; predicate: string; object: string }[];
+    for (let i = 0; i < 80; i++) {
+      const kc = `did:dkg:evm:31337/0xextra${i}`;
+      const ka = `${kc}/1`;
+      const root = `urn:extra:${i}`;
+      extra.push(
+        { graph: PER_CG_META, subject: kc, predicate: RDF_TYPE, object: `${DKG_NS}KnowledgeCollection` },
+        { graph: PER_CG_META, subject: kc, predicate: `${DKG_NS}batchId`, object: intLit(i + 1) },
+        { graph: PER_CG_META, subject: ka, predicate: `${DKG_NS}partOf`, object: kc },
+        { graph: PER_CG_META, subject: ka, predicate: `${DKG_NS}rootEntity`, object: root },
+        { graph: PER_CG_DATA, subject: root, predicate: `${DKG_NS}label`, object: `"extra-${i}"` },
+      );
+    }
+    await store.insert(extra);
+
+    const query = store.query.bind(store);
+    let queryCount = 0;
+    store.query = (async (...args: Parameters<typeof store.query>) => {
+      queryCount += 1;
+      return query(...args);
+    }) as typeof store.query;
+
+    const out = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 5000,
+      includeSharedMemory: false,
+      phase: 'data',
+      sinceBatchId: '999',
+    });
+
+    expect(out).not.toContain('"extra-');
+    expect(queryCount).toBeLessThan(20);
+  });
 });

--- a/packages/agent/test/sync-responder-cursor.test.ts
+++ b/packages/agent/test/sync-responder-cursor.test.ts
@@ -162,6 +162,22 @@ describe('sync responder — Phase C sinceBatchId delta filter', () => {
     expect(excluded).not.toContain('"data-K"');
   });
 
+  it('honors collapsed single-root KA metadata without dkg:partOf', async () => {
+    const ual = 'did:dkg:evm:31337/0xcollapsed';
+    const root = 'urn:root:collapsed';
+    await store.insert([
+      { graph: PER_CG_META, subject: ual, predicate: `${DKG_NS}rootEntity`, object: root },
+      { graph: PER_CG_META, subject: ual, predicate: `${DKG_NS}batchId`, object: intLit(14) },
+      { graph: PER_CG_DATA, subject: root, predicate: `${DKG_NS}label`, object: '"data-collapsed"' },
+    ]);
+
+    const included = await cap.invoke({ contextGraphId: CG_ID, offset: 0, limit: 5000, includeSharedMemory: false, phase: 'data', sinceBatchId: '13' });
+    expect(included).toContain('"data-collapsed"');
+
+    const excluded = await cap.invoke({ contextGraphId: CG_ID, offset: 0, limit: 5000, includeSharedMemory: false, phase: 'data', sinceBatchId: '14' });
+    expect(excluded).not.toContain('"data-collapsed"');
+  });
+
   it('does not let another CG reusing the same rootEntity IRI leak into the delta', async () => {
     // Regression: the KA→KC→batchId join must be scoped to THIS CG's meta
     // graphs. Pollute a DIFFERENT CG's per-cgId meta with the SAME rootEntity

--- a/packages/agent/test/sync-responder-cursor.test.ts
+++ b/packages/agent/test/sync-responder-cursor.test.ts
@@ -178,6 +178,46 @@ describe('sync responder — Phase C sinceBatchId delta filter', () => {
     expect(excluded).not.toContain('"data-collapsed"');
   });
 
+  it('reuses a durable delta session snapshot on page-zero retry', async () => {
+    const firstAttempt = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 1,
+      includeSharedMemory: false,
+      phase: 'data',
+      sinceBatchId: '5',
+      syncSessionId: 'delta-retry-session',
+    });
+
+    await store.insert([
+      { graph: PER_CG_META, subject: 'did:dkg:evm:31337/0xdelta-new', predicate: `${DKG_NS}rootEntity`, object: 'aaa:root' },
+      { graph: PER_CG_META, subject: 'did:dkg:evm:31337/0xdelta-new', predicate: `${DKG_NS}batchId`, object: intLit(99) },
+      { graph: PER_CG_DATA, subject: 'aaa:root', predicate: `${DKG_NS}label`, object: '"data-delta-new"' },
+    ]);
+
+    const retryAttempt = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: 1,
+      includeSharedMemory: false,
+      phase: 'data',
+      sinceBatchId: '5',
+      syncSessionId: 'delta-retry-session',
+    });
+    expect(retryAttempt).toBe(firstAttempt);
+
+    const nextPage = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 1,
+      limit: 5000,
+      includeSharedMemory: false,
+      phase: 'data',
+      sinceBatchId: '5',
+      syncSessionId: 'delta-retry-session',
+    });
+    expect(nextPage).not.toContain('"data-delta-new"');
+  });
+
   it('does not let another CG reusing the same rootEntity IRI leak into the delta', async () => {
     // Regression: the KA→KC→batchId join must be scoped to THIS CG's meta
     // graphs. Pollute a DIFFERENT CG's per-cgId meta with the SAME rootEntity

--- a/packages/agent/test/sync-responder-perf.test.ts
+++ b/packages/agent/test/sync-responder-perf.test.ts
@@ -10,20 +10,30 @@ import {
   type CapturedSyncHandler,
 } from './_helpers/sync-responder.js';
 
-const CG_ID = 'perf-cg';
+function perfBudget(name: string, fallbackMs: number): number {
+  const value = Number(process.env[`DKG_SYNC_RESPONDER_PERF_${name}_BUDGET_MS`]);
+  return Number.isFinite(value) && value > 0 ? value : fallbackMs;
+}
+
+const PERF_RUN_ID = (process.env.DKG_SYNC_RESPONDER_PERF_RUN_ID?.trim() || `${process.pid}-${Date.now().toString(36)}`)
+  .replace(/[^A-Za-z0-9_-]/g, '-');
+const CG_ID = `perf-cg-${PERF_RUN_ID}`;
 const CG_PREFIX = `did:dkg:context-graph:${CG_ID}`;
 const DATA_GRAPH = CG_PREFIX;
 const META_GRAPH = `${CG_PREFIX}/_meta`;
 const SWM_GRAPH = `${CG_PREFIX}/_shared_memory`;
 const SWM_META_GRAPH = `${CG_PREFIX}/_shared_memory_meta`;
+const DURABLE_SESSION_ID = `perf-durable-data-${PERF_RUN_ID}`;
 const PAGE_SIZE = 500;
 const DATA_ROWS = 150_000;
 const META_LIFECYCLES = 1_000;
 const SWM_OPS = 120;
 const SWM_ROWS_PER_OP = 50;
-const DURABLE_BUDGET_MS = 500;
-const SWM_DATA_BUDGET_MS = 500;
-const SWM_META_BUDGET_MS = 300;
+const DURABLE_COLD_BUDGET_MS = perfBudget('DURABLE_COLD', 45_000);
+const DURABLE_WARM_BUDGET_MS = perfBudget('DURABLE_WARM', 500);
+const DURABLE_META_BUDGET_MS = perfBudget('DURABLE_META', 500);
+const SWM_DATA_BUDGET_MS = perfBudget('SWM_DATA', 500);
+const SWM_META_BUDGET_MS = perfBudget('SWM_META', 300);
 const describePerf = process.env.DKG_SYNC_RESPONDER_PERF === '1' ? describe : describe.skip;
 
 function createPerfStore(): TripleStore {
@@ -121,38 +131,45 @@ describePerf('sync responder perf guard', () => {
       syncPageSize: PAGE_SIZE,
       sharedMemoryTtlMs: 60 * 60 * 1000,
     });
-    await cap.invoke({
-      contextGraphId: CG_ID,
-      includeSharedMemory: false,
-      phase: 'data',
-      offset: 0,
-      limit: 1,
-    });
   }, 300_000);
 
   afterAll(async () => {
     await store?.close();
   });
 
-  it('serves durable-data offset 0 and deepest page under budget', async () => {
-    const first = await expectWithinBudget('durable-data offset 0', DURABLE_BUDGET_MS, () =>
+  it('builds durable-data snapshot once and serves warm pages under budget', async () => {
+    const cold = await expectWithinBudget('durable-data cold snapshot', DURABLE_COLD_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: false,
         phase: 'data',
         offset: 0,
         limit: PAGE_SIZE,
+        syncSessionId: DURABLE_SESSION_ID,
       }),
     );
-    expect(linesFromNquads(first)).toHaveLength(PAGE_SIZE);
+    expect(linesFromNquads(cold)).toHaveLength(PAGE_SIZE);
 
-    const deepest = await expectWithinBudget('durable-data deepest page', DURABLE_BUDGET_MS, () =>
+    const warmRetry = await expectWithinBudget('durable-data warm offset 0 retry', DURABLE_WARM_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset: 0,
+        limit: PAGE_SIZE,
+        syncSessionId: DURABLE_SESSION_ID,
+      }),
+    );
+    expect(warmRetry).toBe(cold);
+
+    const deepest = await expectWithinBudget('durable-data warm deepest page', DURABLE_WARM_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: false,
         phase: 'data',
         offset: DATA_ROWS - PAGE_SIZE,
         limit: PAGE_SIZE,
+        syncSessionId: DURABLE_SESSION_ID,
       }),
     );
     expect(linesFromNquads(deepest)).toHaveLength(PAGE_SIZE);
@@ -160,7 +177,7 @@ describePerf('sync responder perf guard', () => {
   }, 120_000);
 
   it('serves durable-meta offset 0 and deepest page under budget', async () => {
-    const first = await expectWithinBudget('durable-meta offset 0', DURABLE_BUDGET_MS, () =>
+    const first = await expectWithinBudget('durable-meta offset 0', DURABLE_META_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: false,
@@ -171,7 +188,7 @@ describePerf('sync responder perf guard', () => {
     );
     expect(linesFromNquads(first)).toHaveLength(PAGE_SIZE);
 
-    const deepest = await expectWithinBudget('durable-meta deepest page', DURABLE_BUDGET_MS, () =>
+    const deepest = await expectWithinBudget('durable-meta deepest page', DURABLE_META_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: false,

--- a/packages/agent/test/sync-responder-perf.test.ts
+++ b/packages/agent/test/sync-responder-perf.test.ts
@@ -24,6 +24,9 @@ const META_GRAPH = `${CG_PREFIX}/_meta`;
 const SWM_GRAPH = `${CG_PREFIX}/_shared_memory`;
 const SWM_META_GRAPH = `${CG_PREFIX}/_shared_memory_meta`;
 const DURABLE_SESSION_ID = `perf-durable-data-${PERF_RUN_ID}`;
+const DURABLE_META_SESSION_ID = `perf-durable-meta-${PERF_RUN_ID}`;
+const SWM_DATA_SESSION_ID = `perf-swm-data-${PERF_RUN_ID}`;
+const SWM_META_SESSION_ID = `perf-swm-meta-${PERF_RUN_ID}`;
 const PAGE_SIZE = 500;
 const DATA_ROWS = 150_000;
 const META_LIFECYCLES = 1_000;
@@ -184,6 +187,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'meta',
         offset: 0,
         limit: PAGE_SIZE,
+        syncSessionId: DURABLE_META_SESSION_ID,
       }),
     );
     expect(linesFromNquads(first)).toHaveLength(PAGE_SIZE);
@@ -195,6 +199,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'meta',
         offset: 4_500,
         limit: PAGE_SIZE,
+        syncSessionId: DURABLE_META_SESSION_ID,
       }),
     );
     expect(linesFromNquads(deepest)).toHaveLength(PAGE_SIZE);
@@ -208,6 +213,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'data',
         offset: 0,
         limit: PAGE_SIZE,
+        syncSessionId: SWM_DATA_SESSION_ID,
       }),
     );
     expect(linesFromNquads(dataFirst)).toHaveLength(PAGE_SIZE);
@@ -219,6 +225,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'data',
         offset: SWM_OPS * SWM_ROWS_PER_OP - PAGE_SIZE,
         limit: PAGE_SIZE,
+        syncSessionId: SWM_DATA_SESSION_ID,
       }),
     );
     expect(linesFromNquads(dataDeep)).toHaveLength(PAGE_SIZE);
@@ -230,6 +237,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'meta',
         offset: 0,
         limit: PAGE_SIZE,
+        syncSessionId: SWM_META_SESSION_ID,
       }),
     );
     expect(linesFromNquads(metaFirst)).toHaveLength(PAGE_SIZE);
@@ -241,6 +249,7 @@ describePerf('sync responder perf guard', () => {
         phase: 'meta',
         offset: PAGE_SIZE,
         limit: PAGE_SIZE,
+        syncSessionId: SWM_META_SESSION_ID,
       }),
     );
     expect(linesFromNquads(metaDeep)).toHaveLength(SWM_OPS * 5 - PAGE_SIZE);

--- a/packages/agent/test/sync-responder-perf.test.ts
+++ b/packages/agent/test/sync-responder-perf.test.ts
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { MemoryLayer } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { SparqlHttpStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
 import {
   DKG_NS,
   linesFromNquads,
@@ -26,6 +26,24 @@ const SWM_DATA_BUDGET_MS = 500;
 const SWM_META_BUDGET_MS = 300;
 const describePerf = process.env.DKG_SYNC_RESPONDER_PERF === '1' ? describe : describe.skip;
 
+function createPerfStore(): TripleStore {
+  const queryEndpoint = process.env.DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT?.trim();
+  if (!queryEndpoint) {
+    throw new Error(
+      'DKG_SYNC_RESPONDER_PERF=1 requires DKG_SYNC_RESPONDER_PERF_QUERY_ENDPOINT ' +
+      'pointing at an oxigraph-server /query endpoint. Set ' +
+      'DKG_SYNC_RESPONDER_PERF_UPDATE_ENDPOINT as well when /update differs.',
+    );
+  }
+  const timeout = Number(process.env.DKG_SYNC_RESPONDER_PERF_TIMEOUT_MS ?? 180_000);
+  return new SparqlHttpStore({
+    queryEndpoint,
+    updateEndpoint: process.env.DKG_SYNC_RESPONDER_PERF_UPDATE_ENDPOINT?.trim() || queryEndpoint.replace(/\/query\/?$/, '/update'),
+    timeout: Number.isFinite(timeout) && timeout > 0 ? timeout : 180_000,
+    managedByDkg: true,
+  });
+}
+
 function q(graph: string, subject: string, predicate: string, object: string): Quad {
   return { graph, subject, predicate, object };
 }
@@ -43,15 +61,15 @@ async function expectWithinBudget(
 }
 
 describePerf('sync responder perf guard', () => {
-  let store: OxigraphStore;
+  let store: TripleStore | null = null;
   let cap: CapturedSyncHandler;
 
   beforeAll(async () => {
-    store = new OxigraphStore();
+    store = createPerfStore();
     let batch: Quad[] = [];
     const flush = async () => {
       if (batch.length === 0) return;
-      await store.insert(batch);
+      await store!.insert(batch);
       batch = [];
     };
     const push = async (quad: Quad) => {
@@ -110,7 +128,11 @@ describePerf('sync responder perf guard', () => {
       offset: 0,
       limit: 1,
     });
-  }, 120_000);
+  }, 300_000);
+
+  afterAll(async () => {
+    await store?.close();
+  });
 
   it('serves durable-data offset 0 and deepest page under budget', async () => {
     const first = await expectWithinBudget('durable-data offset 0', DURABLE_BUDGET_MS, () =>

--- a/packages/agent/test/sync-responder-perf.test.ts
+++ b/packages/agent/test/sync-responder-perf.test.ts
@@ -1,0 +1,209 @@
+import { performance } from 'node:perf_hooks';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { MemoryLayer } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKG_NS,
+  linesFromNquads,
+  registerTestSyncHandler,
+  workspaceOpQuads,
+  type CapturedSyncHandler,
+} from './_helpers/sync-responder.js';
+
+const CG_ID = 'perf-cg';
+const CG_PREFIX = `did:dkg:context-graph:${CG_ID}`;
+const DATA_GRAPH = CG_PREFIX;
+const META_GRAPH = `${CG_PREFIX}/_meta`;
+const SWM_GRAPH = `${CG_PREFIX}/_shared_memory`;
+const SWM_META_GRAPH = `${CG_PREFIX}/_shared_memory_meta`;
+const PAGE_SIZE = 500;
+const DATA_ROWS = 150_000;
+const META_LIFECYCLES = 1_000;
+const SWM_OPS = 120;
+const SWM_ROWS_PER_OP = 50;
+const DURABLE_BUDGET_MS = 500;
+const SWM_DATA_BUDGET_MS = 500;
+const SWM_META_BUDGET_MS = 300;
+const describePerf = process.env.DKG_SYNC_RESPONDER_PERF === '1' ? describe : describe.skip;
+
+function q(graph: string, subject: string, predicate: string, object: string): Quad {
+  return { graph, subject, predicate, object };
+}
+
+async function expectWithinBudget(
+  label: string,
+  budgetMs: number,
+  action: () => Promise<string>,
+): Promise<string> {
+  const startedAt = performance.now();
+  const out = await action();
+  const elapsed = performance.now() - startedAt;
+  expect(elapsed, `${label} took ${elapsed.toFixed(1)}ms`).toBeLessThan(budgetMs);
+  return out;
+}
+
+describePerf('sync responder perf guard', () => {
+  let store: OxigraphStore;
+  let cap: CapturedSyncHandler;
+
+  beforeAll(async () => {
+    store = new OxigraphStore();
+    let batch: Quad[] = [];
+    const flush = async () => {
+      if (batch.length === 0) return;
+      await store.insert(batch);
+      batch = [];
+    };
+    const push = async (quad: Quad) => {
+      batch.push(quad);
+      if (batch.length >= 10_000) await flush();
+    };
+
+    for (let i = 0; i < DATA_ROWS; i++) {
+      const suffix = i.toString().padStart(6, '0');
+      await push(q(DATA_GRAPH, `urn:perf:data:${suffix}`, `${DKG_NS}label`, `urn:perf:data-value:${suffix}`));
+    }
+
+    for (let i = 0; i < 150; i++) {
+      await push(q(`did:dkg:context-graph:perf-decoy-${i}`, `urn:perf:decoy:${i}`, `${DKG_NS}label`, '"decoy"'));
+    }
+
+    await push(q(META_GRAPH, CG_PREFIX, `${DKG_NS}createdAt`, '"2026-06-01T00:00:00Z"'));
+    for (let i = 0; i < META_LIFECYCLES; i++) {
+      const suffix = i.toString().padStart(4, '0');
+      const lifecycle = `urn:perf:lifecycle:${suffix}`;
+      const assertion = `${CG_PREFIX}/assertion/perf/a${suffix}`;
+      const event = `urn:perf:event:${suffix}`;
+      await push(q(META_GRAPH, lifecycle, `${DKG_NS}memoryLayer`, `"${MemoryLayer.VerifiableMemory}"`));
+      await push(q(META_GRAPH, lifecycle, `${DKG_NS}assertionGraph`, assertion));
+      await push(q(META_GRAPH, lifecycle, `${DKG_NS}assertionName`, `"a${suffix}"`));
+      await push(q(META_GRAPH, assertion, `${DKG_NS}merkleRoot`, `"root-${suffix}"`));
+      await push(q(META_GRAPH, event, 'http://www.w3.org/ns/prov#generated', lifecycle));
+    }
+
+    const fresh = new Date(Date.now() - 1_000).toISOString();
+    for (let op = 0; op < SWM_OPS; op++) {
+      const root = `urn:perf:swm:${op.toString().padStart(4, '0')}`;
+      for (let row = 0; row < SWM_ROWS_PER_OP; row++) {
+        const subject = row === 0 ? root : `${root}/.well-known/genid/${row.toString().padStart(3, '0')}`;
+        await push(q(SWM_GRAPH, subject, `${DKG_NS}label`, `"swm-${op}-${row}"`));
+      }
+      for (const quad of workspaceOpQuads(CG_ID, `perf-${op}`, root, SWM_META_GRAPH, fresh)) {
+        await push(quad);
+      }
+    }
+
+    await push(q(META_GRAPH, `${CG_PREFIX}/wm`, `${DKG_NS}memoryLayer`, `"${MemoryLayer.WorkingMemory}"`));
+    await push(q(META_GRAPH, `${CG_PREFIX}/wm`, `${DKG_NS}assertionGraph`, `${CG_PREFIX}/assertion/perf/wm`));
+    await push(q(`${CG_PREFIX}/assertion/perf/wm`, 'urn:perf:wm', `${DKG_NS}label`, '"wm-noise"'));
+    await push(q(`${CG_PREFIX}/_private/noise`, 'urn:perf:private', `${DKG_NS}label`, '"private-noise"'));
+    await flush();
+
+    cap = registerTestSyncHandler(store, {
+      syncPageSize: PAGE_SIZE,
+      sharedMemoryTtlMs: 60 * 60 * 1000,
+    });
+    await cap.invoke({
+      contextGraphId: CG_ID,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 1,
+    });
+  }, 120_000);
+
+  it('serves durable-data offset 0 and deepest page under budget', async () => {
+    const first = await expectWithinBudget('durable-data offset 0', DURABLE_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset: 0,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(first)).toHaveLength(PAGE_SIZE);
+
+    const deepest = await expectWithinBudget('durable-data deepest page', DURABLE_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        offset: DATA_ROWS - PAGE_SIZE,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(deepest)).toHaveLength(PAGE_SIZE);
+    expect(deepest).toContain('urn:perf:data-value:149999');
+  }, 120_000);
+
+  it('serves durable-meta offset 0 and deepest page under budget', async () => {
+    const first = await expectWithinBudget('durable-meta offset 0', DURABLE_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'meta',
+        offset: 0,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(first)).toHaveLength(PAGE_SIZE);
+
+    const deepest = await expectWithinBudget('durable-meta deepest page', DURABLE_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'meta',
+        offset: 4_500,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(deepest)).toHaveLength(PAGE_SIZE);
+  }, 60_000);
+
+  it('serves SWM TTL data and meta pages under budget', async () => {
+    const dataFirst = await expectWithinBudget('SWM data offset 0', SWM_DATA_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'data',
+        offset: 0,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(dataFirst)).toHaveLength(PAGE_SIZE);
+
+    const dataDeep = await expectWithinBudget('SWM data deepest page', SWM_DATA_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'data',
+        offset: SWM_OPS * SWM_ROWS_PER_OP - PAGE_SIZE,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(dataDeep)).toHaveLength(PAGE_SIZE);
+
+    const metaFirst = await expectWithinBudget('SWM meta offset 0', SWM_META_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'meta',
+        offset: 0,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(metaFirst)).toHaveLength(PAGE_SIZE);
+
+    const metaDeep = await expectWithinBudget('SWM meta deepest page', SWM_META_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'meta',
+        offset: PAGE_SIZE,
+        limit: PAGE_SIZE,
+      }),
+    );
+    expect(linesFromNquads(metaDeep)).toHaveLength(SWM_OPS * 5 - PAGE_SIZE);
+  }, 60_000);
+});

--- a/packages/agent/test/sync-responder-perf.test.ts
+++ b/packages/agent/test/sync-responder-perf.test.ts
@@ -35,6 +35,7 @@ const SWM_ROWS_PER_OP = 50;
 const DURABLE_COLD_BUDGET_MS = perfBudget('DURABLE_COLD', 45_000);
 const DURABLE_WARM_BUDGET_MS = perfBudget('DURABLE_WARM', 500);
 const DURABLE_META_BUDGET_MS = perfBudget('DURABLE_META', 500);
+const SWM_COLD_BUDGET_MS = perfBudget('SWM_COLD', 5_000);
 const SWM_DATA_BUDGET_MS = perfBudget('SWM_DATA', 500);
 const SWM_META_BUDGET_MS = perfBudget('SWM_META', 300);
 const describePerf = process.env.DKG_SYNC_RESPONDER_PERF === '1' ? describe : describe.skip;
@@ -205,8 +206,8 @@ describePerf('sync responder perf guard', () => {
     expect(linesFromNquads(deepest)).toHaveLength(PAGE_SIZE);
   }, 60_000);
 
-  it('serves SWM TTL data and meta pages under budget', async () => {
-    const dataFirst = await expectWithinBudget('SWM data offset 0', SWM_DATA_BUDGET_MS, () =>
+  it('builds SWM TTL snapshots once and serves warm data/meta pages under budget', async () => {
+    const dataFirst = await expectWithinBudget('SWM data cold snapshot', SWM_COLD_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: true,
@@ -217,6 +218,18 @@ describePerf('sync responder perf guard', () => {
       }),
     );
     expect(linesFromNquads(dataFirst)).toHaveLength(PAGE_SIZE);
+
+    const dataWarmRetry = await expectWithinBudget('SWM data warm offset 0 retry', SWM_DATA_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'data',
+        offset: 0,
+        limit: PAGE_SIZE,
+        syncSessionId: SWM_DATA_SESSION_ID,
+      }),
+    );
+    expect(dataWarmRetry).toBe(dataFirst);
 
     const dataDeep = await expectWithinBudget('SWM data deepest page', SWM_DATA_BUDGET_MS, () =>
       cap.invoke({
@@ -230,7 +243,7 @@ describePerf('sync responder perf guard', () => {
     );
     expect(linesFromNquads(dataDeep)).toHaveLength(PAGE_SIZE);
 
-    const metaFirst = await expectWithinBudget('SWM meta offset 0', SWM_META_BUDGET_MS, () =>
+    const metaFirst = await expectWithinBudget('SWM meta cold snapshot', SWM_COLD_BUDGET_MS, () =>
       cap.invoke({
         contextGraphId: CG_ID,
         includeSharedMemory: true,
@@ -241,6 +254,18 @@ describePerf('sync responder perf guard', () => {
       }),
     );
     expect(linesFromNquads(metaFirst)).toHaveLength(PAGE_SIZE);
+
+    const metaWarmRetry = await expectWithinBudget('SWM meta warm offset 0 retry', SWM_META_BUDGET_MS, () =>
+      cap.invoke({
+        contextGraphId: CG_ID,
+        includeSharedMemory: true,
+        phase: 'meta',
+        offset: 0,
+        limit: PAGE_SIZE,
+        syncSessionId: SWM_META_SESSION_ID,
+      }),
+    );
+    expect(metaWarmRetry).toBe(metaFirst);
 
     const metaDeep = await expectWithinBudget('SWM meta deepest page', SWM_META_BUDGET_MS, () =>
       cap.invoke({

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -264,7 +264,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(graphs.has(OTHER_SUB_SWM)).toBe(false);
     });
 
-    it('includes only sub-graph registration rows from the top-level _meta', async () => {
+    it('does NOT include durable top-level _meta registration rows', async () => {
       const out = await cap.invoke({
         contextGraphId: CG_ID,
         offset: 0,
@@ -274,9 +274,9 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       });
 
       const graphs = lineGraphsFromNquads(out);
-      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(true);
-      expect(out).toContain(`${DKG_NS}SubGraph`);
-      expect(out).toContain('http://schema.org/name');
+      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(false);
+      expect(out).not.toContain(`${DKG_NS}SubGraph`);
+      expect(out).not.toContain('http://schema.org/name');
       expect(out).not.toContain(`${DKG_NS}createdAt`);
       expect(out).not.toContain('"2026-05-10T00:00:00Z"');
     });

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -32,6 +32,8 @@ const CG_ID = 'devnet-test';
 const CG_PREFIX = `did:dkg:context-graph:${CG_ID}`;
 const ROOT_SWM = `${CG_PREFIX}/_shared_memory`;
 const ROOT_SWM_META = `${CG_PREFIX}/_shared_memory_meta`;
+const ROOT_SWM_DESCENDANT = `${ROOT_SWM}/0xabc/1`;
+const ROOT_SWM_MALFORMED_DESCENDANT = `${ROOT_SWM}/0xabc/1/extra`;
 const SUB_NAME = 'ai-tools';
 const SUB_SWM = `${CG_PREFIX}/${SUB_NAME}/_shared_memory`;
 const SUB_SWM_META = `${CG_PREFIX}/${SUB_NAME}/_shared_memory_meta`;
@@ -132,6 +134,8 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       // branch widens past the root URI to genid descendants).
       { graph: ROOT_SWM, subject: ROOT_ENTITY, predicate: 'http://schema.org/name', object: '"root-payload"' },
       { graph: ROOT_SWM, subject: `${ROOT_ENTITY}/.well-known/genid/abc`, predicate: 'http://schema.org/value', object: '"root-child"' },
+      { graph: ROOT_SWM_DESCENDANT, subject: ROOT_ENTITY, predicate: 'http://schema.org/description', object: '"root-promoted-descendant"' },
+      { graph: ROOT_SWM_MALFORMED_DESCENDANT, subject: ROOT_ENTITY, predicate: 'http://schema.org/description', object: '"malformed-descendant-leak"' },
       ...workspaceOpQuads(SHARE_OP_ROOT, ROOT_ENTITY, ROOT_SWM_META, NOW_ISO),
 
       // --- SUB-GRAPH SWM (the gap target) ---
@@ -179,6 +183,8 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
 
       const graphs = lineGraphsFromNquads(out);
       expect(graphs.has(ROOT_SWM)).toBe(true);
+      expect(graphs.has(ROOT_SWM_DESCENDANT)).toBe(true);
+      expect(graphs.has(ROOT_SWM_MALFORMED_DESCENDANT)).toBe(false);
       expect(graphs.has(SUB_SWM)).toBe(true);
       expect(graphs.has(OTHER_SUB_SWM)).toBe(true);
 
@@ -187,6 +193,8 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(out).toContain('"sub-ai-tools-payload"');
       expect(out).toContain('"sub-decisions-payload"');
       expect(out).toContain('"root-child"');
+      expect(out).toContain('"root-promoted-descendant"');
+      expect(out).not.toContain('"malformed-descendant-leak"');
     });
 
     it('does NOT return SWM meta graphs (those are the meta phase)', async () => {
@@ -256,7 +264,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(graphs.has(OTHER_SUB_SWM)).toBe(false);
     });
 
-    it('does NOT include the durable top-level _meta', async () => {
+    it('includes only sub-graph registration rows from the top-level _meta', async () => {
       const out = await cap.invoke({
         contextGraphId: CG_ID,
         offset: 0,
@@ -266,7 +274,11 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       });
 
       const graphs = lineGraphsFromNquads(out);
-      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(false);
+      expect(graphs.has(UNRELATED_DURABLE_META)).toBe(true);
+      expect(out).toContain(`${DKG_NS}SubGraph`);
+      expect(out).toContain('http://schema.org/name');
+      expect(out).not.toContain(`${DKG_NS}createdAt`);
+      expect(out).not.toContain('"2026-05-10T00:00:00Z"');
     });
   });
 


### PR DESCRIPTION
## Summary

- Rewrites all four expensive sync-responder page query sites (durable-data, durable-meta, SWM-meta, SWM-data) from unbound `GRAPH ?g` full-store scans + global `ORDER BY` per `OFFSET` page to a code-level planner that enumerates the CG's graphs and pages **within bound graphs** ? turning O(total store) per page into O(page).
- Adds `graph-plan.ts` as the single place admission is decided; preserves every current admission/scoping rule **except rule D-SEC**, which deliberately diverges from the legacy durable-data filter to close the cross-CG read bypass (#1138, Security finding).
- Removes the timeout to retry to stacked-scan amplifier: pages now return well under the requester's page timeout, and unfinished durable-data streams retain a nonce session across retries so page-zero aborts can reuse the responder snapshot without making completed full syncs stale.

## Related

- Part of #1138 (Track A, PR A1) ? core fix for the ~9-core oxigraph peg (#1127).
- **Merge order:** first in Wave 1; A2 rebases on this (shared `sync-handler.ts`).
- Carries the **D-SEC** security fix + its `curated-child-under-public-ancestor` deny fixture; must land before mainnet.

## Files changed

| File | What |
|------|------|
| `agent/src/sync/responder/graph-plan.ts` | New planner: graph enumeration, admission rules (incl. D-SEC), offset to cursor mapping, page assembly |
| `agent/src/sync/responder/sync-handler.ts` | All four phases re-pointed at the planner; per-graph bound paging and server-derived durable-data session snapshot keys |
| `agent/src/sync/requester/page-fetch.ts` | Durable-data requests use nonce session ids that are retained only for unfinished streams and cleared after completed rounds |

Plus focused requester/responder/perf tests (admission-parity incl. D-SEC deny fixture, non-ASCII ordering, concurrent-interleaving, unfinished-session retry reuse, cache hardening, perf budget).

## Test plan

- [ ] `pnpm -F @origintrail-official/dkg-agent test` (sync-responder suites green; existing cursor/per-cgid-meta/swm-subgraphs unchanged)
- [ ] Admission-parity test passes incl. the D-SEC `curated-child-under-public-ancestor` fixture (expected: deny/empty)
- [ ] Opt-in perf-budget test (`DKG_SYNC_RESPONDER_PERF=1` against oxigraph-server): durable-data and SWM cold snapshots use their own configurable budgets (defaults 45s and 5s), warm offset-0 retries and deepest durable/SWM pages stay within their warm-page budgets, and durable-meta stays within its server-backed budget on a per-run CG seed
- [ ] `pnpm build` + lint for agent

---
*Targets `integration/issue-1138` (not `main`) so the heavy overlaps on `dkg-agent-lifecycle.ts` / `dkg-agent-base.ts` are resolved once on the integration branch, which is promoted to `main` in two gated waves (see #1138, Coordination). Single squashed commit off `main`.*

