### PR TITLE
A2 — sync responder: concurrency caps + cancellation

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -768,11 +768,16 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
    * Get the peer allowlist for a context graph (if curated).
    * Returns null if no allowlist is set (open CG).
    */
-  async getContextGraphAllowedPeers(this: DKGAgent, contextGraphId: string): Promise<string[] | null> {
+  async getContextGraphAllowedPeers(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string[] | null> {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     const result = await this.store.query(
       `SELECT ?peer WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
+      { signal: options.signal },
     );
     if (result.type !== 'bindings' || result.bindings.length === 0) {
       return null;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1423,7 +1423,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         const pid = peerIdFromString(curatorPeerId);
 
         try {
-          await this.node.libp2p.dial(pid);
+          await this.node.libp2p.dial(pid, { signal: options.signal });
           throwIfSyncAuthAborted(options.signal);
           connections = this.node.libp2p.getConnections();
           isConnected = connections.some((c) => c.remotePeer.toString() === curatorPeerId);
@@ -1437,7 +1437,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             const { multiaddr } = await import('@multiformats/multiaddr');
             const circuitAddr = multiaddr(`${agent.relayAddress}/p2p-circuit/p2p/${curatorPeerId}`);
             await this.node.libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
-            await this.node.libp2p.dial(pid);
+            await this.node.libp2p.dial(pid, { signal: options.signal });
             throwIfSyncAuthAborted(options.signal);
             connections = this.node.libp2p.getConnections();
             isConnected = connections.some((c) => c.remotePeer.toString() === curatorPeerId);

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -710,7 +710,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     options: { signal?: AbortSignal } = {},
   ): Promise<boolean> {
     const isPrivate = await raceSyncAuthAgainstAbort(
-      this.isPrivateContextGraph(request.contextGraphId),
+      this.isPrivateContextGraph(request.contextGraphId, { signal: options.signal }),
       options.signal,
     );
     if (!isPrivate) {
@@ -1077,6 +1077,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    */
   async getExplicitAccessPolicy(this: DKGAgent,
     contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
   ): Promise<'public' | 'private' | null> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return null;
@@ -1096,6 +1097,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           }
         }
       } LIMIT 1`,
+      { signal: options.signal },
     );
     if (result.type !== 'bindings' || result.bindings.length === 0) return null;
     const policyValue = result.bindings[0]?.['policy'];
@@ -1161,7 +1163,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     );
   }
 
-  async isPrivateContextGraph(this: DKGAgent, contextGraphId: string): Promise<boolean> {
+  async isPrivateContextGraph(this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return false;
     }
@@ -1189,7 +1194,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // Codex review on #873 — policy lookup now delegated to the
     // shared `getExplicitAccessPolicy()` helper so this routing
     // function and the invite-path warning helper can never drift.
-    const policy = await this.getExplicitAccessPolicy(contextGraphId);
+    const policy = await this.getExplicitAccessPolicy(contextGraphId, { signal: options.signal });
     if (policy === 'private') return true;
     if (policy === 'public') return false;
     // policy === null falls through to the legacy heuristic below.
@@ -1212,6 +1217,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer }
         }
       }`,
+      { signal: options.signal },
     );
     if (allowlistResult.type === 'boolean' && allowlistResult.value === true) {
       return true;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -390,16 +390,8 @@ function syncAuthAbortError(reason: unknown): Error {
   return err;
 }
 
-function raceSyncAuthAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-  if (!signal) return work;
-  if (signal.aborted) return Promise.reject(syncAuthAbortError(signal.reason));
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(syncAuthAbortError(signal.reason));
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
-  });
+function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw syncAuthAbortError(signal.reason);
 }
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
@@ -709,10 +701,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     remotePeerId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<boolean> {
-    const isPrivate = await raceSyncAuthAgainstAbort(
-      this.isPrivateContextGraph(request.contextGraphId, { signal: options.signal }),
-      options.signal,
-    );
+    throwIfSyncAuthAborted(options.signal);
+    const isPrivate = await this.isPrivateContextGraph(request.contextGraphId, { signal: options.signal });
+    throwIfSyncAuthAborted(options.signal);
     if (!isPrivate) {
       return true;
     }
@@ -725,13 +716,19 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       syncAuthMaxAgeMs: SYNC_AUTH_MAX_AGE_MS,
       seenRequestIds: this.seenPrivateSyncRequestIds,
       computeSyncDigest: this.computeSyncDigest.bind(this),
-      verifyIdentity: typeof verifyIdentity === 'function' ? verifyIdentity.bind(this.chain) : undefined,
-      getParticipants: (contextGraphId) => this.getPrivateContextGraphParticipants(contextGraphId),
-      getAllowedPeers: (contextGraphId) => this.getContextGraphAllowedPeers(contextGraphId),
-      getAgentGateAddresses: (contextGraphId) => this.getContextGraphAgentGateAddresses(contextGraphId),
-      getAllowedDelegateePeers: (contextGraphId) => this.getContextGraphAllowedDelegateePeers(contextGraphId),
-      getAllowedDelegateeKeys: (contextGraphId) => this.getContextGraphAllowedDelegateeKeys(contextGraphId),
-      refreshMetaFromCurator: (contextGraphId) => this.refreshMetaFromCurator(contextGraphId),
+      verifyIdentity: typeof verifyIdentity === 'function'
+        ? async (recoveredAddress, claimedIdentityId, lookupOptions) => {
+            const valid = await verifyIdentity.call(this.chain, recoveredAddress, claimedIdentityId);
+            throwIfSyncAuthAborted(lookupOptions?.signal);
+            return valid;
+          }
+        : undefined,
+      getParticipants: (contextGraphId, lookupOptions) => this.getPrivateContextGraphParticipants(contextGraphId, lookupOptions),
+      getAllowedPeers: (contextGraphId, lookupOptions) => this.getContextGraphAllowedPeers(contextGraphId, lookupOptions),
+      getAgentGateAddresses: (contextGraphId, lookupOptions) => this.getContextGraphAgentGateAddresses(contextGraphId, lookupOptions),
+      getAllowedDelegateePeers: (contextGraphId, lookupOptions) => this.getContextGraphAllowedDelegateePeers(contextGraphId, lookupOptions),
+      getAllowedDelegateeKeys: (contextGraphId, lookupOptions) => this.getContextGraphAllowedDelegateeKeys(contextGraphId, lookupOptions),
+      refreshMetaFromCurator: (contextGraphId, lookupOptions) => this.refreshMetaFromCurator(contextGraphId, lookupOptions),
       signal: options.signal,
       logWarn: (ctx, message) => this.log.warn(ctx, message),
       logInfo: (ctx, message) => this.log.info(ctx, message),
@@ -1226,7 +1223,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     return false;
   }
 
-  async getPrivateContextGraphParticipants(this: DKGAgent, contextGraphId: string): Promise<string[] | null> {
+  async getPrivateContextGraphParticipants(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string[] | null> {
     const merged: string[] = [];
     const seen = new Set<string>();
     const add = (value: string | undefined) => {
@@ -1255,6 +1256,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
         }
       }`,
+      { signal: options.signal },
     );
     if (agentResult.type === 'bindings') {
       for (const row of agentResult.bindings) {
@@ -1270,6 +1272,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
         }
       }`,
+      { signal: options.signal },
     );
     if (metaResult.type === 'bindings') {
       for (const row of metaResult.bindings) {
@@ -1291,7 +1294,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * newly added participants. Rate-limited to avoid abuse.
    * Returns true if meta was refreshed, false if skipped or failed.
    */
-  public async resolveCuratorPeerId(this: DKGAgent, contextGraphId: string): Promise<string | undefined> {
+  public async resolveCuratorPeerId(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string | undefined> {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
 
@@ -1301,6 +1308,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?curator
         }
       } LIMIT 1`,
+      { signal: options.signal },
     );
     if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
       return undefined;
@@ -1337,6 +1345,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             }
           }
         } LIMIT 1`,
+        { signal: options.signal },
       );
       if (creatorResult.type === 'bindings' && creatorResult.bindings.length > 0) {
         const creatorDid = (creatorResult.bindings[0] as Record<string, string>)['creator'] ?? '';
@@ -1353,7 +1362,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       // share the same wallet address, but better than failing outright)
       if (!resolved) {
         try {
+          throwIfSyncAuthAborted(options.signal);
           const agents = await this.discovery.findAgents();
+          throwIfSyncAuthAborted(options.signal);
           const match = agents.find(
             (a) => a.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
           );
@@ -1361,7 +1372,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             curatorPeerId = match.peerId;
             resolved = true;
           }
-        } catch { /* registry unavailable */ }
+        } catch {
+          throwIfSyncAuthAborted(options.signal);
+          /* registry unavailable */
+        }
       }
 
       if (!resolved) return undefined;
@@ -1370,7 +1384,12 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     return curatorPeerId;
   }
 
-  async refreshMetaFromCurator(this: DKGAgent, contextGraphId: string): Promise<boolean> {
+  async refreshMetaFromCurator(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    throwIfSyncAuthAborted(options.signal);
     const now = Date.now();
     const lastRefresh = this.metaRefreshTimestamps.get(contextGraphId) ?? 0;
     if (now - lastRefresh < META_REFRESH_COOLDOWN_MS) {
@@ -1379,7 +1398,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     const ctx = createOperationContext('sync');
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
+    const curatorPeerId = await this.resolveCuratorPeerId(contextGraphId, options);
+    throwIfSyncAuthAborted(options.signal);
     if (!curatorPeerId) {
       return false;
     }
@@ -1400,22 +1420,27 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
         try {
           await this.node.libp2p.dial(pid);
+          throwIfSyncAuthAborted(options.signal);
           connections = this.node.libp2p.getConnections();
           isConnected = connections.some((c) => c.remotePeer.toString() === curatorPeerId);
         } catch { /* direct dial failed, try relay */ }
 
         if (!isConnected) {
+          throwIfSyncAuthAborted(options.signal);
           const agent = await this.discovery.findAgentByPeerId(curatorPeerId);
+          throwIfSyncAuthAborted(options.signal);
           if (agent?.relayAddress) {
             const { multiaddr } = await import('@multiformats/multiaddr');
             const circuitAddr = multiaddr(`${agent.relayAddress}/p2p-circuit/p2p/${curatorPeerId}`);
             await this.node.libp2p.peerStore.merge(pid, { multiaddrs: [circuitAddr] });
             await this.node.libp2p.dial(pid);
+            throwIfSyncAuthAborted(options.signal);
             connections = this.node.libp2p.getConnections();
             isConnected = connections.some((c) => c.remotePeer.toString() === curatorPeerId);
           }
         }
       } catch (err) {
+        throwIfSyncAuthAborted(options.signal);
         this.log.warn(ctx, `Failed to dial curator ${curatorPeerId.slice(-8)} for meta refresh: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
@@ -1427,6 +1452,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     try {
       const deadline = Date.now() + 10_000;
       const metaResult = await this.fetchSyncPages(ctx, curatorPeerId, contextGraphId, false, 'meta', cgMetaGraph, deadline);
+      throwIfSyncAuthAborted(options.signal);
       if (metaResult.quads.length > 0) {
         await this.store.insert(metaResult.quads);
         this.syncCheckpoints.delete(metaResult.checkpointKey);
@@ -1436,6 +1462,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       this.syncCheckpoints.delete(metaResult.checkpointKey);
       return false;
     } catch (err) {
+      throwIfSyncAuthAborted(options.signal);
       this.log.warn(ctx, `Meta refresh for "${contextGraphId}" failed: ${err instanceof Error ? err.message : String(err)}`);
       return false;
     } finally {

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -380,6 +380,28 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+function syncAuthAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function raceSyncAuthAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  if (signal.aborted) return Promise.reject(syncAuthAbortError(signal.reason));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(syncAuthAbortError(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
 export class ContextGraphResolveMethods extends DKGAgentBase {
   /**
    * Check whether a context graph exists in local storage. Definition triples in
@@ -681,8 +703,16 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     );
   }
 
-  public async authorizeSyncRequest(this: DKGAgent, request: SyncRequestEnvelope, remotePeerId: string): Promise<boolean> {
-    const isPrivate = await this.isPrivateContextGraph(request.contextGraphId);
+  public async authorizeSyncRequest(
+    this: DKGAgent,
+    request: SyncRequestEnvelope,
+    remotePeerId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    const isPrivate = await raceSyncAuthAgainstAbort(
+      this.isPrivateContextGraph(request.contextGraphId),
+      options.signal,
+    );
     if (!isPrivate) {
       return true;
     }
@@ -702,6 +732,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       getAllowedDelegateePeers: (contextGraphId) => this.getContextGraphAllowedDelegateePeers(contextGraphId),
       getAllowedDelegateeKeys: (contextGraphId) => this.getContextGraphAllowedDelegateeKeys(contextGraphId),
       refreshMetaFromCurator: (contextGraphId) => this.refreshMetaFromCurator(contextGraphId),
+      signal: options.signal,
       logWarn: (ctx, message) => this.log.warn(ctx, message),
       logInfo: (ctx, message) => this.log.info(ctx, message),
     });

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1455,7 +1455,18 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     try {
       const deadline = Date.now() + 10_000;
-      const metaResult = await this.fetchSyncPages(ctx, curatorPeerId, contextGraphId, false, 'meta', cgMetaGraph, deadline);
+      const metaResult = await this.fetchSyncPages(
+        ctx,
+        curatorPeerId,
+        contextGraphId,
+        false,
+        'meta',
+        cgMetaGraph,
+        deadline,
+        undefined,
+        undefined,
+        options.signal,
+      );
       throwIfSyncAuthAborted(options.signal);
       if (metaResult.quads.length > 0) {
         await this.store.insert(metaResult.quads);

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -721,6 +721,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             // Chain/RPC verifiers are not actually abortable in ethers. Do not
             // race them against request aborts: that would free responder
             // capacity while the RPC keeps running in the background.
+            throwIfSyncAuthAborted(lookupOptions?.signal);
             const valid = await verifyIdentity.call(this.chain, recoveredAddress, claimedIdentityId);
             throwIfSyncAuthAborted(lookupOptions?.signal);
             return valid;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -382,8 +382,11 @@ import type { DKGAgent } from './dkg-agent.js';
 
 function syncAuthAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -718,6 +718,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       computeSyncDigest: this.computeSyncDigest.bind(this),
       verifyIdentity: typeof verifyIdentity === 'function'
         ? async (recoveredAddress, claimedIdentityId, lookupOptions) => {
+            // Chain/RPC verifiers are not actually abortable in ethers. Do not
+            // race them against request aborts: that would free responder
+            // capacity while the RPC keeps running in the background.
             const valid = await verifyIdentity.call(this.chain, recoveredAddress, claimedIdentityId);
             throwIfSyncAuthAborted(lookupOptions?.signal);
             return valid;

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -95,7 +95,6 @@ export const DEBUG_SYNC_PROGRESS = process.env.DKG_DEBUG_SYNC_PROGRESS === '1';
 export const DEFAULT_SWM_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const SWM_CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // run cleanup every 15 minutes
 export const SYNC_DENIED_RESPONSE = '__DKG_SYNC_DENIED__';
-export const SYNC_BUSY_RESPONSE = '__DKG_SYNC_BUSY__';
 
 // ── Gossip reconnect ──────────────────────────────────────────────────
 /**

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -95,6 +95,7 @@ export const DEBUG_SYNC_PROGRESS = process.env.DKG_DEBUG_SYNC_PROGRESS === '1';
 export const DEFAULT_SWM_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const SWM_CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // run cleanup every 15 minutes
 export const SYNC_DENIED_RESPONSE = '__DKG_SYNC_DENIED__';
+export const SYNC_BUSY_RESPONSE = '__DKG_SYNC_BUSY__';
 
 // ── Gossip reconnect ──────────────────────────────────────────────────
 /**

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -424,7 +424,11 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     return null;
   }
 
-  async getContextGraphAgentGateAddresses(this: DKGAgent, contextGraphId: string): Promise<string[] | null> {
+  async getContextGraphAgentGateAddresses(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string[] | null> {
     const seen = new Set<string>();
     const agents: string[] = [];
     let sawAgentGate = false;
@@ -453,6 +457,7 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
           { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
         }
       }`,
+      { signal: options.signal },
     );
     if (result.type === 'bindings') {
       if (result.bindings.length > 0) sawAgentGate = true;
@@ -481,7 +486,11 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
    * granted to agent A's node doesn't accidentally let traffic
    * "on behalf of agent B" through that same node.
    */
-  async getContextGraphAllowedDelegateePeers(this: DKGAgent, contextGraphId: string): Promise<Map<string, string[]>> {
+  async getContextGraphAllowedDelegateePeers(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<Map<string, string[]>> {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     // SELECT also returns `expiresAtMs` so we can filter expired rows in
     // JS — pushing the FILTER into SPARQL would force a string→long
@@ -499,6 +508,7 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
           OPTIONAL { ?d <${DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT}> ?expiresAt }
         }
       }`,
+      { signal: options.signal },
     );
     const out = new Map<string, string[]>();
     if (result.type !== 'bindings') return out;
@@ -531,7 +541,11 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
    * Expired rows are filtered out — see the peer-lookup helper for the
    * rationale (PR #448 review round 4).
    */
-  async getContextGraphAllowedDelegateeKeys(this: DKGAgent, contextGraphId: string): Promise<Map<string, string[]>> {
+  async getContextGraphAllowedDelegateeKeys(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<Map<string, string[]>> {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const result = await this.store.query(
       `SELECT ?agent ?key ?expiresAt WHERE {
@@ -541,6 +555,7 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
           OPTIONAL { ?d <${DKG_ONTOLOGY.DKG_DELEGATION_EXPIRES_AT}> ?expiresAt }
         }
       }`,
+      { signal: options.signal },
     );
     const out = new Map<string, string[]>();
     if (result.type !== 'bindings') return out;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2759,6 +2759,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     deadline: number,
     snapshotRef?: string,
     sinceBatchId?: string,
+    signal?: AbortSignal,
   ): Promise<SyncPageResult> {
     return fetchSyncPages({
       ctx,
@@ -2775,6 +2776,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncPageRetryAttempts: SYNC_PAGE_RETRY_ATTEMPTS,
       syncPageSize: SYNC_PAGE_SIZE,
       syncDeniedResponse: SYNC_DENIED_RESPONSE,
+      signal,
       // Legacy sentinel that older (pre-v10-rc) responders still emit on ACL
       // denial. Recognising it in the requester is what keeps mixed-version
       // catch-up correct: without the second sentinel, a curated-CG denial
@@ -2806,8 +2808,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // `messageId` minted by sync-transport.ts is now unused by this
       // adapter — harmless, left in place to keep the transport surface
       // stable (reverts rc.9 PR-E for sync only).
-      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId) =>
-        this.messenger.sendToPeer(peerId, protocolId, data, { timeoutMs: sendTimeoutMs }),
+      send: async (peerId, protocolId, data, sendTimeoutMs, _messageId, sendSignal) =>
+        this.messenger.sendToPeer(peerId, protocolId, data, { timeoutMs: sendTimeoutMs, signal: sendSignal }),
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1539,7 +1539,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // for sync only; other substrate protocols keep their dedup.)
     registerSyncHandler({
       register: (protocol, handler) =>
-        this.router.register(protocol, (data, peerIdObj) => handler(data, peerIdObj.toString())),
+        this.router.register(protocol, (data, peerIdObj, options) => handler(data, peerIdObj.toString(), options)),
       protocolSync: PROTOCOL_SYNC,
       syncDeniedResponse: SYNC_DENIED_RESPONSE,
       syncPageSize: SYNC_PAGE_SIZE,

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1523,7 +1523,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     peerId: string,
     protocolId: string,
     data: Uint8Array,
-    opts?: { timeoutMs?: number },
+    opts?: { timeoutMs?: number; signal?: AbortSignal },
   ): Promise<Uint8Array> {
     return this.messenger.sendToPeer(peerId, protocolId, data, opts);
   }

--- a/packages/agent/src/p2p/messenger.ts
+++ b/packages/agent/src/p2p/messenger.ts
@@ -162,6 +162,7 @@ export interface MessengerDeps {
 
 export interface SendOpts {
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 export interface SendReliableOpts {
@@ -551,7 +552,7 @@ export class Messenger {
     data: Uint8Array,
     opts: SendOpts = {},
   ): Promise<Uint8Array> {
-    return this.router.send(peerId, protocolId, data, opts.timeoutMs);
+    return this.router.send(peerId, protocolId, data, opts);
   }
 
   /**

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -68,6 +68,12 @@ interface SyncSendParams {
     timeoutMs: number,
     messageId: string,
   ) => Promise<Uint8Array>;
+  /**
+   * Optional per-attempt response validator. Throwing here keeps the attempt
+   * inside `withRetry`, which lets sync-level retry sentinels share the same
+   * bounded backoff path as transport failures.
+   */
+  validateResponse?: (responseBytes: Uint8Array) => void | Promise<void>;
   protocolId: string;
   onRetry: (attempt: number, delay: number, err: unknown) => void;
 }
@@ -77,7 +83,9 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
     async () => {
       const requestBytes = await params.requestFactory();
       const messageId = randomUUID();
-      return params.send(params.remotePeerId, params.protocolId, requestBytes, params.timeoutMs, messageId);
+      const responseBytes = await params.send(params.remotePeerId, params.protocolId, requestBytes, params.timeoutMs, messageId);
+      await params.validateResponse?.(responseBytes);
+      return responseBytes;
     },
     {
       maxAttempts: params.retryAttempts,

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -104,7 +104,7 @@ export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Arra
       maxAttempts: params.retryAttempts,
       baseDelayMs: 1000,
       signal: params.signal,
-      isRetryable: (err) => !isAbortError(err) && params.signal?.aborted !== true,
+      isRetryable: () => params.signal?.aborted !== true,
       onRetry: params.onRetry,
     },
   );
@@ -122,8 +122,4 @@ function asAbortError(reason: unknown): Error {
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';
   return err;
-}
-
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === 'AbortError';
 }

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -47,6 +47,7 @@ interface SyncSendParams {
   remotePeerId: string;
   timeoutMs: number;
   retryAttempts: number;
+  signal?: AbortSignal;
   contextGraphId: string;
   offset: number;
   /**
@@ -67,6 +68,7 @@ interface SyncSendParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
+    signal?: AbortSignal,
   ) => Promise<Uint8Array>;
   /**
    * Optional per-attempt response validator. Throwing here keeps the attempt
@@ -81,16 +83,47 @@ interface SyncSendParams {
 export async function sendSyncRequest(params: SyncSendParams): Promise<Uint8Array> {
   return withRetry(
     async () => {
+      throwIfAborted(params.signal);
       const requestBytes = await params.requestFactory();
+      throwIfAborted(params.signal);
       const messageId = randomUUID();
-      const responseBytes = await params.send(params.remotePeerId, params.protocolId, requestBytes, params.timeoutMs, messageId);
+      const responseBytes = await params.send(
+        params.remotePeerId,
+        params.protocolId,
+        requestBytes,
+        params.timeoutMs,
+        messageId,
+        params.signal,
+      );
+      throwIfAborted(params.signal);
       await params.validateResponse?.(responseBytes);
+      throwIfAborted(params.signal);
       return responseBytes;
     },
     {
       maxAttempts: params.retryAttempts,
       baseDelayMs: 1000,
+      signal: params.signal,
+      isRetryable: (err) => !isAbortError(err) && params.signal?.aborted !== true,
       onRetry: params.onRetry,
     },
   );
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
+}
+
+function asAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
 }

--- a/packages/agent/src/p2p/sync-transport.ts
+++ b/packages/agent/src/p2p/sync-transport.ts
@@ -116,8 +116,11 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 
 function asAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';

--- a/packages/agent/src/sync/auth/request-authorize.ts
+++ b/packages/agent/src/sync/auth/request-authorize.ts
@@ -39,8 +39,35 @@ interface AuthorizeSyncRequestParams {
   getAllowedDelegateePeers: (contextGraphId: string) => Promise<Map<string, string[]>>;
   getAllowedDelegateeKeys: (contextGraphId: string) => Promise<Map<string, string[]>>;
   refreshMetaFromCurator: (contextGraphId: string) => Promise<boolean>;
+  signal?: AbortSignal;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
+}
+
+function asAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
+}
+
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(asAbortError(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
 }
 
 export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestParams): Promise<boolean> {
@@ -59,9 +86,12 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
     getAllowedDelegateePeers,
     getAllowedDelegateeKeys,
     refreshMetaFromCurator,
+    signal,
     logWarn,
     logInfo,
   } = params;
+
+  throwIfAborted(signal);
 
   const now = Date.now();
   for (const [requestId, seenAt] of seenRequestIds) {
@@ -123,7 +153,7 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
       logWarn(ctx, `Denied sync request for "${request.contextGraphId}": identity verification unavailable (identityId=${requesterIdentityId.toString()} signer=${recoveredAddress})`);
       return false;
     }
-    const validIdentity = await verifyIdentity(recoveredAddress, requesterIdentityId);
+    const validIdentity = await raceAgainstAbort(verifyIdentity(recoveredAddress, requesterIdentityId), signal);
     if (!validIdentity) {
       logWarn(ctx, `Denied sync request for "${request.contextGraphId}": signer ${recoveredAddress} does not verify for identityId=${requesterIdentityId.toString()}`);
       return false;
@@ -133,11 +163,11 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
     return false;
   }
 
-  let participants = await getParticipants(request.contextGraphId);
-  let agentGateAddresses = await getAgentGateAddresses(request.contextGraphId);
-  let allowedPeers = await getAllowedPeers(request.contextGraphId);
-  let allowedDelegateePeers = await getAllowedDelegateePeers(request.contextGraphId);
-  let allowedDelegateeKeys = await getAllowedDelegateeKeys(request.contextGraphId);
+  let participants = await raceAgainstAbort(getParticipants(request.contextGraphId), signal);
+  let agentGateAddresses = await raceAgainstAbort(getAgentGateAddresses(request.contextGraphId), signal);
+  let allowedPeers = await raceAgainstAbort(getAllowedPeers(request.contextGraphId), signal);
+  let allowedDelegateePeers = await raceAgainstAbort(getAllowedDelegateePeers(request.contextGraphId), signal);
+  let allowedDelegateeKeys = await raceAgainstAbort(getAllowedDelegateeKeys(request.contextGraphId), signal);
   const isParticipantAllowed = () => participants?.some((p) =>
     p.toLowerCase() === recoveredAddress.toLowerCase() ||
     (requesterIdentityId > 0n && p === String(requesterIdentityId)),
@@ -171,13 +201,13 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   let allowed = resolveAllowed();
 
   if (!allowed) {
-    const refreshed = await refreshMetaFromCurator(request.contextGraphId);
+    const refreshed = await raceAgainstAbort(refreshMetaFromCurator(request.contextGraphId), signal);
     if (refreshed) {
-      participants = await getParticipants(request.contextGraphId);
-      agentGateAddresses = await getAgentGateAddresses(request.contextGraphId);
-      allowedPeers = await getAllowedPeers(request.contextGraphId);
-      allowedDelegateePeers = await getAllowedDelegateePeers(request.contextGraphId);
-      allowedDelegateeKeys = await getAllowedDelegateeKeys(request.contextGraphId);
+      participants = await raceAgainstAbort(getParticipants(request.contextGraphId), signal);
+      agentGateAddresses = await raceAgainstAbort(getAgentGateAddresses(request.contextGraphId), signal);
+      allowedPeers = await raceAgainstAbort(getAllowedPeers(request.contextGraphId), signal);
+      allowedDelegateePeers = await raceAgainstAbort(getAllowedDelegateePeers(request.contextGraphId), signal);
+      allowedDelegateeKeys = await raceAgainstAbort(getAllowedDelegateeKeys(request.contextGraphId), signal);
       allowed = resolveAllowed();
     }
   }
@@ -190,6 +220,7 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   );
 
   if (allowed) {
+    throwIfAborted(signal);
     seenRequestIds.set(request.requestId, now);
   }
   return allowed;

--- a/packages/agent/src/sync/auth/request-authorize.ts
+++ b/packages/agent/src/sync/auth/request-authorize.ts
@@ -2,6 +2,10 @@ import { ethers } from 'ethers';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { SyncRequestEnvelope } from './request-build.js';
 
+interface AuthLookupOptions {
+  signal?: AbortSignal;
+}
+
 interface AuthorizeSyncRequestParams {
   ctx: OperationContext;
   request: SyncRequestEnvelope;
@@ -20,10 +24,10 @@ interface AuthorizeSyncRequestParams {
     issuedAtMs: number,
     requesterAgentAddress: string | undefined,
   ) => Uint8Array;
-  verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
-  getParticipants: (contextGraphId: string) => Promise<string[] | null>;
-  getAllowedPeers: (contextGraphId: string) => Promise<string[] | null>;
-  getAgentGateAddresses: (contextGraphId: string) => Promise<string[] | null>;
+  verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint, options?: AuthLookupOptions) => Promise<boolean>;
+  getParticipants: (contextGraphId: string, options?: AuthLookupOptions) => Promise<string[] | null>;
+  getAllowedPeers: (contextGraphId: string, options?: AuthLookupOptions) => Promise<string[] | null>;
+  getAgentGateAddresses: (contextGraphId: string, options?: AuthLookupOptions) => Promise<string[] | null>;
   /**
    * Per-agent map of libp2p peer-ids / op-keys an agent has delegated
    * to act on its behalf for sync. Keyed by the lowercased agent
@@ -36,9 +40,9 @@ interface AuthorizeSyncRequestParams {
    * same op-key. This is the single most important property of the
    * delegation gate: graph-wide unions silently widen access.
    */
-  getAllowedDelegateePeers: (contextGraphId: string) => Promise<Map<string, string[]>>;
-  getAllowedDelegateeKeys: (contextGraphId: string) => Promise<Map<string, string[]>>;
-  refreshMetaFromCurator: (contextGraphId: string) => Promise<boolean>;
+  getAllowedDelegateePeers: (contextGraphId: string, options?: AuthLookupOptions) => Promise<Map<string, string[]>>;
+  getAllowedDelegateeKeys: (contextGraphId: string, options?: AuthLookupOptions) => Promise<Map<string, string[]>>;
+  refreshMetaFromCurator: (contextGraphId: string, options?: AuthLookupOptions) => Promise<boolean>;
   signal?: AbortSignal;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
@@ -56,18 +60,6 @@ function asAbortError(reason: unknown): Error {
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw asAbortError(signal.reason);
-}
-
-function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-  if (!signal) return work;
-  throwIfAborted(signal);
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(asAbortError(signal.reason));
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
-  });
 }
 
 export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestParams): Promise<boolean> {
@@ -92,6 +84,7 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   } = params;
 
   throwIfAborted(signal);
+  const lookupOptions = signal ? { signal } : undefined;
 
   const now = Date.now();
   for (const [requestId, seenAt] of seenRequestIds) {
@@ -153,7 +146,8 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
       logWarn(ctx, `Denied sync request for "${request.contextGraphId}": identity verification unavailable (identityId=${requesterIdentityId.toString()} signer=${recoveredAddress})`);
       return false;
     }
-    const validIdentity = await raceAgainstAbort(verifyIdentity(recoveredAddress, requesterIdentityId), signal);
+    const validIdentity = await verifyIdentity(recoveredAddress, requesterIdentityId, lookupOptions);
+    throwIfAborted(signal);
     if (!validIdentity) {
       logWarn(ctx, `Denied sync request for "${request.contextGraphId}": signer ${recoveredAddress} does not verify for identityId=${requesterIdentityId.toString()}`);
       return false;
@@ -163,11 +157,16 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
     return false;
   }
 
-  let participants = await raceAgainstAbort(getParticipants(request.contextGraphId), signal);
-  let agentGateAddresses = await raceAgainstAbort(getAgentGateAddresses(request.contextGraphId), signal);
-  let allowedPeers = await raceAgainstAbort(getAllowedPeers(request.contextGraphId), signal);
-  let allowedDelegateePeers = await raceAgainstAbort(getAllowedDelegateePeers(request.contextGraphId), signal);
-  let allowedDelegateeKeys = await raceAgainstAbort(getAllowedDelegateeKeys(request.contextGraphId), signal);
+  let participants = await getParticipants(request.contextGraphId, lookupOptions);
+  throwIfAborted(signal);
+  let agentGateAddresses = await getAgentGateAddresses(request.contextGraphId, lookupOptions);
+  throwIfAborted(signal);
+  let allowedPeers = await getAllowedPeers(request.contextGraphId, lookupOptions);
+  throwIfAborted(signal);
+  let allowedDelegateePeers = await getAllowedDelegateePeers(request.contextGraphId, lookupOptions);
+  throwIfAborted(signal);
+  let allowedDelegateeKeys = await getAllowedDelegateeKeys(request.contextGraphId, lookupOptions);
+  throwIfAborted(signal);
   const isParticipantAllowed = () => participants?.some((p) =>
     p.toLowerCase() === recoveredAddress.toLowerCase() ||
     (requesterIdentityId > 0n && p === String(requesterIdentityId)),
@@ -201,13 +200,19 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   let allowed = resolveAllowed();
 
   if (!allowed) {
-    const refreshed = await raceAgainstAbort(refreshMetaFromCurator(request.contextGraphId), signal);
+    const refreshed = await refreshMetaFromCurator(request.contextGraphId, lookupOptions);
+    throwIfAborted(signal);
     if (refreshed) {
-      participants = await raceAgainstAbort(getParticipants(request.contextGraphId), signal);
-      agentGateAddresses = await raceAgainstAbort(getAgentGateAddresses(request.contextGraphId), signal);
-      allowedPeers = await raceAgainstAbort(getAllowedPeers(request.contextGraphId), signal);
-      allowedDelegateePeers = await raceAgainstAbort(getAllowedDelegateePeers(request.contextGraphId), signal);
-      allowedDelegateeKeys = await raceAgainstAbort(getAllowedDelegateeKeys(request.contextGraphId), signal);
+      participants = await getParticipants(request.contextGraphId, lookupOptions);
+      throwIfAborted(signal);
+      agentGateAddresses = await getAgentGateAddresses(request.contextGraphId, lookupOptions);
+      throwIfAborted(signal);
+      allowedPeers = await getAllowedPeers(request.contextGraphId, lookupOptions);
+      throwIfAborted(signal);
+      allowedDelegateePeers = await getAllowedDelegateePeers(request.contextGraphId, lookupOptions);
+      throwIfAborted(signal);
+      allowedDelegateeKeys = await getAllowedDelegateeKeys(request.contextGraphId, lookupOptions);
+      throwIfAborted(signal);
       allowed = resolveAllowed();
     }
   }

--- a/packages/agent/src/sync/auth/request-authorize.ts
+++ b/packages/agent/src/sync/auth/request-authorize.ts
@@ -50,8 +50,11 @@ interface AuthorizeSyncRequestParams {
 
 function asAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,6 +1,7 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
+import { SYNC_BUSY_RESPONSE } from '../../dkg-agent-constants.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 import {
@@ -123,6 +124,16 @@ interface FetchSyncPagesParams {
   logDebug: (ctx: OperationContext, message: string) => void;
 }
 
+function decodeSyncResponse(responseBytes: Uint8Array): string {
+  return new TextDecoder().decode(responseBytes).trim();
+}
+
+function makeSyncBusyError(remotePeerId: string, contextGraphId: string, phase: SyncPhase): Error & { syncBusy: true } {
+  const error = new Error(`Sync responder busy at ${remotePeerId} for "${contextGraphId}" (${phase})`) as Error & { syncBusy: true };
+  error.syncBusy = true;
+  return error;
+}
+
 export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<SyncPageResult> {
   const {
     ctx,
@@ -207,6 +218,11 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // full rationale (codex review on #569 follow-ups #1, #4-#8).
         requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
         send,
+        validateResponse: (responseBytes) => {
+          if (decodeSyncResponse(responseBytes) === SYNC_BUSY_RESPONSE) {
+            throw makeSyncBusyError(remotePeerId, contextGraphId, phase);
+          }
+        },
         onRetry: (attempt, delay, err) => {
           logWarn(ctx, `Sync page retry ${attempt}/${syncPageRetryAttempts} for offset ${offset} (delay ${Math.round(delay)}ms): ${err instanceof Error ? err.message : String(err)}`);
         },
@@ -214,7 +230,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
       const transportDurationMs = Date.now() - transportStartedAt;
 
       const decodeStartedAt = Date.now();
-      const nquadsText = new TextDecoder().decode(responseBytes).trim();
+      const nquadsText = decodeSyncResponse(responseBytes);
       const decodeDurationMs = Date.now() - decodeStartedAt;
       bytesReceived += responseBytes.byteLength;
       if (

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -140,8 +140,11 @@ function makeLegacySyncBusyError(remotePeerId: string, contextGraphId: string, p
 
 function asAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -74,6 +74,7 @@ interface FetchSyncPagesParams {
   syncPageRetryAttempts: number;
   syncPageSize: number;
   syncDeniedResponse: string;
+  signal?: AbortSignal;
   /**
    * Additional response-body sentinels that also mean "ACL denied". Exists so
    * this requester keeps recognising the legacy `#DKG-SYNC-ACCESS-DENIED`
@@ -117,6 +118,7 @@ interface FetchSyncPagesParams {
     data: Uint8Array,
     timeoutMs: number,
     messageId: string,
+    signal?: AbortSignal,
   ) => Promise<Uint8Array>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
@@ -136,6 +138,20 @@ function makeLegacySyncBusyError(remotePeerId: string, contextGraphId: string, p
   return new Error(`Legacy sync responder busy at ${remotePeerId} for "${contextGraphId}" (${phase})`);
 }
 
+function asAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
+}
+
 export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<SyncPageResult> {
   const {
     ctx,
@@ -151,6 +167,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     syncPageRetryAttempts,
     syncPageSize,
     syncDeniedResponse,
+    signal,
     extraDeniedResponses,
     debugSyncProgress,
     protocolSync,
@@ -165,6 +182,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
   } = params;
 
   const allQuads: Quad[] = [];
+  throwIfAborted(signal);
   const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
   let offset = checkpointStore.get(checkpointKey) ?? 0;
   const usesPageSession = usesResponderSession(includeSharedMemory, phase);
@@ -191,6 +209,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
   try {
     while (true) {
+      throwIfAborted(signal);
       if (Date.now() > deadline) {
         timedOut = true;
         break;
@@ -208,6 +227,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         remotePeerId,
         timeoutMs,
         retryAttempts: syncPageRetryAttempts,
+        signal,
         contextGraphId,
         offset,
         protocolId: protocolSync,
@@ -218,7 +238,12 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // fresh-messageId-per-attempt is generated inside
         // `sendSyncRequest`. See `sendSyncRequest`'s jsdoc for the
         // full rationale (codex review on #569 follow-ups #1, #4-#8).
-        requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
+        requestFactory: async () => {
+          throwIfAborted(signal);
+          const request = await buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId);
+          throwIfAborted(signal);
+          return request;
+        },
         send,
         validateResponse: (responseBytes) => {
           if (decodeSyncResponse(responseBytes) === LEGACY_SYNC_BUSY_RESPONSE) {
@@ -230,6 +255,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         },
       });
       const transportDurationMs = Date.now() - transportStartedAt;
+      throwIfAborted(signal);
 
       const decodeStartedAt = Date.now();
       const nquadsText = decodeSyncResponse(responseBytes);
@@ -247,6 +273,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
       const parseStartedAt = Date.now();
       const parsed = await parseAndFilter(nquadsText, graphUri, contextGraphId);
+      throwIfAborted(signal);
       const parseDurationMs = Date.now() - parseStartedAt;
 
       const stepDurationMs = transportDurationMs + decodeDurationMs + parseDurationMs;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -1,7 +1,6 @@
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { sendSyncRequest } from '../../p2p/sync-transport.js';
-import { SYNC_BUSY_RESPONSE } from '../../dkg-agent-constants.js';
 import type { SyncPhase } from '../auth/request-build.js';
 import { getSyncCheckpointKey, type SyncCheckpointStore } from '../checkpoint/state.js';
 import {
@@ -128,10 +127,13 @@ function decodeSyncResponse(responseBytes: Uint8Array): string {
   return new TextDecoder().decode(responseBytes).trim();
 }
 
-function makeSyncBusyError(remotePeerId: string, contextGraphId: string, phase: SyncPhase): Error & { syncBusy: true } {
-  const error = new Error(`Sync responder busy at ${remotePeerId} for "${contextGraphId}" (${phase})`) as Error & { syncBusy: true };
-  error.syncBusy = true;
-  return error;
+// Compatibility-only: current responders must not emit this body on the
+// unchanged sync protocol, but requesters may still meet A2 pre-fix peers
+// during local/integration rolling tests. Treat it as retryable, not EOF.
+const LEGACY_SYNC_BUSY_RESPONSE = '__DKG_SYNC_BUSY__';
+
+function makeLegacySyncBusyError(remotePeerId: string, contextGraphId: string, phase: SyncPhase): Error {
+  return new Error(`Legacy sync responder busy at ${remotePeerId} for "${contextGraphId}" (${phase})`);
 }
 
 export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<SyncPageResult> {
@@ -219,8 +221,8 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         requestFactory: () => buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId),
         send,
         validateResponse: (responseBytes) => {
-          if (decodeSyncResponse(responseBytes) === SYNC_BUSY_RESPONSE) {
-            throw makeSyncBusyError(remotePeerId, contextGraphId, phase);
+          if (decodeSyncResponse(responseBytes) === LEGACY_SYNC_BUSY_RESPONSE) {
+            throw makeLegacySyncBusyError(remotePeerId, contextGraphId, phase);
           }
         },
         onRetry: (attempt, delay, err) => {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -25,11 +25,11 @@ const PROV_GENERATED = 'http://www.w3.org/ns/prov#generated';
 const PROV_USED = 'http://www.w3.org/ns/prov#used';
 
 export interface GraphListMemo {
-  get(options?: { refresh?: boolean }): Promise<readonly string[]>;
+  get(options?: { refresh?: boolean; signal?: AbortSignal }): Promise<readonly string[]>;
 }
 
 export interface SubGraphNameMemo {
-  get(contextGraphId: string, options?: { refresh?: boolean }): Promise<readonly string[]>;
+  get(contextGraphId: string, options?: { refresh?: boolean; signal?: AbortSignal }): Promise<readonly string[]>;
 }
 
 export interface SyncRowListMemo {
@@ -55,11 +55,12 @@ export function createResponderGraphListMemo(
   let cachedAt = 0;
   let inflight: Promise<readonly string[]> | null = null;
   return {
-    async get(options?: { refresh?: boolean }) {
+    async get(options?: { refresh?: boolean; signal?: AbortSignal }) {
+      throwIfAborted(options?.signal);
       const now = Date.now();
-      if (inflight) return [...(await inflight)];
+      if (inflight) return [...(await raceAgainstAbort(inflight, options?.signal))];
       if (!options?.refresh && cached && now - cachedAt < ttlMs) return [...cached];
-      inflight = store.listGraphs()
+      inflight = store.listGraphs({ signal: options?.signal })
         .then((graphs) => {
           const sorted = [...new Set(graphs)].sort(compareCodePoint);
           cached = sorted;
@@ -69,7 +70,7 @@ export function createResponderGraphListMemo(
         .finally(() => {
           inflight = null;
         });
-      return [...(await inflight)];
+      return [...(await raceAgainstAbort(inflight, options?.signal))];
     },
   };
 }
@@ -189,30 +190,37 @@ export function createResponderSwmAdmissionMemo(
   store: TripleStore,
   ttlMs = 10_000,
 ): SubGraphNameMemo {
-  return createSubGraphNameMemo((contextGraphId) => readAdmittedSwmSubGraphNames(store, contextGraphId), ttlMs);
+  return createSubGraphNameMemo(
+    (contextGraphId, options) => readAdmittedSwmSubGraphNames(store, contextGraphId, options?.signal),
+    ttlMs,
+  );
 }
 
 export function createResponderSubGraphRegistrationMemo(
   store: TripleStore,
   ttlMs = 10_000,
 ): SubGraphNameMemo {
-  return createSubGraphNameMemo((contextGraphId) => readRegisteredSubGraphNames(store, contextGraphId), ttlMs);
+  return createSubGraphNameMemo(
+    (contextGraphId, options) => readRegisteredSubGraphNames(store, contextGraphId, options?.signal),
+    ttlMs,
+  );
 }
 
 function createSubGraphNameMemo(
-  loadNames: (contextGraphId: string) => Promise<string[]>,
+  loadNames: (contextGraphId: string, options?: { signal?: AbortSignal }) => Promise<string[]>,
   ttlMs: number,
 ): SubGraphNameMemo {
   const cached = new Map<string, { value: readonly string[]; cachedAt: number }>();
   const inflight = new Map<string, Promise<readonly string[]>>();
   return {
-    async get(contextGraphId: string, options?: { refresh?: boolean }) {
+    async get(contextGraphId: string, options?: { refresh?: boolean; signal?: AbortSignal }) {
+      throwIfAborted(options?.signal);
       const now = Date.now();
       const existing = cached.get(contextGraphId);
       if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) return [...existing.value];
       const pending = inflight.get(contextGraphId);
-      if (pending) return [...(await pending)];
-      const load = loadNames(contextGraphId)
+      if (pending) return [...(await raceAgainstAbort(pending, options?.signal))];
+      const load = loadNames(contextGraphId, { signal: options?.signal })
         .then((names) => {
           cached.set(contextGraphId, { value: names, cachedAt: Date.now() });
           return names;
@@ -221,7 +229,7 @@ function createSubGraphNameMemo(
           inflight.delete(contextGraphId);
         });
       inflight.set(contextGraphId, load);
-      return [...(await load)];
+      return [...(await raceAgainstAbort(load, options?.signal))];
     },
   };
 }
@@ -587,12 +595,13 @@ function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined):
 async function readAdmittedSwmSubGraphNames(
   store: TripleStore,
   contextGraphId: string,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const cgPrefix = contextGraphDataGraphUri(contextGraphId);
   const names: string[] = [];
-  for (const name of await readRegisteredSubGraphNames(store, contextGraphId)) {
+  for (const name of await readRegisteredSubGraphNames(store, contextGraphId, signal)) {
     const childCgUri = `${cgPrefix}/${name}`;
-    if (await isKnownContextGraph(store, childCgUri)) continue;
+    if (await isKnownContextGraph(store, childCgUri, signal)) continue;
     names.push(name);
   }
   return names.sort(compareCodePoint);
@@ -616,6 +625,7 @@ function swmGraphsForRegisteredSubGraphs(
 async function readRegisteredSubGraphNames(
   store: TripleStore,
   contextGraphId: string,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const res = await store.query(`
@@ -625,7 +635,7 @@ async function readRegisteredSubGraphNames(
             <${SCHEMA_NAME}> ?name .
       }
     }
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ subject: row['sg'], name: stripLiteral(row['name']) }))

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -279,6 +279,7 @@ export async function readSwmMetaPage(params: {
       () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso, params.signal),
       params.offset,
       params.limit,
+      params.signal,
     );
   }
   return readSwmMetaRowsPage(
@@ -340,7 +341,7 @@ export async function readSwmDataPage(params: {
     params.signal,
   );
   if (cache) {
-    return readCachedRowsPage(cache, loadRows, params.offset, params.limit);
+    return readCachedRowsPage(cache, loadRows, params.offset, params.limit, params.signal);
   }
   const rows = await loadRows();
   return rows.slice(Math.max(0, Math.floor(params.offset)), Math.max(0, Math.floor(params.offset)) + Math.max(0, Math.floor(params.limit)));
@@ -369,6 +370,7 @@ export async function readDurableMetaPage(params: {
       loadRows,
       params.offset,
       params.limit,
+      params.signal,
     );
   }
   const rows = await loadRows();
@@ -488,6 +490,7 @@ async function readPagedRowsAcrossGraphs(
     loadRows,
     safeOffset,
     safeLimit,
+    signal,
   );
 }
 
@@ -534,6 +537,7 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
     () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, signal),
     safeOffset,
     safeLimit,
+    signal,
   );
 }
 
@@ -542,18 +546,42 @@ async function readCachedRowsPage(
   loadRows: () => Promise<readonly SyncRow[]>,
   offset: number,
   limit: number,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
   if (safeLimit === 0) return [];
-  const rows = await cache.memo.get(cache.key, loadRows, {
-    refresh: cache.refresh,
-    requireExisting: safeOffset > 0,
-  });
+  const rows = await raceAgainstAbort(
+    cache.memo.get(cache.key, loadRows, {
+      refresh: cache.refresh,
+      requireExisting: safeOffset > 0,
+    }),
+    signal,
+  );
   if (rows == null) {
     throw new Error(cache.expiredMessage ?? 'Sync session snapshot expired before page completion');
   }
   return [...rows].slice(safeOffset, safeOffset + safeLimit);
+}
+
+function asAbortError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
+}
+
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(asAbortError(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
 }
 
 async function readAdmittedSwmSubGraphNames(

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -260,6 +260,7 @@ export async function readSwmMetaPage(params: {
   cutoffIso: string | null;
   offset: number;
   limit: number;
+  signal?: AbortSignal;
   rowListMemo?: SyncRowListMemo;
   rowListCacheKey?: string;
   refreshRowList?: boolean;
@@ -275,7 +276,7 @@ export async function readSwmMetaPage(params: {
         refresh: params.refreshRowList,
         expiredMessage: 'Shared-memory meta sync session snapshot expired before page completion',
       },
-      () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso),
+      () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso, params.signal),
       params.offset,
       params.limit,
     );
@@ -286,6 +287,7 @@ export async function readSwmMetaPage(params: {
     params.cutoffIso,
     params.offset,
     params.limit,
+    params.signal,
   );
 }
 
@@ -297,6 +299,7 @@ export async function readSwmDataPage(params: {
   cutoffIso: string | null;
   offset: number;
   limit: number;
+  signal?: AbortSignal;
   rowListMemo?: SyncRowListMemo;
   rowListCacheKey?: string;
   refreshRowList?: boolean;
@@ -324,6 +327,7 @@ export async function readSwmDataPage(params: {
       params.limit,
       async () => true,
       cache,
+      params.signal,
     );
   }
 
@@ -333,6 +337,7 @@ export async function readSwmDataPage(params: {
     graphSet,
     candidateGraphsFor,
     params.cutoffIso!,
+    params.signal,
   );
   if (cache) {
     return readCachedRowsPage(cache, loadRows, params.offset, params.limit);
@@ -347,11 +352,12 @@ export async function readDurableMetaPage(params: {
   registeredSubGraphNames: readonly string[];
   offset: number;
   limit: number;
+  signal?: AbortSignal;
   rowListMemo?: SyncRowListMemo;
   rowListCacheKey?: string;
   refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
-  const loadRows = () => readDurableMetaRows(params.store, params.contextGraphId, params.registeredSubGraphNames);
+  const loadRows = () => readDurableMetaRows(params.store, params.contextGraphId, params.registeredSubGraphNames, params.signal);
   if (params.rowListMemo && params.rowListCacheKey) {
     return readCachedRowsPage(
       {
@@ -378,6 +384,7 @@ export async function readDurableDataPage(params: {
   sinceBatchId: bigint | null;
   offset: number;
   limit: number;
+  signal?: AbortSignal;
   rowListMemo?: SyncRowListMemo;
   rowListCacheScope?: string;
   refreshRowList?: boolean;
@@ -393,11 +400,11 @@ export async function readDurableDataPage(params: {
   let assertionGraphs: Set<string> | null = null;
   const isAdmitted = async (graph: string): Promise<boolean> => {
     if (graph.includes('/assertion/')) {
-      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId);
+      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId, params.signal);
       const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
       if (!assertionGraphs.has(assertionGraph)) return false;
     }
-    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph));
+    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, params.signal));
   };
 
   if (params.sinceBatchId == null) {
@@ -414,6 +421,7 @@ export async function readDurableDataPage(params: {
           refresh: params.refreshRowList,
         }
         : undefined,
+      params.signal,
     );
   }
 
@@ -442,6 +450,7 @@ export async function readDurableDataPage(params: {
         refresh: params.refreshRowList,
       }
       : undefined,
+    params.signal,
   );
 }
 
@@ -452,9 +461,10 @@ async function readPagedRowsAcrossGraphs(
   limit: number,
   isAdmitted: (graph: string) => Promise<boolean>,
   cache?: RowListCache,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   if (!cache) {
-    return readPagedRowsAcrossGraphsStoreBounded(store, graphs, offset, limit, isAdmitted);
+    return readPagedRowsAcrossGraphsStoreBounded(store, graphs, offset, limit, isAdmitted, signal);
   }
 
   const safeOffset = Math.max(0, Math.floor(offset));
@@ -467,7 +477,7 @@ async function readPagedRowsAcrossGraphs(
       if (!(await isAdmitted(graph))) continue;
       admittedGraphs.push(graph);
     }
-    return readRowsAcrossGraphs(store, admittedGraphs);
+    return readRowsAcrossGraphs(store, admittedGraphs, signal);
   };
 
   return readCachedRowsPage(
@@ -487,6 +497,7 @@ async function readPagedRowsAcrossGraphsStoreBounded(
   offset: number,
   limit: number,
   isAdmitted: (graph: string) => Promise<boolean>,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const admittedGraphs: string[] = [];
   for (const graph of graphs) {
@@ -494,7 +505,7 @@ async function readPagedRowsAcrossGraphsStoreBounded(
     admittedGraphs.push(graph);
   }
 
-  return readRowsPageAcrossGraphs(store, admittedGraphs, offset, limit);
+  return readRowsPageAcrossGraphs(store, admittedGraphs, offset, limit, signal);
 }
 
 async function readPagedDurableDeltaRowsAcrossGraphs(
@@ -505,9 +516,10 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   offset: number,
   limit: number,
   cache?: RowListCache,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   if (!cache) {
-    return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit);
+    return readDurableDeltaRowsPageAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, offset, limit, signal);
   }
 
   const safeOffset = Math.max(0, Math.floor(offset));
@@ -519,7 +531,7 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
       ...cache,
       expiredMessage: cache.expiredMessage ?? 'Durable data sync session snapshot expired before page completion',
     },
-    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId),
+    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, signal),
     safeOffset,
     safeLimit,
   );
@@ -598,7 +610,11 @@ async function readRegisteredSubGraphNames(
     .sort(compareCodePoint);
 }
 
-async function isKnownContextGraph(store: TripleStore, contextGraphUri: string): Promise<boolean> {
+async function isKnownContextGraph(
+  store: TripleStore,
+  contextGraphUri: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
   const metaGraph = `${contextGraphUri}/_meta`;
   const res = await store.query(`
     ASK {
@@ -610,7 +626,7 @@ async function isKnownContextGraph(store: TripleStore, contextGraphUri: string):
         }
       }
     }
-  `);
+  `, { signal });
   return res.type === 'boolean' && res.value;
 }
 
@@ -618,20 +634,21 @@ async function isDescendantOfKnownChildContextGraph(
   store: TripleStore,
   cgPrefix: string,
   graph: string,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   if (graph === cgPrefix || !graph.startsWith(`${cgPrefix}/`)) return false;
   const remainder = graph.slice(cgPrefix.length + 1);
   const segments = remainder.split('/').filter(Boolean);
   if (isParentOwnedReservedGraphSegments(segments)) return false;
-  if (await isKnownContextGraph(store, graph)) return true;
+  if (await isKnownContextGraph(store, graph, signal)) return true;
   if (graph.endsWith('/_meta')) {
     const graphOwner = graph.slice(0, -'/_meta'.length);
-    if (await isKnownContextGraph(store, graphOwner)) return true;
+    if (await isKnownContextGraph(store, graphOwner, signal)) return true;
   }
   let childUri = cgPrefix;
   for (const segment of segments) {
     childUri = `${childUri}/${segment}`;
-    if (await isKnownContextGraph(store, childUri)) return true;
+    if (await isKnownContextGraph(store, childUri, signal)) return true;
   }
   return false;
 }
@@ -662,6 +679,7 @@ function isAssertionGraphSegments(segments: readonly string[]): boolean {
 async function readAdmittedAssertionGraphs(
   store: TripleStore,
   contextGraphId: string,
+  signal?: AbortSignal,
 ): Promise<Set<string>> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const res = await store.query(`
@@ -672,7 +690,7 @@ async function readAdmittedAssertionGraphs(
         FILTER(?layer != ${sparqlString(MemoryLayer.WorkingMemory)})
       }
     }
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return new Set();
   return new Set(res.bindings.map((row) => row['g']).filter(Boolean));
 }
@@ -680,6 +698,7 @@ async function readAdmittedAssertionGraphs(
 async function readRowsAcrossGraphs(
   store: TripleStore,
   graphs: readonly string[],
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const values = graphValues(graphs);
   if (!values) return [];
@@ -688,7 +707,7 @@ async function readRowsAcrossGraphs(
       VALUES ?g { ${values} }
       GRAPH ?g { ?s ?p ?o }
     }
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
@@ -701,6 +720,7 @@ async function readRowsPageAcrossGraphs(
   graphs: readonly string[],
   offset: number,
   limit: number,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
@@ -714,7 +734,7 @@ async function readRowsPageAcrossGraphs(
     ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
     LIMIT ${safeLimit}
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
@@ -725,6 +745,7 @@ async function readSwmMetaRows(
   store: TripleStore,
   swmMetaGraphs: readonly string[],
   cutoffIso: string | null,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const swmMetaValues = graphValues(swmMetaGraphs);
   if (!swmMetaValues) return [];
@@ -740,7 +761,7 @@ async function readSwmMetaRows(
     : ''}
       }
     }
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
@@ -754,6 +775,7 @@ async function readSwmMetaRowsPage(
   cutoffIso: string | null,
   offset: number,
   limit: number,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
@@ -780,7 +802,7 @@ async function readSwmMetaRowsPage(
     ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
     LIMIT ${safeLimit}
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
@@ -793,15 +815,16 @@ async function readFreshSwmDataRows(
   graphSet: ReadonlySet<string>,
   candidateGraphsFor: (graph: string) => string[],
   cutoffIso: string,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const rows: SyncRow[] = [];
   for (const graph of dataGraphs) {
     const metaGraph = `${graph}_meta`;
     if (!graphSet.has(metaGraph)) continue;
-    const roots = await readFreshSwmRoots(store, metaGraph, cutoffIso);
+    const roots = await readFreshSwmRoots(store, metaGraph, cutoffIso, signal);
     if (roots.size === 0) continue;
     const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
-    const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph));
+    const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph), signal);
     rows.push(...graphRows.filter((row) =>
       roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix)),
     ));
@@ -813,6 +836,7 @@ async function readFreshSwmRoots(
   store: TripleStore,
   metaGraph: string,
   cutoffIso: string,
+  signal?: AbortSignal,
 ): Promise<Set<string>> {
   const res = await store.query(`
     SELECT DISTINCT ?root WHERE {
@@ -823,7 +847,7 @@ async function readFreshSwmRoots(
         FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
       }
     }
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return new Set();
   return new Set(res.bindings.map((row) => row['root']).filter(Boolean));
 }
@@ -832,13 +856,14 @@ async function readDurableMetaRows(
   store: TripleStore,
   contextGraphId: string,
   registeredSubGraphNames: readonly string[],
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const cgEntity = contextGraphDataGraphUri(contextGraphId);
   const registeredSubGraphSubjects = new Set(dedupeStrings(registeredSubGraphNames)
     .filter((name) => validateSubGraphName(name).valid)
     .map((name) => `${cgEntity}/${name}`));
-  const rows = await readRowsAcrossGraphs(store, [metaGraph]);
+  const rows = await readRowsAcrossGraphs(store, [metaGraph], signal);
   const nonWorkingLifecycles = new Set<string>();
   for (const row of rows) {
     if (row.p === DKG_MEMORY_LAYER && stripLiteral(row.o) !== MemoryLayer.WorkingMemory) {
@@ -884,6 +909,7 @@ async function readDurableDeltaRowsPageAcrossGraphs(
   sinceBatchId: bigint,
   offset: number,
   limit: number,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
@@ -898,7 +924,7 @@ async function readDurableDeltaRowsPageAcrossGraphs(
     ORDER BY ?g ?s ?p ?o
     OFFSET ${safeOffset}
     LIMIT ${safeLimit}
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
@@ -910,6 +936,7 @@ async function readDurableDeltaRowsAcrossGraphs(
   graphs: readonly string[],
   metaGraphs: readonly string[],
   sinceBatchId: bigint,
+  signal?: AbortSignal,
 ): Promise<SyncRow[]> {
   const values = graphValues(graphs);
   if (!values) return [];
@@ -919,7 +946,7 @@ async function readDurableDeltaRowsAcrossGraphs(
       ${durableDeltaWhereClauseForGraphs(values, metaGraphs)}
     }
     ${durableDeltaGroupClause(metaGraphs, sinceBatchId, true)}
-  `);
+  `, { signal });
   if (res.type !== 'bindings') return [];
   return res.bindings
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -36,7 +36,7 @@ export interface SyncRowListMemo {
   get(
     key: string,
     loadRows: () => Promise<readonly SyncRow[]>,
-    options?: { refresh?: boolean; requireExisting?: boolean },
+    options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
   ): Promise<readonly SyncRow[] | null>;
 }
 
@@ -60,7 +60,7 @@ export function createResponderGraphListMemo(
       const now = Date.now();
       if (inflight) return [...(await raceAgainstAbort(inflight, options?.signal))];
       if (!options?.refresh && cached && now - cachedAt < ttlMs) return [...cached];
-      inflight = store.listGraphs()
+      const load = store.listGraphs()
         .then((graphs) => {
           const sorted = [...new Set(graphs)].sort(compareCodePoint);
           cached = sorted;
@@ -70,7 +70,10 @@ export function createResponderGraphListMemo(
         .finally(() => {
           inflight = null;
         });
-      return [...(await raceAgainstAbort(inflight, options?.signal))];
+      inflight = load;
+      const graphs = await load;
+      throwIfAborted(options?.signal);
+      return [...graphs];
     },
   };
 }
@@ -142,11 +145,12 @@ export function createResponderSyncRowListMemo(
   };
 
   return {
-    async get(key, loadRows, options?: { refresh?: boolean; requireExisting?: boolean }) {
+    async get(key, loadRows, options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal }) {
+      throwIfAborted(options?.signal);
       const now = Date.now();
       pruneExpired(now);
       const pending = inflight.get(key);
-      if (pending) return [...(await pending)];
+      if (pending) return [...(await raceAgainstAbort(pending, options?.signal))];
       if (expired.has(key)) {
         if (options?.refresh) {
           deleteExpired(key);
@@ -181,7 +185,9 @@ export function createResponderSyncRowListMemo(
           if (inflight.get(key) === load) inflight.delete(key);
         });
       inflight.set(key, load);
-      return [...(await load)];
+      const rows = await load;
+      throwIfAborted(options?.signal);
+      return [...rows];
     },
   };
 }
@@ -229,7 +235,9 @@ function createSubGraphNameMemo(
           inflight.delete(contextGraphId);
         });
       inflight.set(contextGraphId, load);
-      return [...(await raceAgainstAbort(load, options?.signal))];
+      const names = await load;
+      throwIfAborted(options?.signal);
+      return [...names];
     },
   };
 }
@@ -561,13 +569,11 @@ async function readCachedRowsPage(
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
   if (safeLimit === 0) return [];
-  const rows = await raceAgainstAbort(
-    cache.memo.get(cache.key, loadRows, {
-      refresh: cache.refresh,
-      requireExisting: safeOffset > 0,
-    }),
+  const rows = await cache.memo.get(cache.key, loadRows, {
+    refresh: cache.refresh,
+    requireExisting: safeOffset > 0,
     signal,
-  );
+  });
   if (rows == null) {
     throw new Error(cache.expiredMessage ?? 'Sync session snapshot expired before page completion');
   }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -60,7 +60,7 @@ export function createResponderGraphListMemo(
       const now = Date.now();
       if (inflight) return [...(await raceAgainstAbort(inflight, options?.signal))];
       if (!options?.refresh && cached && now - cachedAt < ttlMs) return [...cached];
-      inflight = store.listGraphs({ signal: options?.signal })
+      inflight = store.listGraphs()
         .then((graphs) => {
           const sorted = [...new Set(graphs)].sort(compareCodePoint);
           cached = sorted;
@@ -191,7 +191,7 @@ export function createResponderSwmAdmissionMemo(
   ttlMs = 10_000,
 ): SubGraphNameMemo {
   return createSubGraphNameMemo(
-    (contextGraphId, options) => readAdmittedSwmSubGraphNames(store, contextGraphId, options?.signal),
+    (contextGraphId) => readAdmittedSwmSubGraphNames(store, contextGraphId),
     ttlMs,
   );
 }
@@ -201,13 +201,13 @@ export function createResponderSubGraphRegistrationMemo(
   ttlMs = 10_000,
 ): SubGraphNameMemo {
   return createSubGraphNameMemo(
-    (contextGraphId, options) => readRegisteredSubGraphNames(store, contextGraphId, options?.signal),
+    (contextGraphId) => readRegisteredSubGraphNames(store, contextGraphId),
     ttlMs,
   );
 }
 
 function createSubGraphNameMemo(
-  loadNames: (contextGraphId: string, options?: { signal?: AbortSignal }) => Promise<string[]>,
+  loadNames: (contextGraphId: string) => Promise<string[]>,
   ttlMs: number,
 ): SubGraphNameMemo {
   const cached = new Map<string, { value: readonly string[]; cachedAt: number }>();
@@ -220,7 +220,7 @@ function createSubGraphNameMemo(
       if (!options?.refresh && existing && now - existing.cachedAt < ttlMs) return [...existing.value];
       const pending = inflight.get(contextGraphId);
       if (pending) return [...(await raceAgainstAbort(pending, options?.signal))];
-      const load = loadNames(contextGraphId, { signal: options?.signal })
+      const load = loadNames(contextGraphId)
         .then((names) => {
           cached.set(contextGraphId, { value: names, cachedAt: Date.now() });
           return names;
@@ -284,7 +284,7 @@ export async function readSwmMetaPage(params: {
         refresh: params.refreshRowList,
         expiredMessage: 'Shared-memory meta sync session snapshot expired before page completion',
       },
-      () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso, params.signal),
+      () => readSwmMetaRows(params.store, candidateGraphs, params.cutoffIso),
       params.offset,
       params.limit,
       params.signal,
@@ -340,18 +340,18 @@ export async function readSwmDataPage(params: {
     );
   }
 
-  const loadRows = () => readFreshSwmDataRows(
+  const loadRows = (signal?: AbortSignal) => readFreshSwmDataRows(
     params.store,
     dataGraphs,
     graphSet,
     candidateGraphsFor,
     params.cutoffIso!,
-    params.signal,
+    signal,
   );
   if (cache) {
-    return readCachedRowsPage(cache, loadRows, params.offset, params.limit, params.signal);
+    return readCachedRowsPage(cache, () => loadRows(), params.offset, params.limit, params.signal);
   }
-  const rows = await loadRows();
+  const rows = await loadRows(params.signal);
   return rows.slice(Math.max(0, Math.floor(params.offset)), Math.max(0, Math.floor(params.offset)) + Math.max(0, Math.floor(params.limit)));
 }
 
@@ -366,7 +366,8 @@ export async function readDurableMetaPage(params: {
   rowListCacheKey?: string;
   refreshRowList?: boolean;
 }): Promise<SyncRow[]> {
-  const loadRows = () => readDurableMetaRows(params.store, params.contextGraphId, params.registeredSubGraphNames, params.signal);
+  const loadRows = (signal?: AbortSignal) =>
+    readDurableMetaRows(params.store, params.contextGraphId, params.registeredSubGraphNames, signal);
   if (params.rowListMemo && params.rowListCacheKey) {
     return readCachedRowsPage(
       {
@@ -375,13 +376,13 @@ export async function readDurableMetaPage(params: {
         refresh: params.refreshRowList,
         expiredMessage: 'Durable meta sync session snapshot expired before page completion',
       },
-      loadRows,
+      () => loadRows(),
       params.offset,
       params.limit,
       params.signal,
     );
   }
-  const rows = await loadRows();
+  const rows = await loadRows(params.signal);
   const safeOffset = Math.max(0, Math.floor(params.offset));
   const safeLimit = Math.max(0, Math.floor(params.limit));
   return rows.slice(safeOffset, safeOffset + safeLimit);
@@ -408,13 +409,13 @@ export async function readDurableDataPage(params: {
   }).sort(compareCodePoint);
 
   let assertionGraphs: Set<string> | null = null;
-  const isAdmitted = async (graph: string): Promise<boolean> => {
+  const isAdmitted = (signal?: AbortSignal) => async (graph: string): Promise<boolean> => {
     if (graph.includes('/assertion/')) {
-      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId, params.signal);
+      assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId, signal);
       const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
       if (!assertionGraphs.has(assertionGraph)) return false;
     }
-    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, params.signal));
+    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, signal));
   };
 
   if (params.sinceBatchId == null) {
@@ -423,7 +424,7 @@ export async function readDurableDataPage(params: {
       candidateGraphs,
       params.offset,
       params.limit,
-      isAdmitted,
+      isAdmitted(params.rowListMemo ? undefined : params.signal),
       params.rowListMemo
         ? {
           memo: params.rowListMemo,
@@ -436,8 +437,9 @@ export async function readDurableDataPage(params: {
   }
 
   const graphs: string[] = [];
+  const isAdmittedForRequest = isAdmitted(params.signal);
   for (const graph of candidateGraphs) {
-    if (await isAdmitted(graph)) graphs.push(graph);
+    if (await isAdmittedForRequest(graph)) graphs.push(graph);
   }
 
   const metaGraphs = [
@@ -487,7 +489,7 @@ async function readPagedRowsAcrossGraphs(
       if (!(await isAdmitted(graph))) continue;
       admittedGraphs.push(graph);
     }
-    return readRowsAcrossGraphs(store, admittedGraphs, signal);
+    return readRowsAcrossGraphs(store, admittedGraphs);
   };
 
   return readCachedRowsPage(
@@ -542,7 +544,7 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
       ...cache,
       expiredMessage: cache.expiredMessage ?? 'Durable data sync session snapshot expired before page completion',
     },
-    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId, signal),
+    () => readDurableDeltaRowsAcrossGraphs(store, graphs, metaGraphs, sinceBatchId),
     safeOffset,
     safeLimit,
     signal,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -169,9 +169,12 @@ function createSyncResponderLimiter() {
       entry.onAbort = () => {
         if (removeQueued(entry)) reject(asAbortError(signal?.reason));
       };
-      if (signal) signal.addEventListener('abort', entry.onAbort, { once: true });
       incrementQueued(peerId);
       queue.push(entry);
+      if (signal) {
+        signal.addEventListener('abort', entry.onAbort, { once: true });
+        if (signal.aborted) entry.onAbort();
+      }
     });
   };
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -203,6 +203,18 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw asAbortError(signal.reason);
 }
 
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(asAbortError(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
 export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   const {
     register,
@@ -343,8 +355,11 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmMetaPage({
             store,
-            graphList: await graphListMemo.get({ refresh: offset === 0 }),
-            registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+            graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
+            registeredSubGraphNames: await raceAgainstAbort(
+              swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+              signal,
+            ),
             contextGraphId,
             cutoffIso: cutoff,
             offset,
@@ -370,8 +385,11 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmDataPage({
             store,
-            graphList: await graphListMemo.get({ refresh: offset === 0 }),
-            registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+            graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
+            registeredSubGraphNames: await raceAgainstAbort(
+              swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+              signal,
+            ),
             contextGraphId,
             cutoffIso: cutoff,
             offset,
@@ -401,7 +419,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const rows = await readDurableMetaPage({
           store,
           contextGraphId,
-          registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
+          registeredSubGraphNames: await raceAgainstAbort(
+            subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
+            signal,
+          ),
           offset,
           limit,
           signal,
@@ -425,7 +446,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         );
         const rows = await readDurableDataPage({
           store,
-          graphList: await graphListMemo.get({ refresh: offset === 0 }),
+          graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
           contextGraphId,
           sinceBatchId,
           offset,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -42,7 +42,7 @@ interface RegisterSyncHandlerParams {
    */
   register: (
     protocolId: string,
-    handler: (data: Uint8Array, peerId: string) => Promise<Uint8Array>,
+    handler: (data: Uint8Array, peerId: string, options?: { signal?: AbortSignal }) => Promise<Uint8Array>,
   ) => void;
   protocolSync: string;
   syncDeniedResponse: string;
@@ -55,6 +55,123 @@ interface RegisterSyncHandlerParams {
   authorizeSyncRequest: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
+}
+
+const SYNC_RESPONDER_GLOBAL_CONCURRENCY = 3;
+const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 1;
+const SYNC_RESPONDER_QUEUE_LIMIT = 32;
+const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 10_000;
+
+class SyncResponderBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SyncResponderBusyError';
+  }
+}
+
+interface SyncResponderQueueEntry {
+  peerId: string;
+  resolve: (release: () => void) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  timer: ReturnType<typeof setTimeout>;
+  onAbort?: () => void;
+}
+
+function createSyncResponderLimiter() {
+  let running = 0;
+  const runningByPeer = new Map<string, number>();
+  const queue: SyncResponderQueueEntry[] = [];
+
+  const canRun = (peerId: string): boolean =>
+    running < SYNC_RESPONDER_GLOBAL_CONCURRENCY &&
+    (runningByPeer.get(peerId) ?? 0) < SYNC_RESPONDER_PER_PEER_CONCURRENCY;
+
+  const releaseFor = (peerId: string): (() => void) => {
+    let released = false;
+    running += 1;
+    runningByPeer.set(peerId, (runningByPeer.get(peerId) ?? 0) + 1);
+    return () => {
+      if (released) return;
+      released = true;
+      running -= 1;
+      const peerRunning = (runningByPeer.get(peerId) ?? 1) - 1;
+      if (peerRunning <= 0) runningByPeer.delete(peerId);
+      else runningByPeer.set(peerId, peerRunning);
+      pump();
+    };
+  };
+
+  const removeQueued = (entry: SyncResponderQueueEntry): boolean => {
+    const index = queue.indexOf(entry);
+    if (index < 0) return false;
+    queue.splice(index, 1);
+    clearTimeout(entry.timer);
+    if (entry.signal && entry.onAbort) entry.signal.removeEventListener('abort', entry.onAbort);
+    return true;
+  };
+
+  const startQueued = (entry: SyncResponderQueueEntry): void => {
+    clearTimeout(entry.timer);
+    if (entry.signal && entry.onAbort) entry.signal.removeEventListener('abort', entry.onAbort);
+    entry.resolve(releaseFor(entry.peerId));
+  };
+
+  const pump = (): void => {
+    for (let i = 0; i < queue.length && running < SYNC_RESPONDER_GLOBAL_CONCURRENCY;) {
+      const entry = queue[i];
+      if (!canRun(entry.peerId)) {
+        i += 1;
+        continue;
+      }
+      queue.splice(i, 1);
+      startQueued(entry);
+    }
+  };
+
+  const acquire = (peerId: string, signal?: AbortSignal): Promise<() => void> => {
+    throwIfAborted(signal);
+    if (canRun(peerId)) return Promise.resolve(releaseFor(peerId));
+    if (queue.length >= SYNC_RESPONDER_QUEUE_LIMIT) {
+      throw new SyncResponderBusyError('sync responder queue full');
+    }
+    return new Promise((resolve, reject) => {
+      const entry: SyncResponderQueueEntry = {
+        peerId,
+        resolve,
+        reject,
+        signal,
+        timer: setTimeout(() => {
+          if (removeQueued(entry)) reject(new SyncResponderBusyError('sync responder queue wait exceeded'));
+        }, SYNC_RESPONDER_MAX_QUEUE_WAIT_MS),
+      };
+      entry.onAbort = () => {
+        if (removeQueued(entry)) reject(asAbortError(signal?.reason));
+      };
+      if (signal) signal.addEventListener('abort', entry.onAbort, { once: true });
+      queue.push(entry);
+    });
+  };
+
+  return {
+    async run<T>(peerId: string, signal: AbortSignal | undefined, fn: () => Promise<T>): Promise<T> {
+      const release = await acquire(peerId, signal);
+      try {
+        throwIfAborted(signal);
+        return await fn();
+      } finally {
+        release();
+      }
+    },
+  };
+}
+
+function asAbortError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
 }
 
 export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
@@ -78,6 +195,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   const syncSessionTokens = new Map<string, SyncSessionTokenEntry>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
+  const limiter = createSyncResponderLimiter();
 
   const pruneSyncSessionTokens = (now = Date.now()) => {
     for (const [key, entry] of syncSessionTokens) {
@@ -123,7 +241,8 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     };
   };
 
-  register(protocolSync, async (data, peerId) => {
+  register(protocolSync, async (data, peerId, options) => {
+    const signal = options?.signal;
     const handlerStartedAt = Date.now();
     const request = parseSyncRequest(data);
     const offset = Math.max(0, Math.min(Number.isSafeInteger(Number(request.offset)) ? Number(request.offset) : 0, 1_000_000));
@@ -134,6 +253,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     if (!contextGraphId || typeof contextGraphId !== 'string') {
       return new TextEncoder().encode('');
     }
+    throwIfAborted(signal);
 
     // Phase C: validate the optional delta hint into a non-negative bigint.
     // Malformed values are ignored so older or buggy requesters fall back to a
@@ -151,12 +271,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const authStartedAt = Date.now();
     const authorized = await authorizeSyncRequest(request, peerId);
     const authDurationMs = Date.now() - authStartedAt;
+    throwIfAborted(signal);
     if (!authorized) {
       logWarn(createOperationContext('sync'), `Denied sync request for "${contextGraphId}" from peer ${peerId} (phase=${phase})`);
       return new TextEncoder().encode(syncDeniedResponse);
     }
 
-    if (isWorkspace) {
+    return limiter.run(peerId, signal, async () => {
+      throwIfAborted(signal);
+      if (isWorkspace) {
       const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
       if (phase === 'snapshot') {
         const snapshotRef = request.snapshotRef?.trim();
@@ -189,6 +312,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           cutoffIso: cutoff,
           offset,
           limit,
+          signal,
           rowListMemo: session ? swmRowsMemo : undefined,
           rowListCacheKey: session?.rowListCacheKey,
           refreshRowList: session?.refreshRowList,
@@ -215,6 +339,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           cutoffIso: cutoff,
           offset,
           limit,
+          signal,
           rowListMemo: session ? swmRowsMemo : undefined,
           rowListCacheKey: session?.rowListCacheKey,
           refreshRowList: session?.refreshRowList,
@@ -242,6 +367,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
         offset,
         limit,
+        signal,
         rowListMemo: session ? durableMetaRowsMemo : undefined,
         rowListCacheKey: session?.rowListCacheKey,
         refreshRowList: session?.refreshRowList,
@@ -268,6 +394,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           sinceBatchId,
           offset,
           limit,
+          signal,
           rowListMemo: session ? durableDataRowsMemo : undefined,
           rowListCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
@@ -279,6 +406,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           sinceBatchId,
           offset,
           limit,
+          signal,
           rowListMemo: session ? durableDataRowsMemo : undefined,
           rowListCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
@@ -289,12 +417,13 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (serialized) nquads.push(serialized);
       const serializeDurationMs = Date.now() - serializeStartedAt;
       logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-    }
+      }
 
-    const totalDurationMs = Date.now() - handlerStartedAt;
-    if (totalDurationMs > 100) {
-      logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
-    }
-    return new TextEncoder().encode(nquads.join('\n'));
+      const totalDurationMs = Date.now() - handlerStartedAt;
+      if (totalDurationMs > 100) {
+        logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
+      }
+      return new TextEncoder().encode(nquads.join('\n'));
+    });
   });
 }

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -294,17 +294,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     }
     const nquads: string[] = [];
 
-    const authStartedAt = Date.now();
-    const authorized = await authorizeSyncRequest(request, peerId);
-    const authDurationMs = Date.now() - authStartedAt;
-    throwIfAborted(signal);
-    if (!authorized) {
-      logWarn(createOperationContext('sync'), `Denied sync request for "${contextGraphId}" from peer ${peerId} (phase=${phase})`);
-      return new TextEncoder().encode(syncDeniedResponse);
-    }
-
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
+      const authStartedAt = Date.now();
+      const authorized = await authorizeSyncRequest(request, peerId);
+      const authDurationMs = Date.now() - authStartedAt;
+      throwIfAborted(signal);
+      if (!authorized) {
+        logWarn(createOperationContext('sync'), `Denied sync request for "${contextGraphId}" from peer ${peerId} (phase=${phase})`);
+        return new TextEncoder().encode(syncDeniedResponse);
+      }
+
       if (store.queryCancellation === 'pre-dispatch' && !warnedPreDispatchCancellation) {
         warnedPreDispatchCancellation = true;
         logWarn(

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -355,10 +355,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmMetaPage({
             store,
-            graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
-            registeredSubGraphNames: await raceAgainstAbort(
-              swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
-              signal,
+            graphList: await graphListMemo.get({ refresh: offset === 0, signal }),
+            registeredSubGraphNames: await swmAdmissionMemo.get(
+              contextGraphId,
+              { refresh: offset === 0, signal },
             ),
             contextGraphId,
             cutoffIso: cutoff,
@@ -385,10 +385,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmDataPage({
             store,
-            graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
-            registeredSubGraphNames: await raceAgainstAbort(
-              swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
-              signal,
+            graphList: await graphListMemo.get({ refresh: offset === 0, signal }),
+            registeredSubGraphNames: await swmAdmissionMemo.get(
+              contextGraphId,
+              { refresh: offset === 0, signal },
             ),
             contextGraphId,
             cutoffIso: cutoff,
@@ -419,9 +419,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const rows = await readDurableMetaPage({
           store,
           contextGraphId,
-          registeredSubGraphNames: await raceAgainstAbort(
-            subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
-            signal,
+          registeredSubGraphNames: await subGraphRegistrationMemo.get(
+            contextGraphId,
+            { refresh: offset === 0, signal },
           ),
           offset,
           limit,
@@ -446,7 +446,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         );
         const rows = await readDurableDataPage({
           store,
-          graphList: await raceAgainstAbort(graphListMemo.get({ refresh: offset === 0 }), signal),
+          graphList: await graphListMemo.get({ refresh: offset === 0, signal }),
           contextGraphId,
           sinceBatchId,
           offset,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -5,6 +5,7 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
+import { SYNC_BUSY_RESPONSE } from '../../dkg-agent-constants.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
@@ -424,6 +425,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
       }
       return new TextEncoder().encode(nquads.join('\n'));
+    }).catch((err) => {
+      if (err instanceof SyncResponderBusyError) {
+        logDebug(createOperationContext('sync'), `Sync responder busy for "${contextGraphId}" from peer ${peerId} (phase=${phase})`);
+        return new TextEncoder().encode(SYNC_BUSY_RESPONSE);
+      }
+      throw err;
     });
   });
 }

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -61,6 +61,7 @@ interface RegisterSyncHandlerParams {
 const SYNC_RESPONDER_GLOBAL_CONCURRENCY = 3;
 const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 1;
 const SYNC_RESPONDER_QUEUE_LIMIT = 32;
+const SYNC_RESPONDER_PER_PEER_QUEUE_LIMIT = 4;
 const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 10_000;
 
 class SyncResponderBusyError extends Error {
@@ -82,6 +83,7 @@ interface SyncResponderQueueEntry {
 function createSyncResponderLimiter() {
   let running = 0;
   const runningByPeer = new Map<string, number>();
+  const queuedByPeer = new Map<string, number>();
   const queue: SyncResponderQueueEntry[] = [];
 
   const canRun = (peerId: string): boolean =>
@@ -103,16 +105,28 @@ function createSyncResponderLimiter() {
     };
   };
 
+  const incrementQueued = (peerId: string): void => {
+    queuedByPeer.set(peerId, (queuedByPeer.get(peerId) ?? 0) + 1);
+  };
+
+  const decrementQueued = (peerId: string): void => {
+    const count = (queuedByPeer.get(peerId) ?? 1) - 1;
+    if (count <= 0) queuedByPeer.delete(peerId);
+    else queuedByPeer.set(peerId, count);
+  };
+
   const removeQueued = (entry: SyncResponderQueueEntry): boolean => {
     const index = queue.indexOf(entry);
     if (index < 0) return false;
     queue.splice(index, 1);
+    decrementQueued(entry.peerId);
     clearTimeout(entry.timer);
     if (entry.signal && entry.onAbort) entry.signal.removeEventListener('abort', entry.onAbort);
     return true;
   };
 
   const startQueued = (entry: SyncResponderQueueEntry): void => {
+    decrementQueued(entry.peerId);
     clearTimeout(entry.timer);
     if (entry.signal && entry.onAbort) entry.signal.removeEventListener('abort', entry.onAbort);
     entry.resolve(releaseFor(entry.peerId));
@@ -136,6 +150,9 @@ function createSyncResponderLimiter() {
     if (queue.length >= SYNC_RESPONDER_QUEUE_LIMIT) {
       throw new SyncResponderBusyError('sync responder queue full');
     }
+    if ((queuedByPeer.get(peerId) ?? 0) >= SYNC_RESPONDER_PER_PEER_QUEUE_LIMIT) {
+      throw new SyncResponderBusyError('sync responder peer queue full');
+    }
     return new Promise((resolve, reject) => {
       const entry: SyncResponderQueueEntry = {
         peerId,
@@ -150,6 +167,7 @@ function createSyncResponderLimiter() {
         if (removeQueued(entry)) reject(asAbortError(signal?.reason));
       };
       if (signal) signal.addEventListener('abort', entry.onAbort, { once: true });
+      incrementQueued(peerId);
       queue.push(entry);
     });
   };
@@ -197,6 +215,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
   const limiter = createSyncResponderLimiter();
+  let warnedPreDispatchCancellation = false;
 
   const pruneSyncSessionTokens = (now = Date.now()) => {
     for (const [key, entry] of syncSessionTokens) {
@@ -280,6 +299,13 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
 
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
+      if (store.queryCancellation === 'pre-dispatch' && !warnedPreDispatchCancellation) {
+        warnedPreDispatchCancellation = true;
+        logWarn(
+          createOperationContext('sync'),
+          'Sync responder is using a store backend whose query AbortSignal is pre-dispatch only; in-flight sync queries cannot release responder capacity until the synchronous store call returns. Use oxigraph-worker or an HTTP SPARQL backend for interruptible long-query cancellation.',
+        );
+      }
       if (isWorkspace) {
       const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
       if (phase === 'snapshot') {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -5,7 +5,6 @@ import {
   type WorkspacePublicSnapshotStore,
 } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../auth/request-build.js';
-import { SYNC_BUSY_RESPONSE } from '../../dkg-agent-constants.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../durable-session.js';
 import {
   createResponderGraphListMemo,
@@ -451,12 +450,6 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
       }
       return new TextEncoder().encode(nquads.join('\n'));
-    }).catch((err) => {
-      if (err instanceof SyncResponderBusyError) {
-        logDebug(createOperationContext('sync'), `Sync responder busy for "${contextGraphId}" from peer ${peerId} (phase=${phase})`);
-        return new TextEncoder().encode(SYNC_BUSY_RESPONSE);
-      }
-      throw err;
     });
   });
 }

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -56,7 +56,11 @@ interface RegisterSyncHandlerParams {
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   peerId: string;
   parseSyncRequest: (data: Uint8Array) => SyncRequestEnvelope;
-  authorizeSyncRequest: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+  authorizeSyncRequest: (
+    request: SyncRequestEnvelope,
+    remotePeerId: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<boolean>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logDebug: (ctx: OperationContext, message: string) => void;
 }
@@ -297,7 +301,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
       const authStartedAt = Date.now();
-      const authorized = await authorizeSyncRequest(request, peerId);
+      const authorized = await authorizeSyncRequest(request, peerId, { signal });
       const authDurationMs = Date.now() - authStartedAt;
       throwIfAborted(signal);
       if (!authorized) {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -313,40 +313,95 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         );
       }
       if (isWorkspace) {
-      const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
-      if (phase === 'snapshot') {
-        const snapshotRef = request.snapshotRef?.trim();
-        if (!snapshotRef || !publicSnapshotStore) {
-          return new TextEncoder().encode('');
+        const cutoff = sharedMemoryTtlMs > 0 ? new Date(Date.now() - sharedMemoryTtlMs).toISOString() : null;
+        if (phase === 'snapshot') {
+          const snapshotRef = request.snapshotRef?.trim();
+          if (!snapshotRef || !publicSnapshotStore) {
+            return new TextEncoder().encode('');
+          }
+          const snapshot = await publicSnapshotStore.getSnapshot(snapshotRef);
+          if (!snapshot) {
+            return new TextEncoder().encode('');
+          }
+          const page = snapshot.slice(offset, offset + limit);
+          if (page.length === 0) {
+            return new TextEncoder().encode('');
+          }
+          nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
+          logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+        } else if (phase === 'meta') {
+          const queryStartedAt = Date.now();
+          const session = prepareResponderSession(
+            'Shared memory meta',
+            `${peerId}:swm-meta:${contextGraphId}`,
+            request.syncSessionId,
+            offset,
+          );
+          const rows = await readSwmMetaPage({
+            store,
+            graphList: await graphListMemo.get({ refresh: offset === 0 }),
+            registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+            contextGraphId,
+            cutoffIso: cutoff,
+            offset,
+            limit,
+            signal,
+            rowListMemo: session ? swmRowsMemo : undefined,
+            rowListCacheKey: session?.rowListCacheKey,
+            refreshRowList: session?.refreshRowList,
+          });
+          const queryDurationMs = Date.now() - queryStartedAt;
+          const serializeStartedAt = Date.now();
+          const serialized = serializeResponderRows(rows);
+          if (serialized) nquads.push(serialized);
+          const serializeDurationMs = Date.now() - serializeStartedAt;
+          logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+        } else {
+          const queryStartedAt = Date.now();
+          const session = prepareResponderSession(
+            'Shared memory data',
+            `${peerId}:swm-data:${contextGraphId}`,
+            request.syncSessionId,
+            offset,
+          );
+          const rows = await readSwmDataPage({
+            store,
+            graphList: await graphListMemo.get({ refresh: offset === 0 }),
+            registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
+            contextGraphId,
+            cutoffIso: cutoff,
+            offset,
+            limit,
+            signal,
+            rowListMemo: session ? swmRowsMemo : undefined,
+            rowListCacheKey: session?.rowListCacheKey,
+            refreshRowList: session?.refreshRowList,
+          });
+          const queryDurationMs = Date.now() - queryStartedAt;
+          const serializeStartedAt = Date.now();
+          const serialized = serializeResponderRows(rows);
+          if (serialized) nquads.push(serialized);
+          const serializeDurationMs = Date.now() - serializeStartedAt;
+          logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
         }
-        const snapshot = await publicSnapshotStore.getSnapshot(snapshotRef);
-        if (!snapshot) {
-          return new TextEncoder().encode('');
-        }
-        const page = snapshot.slice(offset, offset + limit);
-        if (page.length === 0) {
-          return new TextEncoder().encode('');
-        }
-        nquads.push(serializeWorkspacePublicSnapshotQuads(page).trimEnd());
-        logDebug(createOperationContext('sync'), `Sync responder SWM snapshot for "${contextGraphId}" ref=${snapshotRef}: auth=${authDurationMs}ms quads=${page.length}`);
+
+        if (nquads.length === 0) return new TextEncoder().encode('');
       } else if (phase === 'meta') {
         const queryStartedAt = Date.now();
         const session = prepareResponderSession(
-          'Shared memory meta',
-          `${peerId}:swm-meta:${contextGraphId}`,
+          'Durable meta',
+          `${peerId}:durable-meta:${contextGraphId}`,
           request.syncSessionId,
           offset,
         );
-        const rows = await readSwmMetaPage({
+        const rows = await readDurableMetaPage({
           store,
-          graphList: await graphListMemo.get({ refresh: offset === 0 }),
-          registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
           contextGraphId,
-          cutoffIso: cutoff,
+          registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
           offset,
           limit,
           signal,
-          rowListMemo: session ? swmRowsMemo : undefined,
+          rowListMemo: session ? durableMetaRowsMemo : undefined,
           rowListCacheKey: session?.rowListCacheKey,
           refreshRowList: session?.refreshRowList,
         });
@@ -355,26 +410,25 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const serialized = serializeResponderRows(rows);
         if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
-        logDebug(createOperationContext('sync'), `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+        logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       } else {
         const queryStartedAt = Date.now();
         const session = prepareResponderSession(
-          'Shared memory data',
-          `${peerId}:swm-data:${contextGraphId}`,
+          'Durable data',
+          `${peerId}:durable-data:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`,
           request.syncSessionId,
           offset,
         );
-        const rows = await readSwmDataPage({
+        const rows = await readDurableDataPage({
           store,
           graphList: await graphListMemo.get({ refresh: offset === 0 }),
-          registeredSubGraphNames: await swmAdmissionMemo.get(contextGraphId, { refresh: offset === 0 }),
           contextGraphId,
-          cutoffIso: cutoff,
+          sinceBatchId,
           offset,
           limit,
           signal,
-          rowListMemo: session ? swmRowsMemo : undefined,
-          rowListCacheKey: session?.rowListCacheKey,
+          rowListMemo: session ? durableDataRowsMemo : undefined,
+          rowListCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
@@ -382,74 +436,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         const serialized = serializeResponderRows(rows);
         if (serialized) nquads.push(serialized);
         const serializeDurationMs = Date.now() - serializeStartedAt;
-        logDebug(createOperationContext('sync'), `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-      }
-
-      if (nquads.length === 0) return new TextEncoder().encode('');
-    } else if (phase === 'meta') {
-      const queryStartedAt = Date.now();
-      const session = prepareResponderSession(
-        'Durable meta',
-        `${peerId}:durable-meta:${contextGraphId}`,
-        request.syncSessionId,
-        offset,
-      );
-      const rows = await readDurableMetaPage({
-        store,
-        contextGraphId,
-        registeredSubGraphNames: await subGraphRegistrationMemo.get(contextGraphId, { refresh: offset === 0 }),
-        offset,
-        limit,
-        signal,
-        rowListMemo: session ? durableMetaRowsMemo : undefined,
-        rowListCacheKey: session?.rowListCacheKey,
-        refreshRowList: session?.refreshRowList,
-      });
-      const queryDurationMs = Date.now() - queryStartedAt;
-      const serializeStartedAt = Date.now();
-      const serialized = serializeResponderRows(rows);
-      if (serialized) nquads.push(serialized);
-      const serializeDurationMs = Date.now() - serializeStartedAt;
-      logDebug(createOperationContext('sync'), `Sync responder durable meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
-    } else {
-      const queryStartedAt = Date.now();
-      const session = prepareResponderSession(
-        'Durable data',
-        `${peerId}:durable-data:${contextGraphId}:${sinceBatchId == null ? 'full' : sinceBatchId.toString()}`,
-        request.syncSessionId,
-        offset,
-      );
-      const rows = sinceBatchId == null
-        ? await readDurableDataPage({
-          store,
-          graphList: await graphListMemo.get({ refresh: offset === 0 }),
-          contextGraphId,
-          sinceBatchId,
-          offset,
-          limit,
-          signal,
-          rowListMemo: session ? durableDataRowsMemo : undefined,
-          rowListCacheScope: session ? peerId : undefined,
-          refreshRowList: session?.refreshRowList,
-        })
-        : await readDurableDataPage({
-          store,
-          graphList: await graphListMemo.get({ refresh: offset === 0 }),
-          contextGraphId,
-          sinceBatchId,
-          offset,
-          limit,
-          signal,
-          rowListMemo: session ? durableDataRowsMemo : undefined,
-          rowListCacheScope: session ? peerId : undefined,
-          refreshRowList: session?.refreshRowList,
-        });
-      const queryDurationMs = Date.now() - queryStartedAt;
-      const serializeStartedAt = Date.now();
-      const serialized = serializeResponderRows(rows);
-      if (serialized) nquads.push(serialized);
-      const serializeDurationMs = Date.now() - serializeStartedAt;
-      logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
+        logDebug(createOperationContext('sync'), `Sync responder durable data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
       }
 
       const totalDurationMs = Date.now() - handlerStartedAt;

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -335,7 +335,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           if (!snapshotRef || !publicSnapshotStore) {
             return new TextEncoder().encode('');
           }
-          const snapshot = await publicSnapshotStore.getSnapshot(snapshotRef);
+          const snapshot = await raceAgainstAbort(publicSnapshotStore.getSnapshot(snapshotRef), signal);
           if (!snapshot) {
             return new TextEncoder().encode('');
           }

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -1,4 +1,8 @@
-import { createOperationContext, type OperationContext } from '@origintrail-official/dkg-core';
+import {
+  createOperationContext,
+  QuietRetryableHandlerError,
+  type OperationContext,
+} from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import {
   serializeWorkspacePublicSnapshotQuads,
@@ -450,6 +454,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         logDebug(createOperationContext('sync'), `Sync responder total for "${contextGraphId}" (phase=${phase}, workspace=${isWorkspace}): ${totalDurationMs}ms`);
       }
       return new TextEncoder().encode(nquads.join('\n'));
+    }).catch((err) => {
+      if (err instanceof SyncResponderBusyError) {
+        logDebug(createOperationContext('sync'), `Sync responder busy for "${contextGraphId}" from peer ${peerId} (phase=${phase}): ${err.message}`);
+        throw new QuietRetryableHandlerError(err.message);
+      }
+      throw err;
     });
   });
 }

--- a/packages/agent/test/cg-resolve-refresh.test.ts
+++ b/packages/agent/test/cg-resolve-refresh.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { ContextGraphResolveMethods } from '../src/dkg-agent-cg-resolve.js';
+
+const CURATOR_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const RELAY_ADDR = '/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+describe('refreshMetaFromCurator', () => {
+  it('passes caller abort signal to direct and relay curator dials', async () => {
+    const controller = new AbortController();
+    const dialSignals: Array<AbortSignal | undefined> = [];
+
+    const agent = {
+      metaRefreshTimestamps: new Map<string, number>(),
+      peerId: 'local-peer',
+      resolveCuratorPeerId: async () => CURATOR_PEER_ID,
+      node: {
+        libp2p: {
+          getConnections: () => [],
+          dial: async (_target: unknown, opts?: { signal?: AbortSignal }) => {
+            dialSignals.push(opts?.signal);
+            if (dialSignals.length === 1) {
+              throw new Error('direct dial unavailable');
+            }
+          },
+          peerStore: {
+            merge: async () => undefined,
+          },
+        },
+      },
+      discovery: {
+        findAgentByPeerId: async () => ({ relayAddress: RELAY_ADDR }),
+      },
+      fetchSyncPages: async () => {
+        throw new Error('should not fetch without a connected curator');
+      },
+      log: {
+        warn: () => undefined,
+        info: () => undefined,
+      },
+    };
+
+    const refreshed = await ContextGraphResolveMethods.prototype.refreshMetaFromCurator.call(
+      agent as never,
+      'unit-test-cg',
+      { signal: controller.signal },
+    );
+
+    expect(refreshed).toBe(false);
+    expect(dialSignals).toEqual([controller.signal, controller.signal]);
+  });
+});

--- a/packages/agent/test/p2p-messenger.test.ts
+++ b/packages/agent/test/p2p-messenger.test.ts
@@ -40,23 +40,25 @@ describe('Messenger.sendToPeer', () => {
       PEER_B,
       '/dkg/test/1.0.0',
       expect.any(Uint8Array),
-      undefined,
+      {},
     );
     expect(out).toEqual(new Uint8Array([0x01, 0x02]));
   });
 
-  it('forwards timeoutMs to router.send', async () => {
+  it('forwards timeoutMs and signal to router.send', async () => {
     const { messenger, mocks } = makeMessenger();
+    const controller = new AbortController();
 
     await messenger.sendToPeer(PEER_A, '/dkg/test/1.0.0', new Uint8Array([0xff]), {
       timeoutMs: 5000,
+      signal: controller.signal,
     });
 
     expect(mocks.routerSendMock).toHaveBeenCalledWith(
       PEER_A,
       '/dkg/test/1.0.0',
       expect.any(Uint8Array),
-      5000,
+      { timeoutMs: 5000, signal: controller.signal },
     );
   });
 

--- a/packages/agent/test/request-authorize.test.ts
+++ b/packages/agent/test/request-authorize.test.ts
@@ -102,6 +102,7 @@ interface AuthCallParams {
   allowedDelegateePeers?: Map<string, string[]> | Record<string, string[]>;
   allowedDelegateeKeys?: Map<string, string[]> | Record<string, string[]>;
   verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
+  signal?: AbortSignal;
 }
 
 function toMap(input: Map<string, string[]> | Record<string, string[]> | undefined): Map<string, string[]> {
@@ -130,6 +131,7 @@ async function callAuth(params: AuthCallParams): Promise<{ allowed: boolean; log
     getAllowedDelegateePeers: async () => peersMap,
     getAllowedDelegateeKeys: async () => keysMap,
     refreshMetaFromCurator: async () => false,
+    signal: params.signal,
     logWarn: (_c, m) => logs.push(`WARN: ${m}`),
     logInfo: (_c, m) => logs.push(`INFO: ${m}`),
   });
@@ -392,6 +394,110 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
     });
     expect(allowed).toBe(true);
     expect(callsToGetKeys).toEqual(['before-refresh', 'after-refresh']);
+  });
+
+  it('passes the abort signal to auth lookup helpers', async () => {
+    const { envelope, remotePeerId } = await buildSignedEnvelope({
+      signer: nodeOpKey,
+      identityId: '5',
+      requesterAgentAddress: agentAddress,
+    });
+    const controller = new AbortController();
+    const seenSignals: AbortSignal[] = [];
+    const allowed = await authorizePrivateSyncRequest({
+      ctx: {} as any,
+      request: envelope,
+      remotePeerId,
+      localPeerId: LOCAL_PEER,
+      syncAuthMaxAgeMs: 90_000,
+      seenRequestIds: new Map(),
+      computeSyncDigest: computeDigestStub,
+      verifyIdentity: async (_address, _identityId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return true;
+      },
+      getParticipants: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return [agentAddress];
+      },
+      getAllowedPeers: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return null;
+      },
+      getAgentGateAddresses: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return [agentAddress];
+      },
+      getAllowedDelegateePeers: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return new Map<string, string[]>();
+      },
+      getAllowedDelegateeKeys: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return new Map([[agentAddress.toLowerCase(), [nodeOpKey.address.toLowerCase()]]]);
+      },
+      refreshMetaFromCurator: async () => false,
+      signal: controller.signal,
+      logWarn: () => {},
+      logInfo: () => {},
+    });
+
+    expect(allowed).toBe(true);
+    expect(seenSignals).toHaveLength(6);
+    expect(seenSignals.every((signal) => signal === controller.signal)).toBe(true);
+  });
+
+  it('waits for non-abortable auth helpers to settle before rejecting aborts', async () => {
+    const agentWallet = ethers.Wallet.createRandom();
+    const { envelope, remotePeerId } = await buildSignedEnvelope({
+      signer: agentWallet,
+      requesterAgentAddress: agentWallet.address,
+    });
+    const controller = new AbortController();
+    const participantsGate = (() => {
+      let resolve!: (value: string[] | null) => void;
+      const promise = new Promise<string[] | null>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    })();
+    const seen = new Map<string, number>();
+    let participantsStarted = false;
+    let settled = false;
+    const auth = authorizePrivateSyncRequest({
+      ctx: {} as any,
+      request: envelope,
+      remotePeerId,
+      localPeerId: LOCAL_PEER,
+      syncAuthMaxAgeMs: 90_000,
+      seenRequestIds: seen,
+      computeSyncDigest: computeDigestStub,
+      getParticipants: async () => {
+        participantsStarted = true;
+        return participantsGate.promise;
+      },
+      getAllowedPeers: async () => null,
+      getAgentGateAddresses: async () => null,
+      getAllowedDelegateePeers: async () => new Map<string, string[]>(),
+      getAllowedDelegateeKeys: async () => new Map<string, string[]>(),
+      refreshMetaFromCurator: async () => false,
+      signal: controller.signal,
+      logWarn: () => {},
+      logInfo: () => {},
+    });
+    auth.then(
+      () => { settled = true; },
+      () => { settled = true; },
+    );
+
+    while (!participantsStarted) await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('auth aborted'));
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(settled).toBe(false);
+    participantsGate.resolve(null);
+    await expect(auth).rejects.toThrow(/auth aborted/);
+    expect(seen.size).toBe(0);
   });
 
   it('rejects when verifyIdentity fails even if delegatee key would match', async () => {

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
+import { SYNC_BUSY_RESPONSE } from '../src/dkg-agent-constants.js';
 
 /**
  * Regression tests for the rc.9 PR-E codex review chain on #569.
@@ -925,5 +926,46 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     // failure should not bypass to a send).
     expect(buildCalls).toBe(3);
     expect(sendCalls).toBe(1);
+  });
+
+  it('retries explicit responder busy sentinels before parsing a page', async () => {
+    const warnings: string[] = [];
+    let sendCalls = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 3,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => new TextEncoder().encode('request'),
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          return new TextEncoder().encode(sendCalls === 1 ? SYNC_BUSY_RESPONSE : 'one-quad-line');
+        },
+        logWarn: (_ctx, message) => { warnings.push(message); },
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(sendCalls).toBe(2);
+    expect(warnings.some((message) => message.includes('responder busy'))).toBe(true);
   });
 });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1120,4 +1120,52 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(sendCalls).toBe(1);
     expect(retryWarnings).toBe(0);
   });
+
+  it('rejects pre-aborted DOMException signals without mutating the reason', async () => {
+    const controller = new AbortController();
+    let buildCalls = 0;
+    let sendCalls = 0;
+
+    controller.abort();
+
+    await expect(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 1,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        signal: controller.signal,
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => {
+          buildCalls++;
+          return new TextEncoder().encode('request');
+        },
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          return new TextEncoder().encode('');
+        },
+        logWarn: noopLog,
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(buildCalls).toBe(0);
+    expect(sendCalls).toBe(0);
+  });
 });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1011,6 +1011,55 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(warnings.some((message) => message.includes('Legacy sync responder busy'))).toBe(true);
   });
 
+  it('retries transport AbortErrors while the caller signal is still live', async () => {
+    const warnings: string[] = [];
+    const controller = new AbortController();
+    let sendCalls = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 3,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        signal: controller.signal,
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => new TextEncoder().encode('request'),
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          if (sendCalls === 1) {
+            const err = new Error('remote stream aborted');
+            err.name = 'AbortError';
+            throw err;
+          }
+          return new TextEncoder().encode('one-quad-line');
+        },
+        logWarn: (_ctx, message) => { warnings.push(message); },
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(sendCalls).toBe(2);
+    expect(warnings.some((message) => message.includes('remote stream aborted'))).toBe(true);
+  });
+
   it('passes caller abort signal to sync transport and does not retry aborts', async () => {
     const controller = new AbortController();
     let releaseSendStarted: () => void = () => {};

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -1010,4 +1010,65 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(sendCalls).toBe(2);
     expect(warnings.some((message) => message.includes('Legacy sync responder busy'))).toBe(true);
   });
+
+  it('passes caller abort signal to sync transport and does not retry aborts', async () => {
+    const controller = new AbortController();
+    let releaseSendStarted: () => void = () => {};
+    const sendStarted = new Promise<void>((resolve) => {
+      releaseSendStarted = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    let sendCalls = 0;
+    let retryWarnings = 0;
+
+    const fetchPromise = fetchSyncPages({
+      ctx: makeCtx(),
+      remotePeerId: REMOTE_PEER_ID,
+      contextGraphId: CG_ID,
+      includeSharedMemory: false,
+      phase: 'meta',
+      graphUri: GRAPH_URI,
+      deadline: Date.now() + 60_000,
+      syncPageTimeoutMs: 10_000,
+      syncRouterAttempts: 1,
+      syncPageRetryAttempts: 3,
+      syncPageSize: 100,
+      syncDeniedResponse: '#DENIED',
+      signal: controller.signal,
+      debugSyncProgress: false,
+      protocolSync: PROTOCOL_ID,
+      checkpointStore: {
+        get: () => 0,
+        set: () => {},
+        delete: () => {},
+      },
+      buildSyncRequest: async () => new TextEncoder().encode('request'),
+      parseAndFilter: singleQuadParser,
+      send: async (_peerId, _protocolId, _data, _timeoutMs, _messageId, signal) => {
+        sendCalls++;
+        observedSignal = signal;
+        releaseSendStarted();
+        return new Promise<Uint8Array>((_resolve, reject) => {
+          if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      },
+      logWarn: () => { retryWarnings++; },
+      logInfo: noopLog,
+      logDebug: noopLog,
+    });
+
+    await sendStarted;
+    const abortReason = new Error('request closed');
+    abortReason.name = 'AbortError';
+    controller.abort(abortReason);
+
+    await expect(fetchPromise).rejects.toThrow('request closed');
+    expect(observedSignal).toBe(controller.signal);
+    expect(sendCalls).toBe(1);
+    expect(retryWarnings).toBe(0);
+  });
 });

--- a/packages/agent/test/sync-fresh-per-attempt.test.ts
+++ b/packages/agent/test/sync-fresh-per-attempt.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fetchSyncPages } from '../src/sync/requester/page-fetch.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from '../src/sync/durable-session.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
-import { SYNC_BUSY_RESPONSE } from '../src/dkg-agent-constants.js';
 
 /**
  * Regression tests for the rc.9 PR-E codex review chain on #569.
@@ -29,6 +28,7 @@ const REMOTE_PEER_ID = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 const CG_ID = 'urn:test:cg';
 const GRAPH_URI = `urn:test:cg/graph`;
 const PROTOCOL_ID = '/dkg/10.0.2/sync';
+const LEGACY_SYNC_BUSY_RESPONSE = '__DKG_SYNC_BUSY__';
 
 function noopLog(): void {}
 function makeCtx(): OperationContext {
@@ -928,7 +928,7 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     expect(sendCalls).toBe(1);
   });
 
-  it('retries explicit responder busy sentinels before parsing a page', async () => {
+  it('retries responder overload transport failures before parsing a page', async () => {
     const warnings: string[] = [];
     let sendCalls = 0;
 
@@ -957,7 +957,8 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
         parseAndFilter: singleQuadParser,
         send: async () => {
           sendCalls++;
-          return new TextEncoder().encode(sendCalls === 1 ? SYNC_BUSY_RESPONSE : 'one-quad-line');
+          if (sendCalls === 1) throw new Error('sync responder queue full');
+          return new TextEncoder().encode('one-quad-line');
         },
         logWarn: (_ctx, message) => { warnings.push(message); },
         logInfo: noopLog,
@@ -966,6 +967,47 @@ describe('fetchSyncPages: fresh envelope + fresh messageId per retry attempt', (
     );
 
     expect(sendCalls).toBe(2);
-    expect(warnings.some((message) => message.includes('responder busy'))).toBe(true);
+    expect(warnings.some((message) => message.includes('sync responder queue full'))).toBe(true);
+  });
+
+  it('retries legacy responder busy bodies before parsing a page', async () => {
+    const warnings: string[] = [];
+    let sendCalls = 0;
+
+    await runFetchWithFakeTimers(
+      fetchSyncPages({
+        ctx: makeCtx(),
+        remotePeerId: REMOTE_PEER_ID,
+        contextGraphId: CG_ID,
+        includeSharedMemory: false,
+        phase: 'data',
+        graphUri: GRAPH_URI,
+        deadline: Date.now() + 60_000,
+        syncPageTimeoutMs: 5_000,
+        syncRouterAttempts: 1,
+        syncPageRetryAttempts: 3,
+        syncPageSize: 100,
+        syncDeniedResponse: '#DENIED',
+        debugSyncProgress: false,
+        protocolSync: PROTOCOL_ID,
+        checkpointStore: {
+          get: () => 0,
+          set: () => {},
+          delete: () => {},
+        },
+        buildSyncRequest: async () => new TextEncoder().encode('request'),
+        parseAndFilter: singleQuadParser,
+        send: async () => {
+          sendCalls++;
+          return new TextEncoder().encode(sendCalls === 1 ? LEGACY_SYNC_BUSY_RESPONSE : 'one-quad-line');
+        },
+        logWarn: (_ctx, message) => { warnings.push(message); },
+        logInfo: noopLog,
+        logDebug: noopLog,
+      }),
+    );
+
+    expect(sendCalls).toBe(2);
+    expect(warnings.some((message) => message.includes('Legacy sync responder busy'))).toBe(true);
   });
 });

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -112,23 +112,16 @@ describe('sync responder pagination interleaving', () => {
     await store.insert(rows);
 
     const cap = registerTestSyncHandler(store, { syncPageSize: 3 });
-    const requestPage = (offset: number) =>
+    const requestPage = (offset: number, index: number) =>
       cap.invoke({
         contextGraphId: cgId,
         includeSharedMemory: false,
         phase: 'data',
         offset,
         limit: 3,
-      });
+      }, `12D3KooWInterleavePeer${index}`);
 
-    const outputs = await Promise.all([
-      requestPage(0),
-      requestPage(6),
-      requestPage(3),
-      requestPage(12),
-      requestPage(9),
-      requestPage(15),
-    ]);
+    const outputs = await Promise.all([0, 6, 3, 12, 9, 15].map(requestPage));
 
     const lines = outputs.flatMap(linesFromNquads);
     expect(lines).toHaveLength(rows.length);

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -239,10 +239,12 @@ describe('sync responder protection', () => {
 
   it('races graph-list memo waits against stream abort and releases capacity', async () => {
     const listGate = deferred<readonly string[]>();
+    let listSignal: AbortSignal | undefined;
     let listCalls = 0;
     let authStarted = 0;
     const cap = captureHandler(baseStore({
-      listGraphs: async () => {
+      listGraphs: async (options?: QueryOptions) => {
+        listSignal = options?.signal;
         listCalls += 1;
         return listGate.promise;
       },
@@ -257,6 +259,7 @@ describe('sync responder protection', () => {
 
     const first = cap.invoke(envelope, REMOTE_A, controller.signal);
     while (listCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(listSignal).toBe(controller.signal);
     controller.abort(new Error('memo wait aborted'));
 
     await expect(first).rejects.toThrow(/memo wait aborted/);
@@ -264,6 +267,41 @@ describe('sync responder protection', () => {
     const later = cap.invoke(envelope, REMOTE_A);
     while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
     listGate.resolve([]);
+
+    await later;
+    expect(authStarted).toBe(2);
+  });
+
+  it('passes the stream abort signal to subgraph-name memo queries and releases capacity', async () => {
+    const queryGate = deferred<QueryResult>();
+    let querySignal: AbortSignal | undefined;
+    let queryCalls = 0;
+    let authStarted = 0;
+    const cap = captureHandler(baseStore({
+      query: async (_sparql: string, options?: QueryOptions) => {
+        querySignal = options?.signal;
+        queryCalls += 1;
+        return queryGate.promise;
+      },
+    }), {
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        return true;
+      },
+    });
+    const controller = new AbortController();
+    const envelope = { ...makeEnvelope(), phase: 'meta' as const };
+
+    const first = cap.invoke(envelope, REMOTE_A, controller.signal);
+    while (queryCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(querySignal).toBe(controller.signal);
+    controller.abort(new Error('subgraph memo aborted'));
+
+    await expect(first).rejects.toThrow(/subgraph memo aborted/);
+
+    const later = cap.invoke(makeEnvelope(), REMOTE_A);
+    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    queryGate.resolve({ type: 'bindings', bindings: [] });
 
     await later;
     expect(authStarted).toBe(2);

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -75,7 +75,11 @@ function abortDuringListenerRegistration(message: string): AbortSignal {
 function captureHandler(
   store: TripleStore,
   options: {
-    authorizeSyncRequest?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+    authorizeSyncRequest?: (
+      request: SyncRequestEnvelope,
+      remotePeerId: string,
+      options?: { signal?: AbortSignal },
+    ) => Promise<boolean>;
     logWarn?: (ctx: OperationContext, message: string) => void;
   } = {},
 ) {
@@ -197,6 +201,37 @@ describe('sync responder protection', () => {
 
     authGates.shift()?.resolve(false);
     await second;
+  });
+
+  it('passes the stream abort signal to authorization and releases capacity on abort', async () => {
+    let authStarted = 0;
+    let firstAuthSignal: AbortSignal | undefined;
+    const cap = captureHandler(baseStore(), {
+      authorizeSyncRequest: async (_request, _peerId, options) => {
+        authStarted += 1;
+        if (authStarted === 1) {
+          if (!options?.signal) throw new Error('missing auth signal');
+          firstAuthSignal = options.signal;
+          await new Promise<never>((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () => reject(new Error('auth aborted by test')), { once: true });
+          });
+        }
+        return false;
+      },
+    });
+    const controller = new AbortController();
+    const envelope = makeEnvelope();
+
+    const first = cap.invoke(envelope, REMOTE_A, controller.signal);
+    while (authStarted < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('stream closed'));
+
+    await expect(first).rejects.toThrow(/auth aborted by test/);
+    expect(firstAuthSignal?.aborted).toBe(true);
+
+    const later = await cap.invoke(envelope, REMOTE_A);
+    expect(new TextDecoder().decode(later)).toBe('sync-denied');
+    expect(authStarted).toBe(2);
   });
 
   it('removes queued requests that abort while registering the abort listener', async () => {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -48,6 +48,29 @@ function makeEnvelope(): SyncRequestEnvelope {
   };
 }
 
+function abortDuringListenerRegistration(message: string): AbortSignal {
+  let aborted = false;
+  let reason: Error | undefined;
+  return {
+    get aborted() {
+      return aborted;
+    },
+    get reason() {
+      return reason;
+    },
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      if (type !== 'abort') return;
+      aborted = true;
+      reason = new Error(message);
+      if (typeof listener === 'function') listener(new Event('abort'));
+      else listener.handleEvent(new Event('abort'));
+    },
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    onabort: null,
+  } as unknown as AbortSignal;
+}
+
 function captureHandler(
   store: TripleStore,
   options: { logWarn?: (ctx: OperationContext, message: string) => void } = {},
@@ -126,6 +149,33 @@ describe('sync responder protection', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     await Promise.all(requests);
+  });
+
+  it('removes queued requests that abort while registering the abort listener', async () => {
+    const releases: Array<() => void> = [];
+    const store = {
+      query: async () => {
+        const gate = deferred<void>();
+        releases.push(() => gate.resolve());
+        await gate.promise;
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+    const envelope = makeEnvelope();
+
+    const first = cap.invoke(envelope, REMOTE_A);
+    const raced = cap.invoke(envelope, REMOTE_A, abortDuringListenerRegistration('listener registration aborted'));
+
+    await expect(raced).rejects.toThrow(/listener registration aborted/);
+
+    const later = cap.invoke(envelope, REMOTE_A);
+    while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    releases.shift()?.();
+    await first;
+    while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    releases.shift()?.();
+    await later;
   });
 
   it('rejects requests beyond the per-peer responder queue as transport failures', async () => {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -234,6 +234,38 @@ describe('sync responder protection', () => {
     expect(authStarted).toBe(2);
   });
 
+  it('races graph-list memo waits against stream abort and releases capacity', async () => {
+    const listGate = deferred<readonly string[]>();
+    let listCalls = 0;
+    let authStarted = 0;
+    const cap = captureHandler(baseStore({
+      listGraphs: async () => {
+        listCalls += 1;
+        return listGate.promise;
+      },
+    }), {
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        return true;
+      },
+    });
+    const controller = new AbortController();
+    const envelope = makeEnvelope();
+
+    const first = cap.invoke(envelope, REMOTE_A, controller.signal);
+    while (listCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('memo wait aborted'));
+
+    await expect(first).rejects.toThrow(/memo wait aborted/);
+
+    const later = cap.invoke(envelope, REMOTE_A);
+    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    listGate.resolve([]);
+
+    await later;
+    expect(authStarted).toBe(2);
+  });
+
   it('removes queued requests that abort while registering the abort listener', async () => {
     const releases: Array<() => void> = [];
     const store = baseStore({

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
-import type { QueryOptions, QueryResult, TripleStore } from '@origintrail-official/dkg-storage';
+import type { QueryOptions, QueryResult, Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import type { WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 
 const REMOTE_A = '12D3KooWResponderCapPeerA';
@@ -81,6 +82,7 @@ function captureHandler(
       options?: { signal?: AbortSignal },
     ) => Promise<boolean>;
     logWarn?: (ctx: OperationContext, message: string) => void;
+    publicSnapshotStore?: WorkspacePublicSnapshotStore;
   } = {},
 ) {
   let captured: ((
@@ -96,6 +98,7 @@ function captureHandler(
     syncPageSize: 500,
     sharedMemoryTtlMs: 0,
     store,
+    publicSnapshotStore: options.publicSnapshotStore,
     peerId: 'self-peer',
     parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
     authorizeSyncRequest: options.authorizeSyncRequest ?? (async () => true),
@@ -264,6 +267,89 @@ describe('sync responder protection', () => {
 
     await later;
     expect(authStarted).toBe(2);
+  });
+
+  it('races row-list memo waits against stream abort and releases capacity', async () => {
+    const rowGate = deferred<QueryResult>();
+    let queryCalls = 0;
+    let authStarted = 0;
+    const cap = captureHandler(baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
+      query: async () => {
+        queryCalls += 1;
+        return rowGate.promise;
+      },
+    }), {
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        return true;
+      },
+    });
+    const envelope = { ...makeEnvelope(), syncSessionId: 'row-list-session' };
+    const firstController = new AbortController();
+
+    const first = cap.invoke(envelope, REMOTE_A, firstController.signal);
+    while (queryCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    firstController.abort(new Error('row snapshot aborted'));
+
+    await expect(first).rejects.toThrow(/row snapshot aborted/);
+
+    const secondController = new AbortController();
+    const second = cap.invoke(envelope, REMOTE_A, secondController.signal);
+    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(queryCalls).toBe(1);
+    secondController.abort(new Error('row memo wait aborted'));
+
+    await expect(second).rejects.toThrow(/row memo wait aborted/);
+
+    const later = cap.invoke(envelope, REMOTE_A);
+    while (authStarted < 3) await new Promise((resolve) => setTimeout(resolve, 0));
+    rowGate.resolve({ type: 'bindings', bindings: [] });
+
+    await later;
+    expect(queryCalls).toBe(1);
+    expect(authStarted).toBe(3);
+  });
+
+  it('races public snapshot loads against stream abort and releases capacity', async () => {
+    const snapshotGate = deferred<Quad[] | null>();
+    let snapshotCalls = 0;
+    let authStarted = 0;
+    const publicSnapshotStore: WorkspacePublicSnapshotStore = {
+      putSnapshot: async () => ({ ref: 'unused', byteLength: 0 }),
+      getSnapshot: async () => {
+        snapshotCalls += 1;
+        return snapshotGate.promise;
+      },
+    };
+    const cap = captureHandler(baseStore(), {
+      publicSnapshotStore,
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        return true;
+      },
+    });
+    const controller = new AbortController();
+    const snapshotEnvelope: SyncRequestEnvelope = {
+      contextGraphId: 'sync-protection',
+      includeSharedMemory: true,
+      phase: 'snapshot',
+      snapshotRef: 'snapshot-ref',
+      offset: 0,
+      limit: 1,
+    };
+
+    const first = cap.invoke(snapshotEnvelope, REMOTE_A, controller.signal);
+    while (snapshotCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('snapshot load aborted'));
+
+    await expect(first).rejects.toThrow(/snapshot load aborted/);
+
+    const later = await cap.invoke(makeEnvelope(), REMOTE_A);
+    expect(new TextDecoder().decode(later)).toBe('');
+    expect(authStarted).toBe(2);
+    snapshotGate.resolve([]);
   });
 
   it('removes queued requests that abort while registering the abort listener', async () => {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -237,7 +237,38 @@ describe('sync responder protection', () => {
     expect(authStarted).toBe(2);
   });
 
-  it('races graph-list memo waits against stream abort and releases capacity', async () => {
+  it('keeps non-abortable authorization work counted until it settles', async () => {
+    const authGate = deferred<boolean>();
+    let authStarted = 0;
+    const cap = captureHandler(baseStore(), {
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        if (authStarted === 1) {
+          return authGate.promise;
+        }
+        return false;
+      },
+    });
+    const controller = new AbortController();
+    const envelope = makeEnvelope();
+
+    const first = cap.invoke(envelope, REMOTE_A, controller.signal);
+    while (authStarted < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('stream closed'));
+
+    const later = cap.invoke(envelope, REMOTE_A);
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(authStarted).toBe(1);
+
+    authGate.resolve(false);
+    await expect(first).rejects.toThrow(/stream closed/);
+
+    const denied = await later;
+    expect(new TextDecoder().decode(denied)).toBe('sync-denied');
+    expect(authStarted).toBe(2);
+  });
+
+  it('keeps graph-list cache-miss owners counted until the shared load settles', async () => {
     const listGate = deferred<readonly string[]>();
     let listSignal: AbortSignal | undefined;
     let listCalls = 0;
@@ -262,17 +293,18 @@ describe('sync responder protection', () => {
     expect(listSignal).toBeUndefined();
     controller.abort(new Error('memo wait aborted'));
 
-    await expect(first).rejects.toThrow(/memo wait aborted/);
-
     const later = cap.invoke(envelope, REMOTE_A);
-    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(authStarted).toBe(1);
+
     listGate.resolve([]);
 
+    await expect(first).rejects.toThrow(/memo wait aborted/);
     await later;
     expect(authStarted).toBe(2);
   });
 
-  it('keeps subgraph-name memo loads independent while aborted waiters release capacity', async () => {
+  it('keeps subgraph-name cache-miss owners counted until the shared load settles', async () => {
     const queryGate = deferred<QueryResult>();
     let querySignal: AbortSignal | undefined;
     let queryCalls = 0;
@@ -297,17 +329,18 @@ describe('sync responder protection', () => {
     expect(querySignal).toBeUndefined();
     controller.abort(new Error('subgraph memo aborted'));
 
-    await expect(first).rejects.toThrow(/subgraph memo aborted/);
-
     const later = cap.invoke(makeEnvelope(), REMOTE_A);
-    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(authStarted).toBe(1);
+
     queryGate.resolve({ type: 'bindings', bindings: [] });
 
+    await expect(first).rejects.toThrow(/subgraph memo aborted/);
     await later;
     expect(authStarted).toBe(2);
   });
 
-  it('races row-list memo waits against stream abort and releases capacity', async () => {
+  it('keeps row-list cache-miss owners counted until the shared snapshot settles', async () => {
     const rowGate = deferred<QueryResult>();
     let querySignal: AbortSignal | undefined;
     let queryCalls = 0;
@@ -333,24 +366,27 @@ describe('sync responder protection', () => {
     expect(querySignal).toBeUndefined();
     firstController.abort(new Error('row snapshot aborted'));
 
-    await expect(first).rejects.toThrow(/row snapshot aborted/);
-
-    const secondController = new AbortController();
-    const second = cap.invoke(envelope, REMOTE_A, secondController.signal);
-    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
-    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(queryCalls).toBe(1);
-    secondController.abort(new Error('row memo wait aborted'));
-
-    await expect(second).rejects.toThrow(/row memo wait aborted/);
-
     const later = cap.invoke(envelope, REMOTE_A);
-    while (authStarted < 3) await new Promise((resolve) => setTimeout(resolve, 0));
-    rowGate.resolve({ type: 'bindings', bindings: [] });
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(authStarted).toBe(1);
+    expect(queryCalls).toBe(1);
+
+    rowGate.resolve({
+      type: 'bindings',
+      bindings: [{
+        g: SYNC_PROTECTION_DATA_GRAPH,
+        s: '<urn:test:s>',
+        p: 'http://schema.org/name',
+        o: '"name"',
+      }],
+    });
+
+    await expect(first).rejects.toThrow(/row snapshot aborted/);
+    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
 
     await later;
     expect(queryCalls).toBe(1);
-    expect(authStarted).toBe(3);
+    expect(authStarted).toBe(2);
   });
 
   it('races public snapshot loads against stream abort and releases capacity', async () => {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -8,6 +8,7 @@ const REMOTE_A = '12D3KooWResponderCapPeerA';
 const REMOTE_B = '12D3KooWResponderCapPeerB';
 const REMOTE_C = '12D3KooWResponderCapPeerC';
 const REMOTE_D = '12D3KooWResponderCapPeerD';
+const SYNC_PROTECTION_DATA_GRAPH = 'did:dkg:context-graph:sync-protection';
 
 const noopLog = (_ctx: OperationContext, _message: string) => {};
 
@@ -112,7 +113,8 @@ describe('sync responder protection', () => {
     let completed = 0;
     let inFlight = 0;
     let maxInFlight = 0;
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async () => {
         inFlight += 1;
         maxInFlight = Math.max(maxInFlight, inFlight);
@@ -124,7 +126,7 @@ describe('sync responder protection', () => {
         await gate.promise;
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
     const envelope = makeEnvelope();
 
@@ -199,14 +201,15 @@ describe('sync responder protection', () => {
 
   it('removes queued requests that abort while registering the abort listener', async () => {
     const releases: Array<() => void> = [];
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async () => {
         const gate = deferred<void>();
         releases.push(() => gate.resolve());
         await gate.promise;
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
     const envelope = makeEnvelope();
 
@@ -226,14 +229,15 @@ describe('sync responder protection', () => {
 
   it('rejects requests beyond the per-peer responder queue as transport failures', async () => {
     const releases: Array<() => void> = [];
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async () => {
         const gate = deferred<void>();
         releases.push(() => gate.resolve());
         await gate.promise;
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
     const envelope = makeEnvelope();
 
@@ -255,14 +259,15 @@ describe('sync responder protection', () => {
 
   it('keeps a noisy peer from consuming every shared queue slot', async () => {
     const releases: Array<() => void> = [];
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async () => {
         const gate = deferred<void>();
         releases.push(() => gate.resolve());
         await gate.promise;
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
     const envelope = makeEnvelope();
 
@@ -289,14 +294,15 @@ describe('sync responder protection', () => {
 
   it('removes aborted queued requests and lets later work proceed', async () => {
     const releases: Array<() => void> = [];
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async () => {
         const gate = deferred<void>();
         releases.push(() => gate.resolve());
         await gate.promise;
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
     const envelope = makeEnvelope();
     const queuedController = new AbortController();
@@ -319,7 +325,8 @@ describe('sync responder protection', () => {
   it('passes the stream abort signal to store queries and releases capacity on abort', async () => {
     const controller = new AbortController();
     let querySignal: AbortSignal | undefined;
-    const store = {
+    const store = baseStore({
+      listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
       query: async (_sparql: string, options?: QueryOptions) => {
         querySignal = options?.signal;
         await new Promise((_resolve, reject) => {
@@ -327,7 +334,7 @@ describe('sync responder protection', () => {
         });
         return { type: 'bindings', bindings: [] } satisfies QueryResult;
       },
-    } as unknown as TripleStore;
+    });
     const cap = captureHandler(store);
 
     const request = cap.invoke(makeEnvelope(), REMOTE_A, controller.signal);

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -259,7 +259,7 @@ describe('sync responder protection', () => {
 
     const first = cap.invoke(envelope, REMOTE_A, controller.signal);
     while (listCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(listSignal).toBe(controller.signal);
+    expect(listSignal).toBeUndefined();
     controller.abort(new Error('memo wait aborted'));
 
     await expect(first).rejects.toThrow(/memo wait aborted/);
@@ -272,7 +272,7 @@ describe('sync responder protection', () => {
     expect(authStarted).toBe(2);
   });
 
-  it('passes the stream abort signal to subgraph-name memo queries and releases capacity', async () => {
+  it('keeps subgraph-name memo loads independent while aborted waiters release capacity', async () => {
     const queryGate = deferred<QueryResult>();
     let querySignal: AbortSignal | undefined;
     let queryCalls = 0;
@@ -294,7 +294,7 @@ describe('sync responder protection', () => {
 
     const first = cap.invoke(envelope, REMOTE_A, controller.signal);
     while (queryCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(querySignal).toBe(controller.signal);
+    expect(querySignal).toBeUndefined();
     controller.abort(new Error('subgraph memo aborted'));
 
     await expect(first).rejects.toThrow(/subgraph memo aborted/);
@@ -309,11 +309,13 @@ describe('sync responder protection', () => {
 
   it('races row-list memo waits against stream abort and releases capacity', async () => {
     const rowGate = deferred<QueryResult>();
+    let querySignal: AbortSignal | undefined;
     let queryCalls = 0;
     let authStarted = 0;
     const cap = captureHandler(baseStore({
       listGraphs: async () => [SYNC_PROTECTION_DATA_GRAPH],
-      query: async () => {
+      query: async (_sparql: string, options?: QueryOptions) => {
+        querySignal = options?.signal;
         queryCalls += 1;
         return rowGate.promise;
       },
@@ -328,6 +330,7 @@ describe('sync responder protection', () => {
 
     const first = cap.invoke(envelope, REMOTE_A, firstController.signal);
     while (queryCalls < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(querySignal).toBeUndefined();
     firstController.abort(new Error('row snapshot aborted'));
 
     await expect(first).rejects.toThrow(/row snapshot aborted/);

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+import type { QueryOptions, QueryResult, TripleStore } from '@origintrail-official/dkg-storage';
+import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
+
+const REMOTE_A = '12D3KooWResponderCapPeerA';
+const REMOTE_B = '12D3KooWResponderCapPeerB';
+const REMOTE_C = '12D3KooWResponderCapPeerC';
+const REMOTE_D = '12D3KooWResponderCapPeerD';
+
+const noopLog = (_ctx: OperationContext, _message: string) => {};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeEnvelope(): SyncRequestEnvelope {
+  return {
+    contextGraphId: 'sync-protection',
+    includeSharedMemory: false,
+    phase: 'data',
+    offset: 0,
+    limit: 1,
+  };
+}
+
+function captureHandler(store: TripleStore) {
+  let captured: ((
+    data: Uint8Array,
+    peerId: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<Uint8Array>) | null = null;
+
+  registerSyncHandler({
+    register: (_proto, handler) => { captured = handler; },
+    protocolSync: '/origintrail/dkg/sync/1.0.0',
+    syncDeniedResponse: 'sync-denied',
+    syncPageSize: 500,
+    sharedMemoryTtlMs: 0,
+    store,
+    peerId: 'self-peer',
+    parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+    authorizeSyncRequest: async () => true,
+    logWarn: noopLog,
+    logDebug: noopLog,
+  });
+
+  return {
+    invoke(envelope: SyncRequestEnvelope, peerId = REMOTE_A, signal?: AbortSignal): Promise<Uint8Array> {
+      if (!captured) throw new Error('handler not registered');
+      return captured(new TextEncoder().encode(JSON.stringify(envelope)), peerId, { signal });
+    },
+  };
+}
+
+describe('sync responder protection', () => {
+  it('caps durable page computation at three globally and one per peer', async () => {
+    const releases: Array<() => void> = [];
+    let completed = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const store = {
+      query: async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        const gate = deferred<void>();
+        releases.push(() => {
+          inFlight -= 1;
+          gate.resolve();
+        });
+        await gate.promise;
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+    const envelope = makeEnvelope();
+
+    const requests = [
+      cap.invoke(envelope, REMOTE_A),
+      cap.invoke(envelope, REMOTE_A),
+      cap.invoke(envelope, REMOTE_B),
+      cap.invoke(envelope, REMOTE_C),
+      cap.invoke(envelope, REMOTE_D),
+    ].map((request) => request.finally(() => { completed += 1; }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(inFlight).toBe(3);
+    expect(maxInFlight).toBe(3);
+
+    releases.shift()?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(inFlight).toBe(3);
+    expect(maxInFlight).toBe(3);
+
+    while (completed < requests.length) {
+      const release = releases.shift();
+      if (release) release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    await Promise.all(requests);
+  });
+
+  it('rejects requests beyond the bounded responder queue instead of returning an empty page', async () => {
+    const releases: Array<() => void> = [];
+    const store = {
+      query: async () => {
+        const gate = deferred<void>();
+        releases.push(() => gate.resolve());
+        await gate.promise;
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+    const envelope = makeEnvelope();
+
+    let completed = 0;
+    const requests: Array<Promise<Uint8Array>> = [];
+    for (let i = 0; i < 33; i++) {
+      requests.push(cap.invoke(envelope, REMOTE_A).finally(() => { completed += 1; }));
+    }
+    await expect(cap.invoke(envelope, REMOTE_A)).rejects.toThrow(/queue full/);
+
+    while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    while (completed < requests.length) {
+      const release = releases.shift();
+      if (release) release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    await Promise.all(requests);
+  });
+
+  it('removes aborted queued requests and lets later work proceed', async () => {
+    const releases: Array<() => void> = [];
+    const store = {
+      query: async () => {
+        const gate = deferred<void>();
+        releases.push(() => gate.resolve());
+        await gate.promise;
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+    const envelope = makeEnvelope();
+    const queuedController = new AbortController();
+
+    const first = cap.invoke(envelope, REMOTE_A);
+    const queued = cap.invoke(envelope, REMOTE_A, queuedController.signal);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    queuedController.abort(new Error('queued aborted'));
+    await expect(queued).rejects.toThrow(/queued aborted/);
+
+    const later = cap.invoke(envelope, REMOTE_A);
+    while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    releases.shift()?.();
+    await first;
+    while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    releases.shift()?.();
+    await later;
+  });
+
+  it('passes the stream abort signal to store queries and releases capacity on abort', async () => {
+    const controller = new AbortController();
+    let querySignal: AbortSignal | undefined;
+    const store = {
+      query: async (_sparql: string, options?: QueryOptions) => {
+        querySignal = options?.signal;
+        await new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(new Error('aborted by test')), { once: true });
+        });
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+
+    const request = cap.invoke(makeEnvelope(), REMOTE_A, controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error('stream closed'));
+
+    await expect(request).rejects.toThrow(/aborted by test/);
+    expect(querySignal?.aborted).toBe(true);
+  });
+});

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { QueryOptions, QueryResult, TripleStore } from '@origintrail-official/dkg-storage';
-import { SYNC_BUSY_RESPONSE } from '../src/dkg-agent-constants.js';
 import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 
 const REMOTE_A = '12D3KooWResponderCapPeerA';
@@ -129,7 +128,7 @@ describe('sync responder protection', () => {
     await Promise.all(requests);
   });
 
-  it('returns an explicit busy sentinel for requests beyond the per-peer responder queue', async () => {
+  it('rejects requests beyond the per-peer responder queue as transport failures', async () => {
     const releases: Array<() => void> = [];
     const store = {
       query: async () => {
@@ -147,7 +146,7 @@ describe('sync responder protection', () => {
     for (let i = 0; i < 5; i++) {
       requests.push(cap.invoke(envelope, REMOTE_A).finally(() => { completed += 1; }));
     }
-    await expect(cap.invoke(envelope, REMOTE_A).then((bytes) => new TextDecoder().decode(bytes))).resolves.toBe(SYNC_BUSY_RESPONSE);
+    await expect(cap.invoke(envelope, REMOTE_A)).rejects.toThrow(/sync responder peer queue full/);
 
     while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
     while (completed < requests.length) {
@@ -176,7 +175,7 @@ describe('sync responder protection', () => {
     for (let i = 0; i < 5; i++) {
       noisyRequests.push(cap.invoke(envelope, REMOTE_A).finally(() => { noisyCompleted += 1; }));
     }
-    await expect(cap.invoke(envelope, REMOTE_A).then((bytes) => new TextDecoder().decode(bytes))).resolves.toBe(SYNC_BUSY_RESPONSE);
+    await expect(cap.invoke(envelope, REMOTE_A)).rejects.toThrow(/sync responder peer queue full/);
 
     const otherPeer = cap.invoke(envelope, REMOTE_B);
     while (releases.length < 2) await new Promise((resolve) => setTimeout(resolve, 0));

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { QueryOptions, QueryResult, TripleStore } from '@origintrail-official/dkg-storage';
+import { SYNC_BUSY_RESPONSE } from '../src/dkg-agent-constants.js';
 import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
 
 const REMOTE_A = '12D3KooWResponderCapPeerA';
@@ -108,7 +109,7 @@ describe('sync responder protection', () => {
     await Promise.all(requests);
   });
 
-  it('rejects requests beyond the bounded responder queue instead of returning an empty page', async () => {
+  it('returns an explicit busy sentinel for requests beyond the bounded responder queue', async () => {
     const releases: Array<() => void> = [];
     const store = {
       query: async () => {
@@ -126,7 +127,7 @@ describe('sync responder protection', () => {
     for (let i = 0; i < 33; i++) {
       requests.push(cap.invoke(envelope, REMOTE_A).finally(() => { completed += 1; }));
     }
-    await expect(cap.invoke(envelope, REMOTE_A)).rejects.toThrow(/queue full/);
+    await expect(cap.invoke(envelope, REMOTE_A).then((bytes) => new TextDecoder().decode(bytes))).resolves.toBe(SYNC_BUSY_RESPONSE);
 
     while (releases.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
     while (completed < requests.length) {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -73,7 +73,10 @@ function abortDuringListenerRegistration(message: string): AbortSignal {
 
 function captureHandler(
   store: TripleStore,
-  options: { logWarn?: (ctx: OperationContext, message: string) => void } = {},
+  options: {
+    authorizeSyncRequest?: (request: SyncRequestEnvelope, remotePeerId: string) => Promise<boolean>;
+    logWarn?: (ctx: OperationContext, message: string) => void;
+  } = {},
 ) {
   let captured: ((
     data: Uint8Array,
@@ -90,7 +93,7 @@ function captureHandler(
     store,
     peerId: 'self-peer',
     parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
-    authorizeSyncRequest: async () => true,
+    authorizeSyncRequest: options.authorizeSyncRequest ?? (async () => true),
     logWarn: options.logWarn ?? noopLog,
     logDebug: noopLog,
   });
@@ -149,6 +152,49 @@ describe('sync responder protection', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     await Promise.all(requests);
+  });
+
+  it('applies per-peer backpressure before authorization work starts', async () => {
+    const authGates: Array<ReturnType<typeof deferred<boolean>>> = [];
+    let authStarted = 0;
+    let inAuth = 0;
+    let maxInAuth = 0;
+    const cap = captureHandler(baseStore({
+      query: async () => {
+        throw new Error('denied requests should not query');
+      },
+    }), {
+      authorizeSyncRequest: async () => {
+        authStarted += 1;
+        inAuth += 1;
+        maxInAuth = Math.max(maxInAuth, inAuth);
+        const gate = deferred<boolean>();
+        authGates.push(gate);
+        try {
+          return await gate.promise;
+        } finally {
+          inAuth -= 1;
+        }
+      },
+    });
+    const envelope = makeEnvelope();
+
+    const first = cap.invoke(envelope, REMOTE_A);
+    const second = cap.invoke(envelope, REMOTE_A);
+    while (authStarted < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(authStarted).toBe(1);
+    expect(maxInAuth).toBe(1);
+
+    authGates.shift()?.resolve(false);
+    await first;
+    while (authStarted < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(maxInAuth).toBe(1);
+
+    authGates.shift()?.resolve(false);
+    await second;
   });
 
   it('removes queued requests that abort while registering the abort listener', async () => {

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -12,6 +12,23 @@ const REMOTE_D = '12D3KooWResponderCapPeerD';
 
 const noopLog = (_ctx: OperationContext, _message: string) => {};
 
+function baseStore(overrides: Partial<TripleStore> = {}): TripleStore {
+  return {
+    query: async () => ({ type: 'bindings', bindings: [] }) satisfies QueryResult,
+    insert: async () => {},
+    delete: async () => {},
+    deleteByPattern: async () => 0,
+    hasGraph: async () => false,
+    createGraph: async () => {},
+    dropGraph: async () => {},
+    listGraphs: async () => [],
+    deleteBySubjectPrefix: async () => 0,
+    countQuads: async () => 0,
+    close: async () => {},
+    ...overrides,
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -32,7 +49,10 @@ function makeEnvelope(): SyncRequestEnvelope {
   };
 }
 
-function captureHandler(store: TripleStore) {
+function captureHandler(
+  store: TripleStore,
+  options: { logWarn?: (ctx: OperationContext, message: string) => void } = {},
+) {
   let captured: ((
     data: Uint8Array,
     peerId: string,
@@ -49,7 +69,7 @@ function captureHandler(store: TripleStore) {
     peerId: 'self-peer',
     parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
     authorizeSyncRequest: async () => true,
-    logWarn: noopLog,
+    logWarn: options.logWarn ?? noopLog,
     logDebug: noopLog,
   });
 
@@ -109,7 +129,7 @@ describe('sync responder protection', () => {
     await Promise.all(requests);
   });
 
-  it('returns an explicit busy sentinel for requests beyond the bounded responder queue', async () => {
+  it('returns an explicit busy sentinel for requests beyond the per-peer responder queue', async () => {
     const releases: Array<() => void> = [];
     const store = {
       query: async () => {
@@ -124,7 +144,7 @@ describe('sync responder protection', () => {
 
     let completed = 0;
     const requests: Array<Promise<Uint8Array>> = [];
-    for (let i = 0; i < 33; i++) {
+    for (let i = 0; i < 5; i++) {
       requests.push(cap.invoke(envelope, REMOTE_A).finally(() => { completed += 1; }));
     }
     await expect(cap.invoke(envelope, REMOTE_A).then((bytes) => new TextDecoder().decode(bytes))).resolves.toBe(SYNC_BUSY_RESPONSE);
@@ -136,6 +156,40 @@ describe('sync responder protection', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     await Promise.all(requests);
+  });
+
+  it('keeps a noisy peer from consuming every shared queue slot', async () => {
+    const releases: Array<() => void> = [];
+    const store = {
+      query: async () => {
+        const gate = deferred<void>();
+        releases.push(() => gate.resolve());
+        await gate.promise;
+        return { type: 'bindings', bindings: [] } satisfies QueryResult;
+      },
+    } as unknown as TripleStore;
+    const cap = captureHandler(store);
+    const envelope = makeEnvelope();
+
+    let noisyCompleted = 0;
+    const noisyRequests: Array<Promise<Uint8Array>> = [];
+    for (let i = 0; i < 5; i++) {
+      noisyRequests.push(cap.invoke(envelope, REMOTE_A).finally(() => { noisyCompleted += 1; }));
+    }
+    await expect(cap.invoke(envelope, REMOTE_A).then((bytes) => new TextDecoder().decode(bytes))).resolves.toBe(SYNC_BUSY_RESPONSE);
+
+    const otherPeer = cap.invoke(envelope, REMOTE_B);
+    while (releases.length < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    releases.shift()?.();
+    releases.shift()?.();
+    await otherPeer;
+
+    while (noisyCompleted < noisyRequests.length) {
+      const release = releases.shift();
+      if (release) release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    await Promise.all(noisyRequests);
   });
 
   it('removes aborted queued requests and lets later work proceed', async () => {
@@ -187,5 +241,18 @@ describe('sync responder protection', () => {
 
     await expect(request).rejects.toThrow(/aborted by test/);
     expect(querySignal?.aborted).toBe(true);
+  });
+
+  it('warns once when the store cannot interrupt in-flight sync queries', async () => {
+    const warnings: string[] = [];
+    const cap = captureHandler(baseStore({ queryCancellation: 'pre-dispatch' }), {
+      logWarn: (_ctx, message) => warnings.push(message),
+    });
+
+    await cap.invoke(makeEnvelope(), REMOTE_A);
+    await cap.invoke(makeEnvelope(), REMOTE_B);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('pre-dispatch only');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export {
 } from './network/index.js';
 export {
   ProtocolRouter,
+  QuietRetryableHandlerError,
   type ProtocolRouterOptions,
   type SendOptions,
   DEFAULT_MAX_READ_BYTES,

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -1133,8 +1133,6 @@ function isAbortRelatedError(err: unknown, signal: AbortSignal | undefined): boo
   if (!signal?.aborted) return false;
   if (err === signal?.reason) return true;
   const error = err instanceof Error ? err : undefined;
-  const reason = signal.reason instanceof Error ? signal.reason : undefined;
-  if (error?.name === 'AbortError' && reason && error.message === reason.message) return true;
-  if (error?.name === 'AbortError' && typeof signal.reason === 'string' && error.message === signal.reason) return true;
+  if (error?.name === 'AbortError') return true;
   return false;
 }

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -989,6 +989,10 @@ export class MessageStreamPool {
         }
         try {
           response = await handler(frame.payload, remotePeer, { signal: requestController.signal });
+          if (requestController.signal.aborted) {
+            const reason = requestController.signal.reason;
+            throw reason instanceof Error ? reason : new Error(String(reason ?? 'pooled handler aborted'));
+          }
         } catch (err) {
           if (isAbortRelatedError(err, requestController.signal)) {
             cleanEof = false;

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -99,6 +99,7 @@ export const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
  * surface.
  */
 export interface PoolNode {
+  stopSignal?: AbortSignal;
   libp2p: {
     dialProtocol: (
       peerId: unknown,
@@ -965,15 +966,26 @@ export class MessageStreamPool {
         // requests on this same peer).
         let response: Uint8Array;
         const requestController = new AbortController();
-        const forwardStreamAbort = () => {
+        const abortRequest = (reason: unknown) => {
           if (!requestController.signal.aborted) {
-            requestController.abort(streamController.signal.reason);
+            requestController.abort(reason);
           }
+        };
+        const forwardStreamAbort = () => {
+          abortRequest(streamController.signal.reason);
+        };
+        const forwardNodeStop = () => {
+          abortRequest(this.node.stopSignal?.reason);
         };
         if (streamController.signal.aborted) {
           forwardStreamAbort();
         } else {
           streamController.signal.addEventListener('abort', forwardStreamAbort, { once: true });
+        }
+        if (this.node.stopSignal?.aborted) {
+          forwardNodeStop();
+        } else {
+          this.node.stopSignal?.addEventListener('abort', forwardNodeStop, { once: true });
         }
         try {
           response = await handler(frame.payload, remotePeer, { signal: requestController.signal });
@@ -998,6 +1010,7 @@ export class MessageStreamPool {
           continue;
         } finally {
           streamController.signal.removeEventListener('abort', forwardStreamAbort);
+          this.node.stopSignal?.removeEventListener('abort', forwardNodeStop);
         }
         try {
           stream.send(encodeFrame(FrameType.RESPONSE, response));
@@ -1117,9 +1130,11 @@ export class MessageStreamPool {
 }
 
 function isAbortRelatedError(err: unknown, signal: AbortSignal | undefined): boolean {
+  if (!signal?.aborted) return false;
   if (err === signal?.reason) return true;
   const error = err instanceof Error ? err : undefined;
-  if (error?.name === 'AbortError') return true;
-  const message = (error?.message ?? String(err)).toLowerCase();
-  return message.includes('aborted') || message.includes('aborterror');
+  const reason = signal.reason instanceof Error ? signal.reason : undefined;
+  if (error?.name === 'AbortError' && reason && error.message === reason.message) return true;
+  if (error?.name === 'AbortError' && typeof signal.reason === 'string' && error.message === signal.reason) return true;
+  return false;
 }

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -127,6 +127,7 @@ export interface PoolNode {
 export type PooledStreamHandler = (
   requestData: Uint8Array,
   peerId: unknown,
+  options?: { signal?: AbortSignal },
 ) => Promise<Uint8Array>;
 
 export interface MessageStreamPoolOptions {
@@ -924,6 +925,18 @@ export class MessageStreamPool {
     // it). The finally now guarantees the local side is released
     // on every exit path.
     let cleanEof = true;
+    const streamController = new AbortController();
+    const abortInboundSignal = (reason: unknown) => {
+      if (!streamController.signal.aborted) {
+        streamController.abort(reason);
+      }
+    };
+    const onStreamClose = () => abortInboundSignal(new Error('pooled inbound stream closed by peer'));
+    const eventedStream = stream as Stream & {
+      addEventListener?: (type: 'close', listener: EventListener, options?: { once?: boolean }) => void;
+      removeEventListener?: (type: 'close', listener: EventListener) => void;
+    };
+    eventedStream.addEventListener?.('close', onStreamClose as EventListener, { once: true });
     try {
       for await (const frame of decodeFrames(
         stream as unknown as AsyncIterable<Uint8Array>,
@@ -951,8 +964,19 @@ export class MessageStreamPool {
         // whole pooled stream down and affect other in-flight
         // requests on this same peer).
         let response: Uint8Array;
+        const requestController = new AbortController();
+        const forwardStreamAbort = () => {
+          if (!requestController.signal.aborted) {
+            requestController.abort(streamController.signal.reason);
+          }
+        };
+        if (streamController.signal.aborted) {
+          forwardStreamAbort();
+        } else {
+          streamController.signal.addEventListener('abort', forwardStreamAbort, { once: true });
+        }
         try {
-          response = await handler(frame.payload, remotePeer);
+          response = await handler(frame.payload, remotePeer, { signal: requestController.signal });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           try {
@@ -962,6 +986,8 @@ export class MessageStreamPool {
             return;
           }
           continue;
+        } finally {
+          streamController.signal.removeEventListener('abort', forwardStreamAbort);
         }
         try {
           stream.send(encodeFrame(FrameType.RESPONSE, response));
@@ -972,6 +998,7 @@ export class MessageStreamPool {
       }
     } catch (err) {
       cleanEof = false;
+      abortInboundSignal(err instanceof Error ? err : new Error('pooled inbound reader error'));
       // Reader-side decode error or transport error — abort and let
       // the dialer reconnect.
       try {
@@ -980,6 +1007,8 @@ export class MessageStreamPool {
         // already torn down
       }
     } finally {
+      eventedStream.removeEventListener?.('close', onStreamClose as EventListener);
+      abortInboundSignal(new Error(cleanEof ? 'pooled inbound stream ended' : 'pooled inbound stream aborted'));
       // Clean EOF: remote half-closed gracefully. Close our local
       // write side too so the substream releases cleanly. Without
       // this, the local half stays open until the underlying

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -978,6 +978,16 @@ export class MessageStreamPool {
         try {
           response = await handler(frame.payload, remotePeer, { signal: requestController.signal });
         } catch (err) {
+          if (isAbortRelatedError(err, requestController.signal)) {
+            cleanEof = false;
+            abortInboundSignal(err instanceof Error ? err : new Error('pooled handler aborted'));
+            try {
+              stream.abort(err instanceof Error ? err : new Error('pooled handler aborted'));
+            } catch {
+              // Stream gone; bail quietly.
+            }
+            return;
+          }
           const msg = err instanceof Error ? err.message : String(err);
           try {
             stream.send(encodeFrame(FrameType.ERROR, new TextEncoder().encode(msg)));
@@ -1104,4 +1114,12 @@ export class MessageStreamPool {
     if (err instanceof Error) return new PooledStreamResetError(err.message);
     return new PooledStreamResetError(fallback);
   }
+}
+
+function isAbortRelatedError(err: unknown, signal: AbortSignal | undefined): boolean {
+  if (err === signal?.reason) return true;
+  const error = err instanceof Error ? err : undefined;
+  if (error?.name === 'AbortError') return true;
+  const message = (error?.message ?? String(err)).toLowerCase();
+  return message.includes('aborted') || message.includes('aborterror');
 }

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -89,6 +89,8 @@ export interface SendOptions {
    * there's just one path available, single-path runs.
    */
   parallelPaths?: number;
+  /** Optional caller cancellation signal composed with timeout and node stop. */
+  signal?: AbortSignal;
 }
 
 export interface ProtocolRouterOptions {
@@ -520,7 +522,9 @@ export class ProtocolRouter {
     const overallStartedAt = Date.now();
     const overallDeadline = AbortSignal.timeout(timeoutMs);
     const stopSignal = this.node.stopSignal;
-    const overallSignal = composeAbortSignals(overallDeadline, stopSignal) ?? overallDeadline;
+    const budgetSignal = composeAbortSignals(overallDeadline, opts.signal) ?? overallDeadline;
+    const overallSignal = composeAbortSignals(budgetSignal, stopSignal) ?? budgetSignal;
+    if (overallSignal.aborted) throw asAbortError(overallSignal.reason);
 
     const overlay = this.pooledByLogical.get(protocolId);
     const memoizedVariant = this.peerWireVariantFor(peerIdStr, protocolId);
@@ -597,8 +601,7 @@ export class ProtocolRouter {
     if (parallelPaths > 1) {
       // Reuse the overall budget rather than starting a fresh one
       // — see comment above. Codex PR #560 round 4.
-      const multipathSignal = overallDeadline;
-      const multipathSignalWithStop = composeAbortSignals(multipathSignal, stopSignal) ?? multipathSignal;
+      const multipathSignalWithStop = overallSignal;
       // Multi-path pre-attempt — race up to N live connections.
       // Returns the response on a winning path, or null if there
       // weren't enough live candidates (or all candidates failed).
@@ -672,7 +675,8 @@ export class ProtocolRouter {
         throw lastErr;
       }
       const attemptDeadline = AbortSignal.timeout(remaining);
-      const attemptSignal = composeAbortSignals(attemptDeadline, stopSignal) ?? attemptDeadline;
+      const attemptSignal = composeAbortSignals(attemptDeadline, overallSignal) ?? attemptDeadline;
+      if (attemptSignal.aborted) throw asAbortError(attemptSignal.reason);
       // Track which connection (if any) the fast path picked this
       // attempt so the catch block can blacklist it on failure
       // without needing to inspect stream/connection internals from
@@ -850,7 +854,7 @@ export class ProtocolRouter {
         if (pickedConnection) {
           triedConnections.add(pickedConnection);
         }
-        if (stopSignal?.aborted || attemptDeadline.aborted || overallDeadline.aborted) throw err;
+        if (attemptSignal.aborted || overallSignal.aborted) throw err;
         if (!isRecoverableSendError(err) || attempt >= 2) throw err;
         const backoff = (attempt + 1) * 500;
         // Make the backoff abortable so the overall deadline is
@@ -866,6 +870,10 @@ export class ProtocolRouter {
             clearTimeout(t);
             if (stopSignal?.aborted) {
               reject(asAbortError(stopSignal.reason));
+              return;
+            }
+            if (!overallDeadline.aborted) {
+              reject(asAbortError(overallSignal.reason));
               return;
             }
             reject(new Error(`send timeout: backoff aborted by overall deadline (${timeoutMs}ms)`));

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -312,11 +312,16 @@ export class ProtocolRouter {
           throw new Error('peerId.toBytes not available on pooled handler');
         },
       };
-      const handlerSignal = composeAbortSignals(options?.signal, this.node.stopSignal);
-      if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
-      const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
-      if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
-      return responseData;
+      const handlerSignalScope = composeAbortSignalsScoped(options?.signal, this.node.stopSignal);
+      const handlerSignal = handlerSignalScope.signal;
+      try {
+        if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
+        const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
+        if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
+        return responseData;
+      } finally {
+        handlerSignalScope.dispose();
+      }
     });
   }
 
@@ -381,7 +386,8 @@ export class ProtocolRouter {
         }
       };
       stream.addEventListener('close', onStreamClose as EventListener, { once: true });
-      const handlerSignal = composeAbortSignals(streamController.signal, stopSignal);
+      const handlerSignalScope = composeAbortSignalsScoped(streamController.signal, stopSignal);
+      const handlerSignal = handlerSignalScope.signal;
       try {
         const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         const peerId = {
@@ -426,6 +432,7 @@ export class ProtocolRouter {
           // stream already closed
         }
       } finally {
+        handlerSignalScope.dispose();
         stream.removeEventListener('close', onStreamClose as EventListener);
       }
     }, { runOnLimitedConnection: true });
@@ -1340,6 +1347,40 @@ export function composeAbortSignals(
     secondary.addEventListener('abort', forwardSecondary, { once: true });
   }
   return combined.signal;
+}
+
+function composeAbortSignalsScoped(
+  primary: AbortSignal | undefined,
+  secondary: AbortSignal | undefined,
+): { signal: AbortSignal | undefined; dispose: () => void } {
+  if (!primary || !secondary || primary === secondary) {
+    return { signal: primary ?? secondary, dispose: () => undefined };
+  }
+  const combined = new AbortController();
+  let disposed = false;
+  const cleanup = () => {
+    if (disposed) return;
+    disposed = true;
+    primary.removeEventListener('abort', forwardPrimary);
+    secondary.removeEventListener('abort', forwardSecondary);
+  };
+  const forwardPrimary = () => {
+    if (!combined.signal.aborted) combined.abort(primary.reason);
+    cleanup();
+  };
+  const forwardSecondary = () => {
+    if (!combined.signal.aborted) combined.abort(secondary.reason);
+    cleanup();
+  };
+  if (primary.aborted) {
+    combined.abort(primary.reason);
+  } else if (secondary.aborted) {
+    combined.abort(secondary.reason);
+  } else {
+    primary.addEventListener('abort', forwardPrimary, { once: true });
+    secondary.addEventListener('abort', forwardSecondary, { once: true });
+  }
+  return { signal: combined.signal, dispose: cleanup };
 }
 
 function abortStream(stream: AbortableByteStream, reason: unknown): void {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -314,7 +314,9 @@ export class ProtocolRouter {
       };
       const handlerSignal = composeAbortSignals(options?.signal, this.node.stopSignal);
       if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
-      return handler(requestData, wrappedPeerId, { signal: handlerSignal });
+      const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
+      if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
+      return responseData;
     });
   }
 
@@ -1351,7 +1353,10 @@ function abortStream(stream: AbortableByteStream, reason: unknown): void {
 }
 
 function asAbortError(reason: unknown): Error {
-  if (reason instanceof Error) return reason;
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   (err as Error & { name: string }).name = 'AbortError';
   return err;

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -273,7 +273,7 @@ export class ProtocolRouter {
     logicalProtocolId: string,
     pool: MessageStreamPool,
   ): void {
-    pool.registerHandler(async (requestData, peerId) => {
+    pool.registerHandler(async (requestData, peerId, options) => {
       const handler = this.handlers.get(logicalProtocolId);
       if (!handler) {
         throw new Error(`no application handler for ${logicalProtocolId}`);
@@ -304,7 +304,8 @@ export class ProtocolRouter {
           throw new Error('peerId.toBytes not available on pooled handler');
         },
       };
-      return handler(requestData, wrappedPeerId);
+      const handlerSignal = composeAbortSignals(options?.signal, this.node.stopSignal);
+      return handler(requestData, wrappedPeerId, { signal: handlerSignal });
     });
   }
 

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -362,19 +362,30 @@ export class ProtocolRouter {
       // error. By caching once we make the whole handler consistently
       // abortable, and `stream.close({ signal })` participates in shutdown.
       const stopSignal = this.node.stopSignal;
+      const streamController = new AbortController();
+      const onStreamClose = () => {
+        if (!streamController.signal.aborted) {
+          streamController.abort(new Error('stream closed by peer'));
+        }
+      };
+      stream.addEventListener('close', onStreamClose as EventListener, { once: true });
+      const handlerSignal = composeAbortSignals(streamController.signal, stopSignal);
       try {
-        const requestData = await readAllWithSignal(stream, limit, stopSignal);
+        const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         const peerId = {
           toString: () => connection.remotePeer.toString(),
           toBytes: () => connection.remotePeer.toMultihash().bytes,
         };
-        const responseData = await handler(requestData, peerId);
+        const responseData = await handler(requestData, peerId, { signal: handlerSignal });
+        if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
+        stream.removeEventListener('close', onStreamClose as EventListener);
         stream.send(responseData);
         await stream.close(stopSignal ? { signal: stopSignal } : undefined);
       } catch (err) {
-        if (stopSignal?.aborted) {
+        if (stopSignal?.aborted || handlerSignal?.aborted) {
           try {
-            stream.abort(asAbortError(stopSignal.reason));
+            const abortReason = stopSignal?.aborted ? stopSignal.reason : handlerSignal?.reason;
+            stream.abort(asAbortError(abortReason));
           } catch {
             // stream already closed
           }
@@ -393,6 +404,8 @@ export class ProtocolRouter {
         } catch {
           // stream already closed
         }
+      } finally {
+        stream.removeEventListener('close', onStreamClose as EventListener);
       }
     }, { runOnLimitedConnection: true });
 

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -313,6 +313,7 @@ export class ProtocolRouter {
         },
       };
       const handlerSignal = composeAbortSignals(options?.signal, this.node.stopSignal);
+      if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
       return handler(requestData, wrappedPeerId, { signal: handlerSignal });
     });
   }
@@ -385,6 +386,7 @@ export class ProtocolRouter {
           toString: () => connection.remotePeer.toString(),
           toBytes: () => connection.remotePeer.toMultihash().bytes,
         };
+        if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
         const responseData = await handler(requestData, peerId, { signal: handlerSignal });
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
         stream.removeEventListener('close', onStreamClose as EventListener);

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -1403,8 +1403,11 @@ function abortStream(stream: AbortableByteStream, reason: unknown): void {
 
 function asAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    (err as Error & { name: string }).name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   (err as Error & { name: string }).name = 'AbortError';

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -32,6 +32,7 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('epipe') ||
     msg.includes('aborted') ||
     msg.includes('no valid addresses') ||
+    (msg.includes('sync responder') && (msg.includes('queue full') || msg.includes('queue wait exceeded'))) ||
     // libp2p dial exhaustion — every known multiaddr for the peer
     // failed in one attempt. Surfaced by `transportManager.dial` and
     // by `dialProtocol` after iterating every relay/transport
@@ -116,6 +117,13 @@ export interface ProtocolRouterOptions {
    * call-time surface.
    */
   peerResolver?: PeerResolver;
+}
+
+export class QuietRetryableHandlerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'QuietRetryableHandlerError';
+  }
 }
 
 export class ProtocolRouter {
@@ -383,7 +391,7 @@ export class ProtocolRouter {
         stream.send(responseData);
         await stream.close(stopSignal ? { signal: stopSignal } : undefined);
       } catch (err) {
-        if (stopSignal?.aborted || handlerSignal?.aborted) {
+        if ((stopSignal?.aborted || handlerSignal?.aborted) && isAbortRelatedError(err, handlerSignal, stopSignal)) {
           try {
             const abortReason = stopSignal?.aborted ? stopSignal.reason : handlerSignal?.reason;
             stream.abort(asAbortError(abortReason));
@@ -395,6 +403,14 @@ export class ProtocolRouter {
         // F3: peer closed/reset the stream before the response was written —
         // routine churn, not a fault. Downgrade to a quiet warn (no "error"
         // token) so it doesn't spam the node log as a red error line.
+        if (err instanceof QuietRetryableHandlerError) {
+          try {
+            stream.abort(err);
+          } catch {
+            // stream already closed
+          }
+          return;
+        }
         if (isBenignStreamClosure(err)) {
           console.warn(`[ProtocolRouter] stream closed by peer before response on ${protocolId} from ${connection.remotePeer.toString().slice(-8)}`);
         } else {
@@ -1337,6 +1353,18 @@ function asAbortError(reason: unknown): Error {
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   (err as Error & { name: string }).name = 'AbortError';
   return err;
+}
+
+function isAbortRelatedError(
+  err: unknown,
+  handlerSignal: AbortSignal | undefined,
+  stopSignal: AbortSignal | undefined,
+): boolean {
+  if (err === handlerSignal?.reason || err === stopSignal?.reason) return true;
+  const error = err instanceof Error ? err : undefined;
+  if (error?.name === 'AbortError') return true;
+  const msg = (error?.message ?? String(err)).toLowerCase();
+  return msg.includes('aborted') || msg.includes('aborterror');
 }
 
 // F3: a peer that closes/resets its side of a stream before we finish

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -88,8 +88,11 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 
 function asAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
-    reason.name = 'AbortError';
-    return reason;
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
   }
   const err = new Error(typeof reason === 'string' ? reason : 'aborted');
   err.name = 'AbortError';

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -11,9 +11,11 @@ export interface RetryOptions {
   isRetryable?: (err: unknown) => boolean;
   /** Called on each retry with attempt number and delay (for logging). */
   onRetry?: (attempt: number, delayMs: number, err: unknown) => void;
+  /** Optional signal to abort retries and backoff sleeps. */
+  signal?: AbortSignal;
 }
 
-const DEFAULTS: Required<Omit<RetryOptions, 'isRetryable' | 'onRetry'>> = {
+const DEFAULTS: Required<Omit<RetryOptions, 'isRetryable' | 'onRetry' | 'signal'>> = {
   maxAttempts: 3,
   baseDelayMs: 500,
   maxDelayMs: 30_000,
@@ -35,10 +37,12 @@ export async function withRetry<T>(
   const jitterFactor = opts.jitter ?? DEFAULTS.jitter;
   const isRetryable = opts.isRetryable;
   const onRetry = opts.onRetry;
+  const signal = opts.signal;
 
   let lastErr: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    throwIfAborted(signal);
     try {
       return await fn();
     } catch (err) {
@@ -52,13 +56,42 @@ export async function withRetry<T>(
       const delay = Math.min(exponentialDelay + jitter, maxDelayMs);
 
       onRetry?.(attempt + 1, delay, err);
-      await sleep(delay);
+      await sleep(delay, signal);
     }
   }
 
   throw lastErr;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+  throwIfAborted(signal);
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(asAbortError(signal.reason));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw asAbortError(signal.reason);
+}
+
+function asAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    reason.name = 'AbortError';
+    return reason;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -194,5 +194,9 @@ export interface ConnectionInfo {
 }
 
 export interface StreamHandler {
-  (data: Uint8Array, peerId: PeerId): Promise<Uint8Array>;
+  (
+    data: Uint8Array,
+    peerId: PeerId,
+    options?: { signal?: AbortSignal },
+  ): Promise<Uint8Array>;
 }

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -495,6 +495,45 @@ describe('MessageStreamPool', () => {
     await pool.close();
   });
 
+  it('does not send a pooled response after the request signal aborts', async () => {
+    const stopController = new AbortController();
+    const node = makeFakeNode() as FakeNode & { stopSignal: AbortSignal };
+    Object.defineProperty(node, 'stopSignal', {
+      get: () => stopController.signal,
+    });
+    const pool = new MessageStreamPool(node, {
+      peerIdFromString: stubPeerIdFromString,
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+    });
+
+    let handlerStarted = false;
+    let releaseHandler!: () => void;
+    const handler: PooledStreamHandler = async () => {
+      handlerStarted = true;
+      await new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      return new TextEncoder().encode('too-late');
+    };
+    pool.registerHandler(handler);
+
+    const { remoteWrites, localReads } = node.simulateInboundDial(PEER_B);
+    remoteWrites.send(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('ping')));
+    while (!handlerStarted) await flush();
+
+    stopController.abort(new Error('node stopping'));
+    releaseHandler();
+    await flush();
+    await flush();
+
+    const accum = (remoteWrites as unknown as { readBuf: Uint8Array[] }).readBuf;
+    expect(accum).toHaveLength(0);
+    expect(localReads.abortReason?.message).toContain('node stopping');
+
+    await pool.close();
+  });
+
   it('inbound handler errors surface as ERROR frame, not stream teardown', async () => {
     const node = makeFakeNode();
     const pool = new MessageStreamPool(node, {

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -991,6 +991,75 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await router.closePooling();
   });
 
+  it('treats generic AbortErrors as cancellation when the request signal is aborted', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const stopController = new AbortController();
+    const node = {
+      get stopSignal() {
+        return stopController.signal;
+      },
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    let handlerStarted = false;
+    let releaseHandler!: () => void;
+    router.register('/dkg/10.0.1/message', async () => {
+      handlerStarted = true;
+      await new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      const err = new Error('The operation was aborted.');
+      err.name = 'AbortError';
+      throw err;
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    while (!handlerStarted) await flush();
+
+    stopController.abort(new Error('node stopping'));
+    releaseHandler();
+
+    await inboundRun;
+    for (let i = 0; i < 20 && inboundStream.writeStatus !== 'closed'; i++) {
+      await flush();
+    }
+    expect(inboundStream.sent).toHaveLength(0);
+    expect(inboundStream.writeStatus).toBe('closed');
+    await router.closePooling();
+  });
+
   it('keeps handler-owned AbortErrors as application error frames when the request is live', async () => {
     type HandlerFn = (
       stream: import('@libp2p/interface').Stream,

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -990,4 +990,72 @@ describe('ProtocolRouter pooled inbound handler', () => {
     expect(inboundStream.writeStatus).toBe('closed');
     await router.closePooling();
   });
+
+  it('keeps handler-owned AbortErrors as application error frames when the request is live', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    router.register('/dkg/10.0.1/message', async () => {
+      const err = new Error('inner work aborted');
+      err.name = 'AbortError';
+      throw err;
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    for (let i = 0; i < 20 && inboundStream.sent.length === 0; i++) {
+      await flush();
+    }
+
+    expect(inboundStream.writeStatus).toBe('open');
+    expect(inboundStream.sent).toHaveLength(1);
+
+    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+    for await (const f of decodeFrames(
+      (async function* () {
+        for (const c of inboundStream.sent) yield c;
+      })(),
+    )) {
+      parsed.push(f);
+    }
+    expect(parsed[0].type).toBe(FrameType.ERROR);
+    expect(new TextDecoder().decode(parsed[0].payload)).toBe('inner work aborted');
+
+    inboundStream.endRemote();
+    await inboundRun;
+    await router.closePooling();
+  });
 });

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -680,6 +680,77 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await router.closePooling();
   });
 
+  it('removes the node stop listener after successful pooled inbound handling', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const stopController = new AbortController();
+    let adds = 0;
+    let removes = 0;
+    const originalAdd = stopController.signal.addEventListener.bind(stopController.signal);
+    const originalRemove = stopController.signal.removeEventListener.bind(stopController.signal);
+    stopController.signal.addEventListener = ((type, listener, options) => {
+      if (type === 'abort') adds += 1;
+      return originalAdd(type, listener, options);
+    }) as AbortSignal['addEventListener'];
+    stopController.signal.removeEventListener = ((type, listener, options) => {
+      if (type === 'abort') removes += 1;
+      return originalRemove(type, listener, options);
+    }) as AbortSignal['removeEventListener'];
+    const node = {
+      get stopSignal() {
+        return stopController.signal;
+      },
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    try {
+      const router = new ProtocolRouter(node);
+      router.enablePooling('/dkg/10.0.1/message', {
+        keepaliveIntervalMs: 0,
+        idleTimeoutMs: 0,
+        peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+      });
+      router.register('/dkg/10.0.1/message', async () => new TextEncoder().encode('ok'));
+
+      expect(inboundHandler).toBeDefined();
+      const inboundStream = new FakeStream();
+      inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+        remotePeer: {
+          toString: () => PEER_NEW,
+          toMultihash: () => ({ bytes: new Uint8Array() }),
+        },
+      });
+      await flush();
+      inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+      await flush();
+
+      expect(inboundStream.sent.length).toBeGreaterThanOrEqual(1);
+      expect(adds).toBeGreaterThan(0);
+      expect(removes).toBe(adds);
+
+      inboundStream.endRemote();
+      await router.closePooling();
+    } finally {
+      stopController.signal.addEventListener = originalAdd as AbortSignal['addEventListener'];
+      stopController.signal.removeEventListener = originalRemove as AbortSignal['removeEventListener'];
+    }
+  });
+
   it('passes a stream abort signal to pooled application handlers', async () => {
     type HandlerFn = (
       stream: import('@libp2p/interface').Stream,

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -52,6 +52,18 @@ class FakeStream {
     else this.readBuf.push(data);
   }
 
+  feedAndAbortAfterDelivery(data: Uint8Array, error = new Error('stream closed after request frame')): void {
+    if (this.ended) return;
+    const w = this.waiters.shift();
+    if (w) {
+      w({ value: data, done: false });
+      queueMicrotask(() => this.abort(error));
+    } else {
+      this.readBuf.push(data);
+      queueMicrotask(() => this.abort(error));
+    }
+  }
+
   endRemote(): void {
     this.ended = true;
     while (this.waiters.length) {
@@ -728,6 +740,58 @@ describe('ProtocolRouter pooled inbound handler', () => {
     expect(seenSignal?.aborted).toBe(true);
     await inboundRun;
 
+    await router.closePooling();
+  });
+
+  it('skips pooled application handler dispatch when the stream aborts after the request frame is read', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    let handlerCalls = 0;
+    router.register('/dkg/10.0.1/message', async () => {
+      handlerCalls += 1;
+      return new TextEncoder().encode('should-not-send');
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feedAndAbortAfterDelivery(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await inboundRun;
+
+    expect(handlerCalls).toBe(0);
+    expect(inboundStream.sent).toHaveLength(0);
     await router.closePooling();
   });
 

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -923,4 +923,71 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await inboundRun;
     await router.closePooling();
   });
+
+  it('drops pooled handler responses when the handler signal aborts before return', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const stopController = new AbortController();
+    const node = {
+      get stopSignal() {
+        return stopController.signal;
+      },
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    let handlerStarted = false;
+    let releaseHandler!: () => void;
+    router.register('/dkg/10.0.1/message', async () => {
+      handlerStarted = true;
+      await new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      return new TextEncoder().encode('too-late');
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    while (!handlerStarted) await flush();
+
+    stopController.abort(new Error('node stopping'));
+    releaseHandler();
+
+    await inboundRun;
+    for (let i = 0; i < 20 && inboundStream.writeStatus !== 'closed'; i++) {
+      await flush();
+    }
+    expect(inboundStream.sent).toHaveLength(0);
+    expect(inboundStream.writeStatus).toBe('closed');
+    await router.closePooling();
+  });
 });

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -36,7 +36,9 @@ class FakeStream {
   readonly sent: Uint8Array[] = [];
   private readBuf: Uint8Array[] = [];
   private waiters: Array<(v: IteratorResult<Uint8Array>) => void> = [];
+  private closeListeners: EventListener[] = [];
   private ended = false;
+  private closeEmitted = false;
 
   send(data: Uint8Array): void {
     if (this.writeStatus !== 'open') throw new Error('closed');
@@ -55,6 +57,7 @@ class FakeStream {
     while (this.waiters.length) {
       this.waiters.shift()!({ value: undefined as unknown as Uint8Array, done: true });
     }
+    this.emitClose();
   }
 
   abort(_err: Error): void {
@@ -64,6 +67,24 @@ class FakeStream {
 
   async close(): Promise<void> {
     this.writeStatus = 'closed';
+    this.emitClose();
+  }
+
+  addEventListener(type: 'close', listener: EventListener, _options?: { once?: boolean }): void {
+    if (type === 'close') this.closeListeners.push(listener);
+  }
+
+  removeEventListener(type: 'close', listener: EventListener): void {
+    if (type !== 'close') return;
+    this.closeListeners = this.closeListeners.filter((entry) => entry !== listener);
+  }
+
+  private emitClose(): void {
+    if (this.closeEmitted) return;
+    this.closeEmitted = true;
+    for (const listener of this.closeListeners.splice(0)) {
+      listener(new Event('close'));
+    }
   }
 
   [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
@@ -644,6 +665,198 @@ describe('ProtocolRouter pooled inbound handler', () => {
     expect(parsed[0].type).toBe(FrameType.RESPONSE);
     expect(new TextDecoder().decode(parsed[0].payload)).toBe('echo:hi');
 
+    await router.closePooling();
+  });
+
+  it('passes a stream abort signal to pooled application handlers', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    let seenSignal: AbortSignal | undefined;
+    const signalAborted = new Promise<void>((resolve) => {
+      router.register('/dkg/10.0.1/message', async (_req, _peer, options) => {
+        seenSignal = options?.signal;
+        options?.signal?.addEventListener('abort', () => resolve(), { once: true });
+        await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+      });
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(false);
+
+    inboundStream.abort(new Error('test stream closed'));
+    await signalAborted;
+    expect(seenSignal?.aborted).toBe(true);
+    await inboundRun;
+
+    await router.closePooling();
+  });
+
+  it('uses a fresh abort signal for each pooled request frame', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    const seenSignals: AbortSignal[] = [];
+    router.register('/dkg/10.0.1/message', async (_req, _peer, options) => {
+      if (!options?.signal) throw new Error('missing signal');
+      seenSignals.push(options.signal);
+      return new TextEncoder().encode('ok');
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('one')));
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('two')));
+    await flush();
+
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals[0]).not.toBe(seenSignals[1]);
+    expect(seenSignals[0].aborted).toBe(false);
+    expect(seenSignals[1].aborted).toBe(false);
+
+    inboundStream.endRemote();
+    await inboundRun;
+    await router.closePooling();
+  });
+
+  it('composes node stop into pooled application handler signals', async () => {
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const stopController = new AbortController();
+    const node = {
+      get stopSignal() {
+        return stopController.signal;
+      },
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node);
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+
+    let seenSignal: AbortSignal | undefined;
+    const signalAborted = new Promise<void>((resolve) => {
+      router.register('/dkg/10.0.1/message', async (_req, _peer, options) => {
+        seenSignal = options?.signal;
+        options?.signal?.addEventListener('abort', () => resolve(), { once: true });
+        await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+      });
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(false);
+
+    stopController.abort(new Error('node stopping'));
+    await signalAborted;
+    expect(seenSignal?.aborted).toBe(true);
+
+    inboundStream.endRemote();
+    await inboundRun;
     await router.closePooling();
   });
 });

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -356,6 +356,51 @@ describe('ProtocolRouter', () => {
       expect(dialCalls).toBe(1);
     });
 
+    it('passes caller signals through close/dial work and does not retry caller aborts', async () => {
+      const callerController = new AbortController();
+      let dialCalls = 0;
+      let closeSignal: AbortSignal | undefined;
+      const node = {
+        libp2p: {
+          getConnections: () => [],
+          dialProtocol: async () => {
+            dialCalls += 1;
+            return {
+              writeStatus: 'open' as const,
+              send: () => undefined,
+              close: async (opts?: { signal?: AbortSignal }) => {
+                closeSignal = opts?.signal;
+                const err = new Error('request cancelled');
+                err.name = 'AbortError';
+                callerController.abort(err);
+                throw err;
+              },
+              abort: () => undefined,
+              async *[Symbol.asyncIterator]() {
+                /* never reached */
+              },
+            };
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      await expect(
+        router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]), {
+          timeoutMs: 5000,
+          signal: callerController.signal,
+        }),
+      ).rejects.toThrow('request cancelled');
+
+      expect(closeSignal).toBeDefined();
+      expect(closeSignal?.aborted).toBe(true);
+      expect(dialCalls).toBe(1);
+    });
+
     it('does not fall through from pooled send into one-shot work after node stop aborts', async () => {
       const stopController = new AbortController();
       let dialCalls = 0;

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -54,6 +54,129 @@ describe('ProtocolRouter', () => {
     });
   });
 
+  describe('register() inbound abort signal', () => {
+    const PROTOCOL = '/dkg/test/inbound-abort/1.0.0';
+    const REMOTE_PEER = '12D3KooWInboundAbortPeer';
+
+    class FakeInboundStream extends EventTarget {
+      sent: Uint8Array | null = null;
+      aborted: Error | null = null;
+      closedWithSignal: AbortSignal | undefined;
+
+      constructor(private readonly chunks: Uint8Array[]) {
+        super();
+      }
+
+      send(data: Uint8Array): void {
+        this.sent = data;
+      }
+
+      async close(options?: { signal?: AbortSignal }): Promise<void> {
+        this.closedWithSignal = options?.signal;
+      }
+
+      abort(error: Error): void {
+        this.aborted = error;
+      }
+
+      async *[Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
+        for (const chunk of this.chunks) yield chunk;
+      }
+    }
+
+    function makeInboundFixture(stopSignal?: AbortSignal) {
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      const node = {
+        get stopSignal() {
+          return stopSignal;
+        },
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node);
+      const connection = {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      };
+      return {
+        router,
+        invoke: async (stream: FakeInboundStream) => {
+          if (!inbound) throw new Error('handler not registered');
+          await inbound(stream, connection);
+        },
+      };
+    }
+
+    it('passes a live AbortSignal to raw handlers and preserves it through close', async () => {
+      let seenSignal: AbortSignal | undefined;
+      const fixture = makeInboundFixture();
+      fixture.router.register(PROTOCOL, async (_data, _peer, options) => {
+        seenSignal = options?.signal;
+        return new Uint8Array([0xaa]);
+      });
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+
+      await fixture.invoke(stream);
+
+      expect(seenSignal).toBeDefined();
+      expect(seenSignal?.aborted).toBe(false);
+      expect(stream.sent).toEqual(new Uint8Array([0xaa]));
+      expect(stream.closedWithSignal).toBeUndefined();
+      expect(stream.aborted).toBeNull();
+    });
+
+    it('aborts the handler signal when the inbound stream closes while work is pending', async () => {
+      let seenSignal: AbortSignal | undefined;
+      const fixture = makeInboundFixture();
+      fixture.router.register(PROTOCOL, async (_data, _peer, options) => {
+        seenSignal = options?.signal;
+        await new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+        return new Uint8Array([0xbb]);
+      });
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      const inbound = fixture.invoke(stream);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      stream.dispatchEvent(new Event('close'));
+      await inbound;
+
+      expect(seenSignal?.aborted).toBe(true);
+      expect(stream.sent).toBeNull();
+      expect(stream.aborted?.message).toMatch(/stream closed by peer/);
+    });
+
+    it('aborts the handler signal when node stop fires while work is pending', async () => {
+      const stopController = new AbortController();
+      let seenSignal: AbortSignal | undefined;
+      const fixture = makeInboundFixture(stopController.signal);
+      fixture.router.register(PROTOCOL, async (_data, _peer, options) => {
+        seenSignal = options?.signal;
+        await new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+        });
+        return new Uint8Array([0xcc]);
+      });
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      const inbound = fixture.invoke(stream);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      stopController.abort(new Error('node stopping'));
+      await inbound;
+
+      expect(seenSignal?.aborted).toBe(true);
+      expect(stream.sent).toBeNull();
+      expect(stream.aborted?.message).toMatch(/node stopping/);
+    });
+  });
+
   describe('send() node stop abort propagation', () => {
     const FAKE_PEER_ID = '12D3KooWBzj7Hg2cKCdsKL6QcjC5UbLztKTvzCZQHaT4P4ZyJEAA';
 

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { composeAbortSignals, isRecoverableSendError, DEFAULT_SEND_TIMEOUT_MS, ProtocolRouter } from '../src/protocol-router.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  composeAbortSignals,
+  isRecoverableSendError,
+  DEFAULT_SEND_TIMEOUT_MS,
+  ProtocolRouter,
+  QuietRetryableHandlerError,
+} from '../src/protocol-router.js';
 import type { DKGNode } from '../src/node.js';
 import type { PeerResolver } from '../src/network/peer-resolver.js';
 
@@ -20,6 +26,12 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('no valid addresses'))).toBe(true);
       expect(isRecoverableSendError(new Error('NO_RESERVATION'))).toBe(true);
       expect(isRecoverableSendError(new Error('no reservation for relay'))).toBe(true);
+    });
+
+    it('returns true for retryable sync responder backpressure aborts', () => {
+      expect(isRecoverableSendError(new Error('sync responder queue full'))).toBe(true);
+      expect(isRecoverableSendError(new Error('sync responder peer queue full'))).toBe(true);
+      expect(isRecoverableSendError(new Error('sync responder queue wait exceeded'))).toBe(true);
     });
 
     // Regression for the May 2026 multi-node soak: libp2p surfaces
@@ -174,6 +186,56 @@ describe('ProtocolRouter', () => {
       expect(seenSignal?.aborted).toBe(true);
       expect(stream.sent).toBeNull();
       expect(stream.aborted?.message).toMatch(/node stopping/);
+    });
+
+    it('aborts quietly for retryable handler backpressure', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const fixture = makeInboundFixture();
+        fixture.router.register(PROTOCOL, async () => {
+          throw new QuietRetryableHandlerError('sync responder peer queue full');
+        });
+        const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+
+        await fixture.invoke(stream);
+
+        expect(stream.sent).toBeNull();
+        expect(stream.aborted?.message).toBe('sync responder peer queue full');
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('does not mask non-abort handler failures just because the handler signal is aborted', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        let seenSignal: AbortSignal | undefined;
+        const fixture = makeInboundFixture();
+        fixture.router.register(PROTOCOL, async (_data, _peer, options) => {
+          seenSignal = options?.signal;
+          await new Promise<void>((resolve) => {
+            options?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          throw new Error('store query failed');
+        });
+        const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+        const inbound = fixture.invoke(stream);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        stream.dispatchEvent(new Event('close'));
+        await inbound;
+
+        expect(seenSignal?.aborted).toBe(true);
+        expect(stream.sent).toBeNull();
+        expect(stream.aborted?.message).toBe('handler error');
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[ProtocolRouter] handler error'),
+          'store query failed',
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -167,6 +167,34 @@ describe('ProtocolRouter', () => {
       expect(stream.aborted).toBeNull();
     });
 
+    it('removes the node stop listener after successful raw inbound handling', async () => {
+      const stopController = new AbortController();
+      let adds = 0;
+      let removes = 0;
+      const originalAdd = stopController.signal.addEventListener.bind(stopController.signal);
+      const originalRemove = stopController.signal.removeEventListener.bind(stopController.signal);
+      stopController.signal.addEventListener = ((type, listener, options) => {
+        if (type === 'abort') adds += 1;
+        return originalAdd(type, listener, options);
+      }) as AbortSignal['addEventListener'];
+      stopController.signal.removeEventListener = ((type, listener, options) => {
+        if (type === 'abort') removes += 1;
+        return originalRemove(type, listener, options);
+      }) as AbortSignal['removeEventListener'];
+
+      try {
+        const fixture = makeInboundFixture(stopController.signal);
+        fixture.router.register(PROTOCOL, async () => new Uint8Array([0xaa]));
+        await fixture.invoke(new FakeInboundStream([new Uint8Array([0x01])]));
+
+        expect(adds).toBeGreaterThan(0);
+        expect(removes).toBe(adds);
+      } finally {
+        stopController.signal.addEventListener = originalAdd as AbortSignal['addEventListener'];
+        stopController.signal.removeEventListener = originalRemove as AbortSignal['removeEventListener'];
+      }
+    });
+
     it('aborts the handler signal when the inbound stream closes while work is pending', async () => {
       let seenSignal: AbortSignal | undefined;
       const fixture = makeInboundFixture();

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -356,6 +356,42 @@ describe('ProtocolRouter', () => {
       expect(dialCalls).toBe(1);
     });
 
+    it('does not mutate default AbortController reasons while shutdown cancels backoff', async () => {
+      const stopController = new AbortController();
+      let dialCalls = 0;
+      let releaseDialed: () => void = () => {};
+      const dialed = new Promise<void>((resolve) => {
+        releaseDialed = resolve;
+      });
+      const node = {
+        get stopSignal() {
+          return stopController.signal;
+        },
+        libp2p: {
+          getConnections: () => [],
+          dialProtocol: async () => {
+            dialCalls += 1;
+            releaseDialed();
+            throw new Error('stream reset');
+          },
+          handle: () => undefined,
+          unhandle: () => undefined,
+          peerStore: { get: async () => { throw new Error('NotFound'); } },
+        },
+      } as unknown as DKGNode;
+      const peerResolver = { resolve: async () => [] } as unknown as PeerResolver;
+      const router = new ProtocolRouter(node, { peerResolver });
+
+      const sendPromise = router.send(FAKE_PEER_ID, '/dkg/test/1.0.0', new Uint8Array([1]), 5000);
+
+      await dialed;
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(() => stopController.abort()).not.toThrow();
+      await expect(sendPromise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(dialCalls).toBe(1);
+    });
+
     it('passes caller signals through close/dial work and does not retry caller aborts', async () => {
       const callerController = new AbortController();
       let dialCalls = 0;

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -75,7 +75,10 @@ describe('ProtocolRouter', () => {
       aborted: Error | null = null;
       closedWithSignal: AbortSignal | undefined;
 
-      constructor(private readonly chunks: Uint8Array[]) {
+      constructor(
+        private readonly chunks: Uint8Array[],
+        private readonly afterReadComplete?: () => void,
+      ) {
         super();
       }
 
@@ -91,8 +94,29 @@ describe('ProtocolRouter', () => {
         this.aborted = error;
       }
 
-      async *[Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
-        for (const chunk of this.chunks) yield chunk;
+      [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array> {
+        let index = 0;
+        let completed = false;
+        return {
+          next: async () => {
+            if (index < this.chunks.length) {
+              return { value: this.chunks[index++], done: false };
+            }
+            if (!completed && this.afterReadComplete) {
+              completed = true;
+              return await new Promise<IteratorResult<Uint8Array>>((resolve) => {
+                setTimeout(() => {
+                  resolve({ value: undefined as unknown as Uint8Array, done: true });
+                  queueMicrotask(() => this.afterReadComplete?.());
+                }, 0);
+              });
+            }
+            return { value: undefined as unknown as Uint8Array, done: true };
+          },
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+        };
       }
     }
 
@@ -161,6 +185,25 @@ describe('ProtocolRouter', () => {
       await inbound;
 
       expect(seenSignal?.aborted).toBe(true);
+      expect(stream.sent).toBeNull();
+      expect(stream.aborted?.message).toMatch(/stream closed by peer/);
+    });
+
+    it('skips raw handler dispatch when the stream aborts after the request body is read', async () => {
+      const fixture = makeInboundFixture();
+      let handlerCalls = 0;
+      fixture.router.register(PROTOCOL, async () => {
+        handlerCalls += 1;
+        return new Uint8Array([0xdd]);
+      });
+      let stream!: FakeInboundStream;
+      stream = new FakeInboundStream([new Uint8Array([0x01])], () => {
+        stream.dispatchEvent(new Event('close'));
+      });
+
+      await fixture.invoke(stream);
+
+      expect(handlerCalls).toBe(0);
       expect(stream.sent).toBeNull();
       expect(stream.aborted?.message).toMatch(/stream closed by peer/);
     });

--- a/packages/core/test/retry.test.ts
+++ b/packages/core/test/retry.test.ts
@@ -161,4 +161,34 @@ describe('withRetry', () => {
 
     expect(errors[0]).toBe(specificError);
   });
+
+  it('does not mutate default AbortController reasons while aborting backoff', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    let releaseRetryStarted: () => void = () => {};
+    const retryStarted = new Promise<void>((resolve) => {
+      releaseRetryStarted = resolve;
+    });
+    const fn = async () => {
+      calls++;
+      throw new Error('transient');
+    };
+
+    const promise = withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 30_000,
+      jitter: 0,
+      signal: controller.signal,
+      onRetry: () => {
+        releaseRetryStarted();
+      },
+    });
+
+    await retryStarted;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(() => controller.abort()).not.toThrow();
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(1);
+  });
 });

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -182,9 +182,10 @@ export class BlazegraphStore implements TripleStore {
     await this.sparqlUpdate(`DROP SILENT GRAPH <${escapeUri(graphUri)}>`);
   }
 
-  async listGraphs(): Promise<string[]> {
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
     const r = await this.query(
       'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
+      options,
     );
     if (r.type !== 'bindings') return [];
     return r.bindings.map((b) => b.g).filter(Boolean);

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -19,6 +19,8 @@ import { buildBlankNodeSafeDelete } from './sparql-http.js';
  * plus Blazegraph's N-Quads bulk-insert endpoint.
  */
 export class BlazegraphStore implements TripleStore {
+  readonly queryCancellation = 'interruptible' as const;
+
   private readonly url: string;
 
   constructor(url: string) {

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -1,6 +1,7 @@
 import type {
   TripleStore,
   Quad as DKGQuad,
+  QueryOptions,
   QueryResult,
   SelectResult,
   ConstructResult,
@@ -87,14 +88,18 @@ export class BlazegraphStore implements TripleStore {
   // Queries
   // -------------------------------------------------------------------
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    if (options?.signal?.aborted) {
+      const reason = options.signal.reason;
+      throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+    }
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');
     const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
     if (isConstruct) {
-      return this.queryConstruct(trimmed);
+      return this.queryConstruct(trimmed, options);
     }
 
     // Direct POST (W3C SPARQL 1.1 Protocol): send the query as the raw
@@ -111,6 +116,7 @@ export class BlazegraphStore implements TripleStore {
         Accept: 'application/sparql-results+json',
       },
       body: trimmed,
+      signal: options?.signal,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -136,7 +142,7 @@ export class BlazegraphStore implements TripleStore {
     return { type: 'bindings', bindings } satisfies SelectResult;
   }
 
-  private async queryConstruct(sparql: string): Promise<ConstructResult> {
+  private async queryConstruct(sparql: string, options?: QueryOptions): Promise<ConstructResult> {
     const res = await fetch(this.url, {
       method: 'POST',
       headers: {
@@ -144,6 +150,7 @@ export class BlazegraphStore implements TripleStore {
         Accept: 'text/x-nquads, application/n-quads',
       },
       body: sparql,
+      signal: options?.signal,
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -55,6 +55,10 @@ function normalizeNonNegativeInt(value: number | undefined, fallback: number): n
     : fallback;
 }
 
+function asAbortError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
+
 /**
  * Side-effect-free read methods. ONLY these are bounded by the per-op timeout:
  * rejecting a read after the bound is a clean, determinate failure (nothing was
@@ -156,19 +160,24 @@ export class OxigraphWorkerStore implements TripleStore {
     // Only read-only ops are bounded; mutations run unbounded (timeoutMs 0) so a
     // timed-out write is never reported as a clean failure while still in flight.
     const timeoutMs = READ_ONLY_METHODS.has(method) ? this.operationTimeoutMs : 0;
-    return this.callWithTimeout<T>(timeoutMs, method, ...args);
+    return this.callWithTimeout<T>(timeoutMs, undefined, method, ...args);
   }
 
   /**
    * Post one op to the worker and await its reply, bounding the caller's wait by
-   * `timeoutMs` (0 = wait indefinitely). The bound is per-CALLER: on timeout we
-   * reject and drop the pending entry, but the single-threaded worker is STILL
+   * `timeoutMs` (0 = wait indefinitely). The bound is per-CALLER: on timeout or
+   * caller abort we reject and drop the pending entry, but the single-threaded worker is STILL
    * running the op — the late reply is then ignored (the message handler no-ops
    * on a missing id) rather than double-settling this promise. Only read-only
    * ops are ever given a non-zero timeout (see `call`), so a fired timeout is
    * always a determinate, side-effect-free failure.
    */
-  private callWithTimeout<T>(timeoutMs: number, method: string, ...args: unknown[]): Promise<T> {
+  private callWithTimeout<T>(
+    timeoutMs: number,
+    signal: AbortSignal | undefined,
+    method: string,
+    ...args: unknown[]
+  ): Promise<T> {
     const id = this.nextId++;
     return new Promise<T>((resolve, reject) => {
       // The worker is gone — a posted message would never be answered, so fail
@@ -177,10 +186,20 @@ export class OxigraphWorkerStore implements TripleStore {
         reject(new Error(`oxigraph-worker: cannot run "${method}" — the store is closed.`));
         return;
       }
+      if (signal?.aborted) {
+        reject(asAbortError(signal.reason));
+        return;
+      }
       let timer: ReturnType<typeof setTimeout> | undefined;
+      let onAbort: (() => void) | undefined;
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+      };
       if (timeoutMs > 0) {
         timer = setTimeout(() => {
           if (this.pending.delete(id)) {
+            cleanup();
             const err = new Error(
               `oxigraph-worker: "${method}" timed out after ${timeoutMs}ms. ` +
               `The embedded store runs on a single worker thread, so a long-running or ` +
@@ -197,11 +216,27 @@ export class OxigraphWorkerStore implements TripleStore {
         // A pending-op timer must not keep the process alive on its own.
         if (typeof timer.unref === 'function') timer.unref();
       }
+      if (signal) {
+        onAbort = () => {
+          if (this.pending.delete(id)) {
+            cleanup();
+            reject(asAbortError(signal.reason));
+          }
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
       this.pending.set(id, {
-        resolve: (v) => { if (timer) clearTimeout(timer); resolve(v as T); },
-        reject: (e) => { if (timer) clearTimeout(timer); reject(e); },
+        resolve: (v) => { cleanup(); resolve(v as T); },
+        reject: (e) => { cleanup(); reject(e); },
       });
-      this.worker.postMessage({ id, method, args });
+      try {
+        this.worker.postMessage({ id, method, args });
+      } catch (err) {
+        if (this.pending.delete(id)) {
+          cleanup();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
     });
   }
 
@@ -215,11 +250,7 @@ export class OxigraphWorkerStore implements TripleStore {
   async delete(quads: Quad[]): Promise<void> { return this.call('delete', quads); }
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
-    if (options?.signal?.aborted) {
-      const reason = options.signal.reason;
-      throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
-    }
-    return this.call('query', sparql);
+    return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);
   }
   async hasGraph(graphUri: string): Promise<boolean> { return this.call('hasGraph', graphUri); }
   async createGraph(graphUri: string): Promise<void> { return this.call('createGraph', graphUri); }
@@ -253,7 +284,7 @@ export class OxigraphWorkerStore implements TripleStore {
     // terminate() always runs in `finally`; the worker's 'exit' handler then
     // rejects anything still pending, so nothing leaks or hangs.
     try {
-      await this.callWithTimeout<void>(0, 'close');
+      await this.callWithTimeout<void>(0, undefined, 'close');
     } finally {
       await this.worker.terminate();
     }

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -2,7 +2,7 @@ import { Worker } from 'node:worker_threads';
 import { existsSync } from 'node:fs';
 import { sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { TripleStore, Quad, QueryResult } from '../triple-store.js';
+import type { TripleStore, Quad, QueryOptions, QueryResult } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 
 /**
@@ -214,7 +214,13 @@ export class OxigraphWorkerStore implements TripleStore {
   async insert(quads: Quad[]): Promise<void> { return this.call('insert', quads); }
   async delete(quads: Quad[]): Promise<void> { return this.call('delete', quads); }
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
-  async query(sparql: string): Promise<QueryResult> { return this.call('query', sparql); }
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    if (options?.signal?.aborted) {
+      const reason = options.signal.reason;
+      throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+    }
+    return this.call('query', sparql);
+  }
   async hasGraph(graphUri: string): Promise<boolean> { return this.call('hasGraph', graphUri); }
   async createGraph(graphUri: string): Promise<void> { return this.call('createGraph', graphUri); }
   async dropGraph(graphUri: string): Promise<void> { return this.call('dropGraph', graphUri); }

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -81,6 +81,8 @@ export interface OxigraphWorkerTimeoutError extends Error {
 }
 
 export class OxigraphWorkerStore implements TripleStore {
+  readonly queryCancellation = 'interruptible' as const;
+
   private worker: Worker;
   private nextId = 0;
   private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -261,7 +261,9 @@ export class OxigraphWorkerStore implements TripleStore {
   async hasGraph(graphUri: string): Promise<boolean> { return this.call('hasGraph', graphUri); }
   async createGraph(graphUri: string): Promise<void> { return this.call('createGraph', graphUri); }
   async dropGraph(graphUri: string): Promise<void> { return this.call('dropGraph', graphUri); }
-  async listGraphs(): Promise<string[]> { return this.call('listGraphs'); }
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    return this.callWithTimeout<string[]>(this.operationTimeoutMs, options?.signal, 'listGraphs');
+  }
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> { return this.call('deleteBySubjectPrefix', graphUri, prefix); }
   async countQuads(graphUri?: string): Promise<number> { return this.call('countQuads', graphUri); }
   async flush(): Promise<void> { return this.call('flush'); }

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -218,6 +218,10 @@ export class OxigraphWorkerStore implements TripleStore {
         // A pending-op timer must not keep the process alive on its own.
         if (typeof timer.unref === 'function') timer.unref();
       }
+      this.pending.set(id, {
+        resolve: (v) => { cleanup(); resolve(v as T); },
+        reject: (e) => { cleanup(); reject(e); },
+      });
       if (signal) {
         onAbort = () => {
           if (this.pending.delete(id)) {
@@ -226,11 +230,11 @@ export class OxigraphWorkerStore implements TripleStore {
           }
         };
         signal.addEventListener('abort', onAbort, { once: true });
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
       }
-      this.pending.set(id, {
-        resolve: (v) => { cleanup(); resolve(v as T); },
-        reject: (e) => { cleanup(); reject(e); },
-      });
       try {
         this.worker.postMessage({ id, method, args });
       } catch (err) {

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -18,6 +18,8 @@ type OxTerm = oxigraph.Term;
 type OxQuad = oxigraph.Quad;
 
 export class OxigraphStore implements TripleStore {
+  readonly queryCancellation = 'pre-dispatch' as const;
+
   private store: OxStore;
   private persistPath: string | undefined;
 
@@ -215,7 +217,11 @@ export class OxigraphStore implements TripleStore {
 
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
     throwIfAborted(options?.signal);
+    // The embedded Oxigraph binding executes synchronously, so a caller abort
+    // cannot interrupt this native call mid-flight. Use oxigraph-worker or an
+    // HTTP backend when long sync queries need prompt cancellation.
     const result = this.store.query(sparql);
+    throwIfAborted(options?.signal);
 
     if (typeof result === 'boolean') {
       return { type: 'boolean', value: result } satisfies AskResult;

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -271,10 +271,12 @@ export class OxigraphStore implements TripleStore {
     this.scheduleFlush();
   }
 
-  async listGraphs(): Promise<string[]> {
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    throwIfAborted(options?.signal);
     const result = this.store.query(
       'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
     );
+    throwIfAborted(options?.signal);
     if (typeof result === 'boolean' || typeof result === 'string') return [];
     if (!Array.isArray(result)) return [];
     return (result as Map<string, OxTerm>[])

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -9,6 +9,7 @@ import type {
   SelectResult,
   ConstructResult,
   AskResult,
+  QueryOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 
@@ -212,7 +213,8 @@ export class OxigraphStore implements TripleStore {
     return matches.length;
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    throwIfAborted(options?.signal);
     const result = this.store.query(sparql);
 
     if (typeof result === 'boolean') {
@@ -354,6 +356,12 @@ export class OxigraphStore implements TripleStore {
     }
     await this.flushNow();
   }
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  const reason = signal.reason;
+  throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }
 
 function quadToNQuad(q: DKGQuad): string {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -126,6 +126,8 @@ export interface SparqlHttpStoreOptions {
 }
 
 export class SparqlHttpStore implements TripleStore {
+  readonly queryCancellation = 'interruptible' as const;
+
   private readonly queryEndpoint: string;
   private readonly updateEndpoint: string;
   private readonly timeout: number;

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -82,6 +82,21 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }
 
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
 /**
  * R6-A: how long a managed-endpoint `listGraphs()` result may be served from
  * cache before it is re-validated against the store. The cache is also cleared
@@ -407,22 +422,21 @@ export class SparqlHttpStore implements TripleStore {
     // arriving after a write must not join the pre-write scan (it would observe
     // a stale graph set); it starts a fresh one instead.
     if (this.graphListInflight && this.graphListInflightGen === this.graphListCacheGen) {
-      return [...(await this.graphListInflight)];
+      return [...(await raceAgainstAbort(this.graphListInflight, options?.signal))];
     }
     const startGen = this.graphListCacheGen;
-    const scan = this.scanGraphs(startGen, options);
-    this.graphListInflight = scan;
-    this.graphListInflightGen = startGen;
-    try {
-      return [...(await scan)];
-    } finally {
+    let scan!: Promise<string[]>;
+    scan = this.scanGraphs(startGen).finally(() => {
       // Clear only if a newer scan hasn't already replaced this one, so a
       // post-write rebuild started while this scan was resolving isn't lost.
       if (this.graphListInflight === scan) {
         this.graphListInflight = null;
         this.graphListInflightGen = -1;
       }
-    }
+    });
+    this.graphListInflight = scan;
+    this.graphListInflightGen = startGen;
+    return [...(await raceAgainstAbort(scan, options?.signal))];
   }
 
   /**

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -24,6 +24,7 @@
 import type {
   TripleStore,
   Quad as DKGQuad,
+  QueryOptions,
   QueryResult,
   SelectResult,
   ConstructResult,
@@ -39,6 +40,47 @@ import { performance } from 'node:perf_hooks';
  * would defeat the outage re-validation guarantee).
  */
 const monotonicNow = (): number => performance.now();
+
+function composeAbortSignals(
+  primary: AbortSignal | undefined,
+  secondary: AbortSignal | undefined,
+): AbortSignal | undefined {
+  if (!primary) return secondary;
+  if (!secondary) return primary;
+  const AnyImpl = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (AnyImpl) return AnyImpl([primary, secondary]);
+  const combined = new AbortController();
+  let settled = false;
+  const cleanup = () => {
+    primary.removeEventListener('abort', forwardPrimary);
+    secondary.removeEventListener('abort', forwardSecondary);
+  };
+  const forwardPrimary = () => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    combined.abort(primary.reason);
+  };
+  const forwardSecondary = () => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    combined.abort(secondary.reason);
+  };
+  if (primary.aborted) combined.abort(primary.reason);
+  else if (secondary.aborted) combined.abort(secondary.reason);
+  else {
+    primary.addEventListener('abort', forwardPrimary, { once: true });
+    secondary.addEventListener('abort', forwardSecondary, { once: true });
+  }
+  return combined.signal;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  const reason = signal.reason;
+  throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
 
 /**
  * R6-A: how long a managed-endpoint `listGraphs()` result may be served from
@@ -151,7 +193,7 @@ export class SparqlHttpStore implements TripleStore {
     this.graphListCacheGen++;
   }
 
-  private async postQuery(sparql: string, accept: string): Promise<Response> {
+  private async postQuery(sparql: string, accept: string, options?: QueryOptions): Promise<Response> {
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
     // data. Form-encoded bodies (`query=...`) are parsed by the server's
@@ -159,11 +201,13 @@ export class SparqlHttpStore implements TripleStore {
     // `maxFormContentSize` (~200 KB) and rejects larger payloads with
     // HTTP 400 "Unable to parse form content". The direct-POST body is not
     // form parsed, so large queries are not capped.
+    const timeoutSignal = AbortSignal.timeout(this.timeout);
+    const signal = composeAbortSignals(options?.signal, timeoutSignal) ?? timeoutSignal;
     const res = await fetch(this.queryEndpoint, {
       method: 'POST',
       headers: { ...this.headers, 'Content-Type': 'application/sparql-query', Accept: accept },
       body: sparql,
-      signal: AbortSignal.timeout(this.timeout),
+      signal,
     });
     return res;
   }
@@ -265,17 +309,18 @@ export class SparqlHttpStore implements TripleStore {
     return Math.max(0, before - after);
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    throwIfAborted(options?.signal);
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');
     const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
     if (isConstruct) {
-      return this.queryConstruct(trimmed);
+      return this.queryConstruct(trimmed, options);
     }
 
-    const res = await this.postQuery(trimmed, 'application/sparql-results+json');
+    const res = await this.postQuery(trimmed, 'application/sparql-results+json', options);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
@@ -300,8 +345,8 @@ export class SparqlHttpStore implements TripleStore {
     return { type: 'bindings', bindings } satisfies SelectResult;
   }
 
-  private async queryConstruct(sparql: string): Promise<ConstructResult> {
-    const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads');
+  private async queryConstruct(sparql: string, options?: QueryOptions): Promise<ConstructResult> {
+    const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads', options);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -377,7 +377,8 @@ export class SparqlHttpStore implements TripleStore {
     this.invalidateGraphListCache(); // the graph is gone from listGraphs
   }
 
-  async listGraphs(): Promise<string[]> {
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    throwIfAborted(options?.signal);
     // R6-A: on a managed (daemon-owned) endpoint the graph set only changes
     // when *we* write, so serve a warm cache and skip the full
     // `SELECT DISTINCT ?g` quad-store scan — the dominant idle-node CPU cost
@@ -397,7 +398,7 @@ export class SparqlHttpStore implements TripleStore {
     // External (non-managed) endpoint: never cache (an outside writer could
     // add a graph we'd miss), so just scan.
     if (!this.cacheGraphList) {
-      return [...(await this.scanGraphs(this.graphListCacheGen))];
+      return [...(await this.scanGraphs(this.graphListCacheGen, options))];
     }
     // Managed, cold/expired cache: coalesce concurrent callers onto one
     // in-flight scan so a startup or TTL-boundary burst doesn't fan out into
@@ -409,7 +410,7 @@ export class SparqlHttpStore implements TripleStore {
       return [...(await this.graphListInflight)];
     }
     const startGen = this.graphListCacheGen;
-    const scan = this.scanGraphs(startGen);
+    const scan = this.scanGraphs(startGen, options);
     this.graphListInflight = scan;
     this.graphListInflightGen = startGen;
     try {
@@ -430,8 +431,8 @@ export class SparqlHttpStore implements TripleStore {
    * (`startGen` vs the current generation) discards a snapshot that may predate
    * that write so the next call rebuilds.
    */
-  private async scanGraphs(startGen: number): Promise<string[]> {
-    const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
+  private async scanGraphs(startGen: number, options?: QueryOptions): Promise<string[]> {
+    const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }', options);
     const graphs = r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
     if (this.cacheGraphList && startGen === this.graphListCacheGen) {
       this.graphListCache = graphs;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,6 +2,7 @@ export {
   type Quad,
   type TripleStore,
   type QueryResult,
+  type QueryOptions,
   type SelectResult,
   type ConstructResult,
   type AskResult,

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -102,8 +102,8 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.dropGraph(graphUri);
   }
 
-  async listGraphs(): Promise<string[]> {
-    return this.inner.listGraphs();
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    return this.inner.listGraphs(options);
   }
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import type {
   ConstructResult,
   Quad,
+  QueryOptions,
   QueryResult,
   SelectResult,
   TripleStore,
@@ -71,16 +72,16 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return removed;
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
     const rewritten = this.rewriteLargeLiteralConstants(sparql);
     if (!rewritten) {
-      const result = await this.inner.query(sparql);
+      const result = await this.inner.query(sparql, options);
       return this.hydrateQueryResult(result);
     }
 
     const [original, placeholder] = await Promise.all([
-      this.inner.query(sparql),
-      this.inner.query(rewritten),
+      this.inner.query(sparql, options),
+      this.inner.query(rewritten, options),
     ]);
     return this.hydrateQueryResult(mergeQueryResults(original, placeholder));
   }

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -29,6 +29,10 @@ export interface SharedMemoryLiteralBlobStoreOptions {
 }
 
 export class SharedMemoryLiteralBlobStore implements TripleStore {
+  get queryCancellation() {
+    return this.inner.queryCancellation;
+  }
+
   private readonly inner: TripleStore;
   private readonly blobDir: string;
   private readonly thresholdBytes: number;

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -34,11 +34,15 @@ export interface AskResult {
 
 export type QueryResult = SelectResult | ConstructResult | AskResult;
 
+export interface QueryOptions {
+  signal?: AbortSignal;
+}
+
 export interface TripleStore {
   insert(quads: Quad[]): Promise<void>;
   delete(quads: Quad[]): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>): Promise<number>;
-  query(sparql: string): Promise<QueryResult>;
+  query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
 
   hasGraph(graphUri: string): Promise<boolean>;
   createGraph(graphUri: string): Promise<void>;

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -60,7 +60,7 @@ export interface TripleStore {
   hasGraph(graphUri: string): Promise<boolean>;
   createGraph(graphUri: string): Promise<void>;
   dropGraph(graphUri: string): Promise<void>;
-  listGraphs(): Promise<string[]>;
+  listGraphs(options?: QueryOptions): Promise<string[]>;
 
   deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number>;
 

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -33,12 +33,25 @@ export interface AskResult {
 }
 
 export type QueryResult = SelectResult | ConstructResult | AskResult;
+export type QueryCancellationMode = 'interruptible' | 'pre-dispatch';
 
 export interface QueryOptions {
+  /**
+   * Best-effort caller cancellation. Async backends should reject promptly when
+   * aborted; synchronous embedded backends may only observe the signal before
+   * dispatching or after returning from their blocking native call.
+   */
   signal?: AbortSignal;
 }
 
 export interface TripleStore {
+  /**
+   * Whether `query(..., { signal })` can reject while a query is already in
+   * flight (`interruptible`) or can only observe cancellation before dispatch
+   * and after a blocking call returns (`pre-dispatch`).
+   */
+  readonly queryCancellation?: QueryCancellationMode;
+
   insert(quads: Quad[]): Promise<void>;
   delete(quads: Quad[]): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>): Promise<number>;

--- a/packages/storage/test/external-literal-store.test.ts
+++ b/packages/storage/test/external-literal-store.test.ts
@@ -8,7 +8,10 @@ import {
   OxigraphStore,
   SharedMemoryLiteralBlobStore,
   createTripleStore,
+  type QueryOptions,
+  type QueryResult,
   type Quad,
+  type TripleStore,
 } from '../src/index.js';
 
 const SWM_GRAPH = 'did:dkg:context-graph:test/_shared_memory';
@@ -96,6 +99,28 @@ describe('SharedMemoryLiteralBlobStore', () => {
     if (nonSwm.type === 'bindings') {
       expect(nonSwm.bindings[0].o).toBe(largeNonSwmLiteral);
     }
+  });
+
+  it('forwards query options to original and rewritten literal queries', async () => {
+    const blobDir = await tempBlobDir();
+    const seenOptions: Array<QueryOptions | undefined> = [];
+    const inner = {
+      query: async (_sparql: string, options?: QueryOptions): Promise<QueryResult> => {
+        seenOptions.push(options);
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 10 });
+    const signalController = new AbortController();
+    const largeLiteral = `"${'option-forward'.repeat(8)}"`;
+
+    await store.query(
+      `SELECT ?s WHERE { GRAPH <${SWM_GRAPH}> { ?s <http://schema.org/value> ${largeLiteral} } }`,
+      { signal: signalController.signal },
+    );
+
+    expect(seenOptions).toHaveLength(2);
+    expect(seenOptions.every((options) => options?.signal === signalController.signal)).toBe(true);
   });
 
   it('matches exact large literal constants through SELECT, ASK, and FILTER equality', async () => {

--- a/packages/storage/test/oxigraph-worker-resilience.test.ts
+++ b/packages/storage/test/oxigraph-worker-resilience.test.ts
@@ -53,6 +53,29 @@ function quads(n: number): Quad[] {
   return out;
 }
 
+function abortDuringListenerRegistration(message: string): AbortSignal {
+  let aborted = false;
+  let reason: Error | undefined;
+  return {
+    get aborted() {
+      return aborted;
+    },
+    get reason() {
+      return reason;
+    },
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      if (type !== 'abort') return;
+      aborted = true;
+      reason = new Error(message);
+      if (typeof listener === 'function') listener(new Event('abort'));
+      else listener.handleEvent(new Event('abort'));
+    },
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    onabort: null,
+  } as unknown as AbortSignal;
+}
+
 // Occupy the single worker thread with a large UNBOUNDED insert (mutations are
 // not bounded by the timeout), so a read posted right after it queues behind a
 // busy worker — the production "wedged worker" signature in miniature.
@@ -96,6 +119,17 @@ describe('OxigraphWorkerStore resilience', () => {
       controller.abort(new Error('caller aborted queued read'));
       await expect(read).rejects.toThrow(/caller aborted queued read/);
       await busy.catch(() => {});
+    } finally {
+      await closeQuietly(store);
+    }
+  });
+
+  it('rejects when the caller aborts while registering the abort listener', async () => {
+    const store = makeStore({ operationTimeoutMs: 60_000 });
+    try {
+      await expect(
+        store.query(BUSY_QUERY, { signal: abortDuringListenerRegistration('listener registration aborted') }),
+      ).rejects.toThrow(/listener registration aborted/);
     } finally {
       await closeQuietly(store);
     }

--- a/packages/storage/test/oxigraph-worker-resilience.test.ts
+++ b/packages/storage/test/oxigraph-worker-resilience.test.ts
@@ -87,6 +87,20 @@ describe('OxigraphWorkerStore resilience', () => {
     }
   });
 
+  it('rejects a queued READ promptly when the caller aborts', async () => {
+    const store = makeStore({ operationTimeoutMs: 60_000 });
+    try {
+      const busy = store.insert(quads(50_000));
+      const controller = new AbortController();
+      const read = store.query(BUSY_QUERY, { signal: controller.signal });
+      controller.abort(new Error('caller aborted queued read'));
+      await expect(read).rejects.toThrow(/caller aborted queued read/);
+      await busy.catch(() => {});
+    } finally {
+      await closeQuietly(store);
+    }
+  });
+
   it('does NOT bound mutations — a large insert under a tiny timeout still completes', async () => {
     // The whole point of read-only scoping: a write is never reported as a clean
     // failure while it's still in flight. With a 5ms bound a 50k insert (>>5ms)

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -118,6 +118,59 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('composes caller abort signals into SELECT and CONSTRUCT fetches', async () => {
+    const originalFetch = globalThis.fetch;
+    const seenSignals: AbortSignal[] = [];
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.signal instanceof AbortSignal) seenSignals.push(init.signal);
+      const accept = String((init?.headers as Record<string, string> | undefined)?.Accept ?? '');
+      if (accept.includes('n-quads')) {
+        return new Response('', { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        head: { vars: [] },
+        results: { bindings: [] },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/sparql-results+json' },
+      });
+    }) as typeof fetch;
+    try {
+      const signalController = new AbortController();
+      const signalStore = new SparqlHttpStore({ queryEndpoint: 'http://example.test/query', timeout: 30_000 });
+
+      await signalStore.query('SELECT ?s WHERE { ?s ?p ?o }', { signal: signalController.signal });
+      await signalStore.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }', { signal: signalController.signal });
+
+      expect(seenSignals).toHaveLength(2);
+      expect(seenSignals.every((signal) => !signal.aborted)).toBe(true);
+      signalController.abort(new Error('caller aborted'));
+      expect(seenSignals.every((signal) => signal.aborted)).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects in-flight queries when the caller aborts', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      })) as typeof fetch;
+    try {
+      const signalController = new AbortController();
+      const signalStore = new SparqlHttpStore({ queryEndpoint: 'http://example.test/query', timeout: 30_000 });
+      const query = signalStore.query('SELECT ?s WHERE { ?s ?p ?o }', { signal: signalController.signal });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      signalController.abort(new Error('caller aborted'));
+
+      await expect(query).rejects.toThrow(/caller aborted/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('query ASK returns boolean', async () => {
     const result = await store.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }');
     expect(result.type).toBe('boolean');

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -350,6 +350,32 @@ describe('SparqlHttpStore (test server)', () => {
       expect(listGraphsHits).toBe(1); // all three shared one in-flight scan
     });
 
+    it('lets aborted callers detach without cancelling the shared managed scan', async () => {
+      listGraphsHits = 0;
+      let release!: () => void;
+      listGraphsGate = new Promise<void>((r) => { release = r; });
+      const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+      const store = managedStore();
+      const firstController = new AbortController();
+      try {
+        const first = store.listGraphs({ signal: firstController.signal });
+        await delay(30);
+        expect(listGraphsHits).toBe(1);
+
+        firstController.abort(new Error('first caller left'));
+        await expect(first).rejects.toThrow(/first caller left/);
+
+        const second = store.listGraphs();
+        await delay(30);
+        expect(listGraphsHits).toBe(1);
+
+        release();
+        await expect(second).resolves.toContain('http://ex.org/g1');
+      } finally {
+        listGraphsGate = null;
+      }
+    });
+
     it('a write during an in-flight scan forces the next caller to re-scan, not join stale work', async () => {
       // Read-your-writes: if a scan is in flight and a write invalidates the
       // cache before it resolves, a caller arriving after the write must start


### PR DESCRIPTION
## Summary

- Adds global (3) + per-peer (1) concurrency caps and a bounded queue around the sync handler; sheds overflow by throwing (retryable transport error for old requesters), never via an empty response (which old requesters read as phase-complete).
- Propagates cancellation: a per-stream `AbortController` wired to the libp2p stream `close` event into the handler, and an optional `signal` on `TripleStore.query` composed with the existing 30 s abort in `sparql-http`.
- Honest limit: oxigraph 0.5.8 cannot kill an in-flight query server-side, so caps are the real protection; cancellation saves serialization/post-work.

## Related

- Part of #1138 (Track A, PR A2). Depends on **A1** (shared `sync-handler.ts`) — rebase after A1 merges.
- **Merge order:** Wave 1, after A1.

## Files changed

| File | What |
|------|------|
| `agent/src/sync/responder/sync-handler.ts` | Concurrency limiter + queue; `signal.aborted` checks |
| `core/src/protocol-router.ts`, `core/src/types.ts` | Per-stream `AbortController` on stream `close`; optional handler `signal` |
| `storage/src/triple-store.ts` + adapters | Optional `{ signal }` on `query` |
| `agent/src/dkg-agent-lifecycle.ts` | Caps wired at sync-handler registration |

Plus 4 test files.

## Test plan

- [ ] `pnpm -F dkg-agent -F dkg-core -F dkg-storage test`
- [ ] Cap test: excess concurrent page requests shed as retryable (never an empty page)
- [ ] Cancellation: stream close aborts the in-flight handler/query signal
- [ ] `pnpm build` + lint

---
*Targets `integration/issue-1138` (not `main`) so the heavy overlaps on `dkg-agent-lifecycle.ts` / `dkg-agent-base.ts` are resolved once on the integration branch, which is promoted to `main` in two gated waves (see #1138, Coordination). Single squashed commit off `main`.*