### PR TITLE
A4 — VM-reconcile damping (negative cache + single-peer catch-up)

### DIFF
--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -96,12 +96,24 @@ export async function reconcileContextGraph(
   onChainCgId: bigint,
 ): Promise<ReconcileResult> {
   const head = await deps.getKCCount(onChainCgId);
-  const headBlock = await deps.getHeadBlock();
   const before = state.watermark;
+
+  // Keep transient head-fetch failures distinct from truly head-less chains.
+  // We may still promote ordinals while the head is unavailable, but cannot
+  // safely advance/persist the contiguous watermark until a later real-head
+  // sweep can apply the confirmation-depth gate.
+  let headBlock: number | undefined;
+  let headUnavailable = false;
+  try {
+    headBlock = await deps.getHeadBlock();
+  } catch (err) {
+    headUnavailable = true;
+    deps.log(`reconcile ${localCgId}: getHeadBlock failed, holding watermark (${err instanceof Error ? err.message : String(err)})`);
+  }
 
   // Re-absorb any depth-held ordinals as the head advances — a long-running
   // node makes progress on confirmation-depth-blocked ordinals even with no
-  // new completions this pass.
+  // new completions this pass. Skipped when the head is unobservable.
   if (headBlock !== undefined) absorbConfirmed(state, headBlock, deps.confirmationDepth);
 
   let reconciled = 0;
@@ -110,15 +122,17 @@ export async function reconcileContextGraph(
     const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
     if (outcome.status === 'reconciled' || outcome.status === 'already') {
       reconciled += 1;
-      // With a known head, apply the reorg-depth gate; otherwise (no chain head)
-      // absorb as soon as contiguous (depth 0) using the registration block as
-      // a self-consistent head.
-      recordCompletion(
-        state,
-        { ordinal, blockNumber: outcome.blockNumber },
-        headBlock ?? outcome.blockNumber,
-        headBlock !== undefined ? deps.confirmationDepth : 0,
-      );
+      if (!headUnavailable) {
+        // With a known head, apply the reorg-depth gate; otherwise (no chain
+        // head) absorb as soon as contiguous (depth 0) using the registration
+        // block as a self-consistent head.
+        recordCompletion(
+          state,
+          { ordinal, blockNumber: outcome.blockNumber },
+          headBlock ?? outcome.blockNumber,
+          headBlock !== undefined ? deps.confirmationDepth : 0,
+        );
+      }
     } else {
       pending += 1;
     }
@@ -128,7 +142,7 @@ export async function reconcileContextGraph(
     deps.persistWatermark(localCgId, state.watermark);
     deps.log(`reconcile ${localCgId}: watermark ${before} -> ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending})`);
   } else if (reconciled > 0 || pending > 0) {
-    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending})`);
+    deps.log(`reconcile ${localCgId}: watermark held at ${state.watermark} (head=${head}, reconciled=${reconciled}, pending=${pending}${headUnavailable ? ', headUnavailable' : ''})`);
   }
 
   return { head, watermark: state.watermark, reconciled, pending };

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -99,9 +99,9 @@ export async function reconcileContextGraph(
   const before = state.watermark;
 
   // Keep transient head-fetch failures distinct from truly head-less chains.
-  // We may still promote ordinals while the head is unavailable, but cannot
-  // safely advance/persist the contiguous watermark until a later real-head
-  // sweep can apply the confirmation-depth gate.
+  // A thrown head read means the chain is temporarily unavailable; skip
+  // materialization for this pass so reconcileOrdinal never falls back to a
+  // synthetic version block for chain-backed data.
   let headBlock: number | undefined;
   let headUnavailable = false;
   try {
@@ -118,11 +118,14 @@ export async function reconcileContextGraph(
 
   let reconciled = 0;
   let pending = 0;
-  for (const ordinal of ordinalsToReconcile(state, head)) {
-    const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
-    if (outcome.status === 'reconciled' || outcome.status === 'already') {
-      reconciled += 1;
-      if (!headUnavailable) {
+  const ordinals = ordinalsToReconcile(state, head);
+  if (headUnavailable) {
+    pending = ordinals.length;
+  } else {
+    for (const ordinal of ordinals) {
+      const outcome = await deps.reconcileOrdinal(localCgId, onChainCgId, ordinal, headBlock);
+      if (outcome.status === 'reconciled' || outcome.status === 'already') {
+        reconciled += 1;
         // With a known head, apply the reorg-depth gate; otherwise (no chain
         // head) absorb as soon as contiguous (depth 0) using the registration
         // block as a self-consistent head.
@@ -132,9 +135,9 @@ export async function reconcileContextGraph(
           headBlock ?? outcome.blockNumber,
           headBlock !== undefined ? deps.confirmationDepth : 0,
         );
+      } else {
+        pending += 1;
       }
-    } else {
-      pending += 1;
     }
   }
 

--- a/packages/agent/src/chain-reconciler.ts
+++ b/packages/agent/src/chain-reconciler.ts
@@ -190,4 +190,10 @@ export class RecentUalSet {
       if (oldest !== undefined) this.seen.delete(oldest);
     }
   }
+
+  deleteByPrefix(prefix: string, except?: string): void {
+    for (const key of this.seen.keys()) {
+      if (key !== except && key.startsWith(prefix)) this.seen.delete(key);
+    }
+  }
 }

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -710,8 +710,8 @@ export class DKGAgentBase {
   protected readonly coreHostRecordings = new Set<Promise<void>>();
   /** Stop-time gate: once true, ACK hooks must not start new core-host writes. */
   protected coreHostRecordingsClosed = false;
-  /** Stop-time cancellation guard: late continuations must not persist after drain gives up. */
-  protected coreHostRecordingsAborted = false;
+  /** Monotonic guard: continuations from abandoned drain generations must not persist after restart. */
+  protected coreHostRecordingGeneration = 0;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, {
     localCgId: string;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -712,7 +712,11 @@ export class DKGAgentBase {
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */
   protected readonly vmReconcileCatchupPeerCursor = new Map<string, number>();
-  protected readonly vmReconcileCatchupPeerOrder = new Map<string, { orderedPeers: string[]; nextPeerId?: string }>();
+  protected readonly vmReconcileCatchupPeerOrder = new Map<string, {
+    orderedPeers: string[];
+    nextPeerId?: string;
+    priorityRanks?: Record<string, number>;
+  }>();
   protected hostModeReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   protected hostModePruneTimer: ReturnType<typeof setInterval> | null = null;
   // rc.9 PR-10: joinApprovalRetryQueue + joinApprovalRetryTimer

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -699,7 +699,7 @@ export class DKGAgentBase {
     failures: number;
     nextRetryAt: number;
     swmGen: string;
-    candidateMetaGraphs: string[];
+    candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
   }>();
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -677,6 +677,8 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
+  static readonly VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS']) || 32);
   /**
    * Blocks a completed ordinal must be buried by before its watermark advance
    * commits (reorg gate). The data is promoted to VM eagerly; only the cursor

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -700,6 +700,12 @@ export class DKGAgentBase {
   protected readonly reconcileCursors = new Map<string, CursorState>();
   /** Phase B — bounded dedupe of recently-reconciled UALs (live-burst guard). */
   protected readonly recentReconciledUals = new RecentUalSet();
+  /**
+   * In-flight core-hosted recordings launched from the synchronous StorageACK
+   * pre-sign hook. Tracked so rejections are logged and graceful stop() can
+   * flush the host-only `coreHosted` flag before teardown.
+   */
+  protected readonly coreHostRecordings = new Set<Promise<void>>();
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, {
     localCgId: string;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -679,8 +679,6 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
-  static readonly VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS =
-    Math.max(1, Number(process.env['DKG_VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS']) || 32);
   /**
    * Blocks a completed ordinal must be buried by before its watermark advance
    * commits (reorg gate). The data is promoted to VM eagerly; only the cursor

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -679,6 +679,8 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
+  static readonly CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS =
+    Math.max(1, Number(process.env['DKG_CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS']) || 5_000);
   /**
    * Blocks a completed ordinal must be buried by before its watermark advance
    * commits (reorg gate). The data is promoted to VM eagerly; only the cursor

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -710,6 +710,8 @@ export class DKGAgentBase {
   protected readonly coreHostRecordings = new Set<Promise<void>>();
   /** Stop-time gate: once true, ACK hooks must not start new core-host writes. */
   protected coreHostRecordingsClosed = false;
+  /** Stop-time cancellation guard: late continuations must not persist after drain gives up. */
+  protected coreHostRecordingsAborted = false;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, {
     localCgId: string;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -675,6 +675,8 @@ export class DKGAgentBase {
     Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']) || 10 * 60_000;
   static readonly VM_RECONCILE_CACHE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
+  static readonly VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS']) || 2_000);
   static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
     Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
   static readonly VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -706,6 +706,8 @@ export class DKGAgentBase {
    * flush the host-only `coreHosted` flag before teardown.
    */
   protected readonly coreHostRecordings = new Set<Promise<void>>();
+  /** Stop-time gate: once true, ACK hooks must not start new core-host writes. */
+  protected coreHostRecordingsClosed = false;
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, {
     localCgId: string;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1120,6 +1120,8 @@ export class DKGAgentBase {
   /** Cores keep-alive-pinned on the last warm-core pass, so the next pass can
    *  unpin Cores that fell out of the selection (stale-pin / cap-drift guard). */
   protected warmedCores: Set<string> = new Set();
+  /** Stale warm-core keep-alive removals that failed and should be retried. */
+  protected warmCoreFailedUnpins: Set<string> = new Set();
   /**
    * v10-rc sync-refactor: per-(peer+CG) checkpoint offsets so the paged
    * sync requester in `sync/requester/page-fetch.ts` can resume where it

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -673,6 +673,10 @@ export class DKGAgentBase {
     Math.max(5_000, DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS);
   static readonly VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS =
     Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']) || 10 * 60_000;
+  static readonly VM_RECONCILE_CACHE_MAX_ENTRIES =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_CACHE_MAX_ENTRIES']) || 1_000);
+  static readonly VM_RECONCILE_CG_STATE_MAX_ENTRIES =
+    Math.max(1, Number(process.env['DKG_VM_RECONCILE_CG_STATE_MAX_ENTRIES']) || 1_000);
   /**
    * Blocks a completed ordinal must be buried by before its watermark advance
    * commits (reorg gate). The data is promoted to VM eagerly; only the cursor

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -669,6 +669,10 @@ export class DKGAgentBase {
    */
   static readonly VM_RECONCILE_SWEEP_INTERVAL_MS =
     Number(process.env['DKG_VM_RECONCILE_INTERVAL_MS']) || 60_000;
+  static readonly VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS =
+    Math.max(5_000, DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS);
+  static readonly VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS =
+    Number(process.env['DKG_VM_RECONCILE_BACKOFF_MAX_MS']) || 10 * 60_000;
   /**
    * Blocks a completed ordinal must be buried by before its watermark advance
    * commits (reorg gate). The data is promoted to VM eagerly; only the cursor
@@ -690,6 +694,17 @@ export class DKGAgentBase {
   protected readonly reconcileCursors = new Map<string, CursorState>();
   /** Phase B — bounded dedupe of recently-reconciled UALs (live-burst guard). */
   protected readonly recentReconciledUals = new RecentUalSet();
+  /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
+  protected readonly vmReconcileNegativeCache = new Map<string, {
+    failures: number;
+    nextRetryAt: number;
+    swmGen: string;
+    candidateMetaGraphs: string[];
+  }>();
+  /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
+  protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
+  /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */
+  protected readonly vmReconcileCatchupPeerCursor = new Map<string, number>();
   protected hostModeReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   protected hostModePruneTimer: ReturnType<typeof setInterval> | null = null;
   // rc.9 PR-10: joinApprovalRetryQueue + joinApprovalRetryTimer

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -700,6 +700,7 @@ export class DKGAgentBase {
     nextRetryAt: number;
     swmGen: string;
     candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
+    peerTopologyKey: string;
   }>();
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -700,16 +700,19 @@ export class DKGAgentBase {
   protected readonly recentReconciledUals = new RecentUalSet();
   /** Phase D/A4 — per-UAL retry damping after a chain ordinal has no matching local SWM snapshot. */
   protected readonly vmReconcileNegativeCache = new Map<string, {
+    localCgId: string;
     failures: number;
     nextRetryAt: number;
     swmGen: string;
     candidateNamespaces: Array<{ metaGraph: string; dataGraph: string }>;
     peerTopologyKey: string;
   }>();
+  protected readonly vmReconcileNegativeCacheKeysByCg = new Map<string, Set<string>>();
   /** Phase D/A4 — per-CG active-fetch cooldown so one sweep cannot fan out repeated fetches. */
   protected readonly vmReconcileFetchCooldownAt = new Map<string, number>();
   /** Phase D/A4 — round-robin cursor over the already ordered catch-up peer list. */
   protected readonly vmReconcileCatchupPeerCursor = new Map<string, number>();
+  protected readonly vmReconcileCatchupPeerOrder = new Map<string, { orderedPeers: string[]; nextPeerId?: string }>();
   protected hostModeReconcilerTimer: ReturnType<typeof setInterval> | null = null;
   protected hostModePruneTimer: ReturnType<typeof setInterval> | null = null;
   // rc.9 PR-10: joinApprovalRetryQueue + joinApprovalRetryTimer

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -1134,8 +1134,8 @@ export class ContextGraphMethods extends DKGAgentBase {
       });
       const sub = this.subscribedContextGraphs.get(id);
       if (sub) {
-        this.clearRecentVmReconcileStateForContextGraph(id);
-        this.setContextGraphSubscription(id, { ...sub, onChainId: undefined });
+        this.forceClearVmReconcileStateForContextGraph(id);
+        this.setContextGraphSubscription(id, { ...sub, onChainId: undefined, lastReconciledOrdinal: 0 });
       }
     }
 

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -1106,8 +1106,16 @@ export class ContextGraphMethods extends DKGAgentBase {
       if (typeof this.chain.isContextGraphActiveOnChain === 'function') {
         try {
           onChainLive = await this.chain.isContextGraphActiveOnChain(BigInt(existingOnChainId));
-        } catch {
-          onChainLive = false;
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          this.log.warn(
+            ctx,
+            `Context graph "${id}" has local on-chain id ${existingOnChainId}, but liveness could not be verified: ${reason}`,
+          );
+          throw new Error(
+            `Context graph "${id}" has local on-chain id ${existingOnChainId}, but liveness could not be verified. ` +
+            `Refusing to re-register until the existing slot can be checked: ${reason}`,
+          );
         }
       }
       if (onChainLive) {

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -1134,6 +1134,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       });
       const sub = this.subscribedContextGraphs.get(id);
       if (sub) {
+        this.clearRecentVmReconcileStateForContextGraph(id);
         this.setContextGraphSubscription(id, { ...sub, onChainId: undefined });
       }
     }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2985,7 +2985,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
-    /** Ordered connected peers before optional maxPeers windowing. */
+    /** Peers selected and evaluated after optional maxPeers windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional maxPeers windowing. */
     totalPeers: number;
@@ -3146,7 +3146,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peers: Array<{ toString(): string }>,
     stats?: { totalPeers?: number },
   ): Promise<{
-    /** Ordered connected peers before optional caller windowing. */
+    /** Peers selected and evaluated after optional caller windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional caller windowing. */
     totalPeers: number;
@@ -3385,7 +3385,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     return {
-      connectedPeers: stats?.totalPeers ?? peers.length,
+      connectedPeers: peers.length,
       totalPeers: stats?.totalPeers ?? peers.length,
       selectedPeers: peers.length,
       syncCapablePeers,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2985,10 +2985,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
-    /** Peers selected and evaluated after optional maxPeers windowing. */
+    /** Ordered connected peers before optional maxPeers windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional maxPeers windowing. */
     totalPeers: number;
+    /** Peers selected and evaluated after optional maxPeers windowing. */
     selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
@@ -3146,10 +3147,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peers: Array<{ toString(): string }>,
     stats?: { totalPeers?: number },
   ): Promise<{
-    /** Peers selected and evaluated after optional caller windowing. */
+    /** Ordered connected peers before optional caller windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional caller windowing. */
     totalPeers: number;
+    /** Peers selected and evaluated after optional caller windowing. */
     selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
@@ -3385,7 +3387,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     return {
-      connectedPeers: peers.length,
+      connectedPeers: stats?.totalPeers ?? peers.length,
       totalPeers: stats?.totalPeers ?? peers.length,
       selectedPeers: peers.length,
       syncCapablePeers,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -399,6 +399,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
     this.coreHostRecordingsClosed = false;
+    this.coreHostRecordingsAborted = false;
     const ctx = createOperationContext('connect');
     this.log.info(ctx, `Starting DKG node`);
 
@@ -2984,7 +2985,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
-    /** Peers selected and processed after optional maxPeers windowing. */
+    /** Ordered connected peers before optional maxPeers windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional maxPeers windowing. */
     totalPeers: number;
@@ -3145,7 +3146,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     peers: Array<{ toString(): string }>,
     stats?: { totalPeers?: number },
   ): Promise<{
-    /** Peers selected and processed by this catch-up run. */
+    /** Ordered connected peers before optional caller windowing. */
     connectedPeers: number;
     /** Ordered connected peers before optional caller windowing. */
     totalPeers: number;
@@ -3384,7 +3385,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     return {
-      connectedPeers: peers.length,
+      connectedPeers: stats?.totalPeers ?? peers.length,
       totalPeers: stats?.totalPeers ?? peers.length,
       selectedPeers: peers.length,
       syncCapablePeers,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -243,7 +243,6 @@ import { createCursorState, type CursorState } from './reconcile-cursor.js';
 const DEFAULT_MAX_REHYDRATED_SUBSCRIPTIONS = 64;
 /** Yield to the event loop every N activations so concurrent store work can interleave. */
 const REHYDRATE_THROTTLE_BATCH = 8;
-const catchupPeerOrderSignatures = new WeakMap<object, Map<string, string>>();
 
 // type alias so listPendingJoinApprovalRetries() retains its old
 // public shape while it stubs out to []. PR-12 rebuilds the operator
@@ -3054,31 +3053,43 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return peers;
     }
 
-    const rotationKey = options?.peerRotationKey;
-    if (rotationKey) {
-      this.pruneVmReconcileState();
-      const orderedPeerSignature = JSON.stringify(peers.map((peer) => peer.toString()));
-      let signatures = catchupPeerOrderSignatures.get(this);
-      if (!signatures) {
-        signatures = new Map<string, string>();
-        catchupPeerOrderSignatures.set(this, signatures);
-      }
-      if (signatures.get(rotationKey) !== orderedPeerSignature) {
-        this.vmReconcileCatchupPeerCursor.delete(rotationKey);
-        this.vmReconcileCatchupPeerCursor.set(rotationKey, 0);
-        signatures.set(rotationKey, orderedPeerSignature);
-      }
-    }
-
     if (peers.length <= maxPeers) {
       return peers;
     }
 
     let start = 0;
+    const rotationKey = options?.peerRotationKey;
     if (rotationKey) {
-      start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+      this.pruneVmReconcileState();
+      const peerIds = peers.map((peer) => peer.toString());
+      const previousOrder = this.vmReconcileCatchupPeerOrder.get(rotationKey);
+      const nextPeerId = previousOrder?.nextPeerId;
+      if (nextPeerId) {
+        const nextPeerIndex = peerIds.indexOf(nextPeerId);
+        if (nextPeerIndex >= 0) {
+          const previousPeers = new Set(previousOrder.orderedPeers);
+          const hasNewPrioritizedPeer = peerIds
+            .slice(0, nextPeerIndex)
+            .some((peerId) => !previousPeers.has(peerId));
+          start = hasNewPrioritizedPeer ? 0 : nextPeerIndex;
+        } else {
+          const previousPeers = new Set(previousOrder.orderedPeers);
+          const firstNewPeerIndex = peerIds.findIndex((peerId) => !previousPeers.has(peerId));
+          start = firstNewPeerIndex >= 0
+            ? firstNewPeerIndex
+            : (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+        }
+      } else {
+        start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+      }
+      const nextIndex = (start + maxPeers) % peers.length;
       this.vmReconcileCatchupPeerCursor.delete(rotationKey);
-      this.vmReconcileCatchupPeerCursor.set(rotationKey, (start + maxPeers) % peers.length);
+      this.vmReconcileCatchupPeerCursor.set(rotationKey, nextIndex);
+      this.vmReconcileCatchupPeerOrder.delete(rotationKey);
+      this.vmReconcileCatchupPeerOrder.set(rotationKey, {
+        orderedPeers: peerIds,
+        nextPeerId: peerIds[nextIndex],
+      });
     }
 
     return [...peers.slice(start), ...peers.slice(0, start)].slice(0, maxPeers);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2603,10 +2603,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       unpin: (peerId, ctx) => this.unpinWarmCore(peerId, ctx),
       dial: (peerId, ctx) => this.dialWarmCore(peerId, ctx),
       previouslyWarmed: this.warmedCores,
+      previouslyFailedUnpins: this.warmCoreFailedUnpins,
       log: (ctx, msg) => this.log.info(ctx, msg),
     });
     // Carry the pinned set into the next tick so stale Cores get unpinned.
     this.warmedCores = result.warmed;
+    this.warmCoreFailedUnpins = result.failedUnpins;
   }
 
   /**
@@ -2666,6 +2668,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.log.info(ctx, `warm-core: unpin ${shortPeer} failed: ${message}`);
+      throw err;
     }
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3033,7 +3033,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       preferredPeerId,
       isPrivateContextGraph,
     );
-    const peers = this.selectCatchupPeerWindow(orderedPeers, options);
+    const peerPriorityRanks = new Map<string, number>();
+    for (const peer of orderedPeers) {
+      const peerId = peer.toString();
+      const rank = peerId === preferredPeerId ? 2 : this.knownCorePeerIds.has(peerId) ? 1 : 0;
+      if (rank > 0) peerPriorityRanks.set(peerId, rank);
+    }
+    const peers = this.selectCatchupPeerWindow(orderedPeers, { ...options, peerPriorityRanks });
     const coreCount = orderedPeers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
     this.log.info(
       ctx,
@@ -3046,7 +3052,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   selectCatchupPeerWindow(this: DKGAgent,
     peers: Array<{ toString(): string }>,
-    options?: { maxPeers?: number; peerRotationKey?: string },
+    options?: { maxPeers?: number; peerRotationKey?: string; peerPriorityRanks?: ReadonlyMap<string, number> },
   ): Array<{ toString(): string }> {
     const maxPeers = options?.maxPeers;
     if (maxPeers === undefined || !Number.isInteger(maxPeers) || maxPeers <= 0) {
@@ -3064,19 +3070,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const peerIds = peers.map((peer) => peer.toString());
       const previousOrder = this.vmReconcileCatchupPeerOrder.get(rotationKey);
       const nextPeerId = previousOrder?.nextPeerId;
+      const currentPriorityRank = (peerId: string): number => options?.peerPriorityRanks?.get(peerId) ?? 0;
+      const previousPriorityRank = (peerId: string): number => previousOrder?.priorityRanks?.[peerId] ?? 0;
+      const gainedPriority = (peerId: string): boolean => currentPriorityRank(peerId) > previousPriorityRank(peerId);
       if (nextPeerId) {
         const nextPeerIndex = peerIds.indexOf(nextPeerId);
         if (nextPeerIndex >= 0) {
           const previousPeers = new Set(previousOrder.orderedPeers);
-          const hasNewPrioritizedPeer = peerIds
+          const firstInvalidatingPeerIndex = peerIds
             .slice(0, nextPeerIndex)
-            .some((peerId) => !previousPeers.has(peerId));
-          start = hasNewPrioritizedPeer ? 0 : nextPeerIndex;
+            .findIndex((peerId) => (!previousPeers.has(peerId) && currentPriorityRank(peerId) > 0) || gainedPriority(peerId));
+          start = firstInvalidatingPeerIndex >= 0 ? firstInvalidatingPeerIndex : nextPeerIndex;
         } else {
           const previousPeers = new Set(previousOrder.orderedPeers);
-          const firstNewPeerIndex = peerIds.findIndex((peerId) => !previousPeers.has(peerId));
-          start = firstNewPeerIndex >= 0
-            ? firstNewPeerIndex
+          const firstInvalidatingPeerIndex = peerIds.findIndex((peerId) =>
+            (!previousPeers.has(peerId) && currentPriorityRank(peerId) > 0) || gainedPriority(peerId),
+          );
+          start = firstInvalidatingPeerIndex >= 0
+            ? firstInvalidatingPeerIndex
             : (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
         }
       } else {
@@ -3089,6 +3100,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.vmReconcileCatchupPeerOrder.set(rotationKey, {
         orderedPeers: peerIds,
         nextPeerId: peerIds[nextIndex],
+        priorityRanks: Object.fromEntries(
+          peerIds
+            .map((peerId) => [peerId, currentPriorityRank(peerId)] as const)
+            .filter(([, rank]) => rank > 0),
+        ),
       });
     }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3056,6 +3056,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     const rotationKey = options?.peerRotationKey;
     if (rotationKey) {
+      this.pruneVmReconcileState();
       const orderedPeerSignature = JSON.stringify(peers.map((peer) => peer.toString()));
       let signatures = catchupPeerOrderSignatures.get(this);
       if (!signatures) {
@@ -3063,6 +3064,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         catchupPeerOrderSignatures.set(this, signatures);
       }
       if (signatures.get(rotationKey) !== orderedPeerSignature) {
+        this.vmReconcileCatchupPeerCursor.delete(rotationKey);
         this.vmReconcileCatchupPeerCursor.set(rotationKey, 0);
         signatures.set(rotationKey, orderedPeerSignature);
       }
@@ -3075,6 +3077,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let start = 0;
     if (rotationKey) {
       start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+      this.vmReconcileCatchupPeerCursor.delete(rotationKey);
       this.vmReconcileCatchupPeerCursor.set(rotationKey, (start + maxPeers) % peers.length);
     }
 
@@ -3484,6 +3487,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     options?: { persist?: boolean },
   ): ContextGraphSub {
     this.subscribedContextGraphs.set(contextGraphId, next);
+    if (!next.subscribed && !next.coreHosted) {
+      this.clearVmReconcileStateForContextGraph(contextGraphId);
+    }
     if (options?.persist !== false) {
       this.persistContextGraphSubscription(contextGraphId);
       if (next.subscribed) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -398,6 +398,7 @@ import type { DKGAgent } from './dkg-agent.js';
 export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
+    this.coreHostRecordingsClosed = false;
     const ctx = createOperationContext('connect');
     this.log.info(ctx, `Starting DKG node`);
 
@@ -1104,7 +1105,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 // hosts the CG so the chain-driven VM reconciler fills its gaps
                 // across restarts. Best-effort + public-CG-gated inside the
                 // helper; never blocks or affects the (sync) provenance return.
-                this.trackCoreHostRecording(this.recordCoreHostedPublicCg(cgId, swmGraphId));
+                this.trackCoreHostRecording(() => this.recordCoreHostedPublicCg(cgId, swmGraphId));
                 const wireFromCgId = cgId ? this.gossipWireIdFor(cgId) : undefined;
                 const wireFromSwmGraphId = swmGraphId && swmGraphId !== cgId
                   ? this.gossipWireIdFor(swmGraphId)

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -243,6 +243,7 @@ import { createCursorState, type CursorState } from './reconcile-cursor.js';
 const DEFAULT_MAX_REHYDRATED_SUBSCRIPTIONS = 64;
 /** Yield to the event loop every N activations so concurrent store work can interleave. */
 const REHYDRATE_THROTTLE_BATCH = 8;
+const catchupPeerOrderSignatures = new WeakMap<object, Map<string, string>>();
 
 // type alias so listPendingJoinApprovalRetries() retains its old
 // public shape while it stubs out to []. PR-12 rebuilds the operator
@@ -3046,12 +3047,29 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     options?: { maxPeers?: number; peerRotationKey?: string },
   ): Array<{ toString(): string }> {
     const maxPeers = options?.maxPeers;
-    if (maxPeers === undefined || !Number.isInteger(maxPeers) || maxPeers <= 0 || peers.length <= maxPeers) {
+    if (maxPeers === undefined || !Number.isInteger(maxPeers) || maxPeers <= 0) {
+      return peers;
+    }
+
+    const rotationKey = options?.peerRotationKey;
+    if (rotationKey) {
+      const orderedPeerSignature = JSON.stringify(peers.map((peer) => peer.toString()));
+      let signatures = catchupPeerOrderSignatures.get(this);
+      if (!signatures) {
+        signatures = new Map<string, string>();
+        catchupPeerOrderSignatures.set(this, signatures);
+      }
+      if (signatures.get(rotationKey) !== orderedPeerSignature) {
+        this.vmReconcileCatchupPeerCursor.set(rotationKey, 0);
+        signatures.set(rotationKey, orderedPeerSignature);
+      }
+    }
+
+    if (peers.length <= maxPeers) {
       return peers;
     }
 
     let start = 0;
-    const rotationKey = options?.peerRotationKey;
     if (rotationKey) {
       start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
       this.vmReconcileCatchupPeerCursor.set(rotationKey, (start + maxPeers) % peers.length);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3814,6 +3814,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       } catch {
         /* best-effort teardown */
       }
+      this.clearRecentVmReconcileStateForContextGraph(id);
       this.subscribedContextGraphs.delete(id);
     }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -398,8 +398,8 @@ import type { DKGAgent } from './dkg-agent.js';
 export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
+    this.coreHostRecordingGeneration += 1;
     this.coreHostRecordingsClosed = false;
-    this.coreHostRecordingsAborted = false;
     const ctx = createOperationContext('connect');
     this.log.info(ctx, `Starting DKG node`);
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3060,18 +3060,45 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       return peers;
     }
 
+    let start = 0;
+    const rotationKey = options?.peerRotationKey;
+    const currentPriorityRank = (peerId: string): number => options?.peerPriorityRanks?.get(peerId) ?? 0;
+    const rememberRotation = (peerIds: string[], selectedCount: number): void => {
+      if (!rotationKey) return;
+      if (peerIds.length === 0) {
+        this.vmReconcileCatchupPeerCursor.delete(rotationKey);
+        this.vmReconcileCatchupPeerOrder.delete(rotationKey);
+        return;
+      }
+      const nextCursor = start + selectedCount;
+      const selectedAll = selectedCount >= peerIds.length;
+      this.vmReconcileCatchupPeerCursor.delete(rotationKey);
+      this.vmReconcileCatchupPeerCursor.set(rotationKey, nextCursor);
+      this.vmReconcileCatchupPeerOrder.delete(rotationKey);
+      this.vmReconcileCatchupPeerOrder.set(rotationKey, {
+        orderedPeers: peerIds,
+        nextPeerId: selectedAll ? undefined : peerIds[nextCursor % peerIds.length],
+        priorityRanks: Object.fromEntries(
+          peerIds
+            .map((peerId) => [peerId, currentPriorityRank(peerId)] as const)
+            .filter(([, rank]) => rank > 0),
+        ),
+      });
+    };
+
     if (peers.length <= maxPeers) {
+      if (rotationKey) {
+        this.pruneVmReconcileState();
+        rememberRotation(peers.map((peer) => peer.toString()), peers.length);
+      }
       return peers;
     }
 
-    let start = 0;
-    const rotationKey = options?.peerRotationKey;
     if (rotationKey) {
       this.pruneVmReconcileState();
       const peerIds = peers.map((peer) => peer.toString());
       const previousOrder = this.vmReconcileCatchupPeerOrder.get(rotationKey);
       const nextPeerId = previousOrder?.nextPeerId;
-      const currentPriorityRank = (peerId: string): number => options?.peerPriorityRanks?.get(peerId) ?? 0;
       const previousPriorityRank = (peerId: string): number => previousOrder?.priorityRanks?.[peerId] ?? 0;
       const gainedPriority = (peerId: string): boolean => currentPriorityRank(peerId) > previousPriorityRank(peerId);
       if (nextPeerId) {
@@ -3092,21 +3119,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             : (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
         }
       } else {
-        start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+        const previousPeers = new Set(previousOrder?.orderedPeers ?? []);
+        const firstInvalidatingPeerIndex = peerIds.findIndex((peerId) =>
+          !previousPeers.has(peerId) || gainedPriority(peerId),
+        );
+        start = firstInvalidatingPeerIndex >= 0
+          ? firstInvalidatingPeerIndex
+          : (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
       }
-      const nextIndex = (start + maxPeers) % peers.length;
-      this.vmReconcileCatchupPeerCursor.delete(rotationKey);
-      this.vmReconcileCatchupPeerCursor.set(rotationKey, nextIndex);
-      this.vmReconcileCatchupPeerOrder.delete(rotationKey);
-      this.vmReconcileCatchupPeerOrder.set(rotationKey, {
-        orderedPeers: peerIds,
-        nextPeerId: peerIds[nextIndex],
-        priorityRanks: Object.fromEntries(
-          peerIds
-            .map((peerId) => [peerId, currentPriorityRank(peerId)] as const)
-            .filter(([, rank]) => rank > 0),
-        ),
-      });
+      rememberRotation(peerIds, maxPeers);
     }
 
     return [...peers.slice(start), ...peers.slice(0, start)].slice(0, maxPeers);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1104,7 +1104,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 // hosts the CG so the chain-driven VM reconciler fills its gaps
                 // across restarts. Best-effort + public-CG-gated inside the
                 // helper; never blocks or affects the (sync) provenance return.
-                void this.recordCoreHostedPublicCg(cgId, swmGraphId);
+                this.trackCoreHostRecording(this.recordCoreHostedPublicCg(cgId, swmGraphId));
                 const wireFromCgId = cgId ? this.gossipWireIdFor(cgId) : undefined;
                 const wireFromSwmGraphId = swmGraphId && swmGraphId !== cgId
                   ? this.gossipWireIdFor(swmGraphId)

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3814,7 +3814,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       } catch {
         /* best-effort teardown */
       }
-      this.clearRecentVmReconcileStateForContextGraph(id);
+      this.forceClearVmReconcileStateForContextGraph(id);
       this.subscribedContextGraphs.delete(id);
     }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2978,7 +2978,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async syncContextGraphFromConnectedPeers(this: DKGAgent,
     contextGraphId: string,
-    options?: { includeSharedMemory?: boolean },
+    options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
     connectedPeers: number;
     syncCapablePeers: number;
@@ -3025,19 +3025,39 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     await this.primeCatchupConnections();
 
-    const peers = this.selectCatchupPeers(
+    const orderedPeers = this.selectCatchupPeers(
       [...new Map(
         this.node.libp2p.getConnections().map((conn) => [conn.remotePeer.toString(), conn.remotePeer]),
       ).values()],
       preferredPeerId,
       isPrivateContextGraph,
     );
-    const coreCount = peers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
+    const peers = this.selectCatchupPeerWindow(orderedPeers, options);
+    const coreCount = orderedPeers.filter((p) => this.knownCorePeerIds.has(p.toString())).length;
     this.log.info(
       ctx,
-      `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${peers.length}`,
+      `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${orderedPeers.length} selected=${peers.length}`,
     );
     return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers);
+  }
+
+  selectCatchupPeerWindow(this: DKGAgent,
+    peers: Array<{ toString(): string }>,
+    options?: { maxPeers?: number; peerRotationKey?: string },
+  ): Array<{ toString(): string }> {
+    const maxPeers = options?.maxPeers;
+    if (maxPeers === undefined || !Number.isInteger(maxPeers) || maxPeers <= 0 || peers.length <= maxPeers) {
+      return peers;
+    }
+
+    let start = 0;
+    const rotationKey = options?.peerRotationKey;
+    if (rotationKey) {
+      start = (this.vmReconcileCatchupPeerCursor.get(rotationKey) ?? 0) % peers.length;
+      this.vmReconcileCatchupPeerCursor.set(rotationKey, (start + maxPeers) % peers.length);
+    }
+
+    return [...peers.slice(start), ...peers.slice(0, start)].slice(0, maxPeers);
   }
 
   async runCatchupOverPeers(this: DKGAgent,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2982,6 +2982,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
     connectedPeers: number;
+    selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
     /**
@@ -3039,7 +3040,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ctx,
       `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${orderedPeers.length} selected=${peers.length}`,
     );
-    return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers);
+    return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
+      connectedPeers: orderedPeers.length,
+    });
   }
 
   selectCatchupPeerWindow(this: DKGAgent,
@@ -3082,8 +3085,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     includeSharedMemory: boolean,
     peers: Array<{ toString(): string }>,
+    stats?: { connectedPeers?: number },
   ): Promise<{
     connectedPeers: number;
+    selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
     peersResponded: number;
@@ -3318,7 +3323,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     return {
-      connectedPeers: peers.length,
+      connectedPeers: stats?.connectedPeers ?? peers.length,
+      selectedPeers: peers.length,
       syncCapablePeers,
       peersTried,
       peersResponded,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2984,7 +2984,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string },
   ): Promise<{
+    /** Peers selected and processed after optional maxPeers windowing. */
     connectedPeers: number;
+    /** Ordered connected peers before optional maxPeers windowing. */
+    totalPeers: number;
     selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
@@ -3050,7 +3053,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       `catchup peer order for "${contextGraphId}": preferred=${preferredPeerId ?? 'none'} cores=${coreCount} total=${orderedPeers.length} selected=${peers.length}`,
     );
     return this.runCatchupOverPeers(contextGraphId, includeSharedMemory, peers, {
-      connectedPeers: orderedPeers.length,
+      totalPeers: orderedPeers.length,
     });
   }
 
@@ -3140,9 +3143,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphId: string,
     includeSharedMemory: boolean,
     peers: Array<{ toString(): string }>,
-    stats?: { connectedPeers?: number },
+    stats?: { totalPeers?: number },
   ): Promise<{
+    /** Peers selected and processed by this catch-up run. */
     connectedPeers: number;
+    /** Ordered connected peers before optional caller windowing. */
+    totalPeers: number;
     selectedPeers: number;
     syncCapablePeers: number;
     peersTried: number;
@@ -3378,7 +3384,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }
 
     return {
-      connectedPeers: stats?.connectedPeers ?? peers.length,
+      connectedPeers: peers.length,
+      totalPeers: stats?.totalPeers ?? peers.length,
       selectedPeers: peers.length,
       syncCapablePeers,
       peersTried,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2190,12 +2190,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     candidateNamespaces: VmReconcileSwmNamespace[];
     peerTopologyKey: string;
   }> {
-    let candidateNamespaces = this.vmReconcileRootSwmCandidateNamespaces(localCgId);
-    try {
-      candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
-    } catch {
-      // The root SWM namespace is always the minimum candidate set.
-    }
+    const candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
     return {
       candidateNamespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
@@ -2222,6 +2217,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
       ...this.vmReconcileRootSwmCandidateNamespaces(localCgId),
       ...subGraphNamespaces,
     ];
+  }
+
+  async collectVmReconcileSwmCandidateNamespacesBestEffort(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmNamespace[]> {
+    try {
+      return await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
+    } catch {
+      return this.vmReconcileRootSwmCandidateNamespaces(localCgId);
+    }
   }
 
   vmReconcileSwmNamespaceKey(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): string {
@@ -2366,7 +2369,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         this.vmReconcileFetchCooldownAt.delete(localCgId);
         return false;
       }
-      const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
+      const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
       if (this.vmReconcileSwmNamespaceKey(currentNamespaces) !== this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces)) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
@@ -2500,24 +2503,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.recentReconciledUals.deleteByPrefix(prefix, cacheKey);
   }
 
-  async vmReconcileActiveFetchAttemptLimit(this: DKGAgent): Promise<number> {
-    try {
-      await this.primeCatchupConnections();
-    } catch {
-      // Best effort only; active fetch can still use currently connected peers.
-    }
+  vmReconcileConnectedPeerCount(this: DKGAgent): number {
     try {
       const libp2p = (this.node as any)?.libp2p;
       const getConnections = libp2p?.getConnections;
-      if (typeof getConnections !== 'function') return 1;
+      if (typeof getConnections !== 'function') return 0;
       const uniquePeers = new Set<string>(
         (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
           .map((connection) => connection.remotePeer?.toString())
           .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
       );
-      return Math.max(1, uniquePeers.size);
+      return uniquePeers.size;
     } catch {
-      return 1;
+      return 0;
     }
   }
 
@@ -2606,7 +2604,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'fetch', ordinal, kaId: kaId.toString(), ual,
         });
-        const maxAttempts = await this.vmReconcileActiveFetchAttemptLimit();
+        let maxAttempts = 1;
         for (let attempt = 0; attempt < maxAttempts && outcome === 'no-swm'; attempt += 1) {
           try {
             const fetchResult = await this.syncContextGraphFromConnectedPeers(localCgId, {
@@ -2614,6 +2612,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
               maxPeers: 1,
               peerRotationKey: localCgId,
             });
+            maxAttempts = Math.min(
+              DKGAgentBase.VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS,
+              Math.max(maxAttempts, fetchResult.connectedPeers ?? 0, this.vmReconcileConnectedPeerCount()),
+            );
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }
@@ -2623,6 +2625,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
             activeFetchHadUsableResponse = true;
           } catch (err) {
             this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
+            maxAttempts = Math.min(
+              DKGAgentBase.VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS,
+              Math.max(maxAttempts, this.vmReconcileConnectedPeerCount()),
+            );
             continue;
           }
           outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2338,6 +2338,25 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return branches.join(' UNION ');
   }
 
+  deleteVmReconcileNegativeCacheEntry(this: DKGAgent, cacheKey: string): void {
+    const existing = this.vmReconcileNegativeCache.get(cacheKey);
+    if (!existing) return;
+    this.vmReconcileNegativeCache.delete(cacheKey);
+    const keys = this.vmReconcileNegativeCacheKeysByCg.get(existing.localCgId);
+    if (!keys) return;
+    keys.delete(cacheKey);
+    if (keys.size === 0) this.vmReconcileNegativeCacheKeysByCg.delete(existing.localCgId);
+  }
+
+  indexVmReconcileNegativeCacheEntry(this: DKGAgent, localCgId: string, cacheKey: string): void {
+    let keys = this.vmReconcileNegativeCacheKeysByCg.get(localCgId);
+    if (!keys) {
+      keys = new Set<string>();
+      this.vmReconcileNegativeCacheKeysByCg.set(localCgId, keys);
+    }
+    keys.add(cacheKey);
+  }
+
   async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
     cacheKey: string,
     localCgId: string,
@@ -2348,13 +2367,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     try {
       if (this.vmReconcilePeerTopologyKey() !== cached.peerTopologyKey) {
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.vmReconcileFetchCooldownAt.delete(localCgId);
         return false;
       }
       const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
       if (this.vmReconcileSwmNamespaceKey(currentNamespaces) !== this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces)) {
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
       }
       const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.map((namespace) => namespace.metaGraph));
@@ -2363,7 +2382,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces);
       if (currentSwmGen === null) return true;
       if (currentSwmGen !== cached.swmGen) {
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
       }
     } catch {
@@ -2375,6 +2394,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   recordVmReconcileNegativeCache(this: DKGAgent,
     cacheKey: string,
+    localCgId: string,
     state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string },
   ): void {
     this.pruneVmReconcileState();
@@ -2384,14 +2404,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
     );
-    if (previous) this.vmReconcileNegativeCache.delete(cacheKey);
+    if (previous) this.deleteVmReconcileNegativeCacheEntry(cacheKey);
     this.vmReconcileNegativeCache.set(cacheKey, {
+      localCgId,
       failures,
       nextRetryAt: Date.now() + backoff,
       swmGen: state.swmGen,
       candidateNamespaces: state.candidateNamespaces,
       peerTopologyKey: state.peerTopologyKey,
     });
+    this.indexVmReconcileNegativeCacheEntry(localCgId, cacheKey);
     this.pruneVmReconcileState();
   }
 
@@ -2410,13 +2432,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
   pruneVmReconcileState(this: DKGAgent, now = Date.now()): void {
     for (const [key, entry] of this.vmReconcileNegativeCache) {
       if (now >= entry.nextRetryAt) {
-        this.vmReconcileNegativeCache.delete(key);
+        this.deleteVmReconcileNegativeCacheEntry(key);
       }
     }
     while (this.vmReconcileNegativeCache.size > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       const oldestKey = this.vmReconcileNegativeCache.keys().next().value;
       if (oldestKey === undefined) break;
-      this.vmReconcileNegativeCache.delete(oldestKey);
+      this.deleteVmReconcileNegativeCacheEntry(oldestKey);
     }
 
     for (const [localCgId, lastFetchAt] of this.vmReconcileFetchCooldownAt) {
@@ -2434,14 +2456,28 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const oldestKey = this.vmReconcileCatchupPeerCursor.keys().next().value;
       if (oldestKey === undefined) break;
       this.vmReconcileCatchupPeerCursor.delete(oldestKey);
+      this.vmReconcileCatchupPeerOrder.delete(oldestKey);
+    }
+    while (this.vmReconcileCatchupPeerOrder.size > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileCatchupPeerOrder.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileCatchupPeerOrder.delete(oldestKey);
+      this.vmReconcileCatchupPeerCursor.delete(oldestKey);
     }
   }
 
   clearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
     const sub = this.subscribedContextGraphs.get(localCgId);
     if (sub?.subscribed || sub?.coreHosted) return;
+    const negativeCacheKeys = this.vmReconcileNegativeCacheKeysByCg.get(localCgId);
+    if (negativeCacheKeys) {
+      for (const cacheKey of Array.from(negativeCacheKeys)) {
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
+      }
+    }
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
+    this.vmReconcileCatchupPeerOrder.delete(localCgId);
   }
 
   vmReconcileCacheKey(this: DKGAgent, ual: string, merkleRoot: Uint8Array): string {
@@ -2458,7 +2494,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const prefix = this.vmReconcileCacheKeyPrefix(cacheKey);
     for (const key of this.vmReconcileNegativeCache.keys()) {
       if (key !== cacheKey && key.startsWith(prefix)) {
-        this.vmReconcileNegativeCache.delete(key);
+        this.deleteVmReconcileNegativeCacheEntry(key);
       }
     }
     this.recentReconciledUals.deleteByPrefix(prefix, cacheKey);
@@ -2602,7 +2638,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     switch (outcome) {
       case 'promoted':
         this.pruneVmReconcileCacheKeySiblings(cacheKey);
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
@@ -2616,7 +2652,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'already', ordinal, kaId: kaId.toString(), ual,
         });
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'stale-target':
         // A newer root won; do not prune its cache/recent state.
@@ -2625,7 +2661,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'already', ordinal, kaId: kaId.toString(), ual,
         });
-        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'no-swm':
         if (activeFetchRan && !activeFetchHadUsableResponse) {
@@ -2633,6 +2669,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         } else {
           this.recordVmReconcileNegativeCache(
             cacheKey,
+            localCgId,
             swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
           );
         }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2040,6 +2040,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async recordCoreHostedPublicCg(this: DKGAgent, cgId: string, swmGraphId?: string): Promise<void> {
     if (this.coreHostRecordingsClosed) return;
     if (!this.vmReconcileEnabled()) return;
+    const recordingGeneration = this.coreHostRecordingGeneration;
     let numeric: bigint;
     try {
       numeric = BigInt(cgId);
@@ -2053,7 +2054,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // the ACK-backed compatibility path because signing a StorageACK proves
     // this specific CG registration is live enough for host tracking.
     const policy = await this.readCoreHostedPublicCgAccessPolicy(numericStr);
-    if (this.coreHostRecordingsAborted) return;
+    if (this.coreHostRecordingGeneration !== recordingGeneration) return;
     if (policy !== 0) return; // curated / unknown / not-live — not the public VM-promote path
 
     // Pick the local CG id to key the host-only record under. Prefer an
@@ -2146,11 +2147,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
           `${DKGAgentBase.CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS}ms; continuing shutdown`,
         );
         this.coreHostRecordings.clear();
-        this.coreHostRecordingsAborted = true;
+        this.coreHostRecordingGeneration += 1;
         return;
       }
     }
-    if (this.coreHostRecordingsClosed) this.coreHostRecordingsAborted = true;
   }
 
   // ===== Phase B — chain-driven VM reconciliation (B.4 agent wiring) =========
@@ -2457,6 +2457,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
     });
   }
 
+  vmReconcileSwmGenContainsSnapshot(this: DKGAgent, cachedSwmGen: string, currentSwmGen: string): boolean {
+    return cachedSwmGen === currentSwmGen || cachedSwmGen.split('|').includes(currentSwmGen);
+  }
+
   vmReconcileWorkspaceOperationPattern(this: DKGAgent, candidateMetaGraphs: string[]): string {
     const branches: string[] = [];
     for (const graph of candidateMetaGraphs) {
@@ -2515,7 +2519,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const currentNamespaceKey = this.vmReconcileSwmNamespaceKey(currentNamespaces.namespaces);
       const cachedNamespaceKey = this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces);
       if (currentNamespaceKey !== cachedNamespaceKey) {
-        if (!currentNamespaces.complete) return true;
+        if (!currentNamespaces.complete) {
+          const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces.namespaces);
+          if (currentSwmGen === null) {
+            this.deleteVmReconcileNegativeCacheEntry(cacheKey);
+            return false;
+          }
+          if (!this.vmReconcileSwmGenContainsSnapshot(cached.swmGen, currentSwmGen)) {
+            this.deleteVmReconcileNegativeCacheEntry(cacheKey);
+            return false;
+          }
+          return true;
+        }
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
       }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1940,8 +1940,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const hadProgress =
       (sub.lastReconciledOrdinal ?? 0) > 0 || this.reconcileCursors.has(localCgId);
     sub.lastReconciledOrdinal = 0;
-    this.reconcileCursors.delete(localCgId);
-    this.clearRecentVmReconcileStateForContextGraph(localCgId);
+    this.forceClearVmReconcileStateForContextGraph(localCgId);
     if (hadProgress) {
       this.log.info(
         createOperationContext('system'),
@@ -1956,8 +1955,26 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
     const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
     if (typeof getAccessPolicy !== 'function') return null;
+    const numericId = BigInt(onChainId);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+      timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), CHAIN_POLICY_READ_TIMEOUT_MS);
+      timer.unref?.();
+    });
     try {
-      const policy = await getAccessPolicy.call(this.chain, BigInt(onChainId));
+      const policy = await Promise.race([
+        Promise.resolve(getAccessPolicy.call(this.chain, numericId))
+          .finally(() => { if (timer) clearTimeout(timer); }),
+        timeout,
+      ]);
+      if (policy === TIMEOUT_SENTINEL) {
+        this.log.warn(
+          createOperationContext('system'),
+          `recordCoreHostedPublicCg(${onChainId}): getContextGraphAccessPolicy timed out after ` +
+          `${CHAIN_POLICY_READ_TIMEOUT_MS}ms — treating hosted CG access policy as UNKNOWN`,
+        );
+        return null;
+      }
       return policy === 0 || policy === 1 ? policy : null;
     } catch {
       return null;
@@ -2503,12 +2520,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
   clearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
     const sub = this.subscribedContextGraphs.get(localCgId);
     if (sub?.subscribed || sub?.coreHosted) return;
+    this.forceClearVmReconcileStateForContextGraph(localCgId);
+  }
+
+  forceClearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
     const negativeCacheKeys = this.vmReconcileNegativeCacheKeysByCg.get(localCgId);
     if (negativeCacheKeys) {
       for (const cacheKey of Array.from(negativeCacheKeys)) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
       }
     }
+    this.reconcileCursors.delete(localCgId);
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2189,18 +2189,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
     swmGen: string;
     candidateNamespaces: VmReconcileSwmNamespace[];
   }> {
-    const graphManager = new GraphManager(this.store);
-    const candidateNamespaces: VmReconcileSwmNamespace[] = [{
-      metaGraph: contextGraphWorkspaceMetaGraphUri(localCgId),
-      dataGraph: contextGraphWorkspaceGraphUri(localCgId),
-    }];
+    let candidateNamespaces = this.vmReconcileRootSwmCandidateNamespaces(localCgId);
     try {
-      for (const sg of await graphManager.listSubGraphs(localCgId)) {
-        candidateNamespaces.push({
-          metaGraph: graphManager.sharedMemoryMetaUri(localCgId, sg),
-          dataGraph: graphManager.sharedMemoryUri(localCgId, sg),
-        });
-      }
+      candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
     } catch {
       // The root SWM namespace is always the minimum candidate set.
     }
@@ -2208,6 +2199,34 @@ export class SwmHostModeMethods extends DKGAgentBase {
       candidateNamespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
     };
+  }
+
+  vmReconcileRootSwmCandidateNamespaces(this: DKGAgent, localCgId: string): VmReconcileSwmNamespace[] {
+    return [{
+      metaGraph: contextGraphWorkspaceMetaGraphUri(localCgId),
+      dataGraph: contextGraphWorkspaceGraphUri(localCgId),
+    }];
+  }
+
+  async collectVmReconcileSwmCandidateNamespaces(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmNamespace[]> {
+    const graphManager = new GraphManager(this.store);
+    const subGraphNamespaces = (await graphManager.listSubGraphs(localCgId))
+      .map((sg) => ({
+        metaGraph: graphManager.sharedMemoryMetaUri(localCgId, sg),
+        dataGraph: graphManager.sharedMemoryUri(localCgId, sg),
+      }))
+      .sort((a, b) => `${a.metaGraph}\0${a.dataGraph}`.localeCompare(`${b.metaGraph}\0${b.dataGraph}`));
+    return [
+      ...this.vmReconcileRootSwmCandidateNamespaces(localCgId),
+      ...subGraphNamespaces,
+    ];
+  }
+
+  vmReconcileSwmNamespaceKey(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): string {
+    return candidateNamespaces
+      .map((namespace) => `${namespace.metaGraph}\0${namespace.dataGraph}`)
+      .sort()
+      .join('\n');
   }
 
   async readVmReconcileSwmGen(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): Promise<string | null> {
@@ -2303,16 +2322,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
     cacheKey: string,
+    localCgId: string,
   ): Promise<boolean> {
     const cached = this.vmReconcileNegativeCache.get(cacheKey);
     if (!cached) return false;
     if (Date.now() >= cached.nextRetryAt) return false;
 
-    const pattern = this.vmReconcileWorkspaceOperationPattern(cached.candidateNamespaces.map((namespace) => namespace.metaGraph));
-    if (!pattern) return true;
-    if (cached.swmGen === 'unreadable') return true;
     try {
-      const currentSwmGen = await this.readVmReconcileSwmGen(cached.candidateNamespaces);
+      const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
+      if (this.vmReconcileSwmNamespaceKey(currentNamespaces) !== this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces)) {
+        this.vmReconcileNegativeCache.delete(cacheKey);
+        return false;
+      }
+      const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.map((namespace) => namespace.metaGraph));
+      if (!pattern) return true;
+      if (cached.swmGen === 'unreadable') return true;
+      const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces);
       if (currentSwmGen === null) return true;
       if (currentSwmGen !== cached.swmGen) {
         this.vmReconcileNegativeCache.delete(cacheKey);
@@ -2432,7 +2457,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // cursor advances without redoing chain reads + an SWM scan.
       if (this.recentReconciledUals.has(cacheKey)) return { status: 'already', blockNumber: versionBlock };
 
-      if (await this.shouldDeferVmReconcileByNegativeCache(cacheKey)) {
+      if (await this.shouldDeferVmReconcileByNegativeCache(cacheKey, localCgId)) {
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1949,27 +1949,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   /**
-   * Phase D — resolve the on-chain access policy for a numeric CG id, public(0)
-   * / curated(1) / unknown(null). Cache-first (the StorageACK `isCgCurated`
-   * oracle seeds the same cache), single lazy chain read on miss. Never throws.
-   */
-  async resolveAccessPolicy(this: DKGAgent, numericCgId: bigint): Promise<0 | 1 | null> {
-    const key = numericCgId.toString();
-    const cached = this.onChainAccessPolicyCache.get(key);
-    if (cached === 0 || cached === 1) return cached;
-    const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
-    if (typeof getAccessPolicy !== 'function') return null;
-    try {
-      const policy = await getAccessPolicy.call(this.chain, numericCgId);
-      if (policy === 0 || policy === 1) {
-        this.onChainAccessPolicyCache.set(key, policy);
-        return policy;
-      }
-    } catch { /* unknown — fall through */ }
-    return null;
-  }
-
-  /**
    * Phase D (Cores fill their own gaps) — invoked from the StorageACK
    * pre-sign hook. When this Core signs an ACK for a PUBLIC CG it becomes a
    * storage node for it; mark the CG `coreHosted` (persisted) so the
@@ -1991,10 +1970,13 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
     if (numeric <= 0n) return;
 
-    const policy = await this.resolveAccessPolicy(numeric);
-    if (policy !== 0) return; // curated / unknown — not the public VM-promote path
-
     const numericStr = numeric.toString();
+    // Existence-gated read. `getContextGraphAccessPolicy` can return Solidity's
+    // default public(0) for unknown ids, so prove the slot is live before
+    // trusting the policy; fail closed for curated, unknown, or not-live CGs.
+    const policy = await this.readLiveOnChainAccessPolicy(numericStr);
+    if (policy !== 0) return; // curated / unknown / not-live — not the public VM-promote path
+
     // Pick the local CG id to key the host-only record under. Prefer an
     // existing local mapping; otherwise use the publisher-supplied cleartext
     // `swmGraphId` (the local CG name for a public/cleartext publish). On the
@@ -2038,6 +2020,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // Nudge a reconcile now so the first hosted publish lands promptly; the
     // periodic sweep is the safety net.
     if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
+  }
+
+  trackCoreHostRecording(this: DKGAgent, p: Promise<void>): void {
+    const tracked = p.catch((err) => {
+      this.log.warn(
+        createOperationContext('system'),
+        `Phase D: recordCoreHostedPublicCg failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }).finally(() => {
+      this.coreHostRecordings.delete(tracked);
+    });
+    this.coreHostRecordings.add(tracked);
   }
 
   // ===== Phase B — chain-driven VM reconciliation (B.4 agent wiring) =========
@@ -2124,12 +2118,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const deps: ChainReconcilerDeps = {
       getKCCount: async (cg) => Number(await this.chain.getContextGraphKCCount!(cg)),
       getHeadBlock: async () => {
+        // Capability-absent chains return undefined and disable the reorg gate;
+        // transient RPC failures must throw so the reconciler holds the
+        // watermark instead of advancing on an unobserved head.
         if (typeof this.chain.getBlockNumber !== 'function') return undefined;
-        try {
-          return await this.chain.getBlockNumber();
-        } catch {
-          return undefined;
-        }
+        return await this.chain.getBlockNumber();
       },
       reconcileOrdinal: (lcg, ocg, ordinal, headBlock) =>
         this.reconcileChainOrdinal(lcg, ocg, ordinal, headBlock),

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2234,22 +2234,31 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const libp2p = (this.node as any)?.libp2p;
       const getConnections = libp2p?.getConnections;
       if (typeof getConnections !== 'function') return 'unreadable';
-      const peers = [...new Map(
+      const peerIds = [...new Map(
         (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
           .map((connection) => [connection.remotePeer?.toString(), connection.remotePeer] as const)
           .filter((entry): entry is readonly [string, { toString(): string }] =>
             typeof entry[0] === 'string' && entry[0].length > 0 && !!entry[1],
           ),
-      ).values()];
-      const orderedPeers = this.selectCatchupPeers(peers, preferredPeerId, isPrivateContextGraph);
-      return JSON.stringify(orderedPeers.map((peer) => {
-        const peerId = peer.toString();
-        return {
-          peerId,
-          preferred: peerId === preferredPeerId,
-          core: this.knownCorePeerIds.has(peerId),
-        };
-      }));
+      ).keys()].sort();
+      const orderedPeers = this.selectCatchupPeers(
+        peerIds.map((peerId) => ({ toString: () => peerId })),
+        preferredPeerId,
+        isPrivateContextGraph,
+      );
+      return JSON.stringify({
+        preferredPeerId: preferredPeerId ?? null,
+        privateOnly: isPrivateContextGraph,
+        peers: orderedPeers.map((peer, rank) => {
+          const peerId = peer.toString();
+          return {
+            rank,
+            peerId,
+            preferred: peerId === preferredPeerId,
+            core: this.knownCorePeerIds.has(peerId),
+          };
+        }),
+      });
     } catch {
       return 'unreadable';
     }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1955,38 +1955,71 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   async readCoreHostedPublicCgAccessPolicy(this: DKGAgent, onChainId: string): Promise<0 | 1 | null> {
-    if (typeof this.chain.isContextGraphActiveOnChain === 'function') {
-      return this.readLiveOnChainAccessPolicy(onChainId);
-    }
-    const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
-    if (typeof getAccessPolicy !== 'function') return null;
     const numericId = BigInt(onChainId);
-    const cached = this.onChainAccessPolicyCache.get(onChainId);
-    if (cached === 0 || cached === 1) return cached;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-      timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), CHAIN_POLICY_READ_TIMEOUT_MS);
-      timer.unref?.();
-    });
-    try {
-      const policy = await Promise.race([
-        Promise.resolve(getAccessPolicy.call(this.chain, numericId))
-          .finally(() => { if (timer) clearTimeout(timer); }),
-        timeout,
-      ]);
-      if (policy === TIMEOUT_SENTINEL) {
-        this.log.warn(
-          createOperationContext('system'),
-          `recordCoreHostedPublicCg(${onChainId}): getContextGraphAccessPolicy timed out after ` +
-          `${CHAIN_POLICY_READ_TIMEOUT_MS}ms — treating hosted CG access policy as UNKNOWN`,
-        );
+    const raceChainRead = async <T>(start: () => T | Promise<T>): Promise<T | typeof TIMEOUT_SENTINEL> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), CHAIN_POLICY_READ_TIMEOUT_MS);
+        timer.unref?.();
+      });
+      let work: Promise<T>;
+      try {
+        work = Promise.resolve(start()).finally(() => { if (timer) clearTimeout(timer); });
+      } catch (err) {
+        if (timer) clearTimeout(timer);
+        throw err;
+      }
+      return Promise.race([work, timeout]);
+    };
+    const readAccessPolicy = async (useCache: boolean): Promise<0 | 1 | null> => {
+      const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+      if (typeof getAccessPolicy !== 'function') return null;
+      const cached = this.onChainAccessPolicyCache.get(onChainId);
+      if (useCache && (cached === 0 || cached === 1)) return cached;
+      try {
+        const policy = await raceChainRead(() => getAccessPolicy.call(this.chain, numericId));
+        if (policy === TIMEOUT_SENTINEL) {
+          this.log.warn(
+            createOperationContext('system'),
+            `recordCoreHostedPublicCg(${onChainId}): getContextGraphAccessPolicy timed out after ` +
+            `${CHAIN_POLICY_READ_TIMEOUT_MS}ms — treating hosted CG access policy as UNKNOWN`,
+          );
+          return null;
+        }
+        if (policy === 0 || policy === 1) {
+          this.onChainAccessPolicyCache.set(onChainId, policy);
+          return policy;
+        }
+        return null;
+      } catch {
         return null;
       }
-      if (policy === 0 || policy === 1) {
-        this.onChainAccessPolicyCache.set(onChainId, policy);
-        return policy;
-      }
-      return null;
+    };
+
+    const isActive = this.chain.isContextGraphActiveOnChain;
+    if (typeof isActive !== 'function') return readAccessPolicy(true);
+    try {
+      const live = await raceChainRead(() => isActive.call(this.chain, numericId));
+      if (live === true) return readAccessPolicy(false);
+      if (live !== TIMEOUT_SENTINEL) return null;
+      this.log.warn(
+        createOperationContext('system'),
+        `recordCoreHostedPublicCg(${onChainId}): isContextGraphActiveOnChain timed out after ` +
+        `${CHAIN_POLICY_READ_TIMEOUT_MS}ms — falling back to ACK-backed access policy read`,
+      );
+    } catch (err) {
+      this.log.warn(
+        createOperationContext('system'),
+        `recordCoreHostedPublicCg(${onChainId}): isContextGraphActiveOnChain failed: ` +
+        `${err instanceof Error ? err.message : String(err)} — falling back to ACK-backed access policy read`,
+      );
+    }
+
+    try {
+      // StorageACK signing proves this specific registration was live enough
+      // to host. If the optional liveness probe itself flakes, preserve the
+      // host-tracking path and only fail closed when the policy read is unknown.
+      return await readAccessPolicy(false);
     } catch {
       return null;
     }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2000,7 +2000,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (typeof isActive !== 'function') return readAccessPolicy(true);
     try {
       const live = await raceChainRead(() => isActive.call(this.chain, numericId));
-      if (live === true) return readAccessPolicy(true);
+      if (live === true) return readAccessPolicy(false);
       if (live !== TIMEOUT_SENTINEL) return null;
       this.log.warn(
         createOperationContext('system'),

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -33,7 +33,7 @@ import {
   decodeEncryptedWorkspacePayload, ENCRYPTED_WORKSPACE_ENVELOPE_TYPE,
   decodeSwmSenderKeyMessage, SWM_SENDER_KEY_MESSAGE_TYPE,
   getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
-  Logger, createOperationContext, sparqlString, escapeSparqlLiteral, isSafeIri, assertSafeIri,
+  Logger, createOperationContext, sparqlString, isSafeIri, assertSafeIri,
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
   buildTrustLevelQuads,
@@ -251,7 +251,7 @@ import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResu
 import { buildCclEvaluationQuads } from './ccl-evaluation-publish.js';
 import { buildManualCclFacts, resolveFactsFromSnapshot, type CclFactResolutionMode } from './ccl-fact-resolution.js';
 import {
-  strip, stripLiteral, jsonLdToQuads,
+  stripLiteral, jsonLdToQuads,
   type JsonLdContent,
 } from './dkg-agent-utils.js';
 import {
@@ -2184,6 +2184,117 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
   }
 
+  async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<{
+    swmGen: string;
+    candidateMetaGraphs: string[];
+  }> {
+    const graphManager = new GraphManager(this.store);
+    const candidateMetaGraphs = [contextGraphWorkspaceMetaGraphUri(localCgId)];
+    try {
+      for (const sg of await graphManager.listSubGraphs(localCgId)) {
+        candidateMetaGraphs.push(graphManager.sharedMemoryMetaUri(localCgId, sg));
+      }
+    } catch {
+      // The root SWM namespace is always the minimum candidate set.
+    }
+    return {
+      candidateMetaGraphs,
+      swmGen: await this.readVmReconcileSwmGen(candidateMetaGraphs) ?? 'unreadable',
+    };
+  }
+
+  async readVmReconcileSwmGen(this: DKGAgent, candidateMetaGraphs: string[]): Promise<string | null> {
+    const pattern = this.vmReconcileWorkspaceOperationPattern(candidateMetaGraphs);
+    if (!pattern) return 'empty:0';
+    try {
+      const result = await this.store.query(`SELECT
+        (COUNT(DISTINCT ?op) AS ?opCount)
+        (COUNT(?root) AS ?rootCount)
+        (MAX(?ts) AS ?maxTs)
+      WHERE {
+        ${pattern}
+      }`);
+      if (result.type === 'bindings' && result.bindings.length > 0) {
+        const row = result.bindings[0];
+        const opCount = typeof row['opCount'] === 'string' ? stripLiteral(row['opCount']) : '0';
+        const rootCount = typeof row['rootCount'] === 'string' ? stripLiteral(row['rootCount']) : '0';
+        const maxTs = typeof row['maxTs'] === 'string' ? stripLiteral(row['maxTs']) : '';
+        return `ops:${opCount};roots:${rootCount};maxTs:${maxTs}`;
+      }
+    } catch {
+      // A failed cheap probe is not evidence that the expensive merkle scan
+      // should run again immediately.
+    }
+    return null;
+  }
+
+  vmReconcileWorkspaceOperationPattern(this: DKGAgent, candidateMetaGraphs: string[]): string {
+    const branches: string[] = [];
+    for (const graph of candidateMetaGraphs) {
+      try {
+        branches.push(`{ GRAPH <${assertSafeIri(graph)}> {
+          ?op <http://dkg.io/ontology/rootEntity> ?root .
+          OPTIONAL { ?op <http://dkg.io/ontology/publishedAt> ?ts . }
+        } }`);
+      } catch {
+        // Skip unsafe graph names instead of building a malformed query.
+      }
+    }
+    return branches.join(' UNION ');
+  }
+
+  async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
+    ual: string,
+  ): Promise<boolean> {
+    const cached = this.vmReconcileNegativeCache.get(ual);
+    if (!cached) return false;
+    if (Date.now() >= cached.nextRetryAt) return false;
+
+    const pattern = this.vmReconcileWorkspaceOperationPattern(cached.candidateMetaGraphs);
+    if (!pattern) return true;
+    if (cached.swmGen === 'unreadable') return true;
+    try {
+      const currentSwmGen = await this.readVmReconcileSwmGen(cached.candidateMetaGraphs);
+      if (currentSwmGen === null) return true;
+      if (currentSwmGen !== cached.swmGen) {
+        this.vmReconcileNegativeCache.delete(ual);
+        return false;
+      }
+    } catch {
+      // Stay damped until the backoff expires; a failed cheap probe is not
+      // evidence that the expensive merkle scan should run again immediately.
+    }
+    return true;
+  }
+
+  recordVmReconcileNegativeCache(this: DKGAgent,
+    ual: string,
+    state: { swmGen: string; candidateMetaGraphs: string[] },
+  ): void {
+    const previous = this.vmReconcileNegativeCache.get(ual);
+    const failures = (previous?.failures ?? 0) + 1;
+    const backoff = Math.min(
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
+      DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
+    );
+    this.vmReconcileNegativeCache.set(ual, {
+      failures,
+      nextRetryAt: Date.now() + backoff,
+      swmGen: state.swmGen,
+      candidateMetaGraphs: state.candidateMetaGraphs,
+    });
+  }
+
+  shouldRunVmReconcileActiveFetch(this: DKGAgent, localCgId: string): boolean {
+    const now = Date.now();
+    const lastFetchAt = this.vmReconcileFetchCooldownAt.get(localCgId);
+    if (lastFetchAt !== undefined && now - lastFetchAt < DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS) {
+      return false;
+    }
+    this.vmReconcileFetchCooldownAt.set(localCgId, now);
+    return true;
+  }
+
   /**
    * Reconcile a single per-CG registration ordinal: resolve the kaId + its
    * latest on-chain merkle root + publisher, build the UAL, and ask the
@@ -2218,6 +2329,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // cursor advances without redoing chain reads + an SWM scan.
       if (this.recentReconciledUals.has(ual)) return { status: 'already', blockNumber: versionBlock };
 
+      if (await this.shouldDeferVmReconcileByNegativeCache(ual)) {
+        this.emitReplication({
+          contextGraphId: localCgId,
+          onChainCgId: onChainCgId.toString(),
+          action: 'defer',
+          ordinal,
+          kaId: kaId.toString(),
+          ual,
+          detail: 'negative-cache',
+        });
+        return { status: 'pending' };
+      }
+
       merkleRoot = await this.chain.getLatestMerkleRoot!(kaId);
       publisherAddress = (this.chain.getLatestMerkleRootPublisher
         ? await this.chain.getLatestMerkleRootPublisher(kaId)
@@ -2239,24 +2363,38 @@ export class SwmHostModeMethods extends DKGAgentBase {
       versionBlock,
     };
 
+    let swmState: { swmGen: string; candidateMetaGraphs: string[] } | undefined;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     if (outcome === 'no-swm') {
+      swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
       // Active fetch: pull the missing snapshot core-first (selectCatchupPeers
       // already prioritises known cores + the preferred sync peer), then retry.
-      this.emitReplication({
-        contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
-        action: 'fetch', ordinal, kaId: kaId.toString(), ual,
-      });
-      try {
-        await this.syncContextGraphFromConnectedPeers(localCgId, { includeSharedMemory: true });
-      } catch (err) {
-        this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (this.shouldRunVmReconcileActiveFetch(localCgId)) {
+        this.emitReplication({
+          contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
+          action: 'fetch', ordinal, kaId: kaId.toString(), ual,
+        });
+        try {
+          await this.syncContextGraphFromConnectedPeers(localCgId, {
+            includeSharedMemory: true,
+            maxPeers: 1,
+            peerRotationKey: localCgId,
+          });
+        } catch (err) {
+          this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
+        if (outcome === 'no-swm') {
+          swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
+        }
+      } else {
+        this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) skipped by per-CG cooldown`);
       }
-      outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     }
 
     switch (outcome) {
       case 'promoted':
+        this.vmReconcileNegativeCache.delete(ual);
         this.recentReconciledUals.add(ual);
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
@@ -2271,8 +2409,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'already', ordinal, kaId: kaId.toString(), ual,
         });
+        this.vmReconcileNegativeCache.delete(ual);
         return { status: 'already', blockNumber: versionBlock };
       case 'no-swm':
+        this.recordVmReconcileNegativeCache(
+          ual,
+          swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
+        );
+        this.emitReplication({
+          contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
+          action: 'defer', ordinal, kaId: kaId.toString(), ual, detail: outcome,
+        });
+        return { status: 'pending' };
       case 'unverified':
       default:
         this.emitReplication({

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2000,7 +2000,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (typeof isActive !== 'function') return readAccessPolicy(true);
     try {
       const live = await raceChainRead(() => isActive.call(this.chain, numericId));
-      if (live === true) return readAccessPolicy(false);
+      if (live === true) return readAccessPolicy(true);
       if (live !== TIMEOUT_SENTINEL) return null;
       this.log.warn(
         createOperationContext('system'),
@@ -2019,7 +2019,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // StorageACK signing proves this specific registration was live enough
       // to host. If the optional liveness probe itself flakes, preserve the
       // host-tracking path and only fail closed when the policy read is unknown.
-      return await readAccessPolicy(false);
+      return await readAccessPolicy(true);
     } catch {
       return null;
     }
@@ -2053,7 +2053,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // the ACK-backed compatibility path because signing a StorageACK proves
     // this specific CG registration is live enough for host tracking.
     const policy = await this.readCoreHostedPublicCgAccessPolicy(numericStr);
-    if (this.coreHostRecordingsClosed) return;
+    if (this.coreHostRecordingsAborted) return;
     if (policy !== 0) return; // curated / unknown / not-live — not the public VM-promote path
 
     // Pick the local CG id to key the host-only record under. Prefer an
@@ -2146,9 +2146,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
           `${DKGAgentBase.CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS}ms; continuing shutdown`,
         );
         this.coreHostRecordings.clear();
+        this.coreHostRecordingsAborted = true;
         return;
       }
     }
+    if (this.coreHostRecordingsClosed) this.coreHostRecordingsAborted = true;
   }
 
   // ===== Phase B — chain-driven VM reconciliation (B.4 agent wiring) =========

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2244,9 +2244,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   async shouldDeferVmReconcileByNegativeCache(this: DKGAgent,
-    ual: string,
+    cacheKey: string,
   ): Promise<boolean> {
-    const cached = this.vmReconcileNegativeCache.get(ual);
+    const cached = this.vmReconcileNegativeCache.get(cacheKey);
     if (!cached) return false;
     if (Date.now() >= cached.nextRetryAt) return false;
 
@@ -2257,7 +2257,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       const currentSwmGen = await this.readVmReconcileSwmGen(cached.candidateMetaGraphs);
       if (currentSwmGen === null) return true;
       if (currentSwmGen !== cached.swmGen) {
-        this.vmReconcileNegativeCache.delete(ual);
+        this.vmReconcileNegativeCache.delete(cacheKey);
         return false;
       }
     } catch {
@@ -2268,16 +2268,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   recordVmReconcileNegativeCache(this: DKGAgent,
-    ual: string,
+    cacheKey: string,
     state: { swmGen: string; candidateMetaGraphs: string[] },
   ): void {
-    const previous = this.vmReconcileNegativeCache.get(ual);
+    const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;
     const backoff = Math.min(
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
     );
-    this.vmReconcileNegativeCache.set(ual, {
+    this.vmReconcileNegativeCache.set(cacheKey, {
       failures,
       nextRetryAt: Date.now() + backoff,
       swmGen: state.swmGen,
@@ -2293,6 +2293,47 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
     this.vmReconcileFetchCooldownAt.set(localCgId, now);
     return true;
+  }
+
+  vmReconcileCacheKey(this: DKGAgent, ual: string, merkleRoot: Uint8Array): string {
+    const rootHex = Array.from(merkleRoot, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `${ual}#${rootHex}`;
+  }
+
+  vmReconcileCacheKeyPrefix(this: DKGAgent, cacheKey: string): string {
+    const separator = cacheKey.lastIndexOf('#');
+    return separator >= 0 ? cacheKey.slice(0, separator + 1) : `${cacheKey}#`;
+  }
+
+  pruneVmReconcileCacheKeySiblings(this: DKGAgent, cacheKey: string): void {
+    const prefix = this.vmReconcileCacheKeyPrefix(cacheKey);
+    for (const key of this.vmReconcileNegativeCache.keys()) {
+      if (key !== cacheKey && key.startsWith(prefix)) {
+        this.vmReconcileNegativeCache.delete(key);
+      }
+    }
+    this.recentReconciledUals.deleteByPrefix(prefix, cacheKey);
+  }
+
+  async vmReconcileActiveFetchAttemptLimit(this: DKGAgent): Promise<number> {
+    try {
+      await this.primeCatchupConnections();
+    } catch {
+      // Best effort only; active fetch can still use currently connected peers.
+    }
+    try {
+      const libp2p = (this.node as any)?.libp2p;
+      const getConnections = libp2p?.getConnections;
+      if (typeof getConnections !== 'function') return 1;
+      const uniquePeers = new Set<string>(
+        (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
+          .map((connection) => connection.remotePeer?.toString())
+          .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
+      );
+      return Math.max(1, uniquePeers.size);
+    } catch {
+      return 1;
+    }
   }
 
   /**
@@ -2317,6 +2358,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     let merkleRoot: Uint8Array;
     let publisherAddress: string;
     let ual: string;
+    let cacheKey = '';
     try {
       kaId = await this.chain.getContextGraphKCAt!(onChainCgId, BigInt(ordinal));
       const storageAddr = this.chain.getDKGKnowledgeAssetsAddress
@@ -2324,12 +2366,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
         : undefined;
       if (!storageAddr) return { status: 'skip' };
       ual = buildKnowledgeAssetUal(this.chain.chainId, storageAddr, kaId);
+      merkleRoot = await this.chain.getLatestMerkleRoot!(kaId);
+      cacheKey = this.vmReconcileCacheKey(ual, merkleRoot);
+      this.pruneVmReconcileCacheKeySiblings(cacheKey);
 
       // Recently reconciled (live-burst guard): treat as already-done so the
       // cursor advances without redoing chain reads + an SWM scan.
-      if (this.recentReconciledUals.has(ual)) return { status: 'already', blockNumber: versionBlock };
+      if (this.recentReconciledUals.has(cacheKey)) return { status: 'already', blockNumber: versionBlock };
 
-      if (await this.shouldDeferVmReconcileByNegativeCache(ual)) {
+      if (await this.shouldDeferVmReconcileByNegativeCache(cacheKey)) {
         this.emitReplication({
           contextGraphId: localCgId,
           onChainCgId: onChainCgId.toString(),
@@ -2342,7 +2387,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
         return { status: 'pending' };
       }
 
-      merkleRoot = await this.chain.getLatestMerkleRoot!(kaId);
       publisherAddress = (this.chain.getLatestMerkleRootPublisher
         ? await this.chain.getLatestMerkleRootPublisher(kaId)
         : '') ?? '';
@@ -2374,16 +2418,23 @@ export class SwmHostModeMethods extends DKGAgentBase {
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'fetch', ordinal, kaId: kaId.toString(), ual,
         });
-        try {
-          await this.syncContextGraphFromConnectedPeers(localCgId, {
-            includeSharedMemory: true,
-            maxPeers: 1,
-            peerRotationKey: localCgId,
-          });
-        } catch (err) {
-          this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
+        const maxAttempts = await this.vmReconcileActiveFetchAttemptLimit();
+        for (let attempt = 0; attempt < maxAttempts && outcome === 'no-swm'; attempt += 1) {
+          try {
+            const fetchResult = await this.syncContextGraphFromConnectedPeers(localCgId, {
+              includeSharedMemory: true,
+              maxPeers: 1,
+              peerRotationKey: localCgId,
+            });
+            if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
+              continue;
+            }
+          } catch (err) {
+            this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
+            continue;
+          }
+          outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
         }
-        outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
         if (outcome === 'no-swm') {
           swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
         }
@@ -2394,8 +2445,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     switch (outcome) {
       case 'promoted':
-        this.vmReconcileNegativeCache.delete(ual);
-        this.recentReconciledUals.add(ual);
+        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'promote', ordinal, kaId: kaId.toString(), ual,
@@ -2404,16 +2455,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       case 'already-confirmed':
       case 'stale-target':
         // Already in VM (or a newer update is) — done for cursor purposes.
-        this.recentReconciledUals.add(ual);
+        this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'already', ordinal, kaId: kaId.toString(), ual,
         });
-        this.vmReconcileNegativeCache.delete(ual);
+        this.vmReconcileNegativeCache.delete(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'no-swm':
         this.recordVmReconcileNegativeCache(
-          ual,
+          cacheKey,
           swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
         );
         this.emitReplication({

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2438,6 +2438,21 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return true;
   }
 
+  vmReconcileActiveFetchHadUsableResponse(this: DKGAgent, result: {
+    peersSucceeded?: number;
+    sharedMemorySynced?: number;
+    diagnostics?: { sharedMemory?: Partial<SharedMemorySyncDiagnostics> };
+  }): boolean {
+    if ((result.peersSucceeded ?? 0) > 0) return true;
+    if ((result.sharedMemorySynced ?? 0) > 0) return true;
+    const shared = result.diagnostics?.sharedMemory;
+    if (!shared) return false;
+    return (shared.insertedDataTriples ?? 0) > 0
+      || (shared.insertedMetaTriples ?? 0) > 0
+      || (shared.checkpointAdvances ?? 0) > 0
+      || ((shared.completedPhases ?? 0) > 0 && (shared.resumedPhases ?? 0) > 0);
+  }
+
   pruneVmReconcileState(this: DKGAgent, now = Date.now()): void {
     while (this.vmReconcileNegativeCache.size > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       const oldestKey = this.vmReconcileNegativeCache.keys().next().value;
@@ -2620,7 +2635,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }
-            if ((fetchResult.peersSucceeded ?? 0) === 0) {
+            if (!this.vmReconcileActiveFetchHadUsableResponse(fetchResult)) {
               continue;
             }
             activeFetchHadUsableResponse = true;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2055,8 +2055,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
   }
 
-  trackCoreHostRecording(this: DKGAgent, p: Promise<void>): void {
-    const tracked = p.catch((err) => {
+  trackCoreHostRecording(this: DKGAgent, start: () => Promise<void>): void {
+    if (this.coreHostRecordingsClosed) return;
+    let recording: Promise<void>;
+    try {
+      recording = start();
+    } catch (err) {
+      this.log.warn(
+        createOperationContext('system'),
+        `Phase D: recordCoreHostedPublicCg failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
+    const tracked = recording.catch((err) => {
       this.log.warn(
         createOperationContext('system'),
         `Phase D: recordCoreHostedPublicCg failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -2065,6 +2076,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.coreHostRecordings.delete(tracked);
     });
     this.coreHostRecordings.add(tracked);
+  }
+
+  async drainCoreHostRecordings(this: DKGAgent): Promise<void> {
+    while (this.coreHostRecordings.size > 0) {
+      await Promise.allSettled([...this.coreHostRecordings]);
+    }
   }
 
   // ===== Phase B — chain-driven VM reconciliation (B.4 agent wiring) =========

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1941,11 +1941,26 @@ export class SwmHostModeMethods extends DKGAgentBase {
       (sub.lastReconciledOrdinal ?? 0) > 0 || this.reconcileCursors.has(localCgId);
     sub.lastReconciledOrdinal = 0;
     this.reconcileCursors.delete(localCgId);
+    this.clearRecentVmReconcileStateForContextGraph(localCgId);
     if (hadProgress) {
       this.log.info(
         createOperationContext('system'),
         `VM reconcile: on-chain id for "${localCgId}" changed ${prev}->${newOnChainId}; reset reconcile watermark + cursor to 0`,
       );
+    }
+  }
+
+  async readCoreHostedPublicCgAccessPolicy(this: DKGAgent, onChainId: string): Promise<0 | 1 | null> {
+    if (typeof this.chain.isContextGraphActiveOnChain === 'function') {
+      return this.readLiveOnChainAccessPolicy(onChainId);
+    }
+    const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
+    if (typeof getAccessPolicy !== 'function') return null;
+    try {
+      const policy = await getAccessPolicy.call(this.chain, BigInt(onChainId));
+      return policy === 0 || policy === 1 ? policy : null;
+    } catch {
+      return null;
     }
   }
 
@@ -1972,10 +1987,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (numeric <= 0n) return;
 
     const numericStr = numeric.toString();
-    // Existence-gated read. `getContextGraphAccessPolicy` can return Solidity's
-    // default public(0) for unknown ids, so prove the slot is live before
-    // trusting the policy; fail closed for curated, unknown, or not-live CGs.
-    const policy = await this.readLiveOnChainAccessPolicy(numericStr);
+    // Existence-gated read when the adapter exposes liveness; otherwise use
+    // the ACK-backed compatibility path because signing a StorageACK proves
+    // this specific CG registration is live enough for host tracking.
+    const policy = await this.readCoreHostedPublicCgAccessPolicy(numericStr);
     if (policy !== 0) return; // curated / unknown / not-live — not the public VM-promote path
 
     // Pick the local CG id to key the host-only record under. Prefer an
@@ -2497,6 +2512,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileCatchupPeerCursor.delete(localCgId);
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
+    this.clearRecentVmReconcileStateForContextGraph(localCgId);
+  }
+
+  clearRecentVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
+    this.recentReconciledUals.deleteByPrefix(`${localCgId}\0`);
   }
 
   vmReconcileCacheKey(this: DKGAgent, localCgId: string, ual: string, merkleRoot: Uint8Array): string {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2377,12 +2377,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
     cacheKey: string,
     state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string },
   ): void {
+    this.pruneVmReconcileState();
     const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;
     const backoff = Math.min(
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_MAX_MS,
       DKGAgentBase.VM_RECONCILE_NEGATIVE_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1),
     );
+    if (previous) this.vmReconcileNegativeCache.delete(cacheKey);
     this.vmReconcileNegativeCache.set(cacheKey, {
       failures,
       nextRetryAt: Date.now() + backoff,
@@ -2390,16 +2392,56 @@ export class SwmHostModeMethods extends DKGAgentBase {
       candidateNamespaces: state.candidateNamespaces,
       peerTopologyKey: state.peerTopologyKey,
     });
+    this.pruneVmReconcileState();
   }
 
   shouldRunVmReconcileActiveFetch(this: DKGAgent, localCgId: string): boolean {
     const now = Date.now();
+    this.pruneVmReconcileState(now);
     const lastFetchAt = this.vmReconcileFetchCooldownAt.get(localCgId);
     if (lastFetchAt !== undefined && now - lastFetchAt < DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS) {
       return false;
     }
+    if (lastFetchAt !== undefined) this.vmReconcileFetchCooldownAt.delete(localCgId);
     this.vmReconcileFetchCooldownAt.set(localCgId, now);
     return true;
+  }
+
+  pruneVmReconcileState(this: DKGAgent, now = Date.now()): void {
+    for (const [key, entry] of this.vmReconcileNegativeCache) {
+      if (now >= entry.nextRetryAt) {
+        this.vmReconcileNegativeCache.delete(key);
+      }
+    }
+    while (this.vmReconcileNegativeCache.size > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileNegativeCache.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileNegativeCache.delete(oldestKey);
+    }
+
+    for (const [localCgId, lastFetchAt] of this.vmReconcileFetchCooldownAt) {
+      if (now - lastFetchAt >= DKGAgentBase.VM_RECONCILE_SWEEP_INTERVAL_MS) {
+        this.vmReconcileFetchCooldownAt.delete(localCgId);
+      }
+    }
+    while (this.vmReconcileFetchCooldownAt.size > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileFetchCooldownAt.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileFetchCooldownAt.delete(oldestKey);
+    }
+
+    while (this.vmReconcileCatchupPeerCursor.size > DKGAgentBase.VM_RECONCILE_CG_STATE_MAX_ENTRIES) {
+      const oldestKey = this.vmReconcileCatchupPeerCursor.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.vmReconcileCatchupPeerCursor.delete(oldestKey);
+    }
+  }
+
+  clearVmReconcileStateForContextGraph(this: DKGAgent, localCgId: string): void {
+    const sub = this.subscribedContextGraphs.get(localCgId);
+    if (sub?.subscribed || sub?.coreHosted) return;
+    this.vmReconcileFetchCooldownAt.delete(localCgId);
+    this.vmReconcileCatchupPeerCursor.delete(localCgId);
   }
 
   vmReconcileCacheKey(this: DKGAgent, ual: string, merkleRoot: Uint8Array): string {
@@ -2460,6 +2502,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   ): Promise<OrdinalOutcome> {
     const ctx = createOperationContext('system');
     const versionBlock = headBlock ?? 0;
+    this.pruneVmReconcileState();
 
     let kaId: bigint;
     let merkleRoot: Uint8Array;
@@ -2475,7 +2518,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
       ual = buildKnowledgeAssetUal(this.chain.chainId, storageAddr, kaId);
       merkleRoot = await this.chain.getLatestMerkleRoot!(kaId);
       cacheKey = this.vmReconcileCacheKey(ual, merkleRoot);
-      this.pruneVmReconcileCacheKeySiblings(cacheKey);
 
       // Recently reconciled (live-burst guard): treat as already-done so the
       // cursor advances without redoing chain reads + an SWM scan.
@@ -2559,6 +2601,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
     switch (outcome) {
       case 'promoted':
+        this.pruneVmReconcileCacheKeySiblings(cacheKey);
         this.vmReconcileNegativeCache.delete(cacheKey);
         this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
@@ -2567,8 +2610,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
         });
         return { status: 'reconciled', blockNumber: versionBlock };
       case 'already-confirmed':
+        this.pruneVmReconcileCacheKeySiblings(cacheKey);
+        this.recentReconciledUals.add(cacheKey);
+        this.emitReplication({
+          contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
+          action: 'already', ordinal, kaId: kaId.toString(), ual,
+        });
+        this.vmReconcileNegativeCache.delete(cacheKey);
+        return { status: 'already', blockNumber: versionBlock };
       case 'stale-target':
-        // Already in VM (or a newer update is) — done for cursor purposes.
+        // A newer root won; do not prune its cache/recent state.
         this.recentReconciledUals.add(cacheKey);
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2355,6 +2355,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (Date.now() >= cached.nextRetryAt) return false;
 
     try {
+      try {
+        await this.primeCatchupConnections();
+      } catch {
+        // Best effort only; an unchanged connection view can still honor the
+        // cached miss until the backoff expires.
+      }
       if (await this.vmReconcilePeerTopologyKey(localCgId) !== cached.peerTopologyKey) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.vmReconcileFetchCooldownAt.delete(localCgId);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2484,9 +2484,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
     this.vmReconcileCatchupPeerOrder.delete(localCgId);
   }
 
-  vmReconcileCacheKey(this: DKGAgent, ual: string, merkleRoot: Uint8Array): string {
+  vmReconcileCacheKey(this: DKGAgent, localCgId: string, ual: string, merkleRoot: Uint8Array): string {
     const rootHex = Array.from(merkleRoot, (byte) => byte.toString(16).padStart(2, '0')).join('');
-    return `${ual}#${rootHex}`;
+    return `${localCgId}\0${ual}#${rootHex}`;
   }
 
   vmReconcileCacheKeyPrefix(this: DKGAgent, cacheKey: string): string {
@@ -2552,7 +2552,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       if (!storageAddr) return { status: 'skip' };
       ual = buildKnowledgeAssetUal(this.chain.chainId, storageAddr, kaId);
       merkleRoot = await this.chain.getLatestMerkleRoot!(kaId);
-      cacheKey = this.vmReconcileCacheKey(ual, merkleRoot);
+      cacheKey = this.vmReconcileCacheKey(localCgId, ual, merkleRoot);
 
       // Recently reconciled (live-burst guard): treat as already-done so the
       // cursor advances without redoing chain reads + an SWM scan.

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2038,6 +2038,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
    * host-mode reconciler + LU-11 chunk-backfill path. Best-effort + idempotent.
    */
   async recordCoreHostedPublicCg(this: DKGAgent, cgId: string, swmGraphId?: string): Promise<void> {
+    if (this.coreHostRecordingsClosed) return;
     if (!this.vmReconcileEnabled()) return;
     let numeric: bigint;
     try {
@@ -2052,6 +2053,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // the ACK-backed compatibility path because signing a StorageACK proves
     // this specific CG registration is live enough for host tracking.
     const policy = await this.readCoreHostedPublicCgAccessPolicy(numericStr);
+    if (this.coreHostRecordingsClosed) return;
     if (policy !== 0) return; // curated / unknown / not-live — not the public VM-promote path
 
     // Pick the local CG id to key the host-only record under. Prefer an
@@ -2779,7 +2781,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
               maxPeers: 1,
               peerRotationKey: localCgId,
             });
-            maxAttempts = Math.max(maxAttempts, fetchResult.connectedPeers ?? 0, this.vmReconcileConnectedPeerCount());
+            maxAttempts = Math.max(
+              maxAttempts,
+              fetchResult.totalPeers ?? fetchResult.connectedPeers ?? 0,
+              this.vmReconcileConnectedPeerCount(),
+            );
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2719,10 +2719,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
               maxPeers: 1,
               peerRotationKey: localCgId,
             });
-            maxAttempts = Math.min(
-              DKGAgentBase.VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS,
-              Math.max(maxAttempts, fetchResult.connectedPeers ?? 0, this.vmReconcileConnectedPeerCount()),
-            );
+            maxAttempts = Math.max(maxAttempts, fetchResult.connectedPeers ?? 0, this.vmReconcileConnectedPeerCount());
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }
@@ -2732,10 +2729,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
             activeFetchHadUsableResponse = true;
           } catch (err) {
             this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
-            maxAttempts = Math.min(
-              DKGAgentBase.VM_RECONCILE_ACTIVE_FETCH_MAX_ATTEMPTS,
-              Math.max(maxAttempts, this.vmReconcileConnectedPeerCount()),
-            );
+            maxAttempts = Math.max(maxAttempts, this.vmReconcileConnectedPeerCount());
             continue;
           }
           outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -247,6 +247,11 @@ type JoinApprovalRetryEntry = {
 };
 type VmReconcileSwmNamespace = { metaGraph: string; dataGraph: string };
 type VmReconcileSwmCandidateNamespaces = { namespaces: VmReconcileSwmNamespace[]; complete: boolean };
+type VmReconcileSwmCandidateState = {
+  swmGen: string | null;
+  candidateNamespaces: VmReconcileSwmNamespace[];
+  peerTopologyKey: string;
+};
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -2228,15 +2233,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     }
   }
 
-  async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<{
-    swmGen: string;
-    candidateNamespaces: VmReconcileSwmNamespace[];
-    peerTopologyKey: string;
-  }> {
+  async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmCandidateState> {
     const candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
     return {
       candidateNamespaces: candidateNamespaces.namespaces,
-      swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces) ?? 'unreadable',
+      swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces),
       peerTopologyKey: await this.vmReconcilePeerTopologyKey(localCgId),
     };
   }
@@ -2318,44 +2319,69 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (candidateNamespaces.length === 0) return 'empty:0';
     try {
       const parts: string[] = [];
+      const digestRows = (rows: string[]) =>
+        createHash('sha256').update(rows.join('\n'), 'utf8').digest('hex');
+      const maxRows = DKGAgentBase.VM_RECONCILE_SWM_GEN_FINGERPRINT_MAX_ROWS;
+      const isTooLarge = (rows: unknown[]) => rows.length > maxRows;
       for (const namespace of candidateNamespaces) {
         const metaGraph = assertSafeIri(namespace.metaGraph);
         const dataGraph = assertSafeIri(namespace.dataGraph);
-        const result = await this.store.query(`SELECT
-          (COUNT(DISTINCT ?op) AS ?opCount)
-          (COUNT(?root) AS ?rootCount)
-          (MAX(?ts) AS ?maxTs)
-          (COUNT(?dataS) AS ?dataTripleCount)
-          (COUNT(?privateRoot) AS ?privateRootCount)
-        WHERE {
-          { GRAPH <${metaGraph}> {
+        const operationRows = await this.store.query(`SELECT ?op ?root ?ts WHERE {
+          GRAPH <${metaGraph}> {
             ?op <http://dkg.io/ontology/rootEntity> ?root .
             OPTIONAL { ?op <http://dkg.io/ontology/publishedAt> ?ts . }
-          } }
-          UNION { GRAPH <${dataGraph}> { ?dataS ?dataP ?dataO . } }
-          UNION { GRAPH <${metaGraph}> { ?privateEntity <http://dkg.io/ontology/privateMerkleRoot> ?privateRoot . } }
-        }`);
-        if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-        const row = result.bindings[0];
-        const opCount = typeof row['opCount'] === 'string' ? stripLiteral(row['opCount']) : '0';
-        const rootCount = typeof row['rootCount'] === 'string' ? stripLiteral(row['rootCount']) : '0';
-        const maxTs = typeof row['maxTs'] === 'string' ? stripLiteral(row['maxTs']) : '';
-        const dataTripleCount = typeof row['dataTripleCount'] === 'string' ? stripLiteral(row['dataTripleCount']) : '0';
-        const privateRootCount = typeof row['privateRootCount'] === 'string' ? stripLiteral(row['privateRootCount']) : '0';
+          }
+        } ORDER BY ?op ?root ?ts LIMIT ${maxRows + 1}`);
+        if (operationRows.type !== 'bindings') return null;
+        if (isTooLarge(operationRows.bindings)) return null;
+        const operations = operationRows.bindings
+          .map((row) => [
+            String(row['op'] ?? ''),
+            String(row['root'] ?? ''),
+            String(row['ts'] ?? ''),
+          ].join('\0'))
+          .sort();
+
+        const dataRows = await this.store.query(`SELECT ?s ?p ?o WHERE {
+          GRAPH <${dataGraph}> { ?s ?p ?o . }
+        } ORDER BY ?s ?p ?o LIMIT ${maxRows + 1}`);
+        if (dataRows.type !== 'bindings') return null;
+        if (isTooLarge(dataRows.bindings)) return null;
+        const dataTriples = dataRows.bindings
+          .map((row) => [
+            String(row['s'] ?? ''),
+            String(row['p'] ?? ''),
+            String(row['o'] ?? ''),
+          ].join('\0'))
+          .sort();
+
+        const privateRootRows = await this.store.query(`SELECT ?privateEntity ?privateRoot WHERE {
+          GRAPH <${metaGraph}> { ?privateEntity <http://dkg.io/ontology/privateMerkleRoot> ?privateRoot . }
+        } ORDER BY ?privateEntity ?privateRoot LIMIT ${maxRows + 1}`);
+        if (privateRootRows.type !== 'bindings') return null;
+        if (isTooLarge(privateRootRows.bindings)) return null;
+        const privateRoots = privateRootRows.bindings
+          .map((row) => [
+            String(row['privateEntity'] ?? ''),
+            String(row['privateRoot'] ?? ''),
+          ].join('\0'))
+          .sort();
+
         parts.push([
           `meta:${namespace.metaGraph}`,
           `data:${namespace.dataGraph}`,
-          `ops:${opCount}`,
-          `roots:${rootCount}`,
-          `maxTs:${maxTs}`,
-          `dataTriples:${dataTripleCount}`,
-          `privateRoots:${privateRootCount}`,
+          `ops:${operations.length}`,
+          `opHash:${digestRows(operations)}`,
+          `dataTriples:${dataTriples.length}`,
+          `dataHash:${digestRows(dataTriples)}`,
+          `privateRoots:${privateRoots.length}`,
+          `privateRootHash:${digestRows(privateRoots)}`,
         ].join(';'));
       }
       return parts.join('|');
     } catch {
-      // A failed cheap probe is not evidence that the expensive merkle scan
-      // should run again immediately.
+      // Probe failures are not a stable SWM generation. Callers must not cache
+      // or preserve a negative-cache gate from this result.
     }
     return null;
   }
@@ -2431,16 +2457,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
       }
       const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.namespaces.map((namespace) => namespace.metaGraph));
       if (!pattern) return true;
-      if (cached.swmGen === 'unreadable') return true;
       const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces.namespaces);
-      if (currentSwmGen === null) return true;
+      if (currentSwmGen === null) {
+        this.deleteVmReconcileNegativeCacheEntry(cacheKey);
+        return false;
+      }
       if (currentSwmGen !== cached.swmGen) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
       }
     } catch {
-      // Stay damped until the backoff expires; a failed cheap probe is not
-      // evidence that the expensive merkle scan should run again immediately.
+      // Unexpected validation failures leave the existing backoff in place;
+      // expected generation probe failures return null and clear the gate above.
     }
     return true;
   }
@@ -2448,8 +2476,12 @@ export class SwmHostModeMethods extends DKGAgentBase {
   recordVmReconcileNegativeCache(this: DKGAgent,
     cacheKey: string,
     localCgId: string,
-    state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string },
+    state: VmReconcileSwmCandidateState,
   ): void {
+    if (state.swmGen === null) {
+      this.deleteVmReconcileNegativeCacheEntry(cacheKey);
+      return;
+    }
     // Existing SWM operations can be missing payload/private-root pieces; keep
     // that retry path uncached instead of probing full data graphs here.
     if (this.vmReconcileSwmGenHasOperations(state.swmGen)) {
@@ -2665,7 +2697,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       versionBlock,
     };
 
-    let swmState: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string } | undefined;
+    let swmState: VmReconcileSwmCandidateState | undefined;
     let activeFetchRan = false;
     let activeFetchHadUsableResponse = false;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -2199,7 +2199,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return {
       candidateNamespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
-      peerTopologyKey: this.vmReconcilePeerTopologyKey(),
+      peerTopologyKey: await this.vmReconcilePeerTopologyKey(localCgId),
     };
   }
 
@@ -2231,17 +2231,29 @@ export class SwmHostModeMethods extends DKGAgentBase {
       .join('\n');
   }
 
-  vmReconcilePeerTopologyKey(this: DKGAgent): string {
+  async vmReconcilePeerTopologyKey(this: DKGAgent, localCgId: string): Promise<string> {
     try {
+      const preferredPeerId = await this.resolvePreferredSyncPeerId(localCgId);
+      const isPrivateContextGraph = await this.isPrivateContextGraph(localCgId);
       const libp2p = (this.node as any)?.libp2p;
       const getConnections = libp2p?.getConnections;
       if (typeof getConnections !== 'function') return 'unreadable';
-      const peers = new Set<string>(
+      const peers = [...new Map(
         (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
-          .map((connection) => connection.remotePeer?.toString())
-          .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
-      );
-      return [...peers].sort().join('\n');
+          .map((connection) => [connection.remotePeer?.toString(), connection.remotePeer] as const)
+          .filter((entry): entry is readonly [string, { toString(): string }] =>
+            typeof entry[0] === 'string' && entry[0].length > 0 && !!entry[1],
+          ),
+      ).values()];
+      const orderedPeers = this.selectCatchupPeers(peers, preferredPeerId, isPrivateContextGraph);
+      return JSON.stringify(orderedPeers.map((peer) => {
+        const peerId = peer.toString();
+        return {
+          peerId,
+          preferred: peerId === preferredPeerId,
+          core: this.knownCorePeerIds.has(peerId),
+        };
+      }));
     } catch {
       return 'unreadable';
     }
@@ -2275,27 +2287,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
         const maxTs = typeof row['maxTs'] === 'string' ? stripLiteral(row['maxTs']) : '';
         const dataTripleCount = typeof row['dataTripleCount'] === 'string' ? stripLiteral(row['dataTripleCount']) : '0';
         const privateRootCount = typeof row['privateRootCount'] === 'string' ? stripLiteral(row['privateRootCount']) : '0';
-        const dataDigest = await this.readVmReconcileDataDigest(dataGraph);
-        if (dataDigest === null) return null;
-        const privateRootsResult = await this.store.query(`SELECT DISTINCT ?privateRoot WHERE {
-          GRAPH <${metaGraph}> {
-            ?privateEntity <http://dkg.io/ontology/privateMerkleRoot> ?privateRoot .
-          }
-        } ORDER BY STR(?privateRoot)`);
-        const privateRoots = privateRootsResult.type === 'bindings'
-          ? privateRootsResult.bindings
-            .map((binding) => typeof binding['privateRoot'] === 'string' ? stripLiteral(binding['privateRoot']) : '')
-            .filter((value) => value.length > 0)
-            .join(',')
-          : '';
         parts.push([
           `meta:${namespace.metaGraph}`,
           `data:${namespace.dataGraph}`,
           `ops:${opCount}`,
           `roots:${rootCount}`,
           `maxTs:${maxTs}`,
-          `dataTriples:${dataTripleCount}:${dataDigest}`,
-          `privateRoots:${privateRootCount}:${privateRoots}`,
+          `dataTriples:${dataTripleCount}`,
+          `privateRoots:${privateRootCount}`,
         ].join(';'));
       }
       return parts.join('|');
@@ -2306,21 +2305,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return null;
   }
 
-  async readVmReconcileDataDigest(this: DKGAgent, dataGraph: string): Promise<string | null> {
-    const result = await this.store.query(`SELECT ?s ?p ?o WHERE {
-      GRAPH <${dataGraph}> { ?s ?p ?o . }
-    } ORDER BY STR(?s) STR(?p) STR(?o)`);
-    if (result.type !== 'bindings') return null;
-    const hash = createHash('sha256');
-    for (const binding of result.bindings) {
-      hash.update(typeof binding['s'] === 'string' ? binding['s'] : '');
-      hash.update('\0');
-      hash.update(typeof binding['p'] === 'string' ? binding['p'] : '');
-      hash.update('\0');
-      hash.update(typeof binding['o'] === 'string' ? binding['o'] : '');
-      hash.update('\n');
-    }
-    return hash.digest('hex');
+  vmReconcileSwmGenHasOperations(this: DKGAgent, swmGen: string): boolean {
+    return swmGen.split('|').some((part) => {
+      const match = /(?:^|;)ops:(\d+)(?:;|$)/.exec(part);
+      return match ? Number(match[1]) > 0 : false;
+    });
   }
 
   vmReconcileWorkspaceOperationPattern(this: DKGAgent, candidateMetaGraphs: string[]): string {
@@ -2366,7 +2355,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (Date.now() >= cached.nextRetryAt) return false;
 
     try {
-      if (this.vmReconcilePeerTopologyKey() !== cached.peerTopologyKey) {
+      if (await this.vmReconcilePeerTopologyKey(localCgId) !== cached.peerTopologyKey) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         this.vmReconcileFetchCooldownAt.delete(localCgId);
         return false;
@@ -2397,6 +2386,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     localCgId: string,
     state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string },
   ): void {
+    // Existing SWM operations can be missing payload/private-root pieces; keep
+    // that retry path uncached instead of probing full data graphs here.
+    if (this.vmReconcileSwmGenHasOperations(state.swmGen)) {
+      return;
+    }
     this.pruneVmReconcileState();
     const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1961,6 +1961,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const getAccessPolicy = this.chain.getContextGraphAccessPolicy;
     if (typeof getAccessPolicy !== 'function') return null;
     const numericId = BigInt(onChainId);
+    const cached = this.onChainAccessPolicyCache.get(onChainId);
+    if (cached === 0 || cached === 1) return cached;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
       timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), CHAIN_POLICY_READ_TIMEOUT_MS);
@@ -1980,7 +1982,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
         );
         return null;
       }
-      return policy === 0 || policy === 1 ? policy : null;
+      if (policy === 0 || policy === 1) {
+        this.onChainAccessPolicyCache.set(onChainId, policy);
+        return policy;
+      }
+      return null;
     } catch {
       return null;
     }
@@ -2084,8 +2090,29 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   async drainCoreHostRecordings(this: DKGAgent): Promise<void> {
+    const ctx = createOperationContext('system');
     while (this.coreHostRecordings.size > 0) {
-      await Promise.allSettled([...this.coreHostRecordings]);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), DKGAgentBase.CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS);
+        timer.unref?.();
+      });
+      const outcome = await Promise.race([
+        Promise.allSettled([...this.coreHostRecordings])
+          .then(() => 'drained' as const)
+          .finally(() => { if (timer) clearTimeout(timer); }),
+        timeout,
+      ]);
+      if (outcome === 'timeout') {
+        const pending = this.coreHostRecordings.size;
+        this.log.warn(
+          ctx,
+          `Phase D: timed out draining ${pending} core-host recording(s) after ` +
+          `${DKGAgentBase.CORE_HOST_RECORDING_DRAIN_TIMEOUT_MS}ms; continuing shutdown`,
+        );
+        this.coreHostRecordings.clear();
+        return;
+      }
     }
   }
 

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -246,6 +246,7 @@ type JoinApprovalRetryEntry = {
   lastError: string;
 };
 type VmReconcileSwmNamespace = { metaGraph: string; dataGraph: string };
+type VmReconcileSwmCandidateNamespaces = { namespaces: VmReconcileSwmNamespace[]; complete: boolean };
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -2185,8 +2186,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }> {
     const candidateNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
     return {
-      candidateNamespaces,
-      swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
+      candidateNamespaces: candidateNamespaces.namespaces,
+      swmGen: await this.readVmReconcileSwmGen(candidateNamespaces.namespaces) ?? 'unreadable',
       peerTopologyKey: await this.vmReconcilePeerTopologyKey(localCgId),
     };
   }
@@ -2212,11 +2213,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     ];
   }
 
-  async collectVmReconcileSwmCandidateNamespacesBestEffort(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmNamespace[]> {
+  async collectVmReconcileSwmCandidateNamespacesBestEffort(this: DKGAgent, localCgId: string): Promise<VmReconcileSwmCandidateNamespaces> {
     try {
-      return await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
+      return { namespaces: await this.collectVmReconcileSwmCandidateNamespaces(localCgId), complete: true };
     } catch {
-      return this.vmReconcileRootSwmCandidateNamespaces(localCgId);
+      return { namespaces: this.vmReconcileRootSwmCandidateNamespaces(localCgId), complete: false };
     }
   }
 
@@ -2372,14 +2373,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
         return false;
       }
       const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespacesBestEffort(localCgId);
-      if (this.vmReconcileSwmNamespaceKey(currentNamespaces) !== this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces)) {
+      const currentNamespaceKey = this.vmReconcileSwmNamespaceKey(currentNamespaces.namespaces);
+      const cachedNamespaceKey = this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces);
+      if (currentNamespaceKey !== cachedNamespaceKey) {
+        if (!currentNamespaces.complete) return true;
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
         return false;
       }
-      const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.map((namespace) => namespace.metaGraph));
+      const pattern = this.vmReconcileWorkspaceOperationPattern(currentNamespaces.namespaces.map((namespace) => namespace.metaGraph));
       if (!pattern) return true;
       if (cached.swmGen === 'unreadable') return true;
-      const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces);
+      const currentSwmGen = await this.readVmReconcileSwmGen(currentNamespaces.namespaces);
       if (currentSwmGen === null) return true;
       if (currentSwmGen !== cached.swmGen) {
         this.deleteVmReconcileNegativeCacheEntry(cacheKey);
@@ -2435,11 +2439,6 @@ export class SwmHostModeMethods extends DKGAgentBase {
   }
 
   pruneVmReconcileState(this: DKGAgent, now = Date.now()): void {
-    for (const [key, entry] of this.vmReconcileNegativeCache) {
-      if (now >= entry.nextRetryAt) {
-        this.deleteVmReconcileNegativeCacheEntry(key);
-      }
-    }
     while (this.vmReconcileNegativeCache.size > DKGAgentBase.VM_RECONCILE_CACHE_MAX_ENTRIES) {
       const oldestKey = this.vmReconcileNegativeCache.keys().next().value;
       if (oldestKey === undefined) break;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2188,6 +2188,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
   async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<{
     swmGen: string;
     candidateNamespaces: VmReconcileSwmNamespace[];
+    peerTopologyKey: string;
   }> {
     let candidateNamespaces = this.vmReconcileRootSwmCandidateNamespaces(localCgId);
     try {
@@ -2198,6 +2199,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     return {
       candidateNamespaces,
       swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
+      peerTopologyKey: this.vmReconcilePeerTopologyKey(),
     };
   }
 
@@ -2227,6 +2229,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
       .map((namespace) => `${namespace.metaGraph}\0${namespace.dataGraph}`)
       .sort()
       .join('\n');
+  }
+
+  vmReconcilePeerTopologyKey(this: DKGAgent): string {
+    try {
+      const libp2p = (this.node as any)?.libp2p;
+      const getConnections = libp2p?.getConnections;
+      if (typeof getConnections !== 'function') return 'unreadable';
+      const peers = new Set<string>(
+        (getConnections.call(libp2p) as Array<{ remotePeer?: { toString(): string } }>)
+          .map((connection) => connection.remotePeer?.toString())
+          .filter((peerId): peerId is string => typeof peerId === 'string' && peerId.length > 0),
+      );
+      return [...peers].sort().join('\n');
+    } catch {
+      return 'unreadable';
+    }
   }
 
   async readVmReconcileSwmGen(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): Promise<string | null> {
@@ -2329,6 +2347,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (Date.now() >= cached.nextRetryAt) return false;
 
     try {
+      if (this.vmReconcilePeerTopologyKey() !== cached.peerTopologyKey) {
+        this.vmReconcileNegativeCache.delete(cacheKey);
+        this.vmReconcileFetchCooldownAt.delete(localCgId);
+        return false;
+      }
       const currentNamespaces = await this.collectVmReconcileSwmCandidateNamespaces(localCgId);
       if (this.vmReconcileSwmNamespaceKey(currentNamespaces) !== this.vmReconcileSwmNamespaceKey(cached.candidateNamespaces)) {
         this.vmReconcileNegativeCache.delete(cacheKey);
@@ -2352,7 +2375,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   recordVmReconcileNegativeCache(this: DKGAgent,
     cacheKey: string,
-    state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[] },
+    state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string },
   ): void {
     const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;
@@ -2365,6 +2388,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       nextRetryAt: Date.now() + backoff,
       swmGen: state.swmGen,
       candidateNamespaces: state.candidateNamespaces,
+      peerTopologyKey: state.peerTopologyKey,
     });
   }
 
@@ -2490,7 +2514,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       versionBlock,
     };
 
-    let swmState: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[] } | undefined;
+    let swmState: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[]; peerTopologyKey: string } | undefined;
     let activeFetchRan = false;
     let activeFetchHadUsableResponse = false;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -8,7 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -245,6 +245,7 @@ type JoinApprovalRetryEntry = {
   nextAttemptAt: number;
   lastError: string;
 };
+type VmReconcileSwmNamespace = { metaGraph: string; dataGraph: string };
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -2186,46 +2187,103 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   async collectVmReconcileSwmCandidateState(this: DKGAgent, localCgId: string): Promise<{
     swmGen: string;
-    candidateMetaGraphs: string[];
+    candidateNamespaces: VmReconcileSwmNamespace[];
   }> {
     const graphManager = new GraphManager(this.store);
-    const candidateMetaGraphs = [contextGraphWorkspaceMetaGraphUri(localCgId)];
+    const candidateNamespaces: VmReconcileSwmNamespace[] = [{
+      metaGraph: contextGraphWorkspaceMetaGraphUri(localCgId),
+      dataGraph: contextGraphWorkspaceGraphUri(localCgId),
+    }];
     try {
       for (const sg of await graphManager.listSubGraphs(localCgId)) {
-        candidateMetaGraphs.push(graphManager.sharedMemoryMetaUri(localCgId, sg));
+        candidateNamespaces.push({
+          metaGraph: graphManager.sharedMemoryMetaUri(localCgId, sg),
+          dataGraph: graphManager.sharedMemoryUri(localCgId, sg),
+        });
       }
     } catch {
       // The root SWM namespace is always the minimum candidate set.
     }
     return {
-      candidateMetaGraphs,
-      swmGen: await this.readVmReconcileSwmGen(candidateMetaGraphs) ?? 'unreadable',
+      candidateNamespaces,
+      swmGen: await this.readVmReconcileSwmGen(candidateNamespaces) ?? 'unreadable',
     };
   }
 
-  async readVmReconcileSwmGen(this: DKGAgent, candidateMetaGraphs: string[]): Promise<string | null> {
-    const pattern = this.vmReconcileWorkspaceOperationPattern(candidateMetaGraphs);
-    if (!pattern) return 'empty:0';
+  async readVmReconcileSwmGen(this: DKGAgent, candidateNamespaces: VmReconcileSwmNamespace[]): Promise<string | null> {
+    if (candidateNamespaces.length === 0) return 'empty:0';
     try {
-      const result = await this.store.query(`SELECT
-        (COUNT(DISTINCT ?op) AS ?opCount)
-        (COUNT(?root) AS ?rootCount)
-        (MAX(?ts) AS ?maxTs)
-      WHERE {
-        ${pattern}
-      }`);
-      if (result.type === 'bindings' && result.bindings.length > 0) {
+      const parts: string[] = [];
+      for (const namespace of candidateNamespaces) {
+        const metaGraph = assertSafeIri(namespace.metaGraph);
+        const dataGraph = assertSafeIri(namespace.dataGraph);
+        const result = await this.store.query(`SELECT
+          (COUNT(DISTINCT ?op) AS ?opCount)
+          (COUNT(?root) AS ?rootCount)
+          (MAX(?ts) AS ?maxTs)
+          (COUNT(?dataS) AS ?dataTripleCount)
+          (COUNT(?privateRoot) AS ?privateRootCount)
+        WHERE {
+          { GRAPH <${metaGraph}> {
+            ?op <http://dkg.io/ontology/rootEntity> ?root .
+            OPTIONAL { ?op <http://dkg.io/ontology/publishedAt> ?ts . }
+          } }
+          UNION { GRAPH <${dataGraph}> { ?dataS ?dataP ?dataO . } }
+          UNION { GRAPH <${metaGraph}> { ?privateEntity <http://dkg.io/ontology/privateMerkleRoot> ?privateRoot . } }
+        }`);
+        if (result.type !== 'bindings' || result.bindings.length === 0) return null;
         const row = result.bindings[0];
         const opCount = typeof row['opCount'] === 'string' ? stripLiteral(row['opCount']) : '0';
         const rootCount = typeof row['rootCount'] === 'string' ? stripLiteral(row['rootCount']) : '0';
         const maxTs = typeof row['maxTs'] === 'string' ? stripLiteral(row['maxTs']) : '';
-        return `ops:${opCount};roots:${rootCount};maxTs:${maxTs}`;
+        const dataTripleCount = typeof row['dataTripleCount'] === 'string' ? stripLiteral(row['dataTripleCount']) : '0';
+        const privateRootCount = typeof row['privateRootCount'] === 'string' ? stripLiteral(row['privateRootCount']) : '0';
+        const dataDigest = await this.readVmReconcileDataDigest(dataGraph);
+        if (dataDigest === null) return null;
+        const privateRootsResult = await this.store.query(`SELECT DISTINCT ?privateRoot WHERE {
+          GRAPH <${metaGraph}> {
+            ?privateEntity <http://dkg.io/ontology/privateMerkleRoot> ?privateRoot .
+          }
+        } ORDER BY STR(?privateRoot)`);
+        const privateRoots = privateRootsResult.type === 'bindings'
+          ? privateRootsResult.bindings
+            .map((binding) => typeof binding['privateRoot'] === 'string' ? stripLiteral(binding['privateRoot']) : '')
+            .filter((value) => value.length > 0)
+            .join(',')
+          : '';
+        parts.push([
+          `meta:${namespace.metaGraph}`,
+          `data:${namespace.dataGraph}`,
+          `ops:${opCount}`,
+          `roots:${rootCount}`,
+          `maxTs:${maxTs}`,
+          `dataTriples:${dataTripleCount}:${dataDigest}`,
+          `privateRoots:${privateRootCount}:${privateRoots}`,
+        ].join(';'));
       }
+      return parts.join('|');
     } catch {
       // A failed cheap probe is not evidence that the expensive merkle scan
       // should run again immediately.
     }
     return null;
+  }
+
+  async readVmReconcileDataDigest(this: DKGAgent, dataGraph: string): Promise<string | null> {
+    const result = await this.store.query(`SELECT ?s ?p ?o WHERE {
+      GRAPH <${dataGraph}> { ?s ?p ?o . }
+    } ORDER BY STR(?s) STR(?p) STR(?o)`);
+    if (result.type !== 'bindings') return null;
+    const hash = createHash('sha256');
+    for (const binding of result.bindings) {
+      hash.update(typeof binding['s'] === 'string' ? binding['s'] : '');
+      hash.update('\0');
+      hash.update(typeof binding['p'] === 'string' ? binding['p'] : '');
+      hash.update('\0');
+      hash.update(typeof binding['o'] === 'string' ? binding['o'] : '');
+      hash.update('\n');
+    }
+    return hash.digest('hex');
   }
 
   vmReconcileWorkspaceOperationPattern(this: DKGAgent, candidateMetaGraphs: string[]): string {
@@ -2250,11 +2308,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (!cached) return false;
     if (Date.now() >= cached.nextRetryAt) return false;
 
-    const pattern = this.vmReconcileWorkspaceOperationPattern(cached.candidateMetaGraphs);
+    const pattern = this.vmReconcileWorkspaceOperationPattern(cached.candidateNamespaces.map((namespace) => namespace.metaGraph));
     if (!pattern) return true;
     if (cached.swmGen === 'unreadable') return true;
     try {
-      const currentSwmGen = await this.readVmReconcileSwmGen(cached.candidateMetaGraphs);
+      const currentSwmGen = await this.readVmReconcileSwmGen(cached.candidateNamespaces);
       if (currentSwmGen === null) return true;
       if (currentSwmGen !== cached.swmGen) {
         this.vmReconcileNegativeCache.delete(cacheKey);
@@ -2269,7 +2327,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   recordVmReconcileNegativeCache(this: DKGAgent,
     cacheKey: string,
-    state: { swmGen: string; candidateMetaGraphs: string[] },
+    state: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[] },
   ): void {
     const previous = this.vmReconcileNegativeCache.get(cacheKey);
     const failures = (previous?.failures ?? 0) + 1;
@@ -2281,7 +2339,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       failures,
       nextRetryAt: Date.now() + backoff,
       swmGen: state.swmGen,
-      candidateMetaGraphs: state.candidateMetaGraphs,
+      candidateNamespaces: state.candidateNamespaces,
     });
   }
 
@@ -2407,13 +2465,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
       versionBlock,
     };
 
-    let swmState: { swmGen: string; candidateMetaGraphs: string[] } | undefined;
+    let swmState: { swmGen: string; candidateNamespaces: VmReconcileSwmNamespace[] } | undefined;
+    let activeFetchRan = false;
+    let activeFetchHadUsableResponse = false;
     let outcome = await fh.handleChainReconciledKC(reconcileInput, ctx);
     if (outcome === 'no-swm') {
       swmState = await this.collectVmReconcileSwmCandidateState(localCgId);
       // Active fetch: pull the missing snapshot core-first (selectCatchupPeers
       // already prioritises known cores + the preferred sync peer), then retry.
       if (this.shouldRunVmReconcileActiveFetch(localCgId)) {
+        activeFetchRan = true;
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
           action: 'fetch', ordinal, kaId: kaId.toString(), ual,
@@ -2429,6 +2490,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
             if ((fetchResult.peersTried ?? 0) === 0 && (fetchResult.syncCapablePeers ?? 0) === 0) {
               continue;
             }
+            if ((fetchResult.peersSucceeded ?? 0) === 0) {
+              continue;
+            }
+            activeFetchHadUsableResponse = true;
           } catch (err) {
             this.log.info(ctx, `Phase B: active fetch for "${localCgId}" (ordinal ${ordinal}) failed: ${err instanceof Error ? err.message : String(err)}`);
             continue;
@@ -2463,13 +2528,17 @@ export class SwmHostModeMethods extends DKGAgentBase {
         this.vmReconcileNegativeCache.delete(cacheKey);
         return { status: 'already', blockNumber: versionBlock };
       case 'no-swm':
-        this.recordVmReconcileNegativeCache(
-          cacheKey,
-          swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
-        );
+        if (activeFetchRan && !activeFetchHadUsableResponse) {
+          this.vmReconcileFetchCooldownAt.delete(localCgId);
+        } else {
+          this.recordVmReconcileNegativeCache(
+            cacheKey,
+            swmState ?? await this.collectVmReconcileSwmCandidateState(localCgId),
+          );
+        }
         this.emitReplication({
           contextGraphId: localCgId, onChainCgId: onChainCgId.toString(),
-          action: 'defer', ordinal, kaId: kaId.toString(), ual, detail: outcome,
+          action: 'defer', ordinal, kaId: kaId.toString(), ual, detail: activeFetchRan && !activeFetchHadUsableResponse ? 'network-unavailable' : outcome,
         });
         return { status: 'pending' };
       case 'unverified':

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1154,9 +1154,8 @@ export class DKGAgent extends DKGAgentBase {
       clearInterval(this.vmReconcileTimer);
       this.vmReconcileTimer = null;
     }
-    if (this.coreHostRecordings.size > 0) {
-      await Promise.allSettled([...this.coreHostRecordings]);
-    }
+    this.coreHostRecordingsClosed = true;
+    await this.drainCoreHostRecordings();
     if (this.messengerOutboxTimer) {
       clearInterval(this.messengerOutboxTimer);
       this.messengerOutboxTimer = null;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1154,6 +1154,9 @@ export class DKGAgent extends DKGAgentBase {
       clearInterval(this.vmReconcileTimer);
       this.vmReconcileTimer = null;
     }
+    if (this.coreHostRecordings.size > 0) {
+      await Promise.allSettled([...this.coreHostRecordings]);
+    }
     if (this.messengerOutboxTimer) {
       clearInterval(this.messengerOutboxTimer);
       this.messengerOutboxTimer = null;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -787,7 +787,10 @@ export class FinalizationHandler {
 
     if (rootsByOp.size === 0) return null;
 
-    for (const roots of rootsByOp.values()) {
+    const opsSorted = [...rootsByOp.entries()].sort(
+      ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0),
+    );
+    for (const [, roots] of opsSorted) {
       const sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(contextGraphId, roots, subGraphName);
       if (sharedMemoryQuads.length === 0) continue;
       const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -169,7 +169,6 @@ export async function reconcileWarmCoreConnections(
   });
 
   const warmed = new Set<string>();
-  const selectedThisPass: string[] = [];
   let dialed = 0;
   let skippedGate = 0;
 
@@ -193,7 +192,6 @@ export async function reconcileWarmCoreConnections(
     });
     if (!pinOk) continue;
     warmed.add(core.peerId);
-    selectedThisPass.push(core.peerId);
 
     if (deps.isConnected(core.peerId)) continue;
     const ok = await deps.dial(core.peerId, ctx).catch(() => false);
@@ -221,22 +219,9 @@ export async function reconcileWarmCoreConnections(
     }
   }
 
-  // Failed unpins still represent live keep-alive tags in the peerStore. Count
-  // them against the warm budget by dropping the lowest-priority fresh picks.
-  while (warmed.size > deps.maxCores && selectedThisPass.length > 0) {
-    const peerId = selectedThisPass.pop()!;
-    if (!warmed.has(peerId)) continue;
-    let unpinOk = true;
-    await deps.unpin(peerId, ctx).catch(() => {
-      unpinOk = false;
-    });
-    if (unpinOk) {
-      warmed.delete(peerId);
-      unpinned += 1;
-    } else {
-      unpinFailed += 1;
-    }
-  }
+  // If stale unpins fail, keep those peers in `warmed` so the next pass
+  // retries them. This may temporarily exceed the cap, but preserves the
+  // current winning selection instead of evicting a healthy Core.
 
   deps.log(
     ctx,

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -169,6 +169,7 @@ export async function reconcileWarmCoreConnections(
   });
 
   const warmed = new Set<string>();
+  const selectedThisPass: string[] = [];
   let dialed = 0;
   let skippedGate = 0;
 
@@ -192,6 +193,7 @@ export async function reconcileWarmCoreConnections(
     });
     if (!pinOk) continue;
     warmed.add(core.peerId);
+    selectedThisPass.push(core.peerId);
 
     if (deps.isConnected(core.peerId)) continue;
     const ok = await deps.dial(core.peerId, ctx).catch(() => false);
@@ -216,6 +218,23 @@ export async function reconcileWarmCoreConnections(
           warmed.add(peerId);
         }
       }
+    }
+  }
+
+  // Failed unpins still represent live keep-alive tags in the peerStore. Count
+  // them against the warm budget by dropping the lowest-priority fresh picks.
+  while (warmed.size > deps.maxCores && selectedThisPass.length > 0) {
+    const peerId = selectedThisPass.pop()!;
+    if (!warmed.has(peerId)) continue;
+    let unpinOk = true;
+    await deps.unpin(peerId, ctx).catch(() => {
+      unpinOk = false;
+    });
+    if (unpinOk) {
+      warmed.delete(peerId);
+      unpinned += 1;
+    } else {
+      unpinFailed += 1;
     }
   }
 

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -156,7 +156,7 @@ export interface WarmCoreReconcileResult {
   unpinFailed: number;
   /** Cores pinned this pass — feed back as `previouslyWarmed` next tick. */
   warmed: Set<string>;
-  /** Failed stale unpins to retry next tick, bounded by `maxCores`. */
+  /** Failed stale unpins to retry next tick, independent of the warm-set cap. */
   failedUnpins: Set<string>;
 }
 
@@ -227,7 +227,7 @@ export async function reconcileWarmCoreConnections(
           unpinned += 1;
         } else {
           unpinFailed += 1;
-          if (failedUnpins.size < deps.maxCores) failedUnpins.add(peerId);
+          failedUnpins.add(peerId);
         }
       }
     }
@@ -240,7 +240,7 @@ export async function reconcileWarmCoreConnections(
     ctx,
     `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} ` +
     `skippedGate=${skippedGate} unpinned=${unpinned} unpinFailed=${unpinFailed} ` +
-    `unpinRetry=${failedUnpins.size} (cap=${deps.maxCores})`,
+    `unpinRetry=${failedUnpins.size} warmCap=${deps.maxCores}`,
   );
 
   return {

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -138,6 +138,12 @@ export interface WarmCoreDeps {
    * carry into the next pass.
    */
   previouslyWarmed?: ReadonlySet<string>;
+  /**
+   * Cores whose keep-alive tag failed to remove on an earlier pass. Retried
+   * separately from `previouslyWarmed` so failed unpins do not inflate the
+   * selected warm set beyond `maxCores`.
+   */
+  previouslyFailedUnpins?: ReadonlySet<string>;
   log: (ctx: OperationContext, msg: string) => void;
 }
 
@@ -147,8 +153,11 @@ export interface WarmCoreReconcileResult {
   dialed: number;
   skippedGate: number;
   unpinned: number;
+  unpinFailed: number;
   /** Cores pinned this pass — feed back as `previouslyWarmed` next tick. */
   warmed: Set<string>;
+  /** Failed stale unpins to retry next tick, bounded by `maxCores`. */
+  failedUnpins: Set<string>;
 }
 
 /**
@@ -202,8 +211,13 @@ export async function reconcileWarmCoreConnections(
   // one, so the pinned set tracks the live selection and never exceeds the cap.
   let unpinned = 0;
   let unpinFailed = 0;
-  if (deps.previouslyWarmed) {
-    for (const peerId of deps.previouslyWarmed) {
+  const failedUnpins = new Set<string>();
+  const pruneCandidates = new Set([
+    ...(deps.previouslyWarmed ?? []),
+    ...(deps.previouslyFailedUnpins ?? []),
+  ]);
+  if (pruneCandidates.size > 0) {
+    for (const peerId of pruneCandidates) {
       if (!warmed.has(peerId)) {
         let unpinOk = true;
         await deps.unpin(peerId, ctx).catch(() => {
@@ -213,20 +227,30 @@ export async function reconcileWarmCoreConnections(
           unpinned += 1;
         } else {
           unpinFailed += 1;
-          warmed.add(peerId);
+          if (failedUnpins.size < deps.maxCores) failedUnpins.add(peerId);
         }
       }
     }
   }
 
-  // If stale unpins fail, keep those peers in `warmed` so the next pass
-  // retries them. This may temporarily exceed the cap, but preserves the
-  // current winning selection instead of evicting a healthy Core.
+  // Failed stale unpins are retried out-of-band so the returned warm set stays
+  // the current selected/pinned set and remains bounded by `maxCores`.
 
   deps.log(
     ctx,
-    `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} skippedGate=${skippedGate} unpinned=${unpinned} unpinFailed=${unpinFailed} (cap=${deps.maxCores})`,
+    `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} ` +
+    `skippedGate=${skippedGate} unpinned=${unpinned} unpinFailed=${unpinFailed} ` +
+    `unpinRetry=${failedUnpins.size} (cap=${deps.maxCores})`,
   );
 
-  return { candidates: candidates.length, pinned: warmed.size, dialed, skippedGate, unpinned, warmed };
+  return {
+    candidates: candidates.length,
+    pinned: warmed.size,
+    dialed,
+    skippedGate,
+    unpinned,
+    unpinFailed,
+    warmed,
+    failedUnpins,
+  };
 }

--- a/packages/agent/src/p2p/warm-core-connections.ts
+++ b/packages/agent/src/p2p/warm-core-connections.ts
@@ -201,18 +201,27 @@ export async function reconcileWarmCoreConnections(
   // Prune: drop the keep-alive tag from Cores warmed last pass but not this
   // one, so the pinned set tracks the live selection and never exceeds the cap.
   let unpinned = 0;
+  let unpinFailed = 0;
   if (deps.previouslyWarmed) {
     for (const peerId of deps.previouslyWarmed) {
       if (!warmed.has(peerId)) {
-        await deps.unpin(peerId, ctx).catch(() => {});
-        unpinned += 1;
+        let unpinOk = true;
+        await deps.unpin(peerId, ctx).catch(() => {
+          unpinOk = false;
+        });
+        if (unpinOk) {
+          unpinned += 1;
+        } else {
+          unpinFailed += 1;
+          warmed.add(peerId);
+        }
       }
     }
   }
 
   deps.log(
     ctx,
-    `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} skippedGate=${skippedGate} unpinned=${unpinned} (cap=${deps.maxCores})`,
+    `warm-core reconcile: candidates=${candidates.length} pinned=${warmed.size} dialed=${dialed} skippedGate=${skippedGate} unpinned=${unpinned} unpinFailed=${unpinFailed} (cap=${deps.maxCores})`,
   );
 
   return { candidates: candidates.length, pinned: warmed.size, dialed, skippedGate, unpinned, warmed };

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -720,7 +720,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
-        expect(firstResult.connectedPeers).toBe(1);
+        expect(firstResult.connectedPeers).toBe(3);
         expect(firstResult.totalPeers).toBe(3);
         expect(firstResult.selectedPeers).toBe(1);
         expect(firstResult.syncCapablePeers).toBe(1);
@@ -731,7 +731,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
-    it('keeps connectedPeers scoped to the selected catchup window', async () => {
+    it('reports full connectedPeers while selectedPeers tracks the catchup window', async () => {
       const agent = await DKGAgent.create({
         name: 'RuntimeCatchupSelectedPeerCounts',
         listenHost: '127.0.0.1',
@@ -757,7 +757,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
-        expect(result.connectedPeers).toBe(1);
+        expect(result.connectedPeers).toBe(2);
         expect(result.selectedPeers).toBe(1);
         expect(result.totalPeers).toBe(2);
         expect(result.syncCapablePeers).toBe(0);

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -753,6 +753,30 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('seeds VM reconcile catchup rotation when all current peers fit the window', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupRotationSinglePeerSeed',
+        chainAdapter: new MockChainAdapter(),
+      });
+      const peer = (peerId: string) => ({ toString: () => peerId });
+      const select = (peerIds: string[], peerRotationKey = 'runtime-contextGraph') => (agent as any)
+        .selectCatchupPeerWindow(peerIds.map(peer), {
+          maxPeers: 1,
+          peerRotationKey,
+        })
+        .map((selected: { toString(): string }) => selected.toString());
+
+      try {
+        expect(select(['peer-a'])).toEqual(['peer-a']);
+        expect(select(['peer-a', 'peer-b'])).toEqual(['peer-b']);
+        expect(select(['peer-a', 'peer-b'])).toEqual(['peer-a']);
+        expect(select(['peer-b'], 'runtime-contextGraph-prepend')).toEqual(['peer-b']);
+        expect(select(['peer-a', 'peer-b'], 'runtime-contextGraph-prepend')).toEqual(['peer-a']);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('resets VM reconcile catchup rotation when an existing peer gains priority before the cursor', async () => {
       const agent = await DKGAgent.create({
         name: 'RuntimeCatchupRotationPriorityGain',

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -730,6 +730,29 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('keeps VM reconcile catchup rotation anchored by peer id across connection order churn', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupRotationOrderChurn',
+        chainAdapter: new MockChainAdapter(),
+      });
+      const peer = (peerId: string) => ({ toString: () => peerId });
+      const select = (peerIds: string[]) => (agent as any)
+        .selectCatchupPeerWindow(peerIds.map(peer), {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        })
+        .map((selected: { toString(): string }) => selected.toString());
+
+      try {
+        expect(select(['peer-a', 'peer-b', 'peer-c'])).toEqual(['peer-a']);
+        expect(select(['peer-c', 'peer-a', 'peer-b'])).toEqual(['peer-b']);
+        expect(select(['peer-a', 'peer-c', 'peer-b'])).toEqual(['peer-c']);
+        expect((agent as any).vmReconcileCatchupPeerOrder.size).toBe(1);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('resets VM reconcile catchup rotation when a core peer joins before the cursor', async () => {
       const agent = await DKGAgent.create({
         name: 'RuntimeCatchupRotationCoreJoin',

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -753,6 +753,39 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('resets VM reconcile catchup rotation when an existing peer gains priority before the cursor', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupRotationPriorityGain',
+        chainAdapter: new MockChainAdapter(),
+      });
+      const peer = (peerId: string) => ({ toString: () => peerId });
+      const select = (peerIds: string[], priorityRanks: Record<string, number> = {}, peerRotationKey = 'runtime-contextGraph') => (agent as any)
+        .selectCatchupPeerWindow(peerIds.map(peer), {
+          maxPeers: 1,
+          peerRotationKey,
+          peerPriorityRanks: new Map(Object.entries(priorityRanks)),
+        })
+        .map((selected: { toString(): string }) => selected.toString());
+
+      try {
+        expect(select(['peer-a', 'peer-b', 'peer-c'])).toEqual(['peer-a']);
+        expect(select(['peer-a', 'peer-b', 'peer-c'], { 'peer-a': 1 })).toEqual(['peer-a']);
+        expect(select(['peer-c', 'peer-a', 'peer-b'], { 'peer-c': 2 })).toEqual(['peer-c']);
+        expect(select(
+          ['peer-preferred', 'peer-edge', 'peer-reclassified'],
+          { 'peer-preferred': 2 },
+          'runtime-contextGraph-masked-core',
+        )).toEqual(['peer-preferred']);
+        expect(select(
+          ['peer-preferred', 'peer-reclassified', 'peer-edge'],
+          { 'peer-preferred': 2, 'peer-reclassified': 1 },
+          'runtime-contextGraph-masked-core',
+        )).toEqual(['peer-reclassified']);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('resets VM reconcile catchup rotation when a core peer joins before the cursor', async () => {
       const agent = await DKGAgent.create({
         name: 'RuntimeCatchupRotationCoreJoin',

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -720,12 +720,50 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
-        expect(firstResult.connectedPeers).toBe(3);
+        expect(firstResult.connectedPeers).toBe(1);
         expect(firstResult.totalPeers).toBe(3);
         expect(firstResult.selectedPeers).toBe(1);
         expect(firstResult.syncCapablePeers).toBe(1);
         expect(firstResult.peersTried).toBe(1);
         expect(triedPeers).toEqual(['peer-preferred', 'peer-core', 'peer-edge']);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('keeps connectedPeers scoped to the selected catchup window', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupSelectedPeerCounts',
+        listenHost: '127.0.0.1',
+        chainAdapter: new MockChainAdapter(),
+      });
+
+      try {
+        await agent.start();
+        agent.subscribeToContextGraph('runtime-contextGraph');
+
+        const peerNoProtocol = { toString: () => 'peer-no-protocol' };
+        const peerUnselected = { toString: () => 'peer-unselected' };
+        vi.spyOn(agent.node.libp2p, 'getConnections').mockReturnValue([
+          { remotePeer: peerNoProtocol } as any,
+          { remotePeer: peerUnselected } as any,
+        ]);
+        vi.spyOn((agent as any).discovery, 'findAgents').mockResolvedValue([]);
+        vi.spyOn(agent as any, 'waitForSyncProtocol').mockResolvedValue(false);
+        const syncFromPeerDetailed = vi.spyOn(agent as any, 'syncFromPeerDetailed');
+
+        const result = await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+
+        expect(result.connectedPeers).toBe(1);
+        expect(result.selectedPeers).toBe(1);
+        expect(result.totalPeers).toBe(2);
+        expect(result.syncCapablePeers).toBe(0);
+        expect(result.peersTried).toBe(0);
+        expect(result.diagnostics.noProtocolPeers).toBe(1);
+        expect(syncFromPeerDetailed).not.toHaveBeenCalled();
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -720,7 +720,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
-        expect(firstResult.connectedPeers).toBe(1);
+        expect(firstResult.connectedPeers).toBe(3);
         expect(firstResult.totalPeers).toBe(3);
         expect(firstResult.selectedPeers).toBe(1);
         expect(firstResult.syncCapablePeers).toBe(1);

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -726,6 +726,72 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('resets VM reconcile catchup rotation when a core peer joins before the cursor', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupRotationCoreJoin',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      try {
+        await agent.start();
+        agent.subscribeToContextGraph('runtime-contextGraph');
+
+        const peerEdgeA = { toString: () => 'peer-edge-a' };
+        const peerEdgeB = { toString: () => 'peer-edge-b' };
+        const peerCore = { toString: () => 'peer-core-new' };
+        let connections = [
+          { remotePeer: peerEdgeA } as any,
+          { remotePeer: peerEdgeB } as any,
+        ];
+        vi.spyOn(agent.node.libp2p, 'getConnections').mockImplementation(() => connections);
+        vi.spyOn((agent as any).discovery, 'findAgents').mockResolvedValue([]);
+        vi.spyOn(agent as any, 'ensurePeerConnected').mockResolvedValue(undefined);
+        vi.spyOn(agent as any, 'waitForSyncProtocol').mockResolvedValue(true);
+
+        const triedPeers: string[] = [];
+        vi.spyOn(agent as any, 'syncFromPeerDetailed').mockImplementation(async (...args: unknown[]) => {
+          triedPeers.push(String(args[0]));
+          return {
+            insertedTriples: 0,
+            fetchedMetaTriples: 0,
+            fetchedDataTriples: 0,
+            insertedMetaTriples: 0,
+            insertedDataTriples: 0,
+            bytesReceived: 0,
+            resumedPhases: 0,
+            emptyResponses: 1,
+            metaOnlyResponses: 0,
+            dataRejectedMissingMeta: 0,
+            rejectedKcs: 0,
+            failedPeers: 0,
+            deniedPhases: 0,
+          };
+        });
+
+        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+
+        (agent as any).knownCorePeerIds.add('peer-core-new');
+        connections = [
+          { remotePeer: peerEdgeA } as any,
+          { remotePeer: peerCore } as any,
+          { remotePeer: peerEdgeB } as any,
+        ];
+
+        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+
+        expect(triedPeers).toEqual(['peer-edge-a', 'peer-core-new']);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
 
     // "allocates a fresh sync deadline per context graph" removed: the
     // test mocks `fetchSyncPages` with a signature that the current

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -720,7 +720,8 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
-        expect(firstResult.connectedPeers).toBe(3);
+        expect(firstResult.connectedPeers).toBe(1);
+        expect(firstResult.totalPeers).toBe(3);
         expect(firstResult.selectedPeers).toBe(1);
         expect(firstResult.syncCapablePeers).toBe(1);
         expect(firstResult.peersTried).toBe(1);

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -662,6 +662,70 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('can limit VM reconcile catchup to one ordered peer and rotate on later attempts', async () => {
+      const agent = await DKGAgent.create({
+        name: 'RuntimeCatchupSinglePeerRotation',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      try {
+        await agent.start();
+        agent.subscribeToContextGraph('runtime-contextGraph');
+        (agent as any).preferredSyncPeers.set('runtime-contextGraph', 'peer-preferred');
+        (agent as any).knownCorePeerIds.add('peer-core');
+
+        const peerEdge = { toString: () => 'peer-edge' };
+        const peerCore = { toString: () => 'peer-core' };
+        const peerPreferred = { toString: () => 'peer-preferred' };
+        vi.spyOn(agent.node.libp2p, 'getConnections').mockReturnValue([
+          { remotePeer: peerEdge } as any,
+          { remotePeer: peerCore } as any,
+          { remotePeer: peerPreferred } as any,
+        ]);
+        vi.spyOn((agent as any).discovery, 'findAgents').mockResolvedValue([]);
+        vi.spyOn(agent as any, 'ensurePeerConnected').mockResolvedValue(undefined);
+        vi.spyOn(agent as any, 'waitForSyncProtocol').mockResolvedValue(true);
+
+        const triedPeers: string[] = [];
+        vi.spyOn(agent as any, 'syncFromPeerDetailed').mockImplementation(async (...args: unknown[]) => {
+          triedPeers.push(String(args[0]));
+          return {
+            insertedTriples: 0,
+            fetchedMetaTriples: 0,
+            fetchedDataTriples: 0,
+            insertedMetaTriples: 0,
+            insertedDataTriples: 0,
+            bytesReceived: 0,
+            resumedPhases: 0,
+            emptyResponses: 1,
+            metaOnlyResponses: 0,
+            dataRejectedMissingMeta: 0,
+            rejectedKcs: 0,
+            failedPeers: 0,
+            deniedPhases: 0,
+          };
+        });
+
+        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+          maxPeers: 1,
+          peerRotationKey: 'runtime-contextGraph',
+        });
+
+        expect(triedPeers).toEqual(['peer-preferred', 'peer-core', 'peer-edge']);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
 
     // "allocates a fresh sync deadline per context graph" removed: the
     // test mocks `fetchSyncPages` with a signature that the current

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -707,7 +707,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           };
         });
 
-        await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
+        const firstResult = await agent.syncContextGraphFromConnectedPeers('runtime-contextGraph', {
           maxPeers: 1,
           peerRotationKey: 'runtime-contextGraph',
         });
@@ -720,6 +720,10 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           peerRotationKey: 'runtime-contextGraph',
         });
 
+        expect(firstResult.connectedPeers).toBe(3);
+        expect(firstResult.selectedPeers).toBe(1);
+        expect(firstResult.syncCapablePeers).toBe(1);
+        expect(firstResult.peersTried).toBe(1);
         expect(triedPeers).toEqual(['peer-preferred', 'peer-core', 'peer-edge']);
       } finally {
         await agent.stop().catch(() => {});

--- a/packages/agent/test/chain-reconcile-e2e.test.ts
+++ b/packages/agent/test/chain-reconcile-e2e.test.ts
@@ -50,11 +50,19 @@ async function seedSwmSnapshot(store: OxigraphStore, entity: string, value: stri
  * of the gossip envelope flag). `FinalizationHandler.getKeepRootCopySignal`
  * reads it back to decide the same-graph dual-write during reconcile.
  */
-async function seedKeepRootSignal(store: OxigraphStore, entity: string, keep: boolean): Promise<void> {
+async function seedKeepRootSignal(
+  store: OxigraphStore,
+  entity: string,
+  keep: boolean,
+  form: 'plain' | 'typed' = 'plain',
+): Promise<void> {
+  const object = form === 'typed'
+    ? `"${keep}"^^<http://www.w3.org/2001/XMLSchema#boolean>`
+    : `"${keep}"`;
   await store.insert([{
     subject: entity,
     predicate: 'http://dkg.io/ontology/keepRootCopyOnLabel',
-    object: `"${keep}"`,
+    object,
     graph: contextGraphWorkspaceMetaGraphUri(LOCAL_CG),
   }]);
 }
@@ -208,6 +216,27 @@ describe('Phase B e2e — chain registration -> VM via the sweep', () => {
     expect(res.reconciled).toBe(1);
     expect(await isInVm(store, 'urn:fact:dw', value)).toBe(true);
     expect(await isInRootLabel(store, 'urn:fact:dw', value)).toBe(true);
+  });
+
+  it('recovers a typed boolean keepRootCopyOnLabel literal and dual-writes', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    const value = 'Honey never spoils';
+    const root = await seedSwmSnapshot(store, 'urn:fact:dwtyped', value);
+    await seedKeepRootSignal(store, 'urn:fact:dwtyped', true, 'typed');
+    chain.__registerKC({ kaId: 303n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(root), chunks: [] });
+
+    const persisted: number[] = [];
+    const deps = makeDeps(store, chain, fh, persisted);
+    const cursor = createCursorState(0);
+
+    const res = await reconcileContextGraph(deps, cursor, LOCAL_CG, ON_CHAIN_CG);
+
+    expect(res.reconciled).toBe(1);
+    expect(await isInVm(store, 'urn:fact:dwtyped', value)).toBe(true);
+    expect(await isInRootLabel(store, 'urn:fact:dwtyped', value)).toBe(true);
   });
 
   it('does NOT dual-write to the root label graph when no keep-root signal is persisted', async () => {

--- a/packages/agent/test/chain-reconcile-e2e.test.ts
+++ b/packages/agent/test/chain-reconcile-e2e.test.ts
@@ -156,6 +156,30 @@ describe('Phase B e2e — chain registration -> VM via the sweep', () => {
     expect(await isInVm(store, 'urn:fact:b', 'Octopuses have three hearts')).toBe(true);
   });
 
+  it('does not materialize a chain-backed reconcile when the head block read fails', async () => {
+    const store = new OxigraphStore();
+    const chain = new MockChainAdapter();
+    const fh = new FinalizationHandler(store, chain);
+
+    const root = await seedSwmSnapshot(store, 'urn:fact:headfail', 'Chain heads matter');
+    chain.__registerKC({ kaId: 103n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(root), chunks: [] });
+
+    const persisted: number[] = [];
+    const deps = {
+      ...makeDeps(store, chain, fh, persisted),
+      getHeadBlock: async () => {
+        throw new Error('RPC down');
+      },
+    };
+    const cursor = createCursorState(0);
+
+    const res = await reconcileContextGraph(deps, cursor, LOCAL_CG, ON_CHAIN_CG);
+
+    expect(res).toMatchObject({ head: 1, watermark: 0, reconciled: 0, pending: 1 });
+    expect(persisted).toEqual([]);
+    expect(await isInVm(store, 'urn:fact:headfail', 'Chain heads matter')).toBe(false);
+  });
+
   it('holds the watermark at a gap and fills it on a later sweep (late SWM arrival)', async () => {
     const store = new OxigraphStore();
     const chain = new MockChainAdapter();

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -119,6 +119,34 @@ describe('reconcileContextGraph — sweep', () => {
     const r2 = await reconcileContextGraph(deps, state, 'cg', 1n);
     expect(r2.watermark).toBe(1);
   });
+
+  it('promotes during transient head fetch failure but does not advance or persist the watermark', async () => {
+    let headThrows = true;
+    const attempted: number[] = [];
+    const { deps, persisted } = makeDeps({
+      getKCCount: async () => 2,
+      confirmationDepth: 5,
+      getHeadBlock: async () => {
+        if (headThrows) throw new Error('RPC down');
+        return 100;
+      },
+      reconcileOrdinal: async (_cg, _onchain, ordinal) => {
+        attempted.push(ordinal);
+        return { status: 'reconciled', blockNumber: 90 };
+      },
+    });
+    const state = createCursorState(0);
+
+    const r1 = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(r1.reconciled).toBe(2);
+    expect(r1.watermark).toBe(0);
+    expect(persisted).toEqual([]);
+
+    headThrows = false;
+    const r2 = await reconcileContextGraph(deps, state, 'cg', 1n);
+    expect(r2.watermark).toBe(2);
+    expect(persisted).toEqual([{ cg: 'cg', watermark: 2 }]);
+  });
 });
 
 describe('ReconcileCoalescer', () => {

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -120,7 +120,7 @@ describe('reconcileContextGraph — sweep', () => {
     expect(r2.watermark).toBe(1);
   });
 
-  it('promotes during transient head fetch failure but does not advance or persist the watermark', async () => {
+  it('skips promotion during transient head fetch failure and retries when the head recovers', async () => {
     let headThrows = true;
     const attempted: number[] = [];
     const { deps, persisted } = makeDeps({
@@ -138,13 +138,16 @@ describe('reconcileContextGraph — sweep', () => {
     const state = createCursorState(0);
 
     const r1 = await reconcileContextGraph(deps, state, 'cg', 1n);
-    expect(r1.reconciled).toBe(2);
+    expect(r1.reconciled).toBe(0);
+    expect(r1.pending).toBe(2);
     expect(r1.watermark).toBe(0);
+    expect(attempted).toEqual([]);
     expect(persisted).toEqual([]);
 
     headThrows = false;
     const r2 = await reconcileContextGraph(deps, state, 'cg', 1n);
     expect(r2.watermark).toBe(2);
+    expect(attempted).toEqual([0, 1]);
     expect(persisted).toEqual([{ cg: 'cg', watermark: 2 }]);
   });
 });

--- a/packages/agent/test/chain-reconciler.test.ts
+++ b/packages/agent/test/chain-reconciler.test.ts
@@ -201,4 +201,17 @@ describe('RecentUalSet', () => {
     expect(set.has('b')).toBe(true);
     expect(set.has('c')).toBe(true);
   });
+
+  it('deletes all entries for one local CG prefix without touching others', () => {
+    const set = new RecentUalSet(10);
+    set.add('cg-a\0ual#01');
+    set.add('cg-a\0ual#02');
+    set.add('cg-b\0ual#01');
+
+    set.deleteByPrefix('cg-a\0');
+
+    expect(set.has('cg-a\0ual#01')).toBe(false);
+    expect(set.has('cg-a\0ual#02')).toBe(false);
+    expect(set.has('cg-b\0ual#01')).toBe(true);
+  });
 });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -23,6 +23,9 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import { MockChainAdapter, buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
 import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
 import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  contextGraphDataGraphUri,
   contextGraphWorkspaceGraphUri,
   contextGraphWorkspaceMetaGraphUri,
 } from '@origintrail-official/dkg-core';
@@ -31,6 +34,8 @@ import type { ReplicationEvent, ContextGraphSubscriptionRecord } from '../src/dk
 import { DKGAgent } from '../src/index.js';
 
 interface AgentInternals {
+  createContextGraph(opts: { id: string; name: string; description?: string; private?: boolean; callerAgentAddress?: string }): Promise<void>;
+  registerContextGraph(id: string, opts?: { callerAgentAddress?: string }): Promise<{ onChainId: string; txHash?: string }>;
   recordCoreHostedPublicCg(cgId: string, swmGraphId?: string): Promise<void>;
   reconcileChainOrdinal(localCgId: string, onChainCgId: bigint, ordinal: number, headBlock: number | undefined): Promise<{ status: string }>;
   syncContextGraphFromConnectedPeers(contextGraphId: string, options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string }): Promise<unknown>;
@@ -247,6 +252,19 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(persisted?.subscribed).toBe(false);
   });
 
+  it('records a public hosted CG for ACK-backed adapters without a liveness probe', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0; // public
+    (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+
+    await internals.recordCoreHostedPublicCg('43');
+
+    const sub = internals.subscribedContextGraphs.get('43');
+    expect(sub?.coreHosted).toBe(true);
+    expect(sub?.onChainId).toBe('43');
+    expect(saved.find((r) => r.id === '43')?.coreHosted).toBe(true);
+  });
+
   it('keys the host row under the cleartext swmGraphId (not the numeric id) on first ACK', async () => {
     // Regression: on the first ACK for a CG we only host, there is no local
     // mapping yet, so without the cleartext hint the row would land under the
@@ -347,6 +365,12 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     internals.subscribedContextGraphs.set('devnet-test', {
       subscribed: true, onChainId: '5', lastReconciledOrdinal: 3,
     });
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, 777n);
+    const root = new Uint8Array(32);
+    root[31] = 3;
+    const recentKey = (internals as any).vmReconcileCacheKey('devnet-test', ual, root);
+    ((internals as any).recentReconciledUals as { add(key: string): void }).add(recentKey);
 
     // Same local id ("devnet-test"), but now hosting a DIFFERENT chain graph (9).
     await internals.recordCoreHostedPublicCg('9', 'devnet-test');
@@ -356,6 +380,44 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(sub!.coreHosted).toBe(true);
     expect(sub!.onChainId).toBe('9');              // rebound to the new graph
     expect(sub!.lastReconciledOrdinal).toBe(0);    // stale watermark dropped
+    expect(((internals as any).recentReconciledUals as { has(key: string): boolean }).has(recentKey)).toBe(false);
+  });
+
+  it('clears recent VM reconcile dedupe when stale inactive on-chain ids are re-registered', async () => {
+    const internals = await boot();
+    const localCgId = 'stale-register';
+    const ownerAddr = (internals.chain as unknown as { signerAddress: string }).signerAddress;
+
+    await internals.createContextGraph({
+      id: localCgId,
+      name: 'Stale Register',
+      private: true,
+      callerAgentAddress: ownerAddr,
+    });
+    await internals.store.insert([{
+      subject: `did:dkg:context-graph:${localCgId}`,
+      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+      object: '"5"',
+      graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+    }]);
+    internals.subscribedContextGraphs.set(localCgId, {
+      subscribed: true, onChainId: '5', lastReconciledOrdinal: 4,
+    });
+    internals.chain.isContextGraphActiveOnChain = async (id) => id !== 5n;
+
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, 778n);
+    const root = new Uint8Array(32);
+    root[31] = 4;
+    const recentKey = (internals as any).vmReconcileCacheKey(localCgId, ual, root);
+    const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
+    recent.add(recentKey);
+
+    await expect(internals.registerContextGraph(localCgId, { callerAgentAddress: ownerAddr }))
+      .resolves.toMatchObject({ onChainId: expect.any(String) });
+
+    expect(internals.subscribedContextGraphs.get(localCgId)?.onChainId).not.toBe('5');
+    expect(recent.has(recentKey)).toBe(false);
   });
 });
 
@@ -1082,6 +1144,7 @@ describe('Phase D - VM reconcile damping', () => {
     const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
     const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
     const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
+    const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
     const now = Date.now();
 
     for (let i = 0; i < DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES + 2; i += 1) {
@@ -1122,11 +1185,13 @@ describe('Phase D - VM reconcile damping', () => {
     fetchCooldown.set('cleanup-cg', now);
     peerCursor.set('cleanup-cg', 7);
     peerOrder.set('cleanup-cg', { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
+    recent.add('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01');
     (agent as any).unsubscribeFromContextGraph('cleanup-cg');
     expect(negativeCache.has('cleanup-cache')).toBe(false);
     expect(fetchCooldown.has('cleanup-cg')).toBe(false);
     expect(peerCursor.has('cleanup-cg')).toBe(false);
     expect(peerOrder.has('cleanup-cg')).toBe(false);
+    expect(recent.has('cleanup-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/1#01')).toBe(false);
 
     internals.subscribedContextGraphs.set('hosted-cg', { subscribed: true, coreHosted: true });
     negativeCache.set('hosted-cache', {
@@ -1141,11 +1206,13 @@ describe('Phase D - VM reconcile damping', () => {
     fetchCooldown.set('hosted-cg', now);
     peerCursor.set('hosted-cg', 3);
     peerOrder.set('hosted-cg', { orderedPeers: ['peer-b'], nextPeerId: 'peer-b' });
+    recent.add('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02');
     (agent as any).unsubscribeFromContextGraph('hosted-cg');
     expect(negativeCache.has('hosted-cache')).toBe(true);
     expect(fetchCooldown.has('hosted-cg')).toBe(true);
     expect(peerCursor.has('hosted-cg')).toBe(true);
     expect(peerOrder.has('hosted-cg')).toBe(true);
+    expect(recent.has('hosted-cg\0did:dkg:mock:31337/0x000000000000000000000000000000000000c10a/2#02')).toBe(true);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -607,6 +607,39 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
+  it('retries finalization after shared-memory fetch progress even when peer success is zero', async () => {
+    const internals = await boot();
+    const onChainCgId = 61n;
+    const entity = 'urn:fact:shared-progress';
+    const value = 'Shared memory fetched despite durable failure';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9022n, onChainCgId, bytesToHex(root));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockImplementation(async () => {
+      await seedSwmSnapshot(internals.store, '61', entity, value);
+      return {
+        ...emptyCatchupStats(),
+        peersSucceeded: 0,
+        sharedMemorySynced: 2,
+        diagnostics: {
+          ...emptyCatchupStats().diagnostics,
+          sharedMemory: {
+            ...emptyCatchupStats().diagnostics.sharedMemory,
+            insertedDataTriples: 1,
+            insertedMetaTriples: 1,
+          },
+        },
+      };
+    });
+
+    await expect(internals.reconcileChainOrdinal('61', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
   it('retries an incomplete SWM operation when data changes without triple-count changes', async () => {
     const internals = await boot();
     const onChainCgId = 52n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -94,6 +94,15 @@ function emptyCatchupStats() {
   };
 }
 
+function noProtocolCatchupStats() {
+  return {
+    ...emptyCatchupStats(),
+    syncCapablePeers: 0,
+    peersTried: 0,
+    peersSucceeded: 0,
+  };
+}
+
 async function insertWorkspaceOperationMeta(
   store: TripleStore,
   metaGraph: string,
@@ -288,11 +297,16 @@ describe('Phase D - VM reconcile damping', () => {
     return agent as unknown as AgentInternals;
   }
 
-  function registerUnmatchedKC(chain: MockChainAdapter, kaId: bigint, onChainCgId: bigint): void {
+  function registerUnmatchedKC(
+    chain: MockChainAdapter,
+    kaId: bigint,
+    onChainCgId: bigint,
+    merkleRootHex = '0x' + kaId.toString(16).padStart(64, '0'),
+  ): void {
     chain.__registerKC({
       kaId,
       contextGraphId: onChainCgId,
-      merkleRootHex: '0x' + kaId.toString(16).padStart(64, '0'),
+      merkleRootHex,
       chunks: [],
     });
   }
@@ -318,6 +332,41 @@ describe('Phase D - VM reconcile damping', () => {
     await expect(internals.reconcileChainOrdinal('42', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(expensiveScans).toBe(0);
+  });
+
+  it('does not reuse a negative cache entry when the same KA has a newer merkle root', async () => {
+    const internals = await boot();
+    const onChainCgId = 46n;
+    registerUnmatchedKC(internals.chain, 9006n, onChainCgId, '0x' + '11'.repeat(32));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('46', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+
+    expensiveScans = 0;
+    await expect(internals.reconcileChainOrdinal('46', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBe(0);
+
+    registerUnmatchedKC(internals.chain, 9006n, onChainCgId, '0x' + '22'.repeat(32));
+    await expect(internals.reconcileChainOrdinal('46', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    // New root bypasses the negative-cache deferral and re-runs the SWM scan;
+    // the independent per-CG active-fetch cooldown may still suppress another
+    // network fetch in the same sweep interval.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+    const cacheKeys = Array.from(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).keys());
+    expect(cacheKeys).toHaveLength(1);
+    expect(cacheKeys[0]).toContain('22'.repeat(32));
+    expect(cacheKeys[0]).not.toContain('11'.repeat(32));
   });
 
   it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
@@ -411,6 +460,34 @@ describe('Phase D - VM reconcile damping', () => {
     await internals.reconcileChainOrdinal('44', onChainCgId, 1, undefined);
 
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through a no-protocol active-fetch peer before caching a miss', async () => {
+    const internals = await boot();
+    const onChainCgId = 47n;
+    registerUnmatchedKC(internals.chain, 9007n, onChainCgId);
+    (agent as any).node.libp2p.getConnections = () => [
+      { remotePeer: { toString: () => 'peer-no-protocol' } },
+      { remotePeer: { toString: () => 'peer-empty' } },
+    ];
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers')
+      .mockResolvedValueOnce(noProtocolCatchupStats())
+      .mockResolvedValueOnce(emptyCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal('47', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(1, '47', {
+      includeSharedMemory: true,
+      maxPeers: 1,
+      peerRotationKey: '47',
+    });
+    expect(fetch).toHaveBeenNthCalledWith(2, '47', {
+      includeSharedMemory: true,
+      maxPeers: 1,
+      peerRotationKey: '47',
+    });
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -118,6 +118,52 @@ async function insertWorkspaceOperationMeta(
   ]);
 }
 
+function bytesToHex(bytes: Uint8Array): string {
+  return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+async function insertWorkspaceDataTriple(
+  store: TripleStore,
+  localCgId: string,
+  entity: string,
+  value: string,
+): Promise<void> {
+  await store.insert([{
+    subject: entity,
+    predicate: 'http://schema.org/name',
+    object: `"${value}"`,
+    graph: contextGraphWorkspaceGraphUri(localCgId),
+  }]);
+}
+
+async function replaceWorkspaceDataTriple(
+  store: TripleStore,
+  localCgId: string,
+  entity: string,
+  value: string,
+): Promise<void> {
+  await store.deleteByPattern({
+    subject: entity,
+    predicate: 'http://schema.org/name',
+    graph: contextGraphWorkspaceGraphUri(localCgId),
+  });
+  await insertWorkspaceDataTriple(store, localCgId, entity, value);
+}
+
+async function insertPrivateMerkleRoot(
+  store: TripleStore,
+  localCgId: string,
+  entity: string,
+  privateRoot: Uint8Array,
+): Promise<void> {
+  await store.insert([{
+    subject: entity,
+    predicate: 'http://dkg.io/ontology/privateMerkleRoot',
+    object: `"${bytesToHex(privateRoot)}"`,
+    graph: contextGraphWorkspaceMetaGraphUri(localCgId),
+  }]);
+}
+
 /** Seed a local SWM snapshot for one KA under a CG and return its flat-KC root. */
 async function seedSwmSnapshot(store: TripleStore, localCgId: string, entity: string, value: string): Promise<Uint8Array> {
   const wsGraph = contextGraphWorkspaceGraphUri(localCgId);
@@ -369,6 +415,101 @@ describe('Phase D - VM reconcile damping', () => {
     expect(cacheKeys[0]).not.toContain('11'.repeat(32));
   });
 
+  it('invalidates a negative cache entry when SWM data arrives without operation-meta changes', async () => {
+    const internals = await boot();
+    const onChainCgId = 48n;
+    const entity = 'urn:fact:data-arrival';
+    const value = 'Data arrived after cache';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9008n, onChainCgId, bytesToHex(root));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      contextGraphWorkspaceMetaGraphUri('48'),
+      'data-arrival-op',
+      entity,
+      '2030-01-01T00:00:00.000Z',
+    );
+
+    await expect(internals.reconcileChainOrdinal('48', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await insertWorkspaceDataTriple(internals.store, '48', entity, value);
+
+    await expect(internals.reconcileChainOrdinal('48', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
+  it('invalidates a negative cache entry when SWM data changes without triple-count changes', async () => {
+    const internals = await boot();
+    const onChainCgId = 52n;
+    const entity = 'urn:fact:data-replacement';
+    const staleValue = 'Stale value';
+    const freshValue = 'Fresh value';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${freshValue}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9012n, onChainCgId, bytesToHex(root));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      contextGraphWorkspaceMetaGraphUri('52'),
+      'data-replacement-op',
+      entity,
+      '2030-01-01T00:00:00.000Z',
+    );
+    await insertWorkspaceDataTriple(internals.store, '52', entity, staleValue);
+
+    await expect(internals.reconcileChainOrdinal('52', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await replaceWorkspaceDataTriple(internals.store, '52', entity, freshValue);
+
+    await expect(internals.reconcileChainOrdinal('52', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
+  it('invalidates a negative cache entry when private-root metadata arrives without operation-meta changes', async () => {
+    const internals = await boot();
+    const onChainCgId = 49n;
+    const entity = 'urn:fact:private-arrival';
+    const value = 'Private root arrived after cache';
+    const privateRoot = new Uint8Array(32);
+    privateRoot[31] = 7;
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [privateRoot],
+    );
+    registerUnmatchedKC(internals.chain, 9009n, onChainCgId, bytesToHex(root));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      contextGraphWorkspaceMetaGraphUri('49'),
+      'private-arrival-op',
+      entity,
+      '2030-01-01T00:00:00.000Z',
+    );
+    await insertWorkspaceDataTriple(internals.store, '49', entity, value);
+
+    await expect(internals.reconcileChainOrdinal('49', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await insertPrivateMerkleRoot(internals.store, '49', entity, privateRoot);
+
+    await expect(internals.reconcileChainOrdinal('49', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
   it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
     const internals = await boot();
     const onChainCgId = 45n;
@@ -488,6 +629,42 @@ describe('Phase D - VM reconcile damping', () => {
       maxPeers: 1,
       peerRotationKey: '47',
     });
+  });
+
+  it('does not negative-cache no-swm when active fetch reaches no sync-capable peer', async () => {
+    const internals = await boot();
+    const onChainCgId = 50n;
+    registerUnmatchedKC(internals.chain, 9010n, onChainCgId);
+    (agent as any).node.libp2p.getConnections = () => [
+      { remotePeer: { toString: () => 'peer-no-protocol-a' } },
+      { remotePeer: { toString: () => 'peer-no-protocol-b' } },
+    ];
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(noProtocolCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal('50', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+    expect(((internals as any).vmReconcileFetchCooldownAt as Map<string, unknown>).has('50')).toBe(false);
+  });
+
+  it('does not negative-cache no-swm when every active fetch attempt fails', async () => {
+    const internals = await boot();
+    const onChainCgId = 51n;
+    registerUnmatchedKC(internals.chain, 9011n, onChainCgId);
+    (agent as any).node.libp2p.getConnections = () => [
+      { remotePeer: { toString: () => 'peer-fails-a' } },
+      { remotePeer: { toString: () => 'peer-fails-b' } },
+    ];
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockRejectedValue(new Error('fetch failed'));
+
+    await expect(internals.reconcileChainOrdinal('51', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+    expect(((internals as any).vmReconcileFetchCooldownAt as Map<string, unknown>).has('51')).toBe(false);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -299,7 +299,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(internals.subscribedContextGraphs.get('45')?.coreHosted).toBe(true);
   });
 
-  it('ignores late core-host recording completions after recordings are closed', async () => {
+  it('lets in-flight core-host recordings finish while shutdown is draining', async () => {
     const internals = await boot();
     let resolvePolicy!: (value: number) => void;
     internals.chain.getContextGraphAccessPolicy = vi.fn(() => new Promise<number>((resolve) => {
@@ -312,8 +312,39 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     resolvePolicy(0);
     await recording;
 
-    expect(internals.subscribedContextGraphs.get('late-hosted')).toBeUndefined();
-    expect(saved.find((r) => r.id === 'late-hosted')).toBeUndefined();
+    expect(internals.subscribedContextGraphs.get('late-hosted')?.coreHosted).toBe(true);
+    expect(saved.find((r) => r.id === 'late-hosted')?.coreHosted).toBe(true);
+  });
+
+  it('ignores late core-host recording completions after drain gives up', async () => {
+    const internals = await boot();
+    let resolvePolicy!: (value: number) => void;
+    internals.chain.getContextGraphAccessPolicy = vi.fn(() => new Promise<number>((resolve) => {
+      resolvePolicy = resolve;
+    }));
+    (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+
+    const recording = internals.recordCoreHostedPublicCg('49', 'late-after-timeout');
+    (internals as any).coreHostRecordingsAborted = true;
+    resolvePolicy(0);
+    await recording;
+
+    expect(internals.subscribedContextGraphs.get('late-after-timeout')).toBeUndefined();
+    expect(saved.find((r) => r.id === 'late-after-timeout')).toBeUndefined();
+  });
+
+  it('uses cached public access policy when the live policy read flakes', async () => {
+    const internals = await boot();
+    ((internals as any).onChainAccessPolicyCache as Map<string, 0 | 1>).set('50', 0);
+    internals.chain.getContextGraphAccessPolicy = vi.fn(async () => {
+      throw new Error('rpc unavailable');
+    });
+
+    await internals.recordCoreHostedPublicCg('50', 'cached-public');
+
+    expect(internals.chain.getContextGraphAccessPolicy).not.toHaveBeenCalled();
+    expect(internals.subscribedContextGraphs.get('cached-public')?.coreHosted).toBe(true);
+    expect(saved.find((r) => r.id === 'cached-public')?.coreHosted).toBe(true);
   });
 
   it('falls back to ACK-backed policy read when the liveness probe rejects', async () => {
@@ -1207,7 +1238,7 @@ describe('Phase D - VM reconcile damping', () => {
       }
       return {
         ...emptyCatchupStats(),
-        connectedPeers: 1,
+        connectedPeers: connectedPeers.length,
         totalPeers: connectedPeers.length,
         selectedPeers: 1,
       };
@@ -1225,7 +1256,7 @@ describe('Phase D - VM reconcile damping', () => {
 
     const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue({
       ...emptyCatchupStats(),
-      connectedPeers: 1,
+      connectedPeers: 33,
       totalPeers: 33,
       selectedPeers: 1,
     });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -278,6 +278,39 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(saved.find((r) => r.id === '44')).toBeUndefined();
   });
 
+  it('stops accepting and drains core-host recordings deterministically', async () => {
+    const internals = await boot();
+    let startedAfterClose = false;
+    (internals as any).coreHostRecordingsClosed = true;
+    (internals as any).trackCoreHostRecording(async () => { startedAfterClose = true; });
+    expect(startedAfterClose).toBe(false);
+
+    (internals as any).coreHostRecordingsClosed = false;
+    const recordings = (internals as any).coreHostRecordings as Set<Promise<void>>;
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstBase = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let firstTracked!: Promise<void>;
+    firstTracked = firstBase.finally(() => {
+      recordings.delete(firstTracked);
+      let secondTracked!: Promise<void>;
+      secondTracked = new Promise<void>((resolve) => { releaseSecond = resolve; })
+        .finally(() => { recordings.delete(secondTracked); });
+      recordings.add(secondTracked);
+    });
+    recordings.add(firstTracked);
+
+    const drained = (internals as any).drainCoreHostRecordings();
+    releaseFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(recordings.size).toBe(1);
+    releaseSecond();
+    await drained;
+
+    expect(recordings.size).toBe(0);
+  });
+
   it('keys the host row under the cleartext swmGraphId (not the numeric id) on first ACK', async () => {
     // Regression: on the first ACK for a CG we only host, there is no local
     // mapping yet, so without the cleartext hint the row would land under the

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -429,6 +429,44 @@ describe('Phase D - VM reconcile damping', () => {
     expect(expensiveScans).toBeGreaterThan(0);
   });
 
+  it('primes catchup connections before reusing a negative cache entry', async () => {
+    const internals = await boot();
+    const onChainCgId = 57n;
+    registerUnmatchedKC(internals.chain, 9017n, onChainCgId);
+
+    let connectedPeers = ['peer-empty'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+
+    let primeCalls = 0;
+    vi.spyOn(internals as any, 'primeCatchupConnections').mockImplementation(async () => {
+      primeCalls += 1;
+      if (primeCalls >= 2) {
+        connectedPeers = ['peer-empty', 'peer-discovered'];
+      }
+    });
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('57', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    expensiveScans = 0;
+
+    await expect(internals.reconcileChainOrdinal('57', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(primeCalls).toBeGreaterThanOrEqual(2);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(expensiveScans).toBeGreaterThan(0);
+  });
+
   it('does not reuse a negative cache entry when catchup ranking changes for the same peer set', async () => {
     const internals = await boot();
     const onChainCgId = 56n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -316,7 +316,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(saved.find((r) => r.id === 'late-hosted')?.coreHosted).toBe(true);
   });
 
-  it('ignores late core-host recording completions after drain gives up', async () => {
+  it('ignores late core-host recording completions from abandoned drain generations after restart', async () => {
     const internals = await boot();
     let resolvePolicy!: (value: number) => void;
     internals.chain.getContextGraphAccessPolicy = vi.fn(() => new Promise<number>((resolve) => {
@@ -325,7 +325,10 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
 
     const recording = internals.recordCoreHostedPublicCg('49', 'late-after-timeout');
-    (internals as any).coreHostRecordingsAborted = true;
+    (internals as any).coreHostRecordingGeneration += 1;
+    // Simulate a later restart opening new recordings; the abandoned
+    // continuation captured the previous generation and must still be ignored.
+    (internals as any).coreHostRecordingsClosed = false;
     resolvePolicy(0);
     await recording;
 
@@ -410,6 +413,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     const recordings = (internals as any).coreHostRecordings as Set<Promise<void>>;
     recordings.add(new Promise<void>(() => undefined));
     const warn = vi.spyOn((internals as any).log, 'warn');
+    const generationBeforeDrain = (internals as any).coreHostRecordingGeneration;
 
     vi.useFakeTimers();
     try {
@@ -418,6 +422,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
       await expect(drained).resolves.toBeUndefined();
 
       expect(recordings.size).toBe(0);
+      expect((internals as any).coreHostRecordingGeneration).toBe(generationBeforeDrain + 1);
       expect(warn).toHaveBeenCalledWith(
         expect.anything(),
         expect.stringContaining('timed out draining 1 core-host recording'),
@@ -1040,6 +1045,41 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch).toHaveBeenCalledTimes(fetchesAfterFirstMiss);
     expect(expensiveScans).toBe(0);
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+  });
+
+  it('invalidates a negative cache entry when root SWM changes while subgraph enumeration fails', async () => {
+    const internals = await boot();
+    const onChainCgId = 65n;
+    const entity = 'urn:fact:root-arrival-after-subgraph-cache';
+    const value = 'Root SWM arrived after subgraph cache';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9025n, onChainCgId, bytesToHex(root));
+
+    const graphManager = new GraphManager(internals.store);
+    await internals.store.insert([{
+      subject: 'urn:test:subgraph-marker:code',
+      predicate: 'http://schema.org/name',
+      object: '"marker"',
+      graph: graphManager.subGraphUri('65', 'code'),
+    }]);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal('65', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    const fetchesAfterFirstMiss = fetch.mock.calls.length;
+    expect(fetchesAfterFirstMiss).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    vi.spyOn(GraphManager.prototype, 'listSubGraphs').mockRejectedValue(new Error('transient subgraph listing failure'));
+    const seededRoot = await seedSwmSnapshot(internals.store, '65', entity, value);
+    expect(bytesToHex(seededRoot)).toBe(bytesToHex(root));
+
+    await expect(internals.reconcileChainOrdinal('65', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(fetchesAfterFirstMiss);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
   it('does not reuse a negative cache entry across local CGs for the same KA root', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -1131,6 +1131,22 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
+  it('attempts every connected peer before recording a miss', async () => {
+    const internals = await boot();
+    const onChainCgId = 64n;
+    registerUnmatchedKC(internals.chain, 9024n, onChainCgId);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue({
+      ...emptyCatchupStats(),
+      connectedPeers: 33,
+      selectedPeers: 1,
+    });
+
+    await expect(internals.reconcileChainOrdinal('64', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+
+    expect(fetch).toHaveBeenCalledTimes(33);
+  });
+
   it('does not negative-cache no-swm when active fetch reaches no sync-capable peer', async () => {
     const internals = await boot();
     const onChainCgId = 50n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -336,9 +336,12 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(saved.find((r) => r.id === 'late-after-timeout')).toBeUndefined();
   });
 
-  it('uses cached public access policy when the live policy read flakes', async () => {
+  it('uses cached public access policy when liveness fails and the fallback policy read flakes', async () => {
     const internals = await boot();
     ((internals as any).onChainAccessPolicyCache as Map<string, 0 | 1>).set('50', 0);
+    internals.chain.isContextGraphActiveOnChain = vi.fn(async () => {
+      throw new Error('liveness rpc unavailable');
+    });
     internals.chain.getContextGraphAccessPolicy = vi.fn(async () => {
       throw new Error('rpc unavailable');
     });
@@ -348,6 +351,19 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(internals.chain.getContextGraphAccessPolicy).not.toHaveBeenCalled();
     expect(internals.subscribedContextGraphs.get('cached-public')?.coreHosted).toBe(true);
     expect(saved.find((r) => r.id === 'cached-public')?.coreHosted).toBe(true);
+  });
+
+  it('forces a fresh policy read after liveness proves the slot is live', async () => {
+    const internals = await boot();
+    ((internals as any).onChainAccessPolicyCache as Map<string, 0 | 1>).set('51', 0);
+    internals.chain.isContextGraphActiveOnChain = vi.fn(async () => true);
+    internals.chain.getContextGraphAccessPolicy = vi.fn(async () => 1);
+
+    await internals.recordCoreHostedPublicCg('51', 'stale-cache-curated');
+
+    expect(internals.chain.getContextGraphAccessPolicy).toHaveBeenCalledWith(51n);
+    expect(internals.subscribedContextGraphs.get('stale-cache-curated')).toBeUndefined();
+    expect(saved.find((r) => r.id === 'stale-cache-curated')).toBeUndefined();
   });
 
   it('falls back to ACK-backed policy read when the liveness probe rejects', async () => {
@@ -615,6 +631,42 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(peerCursor.has(localCgId)).toBe(false);
     expect(peerOrder.has(localCgId)).toBe(false);
     expect(reconcileCursors.has(localCgId)).toBe(false);
+  });
+
+  it('does not re-register an existing on-chain id when liveness is unknown', async () => {
+    const internals = await boot();
+    const localCgId = 'unknown-live-register';
+    const ownerAddr = (internals.chain as unknown as { signerAddress: string }).signerAddress;
+
+    await internals.createContextGraph({
+      id: localCgId,
+      name: 'Unknown Live Register',
+      private: true,
+      callerAgentAddress: ownerAddr,
+    });
+    await internals.store.insert([{
+      subject: `did:dkg:context-graph:${localCgId}`,
+      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+      object: '"5"',
+      graph: contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY),
+    }]);
+    internals.subscribedContextGraphs.set(localCgId, {
+      subscribed: true, onChainId: '5', lastReconciledOrdinal: 4,
+    });
+    internals.chain.isContextGraphActiveOnChain = vi.fn(async () => {
+      throw new Error('rpc unavailable');
+    });
+    const registerOnChain = vi.spyOn(internals as any, 'registerContextGraphOnChain');
+
+    await expect(internals.registerContextGraph(localCgId, { callerAgentAddress: ownerAddr }))
+      .rejects.toThrow(/liveness could not be verified/);
+
+    expect(registerOnChain).not.toHaveBeenCalled();
+    expect(internals.subscribedContextGraphs.get(localCgId)).toMatchObject({
+      subscribed: true,
+      onChainId: '5',
+      lastReconciledOrdinal: 4,
+    });
   });
 });
 
@@ -1280,7 +1332,7 @@ describe('Phase D - VM reconcile damping', () => {
       }
       return {
         ...emptyCatchupStats(),
-        connectedPeers: 1,
+        connectedPeers: connectedPeers.length,
         totalPeers: connectedPeers.length,
         selectedPeers: 1,
       };
@@ -1298,7 +1350,7 @@ describe('Phase D - VM reconcile damping', () => {
 
     const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue({
       ...emptyCatchupStats(),
-      connectedPeers: 1,
+      connectedPeers: 33,
       totalPeers: 33,
       selectedPeers: 1,
     });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -441,7 +441,7 @@ describe('Phase D - VM reconcile damping', () => {
     let primeCalls = 0;
     vi.spyOn(internals as any, 'primeCatchupConnections').mockImplementation(async () => {
       primeCalls += 1;
-      if (primeCalls >= 2) {
+      if (primeCalls >= 1) {
         connectedPeers = ['peer-empty', 'peer-discovered'];
       }
     });
@@ -462,7 +462,7 @@ describe('Phase D - VM reconcile damping', () => {
     expensiveScans = 0;
 
     await expect(internals.reconcileChainOrdinal('57', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
-    expect(primeCalls).toBeGreaterThanOrEqual(2);
+    expect(primeCalls).toBeGreaterThanOrEqual(1);
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(expensiveScans).toBeGreaterThan(0);
   });
@@ -650,6 +650,31 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
+  it('rechecks the root SWM generation when subgraph enumeration fails during negative-cache validation', async () => {
+    const internals = await boot();
+    const onChainCgId = 58n;
+    const entity = 'urn:fact:root-fallback-arrival';
+    const value = 'Root fallback arrived after cache';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9018n, onChainCgId, bytesToHex(root));
+
+    vi.spyOn(GraphManager.prototype, 'listSubGraphs').mockRejectedValue(new Error('subgraph listing failed'));
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal('58', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    const seededRoot = await seedSwmSnapshot(internals.store, '58', entity, value);
+    expect(bytesToHex(seededRoot)).toBe(bytesToHex(root));
+
+    await expect(internals.reconcileChainOrdinal('58', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
   it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
     const internals = await boot();
     const onChainCgId = 45n;
@@ -771,6 +796,31 @@ describe('Phase D - VM reconcile damping', () => {
       maxPeers: 1,
       peerRotationKey: '47',
     });
+  });
+
+  it('extends active-fetch attempts after the first fetch round dials another peer', async () => {
+    const internals = await boot();
+    const onChainCgId = 59n;
+    registerUnmatchedKC(internals.chain, 9019n, onChainCgId);
+
+    let connectedPeers = ['peer-initial'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockImplementation(async () => {
+      if (connectedPeers.length === 1) {
+        connectedPeers = ['peer-initial', 'peer-dialed'];
+      }
+      return {
+        ...emptyCatchupStats(),
+        connectedPeers: connectedPeers.length,
+        selectedPeers: 1,
+      };
+    });
+
+    await expect(internals.reconcileChainOrdinal('59', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   it('does not negative-cache no-swm when active fetch reaches no sync-capable peer', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -39,7 +39,10 @@ interface AgentInternals {
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string; lastReconciledOrdinal?: number }>;
   reconcileCoalescer: { trigger: (cg: string) => void } | null;
   store: TripleStore;
-  chain: MockChainAdapter & { getContextGraphAccessPolicy?: (id: bigint) => Promise<number> };
+  chain: MockChainAdapter & {
+    getContextGraphAccessPolicy?: (id: bigint) => Promise<number>;
+    isContextGraphActiveOnChain?: (id: bigint) => Promise<boolean>;
+  };
 }
 
 /**
@@ -222,6 +225,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
       },
     });
     stubNode(agent);
+    chain.isContextGraphActiveOnChain = async () => true;
     return agent as unknown as AgentInternals;
   }
 
@@ -282,6 +286,17 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
 
     expect(internals.subscribedContextGraphs.get('99')?.coreHosted).toBeUndefined();
     expect(saved.find((r) => r.id === '99')).toBeUndefined();
+  });
+
+  it('does NOT mark an UNKNOWN CG even when the policy getter defaults to public', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => 0;
+    internals.chain.isContextGraphActiveOnChain = async () => false;
+
+    await internals.recordCoreHostedPublicCg('123456');
+
+    expect(internals.subscribedContextGraphs.get('123456')).toBeUndefined();
+    expect(saved.find((r) => r.id === '123456')).toBeUndefined();
   });
 
   it('ignores a non-numeric id (cannot index the on-chain ordinal list)', async () => {
@@ -1021,33 +1036,36 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     });
     stubNode(agent);
     const internals = agent as unknown as AgentInternals;
-    internals.chain.getContextGraphAccessPolicy = async () => 0;
 
-    const ON_CHAIN_CG = 42n;
+    const { contextGraphId: ON_CHAIN_CG } = await chain.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+    });
+    const localCgId = ON_CHAIN_CG.toString();
     // The Core already has the SWM snapshot locally (simulating a pull from
     // another Core), but never member-subscribed — it only hosts the CG.
-    const root = await seedSwmSnapshot(internals.store, '42', 'urn:fact:monday', 'Monday fun fact');
+    const root = await seedSwmSnapshot(internals.store, localCgId, 'urn:fact:monday', 'Monday fun fact');
     const { ethers } = await import('ethers');
     chain.__registerKC({ kaId: 4242n, contextGraphId: ON_CHAIN_CG, merkleRootHex: ethers.hexlify(root), chunks: [] });
 
-    await internals.recordCoreHostedPublicCg('42');
-    await internals.runVmReconcileForCg('42');
+    await internals.recordCoreHostedPublicCg(localCgId);
+    await internals.runVmReconcileForCg(localCgId);
 
     // Promoted into the per-CG VM graph.
     const storageAddr = await chain.getDKGKnowledgeAssetsAddress();
     const ual = buildKnowledgeAssetUal(chain.chainId, storageAddr, 4242n);
     expect(ual).toContain('4242');
-    const vmGraph = `did:dkg:context-graph:42/context/${ON_CHAIN_CG}`;
+    const vmGraph = `did:dkg:context-graph:${localCgId}/context/${ON_CHAIN_CG}`;
     const res = await internals.store.query(
       `ASK { GRAPH <${vmGraph}> { <urn:fact:monday> <http://schema.org/name> "Monday fun fact" } }`,
     );
     expect(res.type === 'boolean' && res.value).toBe(true);
 
     // Watermark advanced + distinct core-fill telemetry emitted.
-    expect(internals.subscribedContextGraphs.get('42')?.lastReconciledOrdinal).toBe(1);
+    expect(internals.subscribedContextGraphs.get(localCgId)?.lastReconciledOrdinal).toBe(1);
     const coreFill = captured.find((e) => e.action === 'core-fill');
     expect(coreFill).toBeDefined();
     expect(coreFill?.reconciled).toBe(1);
-    expect(coreFill?.contextGraphId).toBe('42');
+    expect(coreFill?.contextGraphId).toBe(localCgId);
   });
 });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -459,9 +459,9 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(expensiveScans).toBeGreaterThan(0);
     const cacheKeys = Array.from(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).keys());
-    expect(cacheKeys).toHaveLength(1);
-    expect(cacheKeys[0]).toContain('22'.repeat(32));
-    expect(cacheKeys[0]).not.toContain('11'.repeat(32));
+    expect(cacheKeys).toHaveLength(2);
+    expect(cacheKeys.some((key) => key.includes('11'.repeat(32)))).toBe(true);
+    expect(cacheKeys.some((key) => key.includes('22'.repeat(32)))).toBe(true);
   });
 
   it('invalidates a negative cache entry when SWM data arrives without operation-meta changes', async () => {
@@ -738,6 +738,97 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
     expect(((internals as any).vmReconcileFetchCooldownAt as Map<string, unknown>).has('51')).toBe(false);
+  });
+
+  it('does not prune newer root cache state when a stale root is replayed', async () => {
+    const internals = await boot();
+    const onChainCgId = 55n;
+    const kaId = 9015n;
+    const staleRoot = new Uint8Array(32);
+    const freshRoot = new Uint8Array(32);
+    staleRoot[31] = 1;
+    freshRoot[31] = 2;
+    registerUnmatchedKC(internals.chain, kaId, onChainCgId, bytesToHex(staleRoot));
+
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, kaId);
+    const staleKey = (internals as any).vmReconcileCacheKey(ual, staleRoot);
+    const freshKey = (internals as any).vmReconcileCacheKey(ual, freshRoot);
+    ((internals as any).recentReconciledUals as { add(key: string): void }).add(freshKey);
+    ((internals as any).vmReconcileNegativeCache as Map<string, unknown>).set(freshKey, {
+      failures: 1,
+      nextRetryAt: Date.now() + 60_000,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+    vi.spyOn(internals as any, 'getOrCreateFinalizationHandler').mockReturnValue({
+      handleChainReconciledKC: vi.fn().mockResolvedValue('stale-target'),
+    });
+
+    await expect(internals.reconcileChainOrdinal('55', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'already', blockNumber: 0 });
+
+    expect(((internals as any).recentReconciledUals as { has(key: string): boolean }).has(freshKey)).toBe(true);
+    expect(((internals as any).recentReconciledUals as { has(key: string): boolean }).has(staleKey)).toBe(true);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).has(freshKey)).toBe(true);
+  });
+
+  it('prunes expired and oversized VM reconcile state and clears non-hosted CG state on unsubscribe', async () => {
+    const internals = await boot();
+    const negativeCache = (internals as any).vmReconcileNegativeCache as Map<string, {
+      failures: number;
+      nextRetryAt: number;
+      swmGen: string;
+      candidateNamespaces: unknown[];
+      peerTopologyKey: string;
+    }>;
+    const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
+    const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
+    const now = Date.now();
+
+    negativeCache.set('expired', {
+      failures: 1,
+      nextRetryAt: now - 1,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+    for (let i = 0; i < DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES + 2; i += 1) {
+      negativeCache.set(`future-${i}`, {
+        failures: 1,
+        nextRetryAt: now + 60_000,
+        swmGen: 'empty:0',
+        candidateNamespaces: [],
+        peerTopologyKey: '',
+      });
+    }
+    fetchCooldown.set('expired-cg', now - DKGAgent.VM_RECONCILE_SWEEP_INTERVAL_MS - 1);
+    for (let i = 0; i < DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES + 2; i += 1) {
+      fetchCooldown.set(`fetch-${i}`, now);
+      peerCursor.set(`cursor-${i}`, i);
+    }
+
+    (internals as any).pruneVmReconcileState(now);
+
+    expect(negativeCache.has('expired')).toBe(false);
+    expect(negativeCache.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES);
+    expect(fetchCooldown.has('expired-cg')).toBe(false);
+    expect(fetchCooldown.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
+    expect(peerCursor.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
+
+    internals.subscribedContextGraphs.set('cleanup-cg', { subscribed: true });
+    fetchCooldown.set('cleanup-cg', now);
+    peerCursor.set('cleanup-cg', 7);
+    (agent as any).unsubscribeFromContextGraph('cleanup-cg');
+    expect(fetchCooldown.has('cleanup-cg')).toBe(false);
+    expect(peerCursor.has('cleanup-cg')).toBe(false);
+
+    internals.subscribedContextGraphs.set('hosted-cg', { subscribed: true, coreHosted: true });
+    fetchCooldown.set('hosted-cg', now);
+    peerCursor.set('hosted-cg', 3);
+    (agent as any).unsubscribeFromContextGraph('hosted-cg');
+    expect(fetchCooldown.has('hosted-cg')).toBe(true);
+    expect(peerCursor.has('hosted-cg')).toBe(true);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -757,6 +757,33 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
   });
 
+  it('does not reuse a negative cache entry across local CGs for the same KA root', async () => {
+    const internals = await boot();
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, 9021n);
+    const root = new Uint8Array(32);
+    root[31] = 21;
+    const keyA = (internals as any).vmReconcileCacheKey('61', ual, root);
+    const keyB = (internals as any).vmReconcileCacheKey('62', ual, root);
+    expect(keyA).not.toBe(keyB);
+
+    (internals as any).recordVmReconcileNegativeCache(keyA, '61', {
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: 'unreadable',
+    });
+
+    await expect((internals as any).shouldDeferVmReconcileByNegativeCache(keyB, '62')).resolves.toBe(false);
+
+    (internals as any).recordVmReconcileNegativeCache(keyB, '62', {
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: 'unreadable',
+    });
+
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(2);
+  });
+
   it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
     const internals = await boot();
     const onChainCgId = 45n;
@@ -953,8 +980,8 @@ describe('Phase D - VM reconcile damping', () => {
 
     const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
     const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, kaId);
-    const staleKey = (internals as any).vmReconcileCacheKey(ual, staleRoot);
-    const freshKey = (internals as any).vmReconcileCacheKey(ual, freshRoot);
+    const staleKey = (internals as any).vmReconcileCacheKey('55', ual, staleRoot);
+    const freshKey = (internals as any).vmReconcileCacheKey('55', ual, freshRoot);
     ((internals as any).recentReconciledUals as { add(key: string): void }).add(freshKey);
     ((internals as any).vmReconcileNegativeCache as Map<string, unknown>).set(freshKey, {
       localCgId: '55',

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -721,6 +721,42 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
+  it('keeps a negative cache entry when subgraph enumeration fails during namespace validation', async () => {
+    const internals = await boot();
+    const onChainCgId = 60n;
+    registerUnmatchedKC(internals.chain, 9020n, onChainCgId);
+
+    const graphManager = new GraphManager(internals.store);
+    await internals.store.insert([{
+      subject: 'urn:test:subgraph-marker:code',
+      predicate: 'http://schema.org/name',
+      object: '"marker"',
+      graph: graphManager.subGraphUri('60', 'code'),
+    }]);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('60', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    const fetchesAfterFirstMiss = fetch.mock.calls.length;
+    expect(fetchesAfterFirstMiss).toBeGreaterThan(0);
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    vi.spyOn(GraphManager.prototype, 'listSubGraphs').mockRejectedValue(new Error('transient subgraph listing failure'));
+    expensiveScans = 0;
+
+    await expect(internals.reconcileChainOrdinal('60', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(fetchesAfterFirstMiss);
+    expect(expensiveScans).toBe(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+  });
+
   it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
     const internals = await boot();
     const onChainCgId = 45n;
@@ -939,7 +975,42 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).has(freshKey)).toBe(true);
   });
 
-  it('prunes expired and oversized VM reconcile state and clears non-hosted CG state on unsubscribe', async () => {
+  it('keeps expired negative-cache entries as bounded retry history', async () => {
+    const internals = await boot();
+    const negativeCache = (internals as any).vmReconcileNegativeCache as Map<string, {
+      failures: number;
+      nextRetryAt: number;
+      swmGen: string;
+      candidateNamespaces: unknown[];
+      peerTopologyKey: string;
+    }>;
+    const now = Date.now();
+    const cacheKey = 'retry-history-key';
+
+    negativeCache.set(cacheKey, {
+      localCgId: 'retry-cg',
+      failures: 1,
+      nextRetryAt: now - 1,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    } as any);
+
+    (internals as any).pruneVmReconcileState(now);
+    expect(negativeCache.has(cacheKey)).toBe(true);
+    await expect((internals as any).shouldDeferVmReconcileByNegativeCache(cacheKey, 'retry-cg')).resolves.toBe(false);
+
+    (internals as any).recordVmReconcileNegativeCache(cacheKey, 'retry-cg', {
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+
+    expect(negativeCache.get(cacheKey)?.failures).toBe(2);
+    expect(negativeCache.get(cacheKey)?.nextRetryAt).toBeGreaterThan(now);
+  });
+
+  it('prunes oversized VM reconcile state and clears non-hosted CG state on unsubscribe', async () => {
     const internals = await boot();
     const negativeCache = (internals as any).vmReconcileNegativeCache as Map<string, {
       failures: number;
@@ -953,14 +1024,6 @@ describe('Phase D - VM reconcile damping', () => {
     const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
     const now = Date.now();
 
-    negativeCache.set('expired', {
-      localCgId: 'expired-cg',
-      failures: 1,
-      nextRetryAt: now - 1,
-      swmGen: 'empty:0',
-      candidateNamespaces: [],
-      peerTopologyKey: '',
-    });
     for (let i = 0; i < DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES + 2; i += 1) {
       negativeCache.set(`future-${i}`, {
         localCgId: `future-cg-${i}`,
@@ -980,7 +1043,6 @@ describe('Phase D - VM reconcile damping', () => {
 
     (internals as any).pruneVmReconcileState(now);
 
-    expect(negativeCache.has('expired')).toBe(false);
     expect(negativeCache.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES);
     expect(fetchCooldown.has('expired-cg')).toBe(false);
     expect(fetchCooldown.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -444,6 +444,37 @@ describe('Phase D - VM reconcile damping', () => {
     expect(expensiveScans).toBeGreaterThan(0);
   });
 
+  it('reuses a negative cache entry when connected peers only reorder', async () => {
+    const internals = await boot();
+    const onChainCgId = 55n;
+    registerUnmatchedKC(internals.chain, 9015n, onChainCgId);
+
+    let connectedPeers = ['peer-a', 'peer-b'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('55', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    const fetchesAfterFirstMiss = fetch.mock.calls.length;
+    expect(fetchesAfterFirstMiss).toBeGreaterThan(0);
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    expensiveScans = 0;
+    connectedPeers = ['peer-b', 'peer-a'];
+
+    await expect(internals.reconcileChainOrdinal('55', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(fetchesAfterFirstMiss);
+    expect(expensiveScans).toBe(0);
+  });
+
   it('primes catchup connections before reusing a negative cache entry', async () => {
     const internals = await boot();
     const onChainCgId = 57n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -210,6 +210,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
   const saved: ContextGraphSubscriptionRecord[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (agent) {
       await agent.stop().catch(() => undefined);
       agent = null;
@@ -265,6 +266,19 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(saved.find((r) => r.id === '43')?.coreHosted).toBe(true);
   });
 
+  it('memoizes ACK-backed access-policy reads when the adapter has no liveness probe', async () => {
+    const internals = await boot();
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    internals.chain.getContextGraphAccessPolicy = getContextGraphAccessPolicy;
+    (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+
+    await internals.recordCoreHostedPublicCg('43');
+    await internals.recordCoreHostedPublicCg('43');
+
+    expect(getContextGraphAccessPolicy).toHaveBeenCalledTimes(1);
+    expect((internals as any).onChainAccessPolicyCache.get('43')).toBe(0);
+  });
+
   it('bounds ACK-backed access-policy reads when the adapter has no liveness probe', async () => {
     const internals = await boot();
     internals.chain.getContextGraphAccessPolicy = async () => new Promise<number>(() => undefined);
@@ -309,6 +323,29 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     await drained;
 
     expect(recordings.size).toBe(0);
+  });
+
+  it('bounds core-host recording drain during shutdown', async () => {
+    const internals = await boot();
+    const recordings = (internals as any).coreHostRecordings as Set<Promise<void>>;
+    recordings.add(new Promise<void>(() => undefined));
+    const warn = vi.spyOn((internals as any).log, 'warn');
+
+    vi.useFakeTimers();
+    try {
+      const drained = (internals as any).drainCoreHostRecordings();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(drained).resolves.toBeUndefined();
+
+      expect(recordings.size).toBe(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('timed out draining 1 core-host recording'),
+      );
+    } finally {
+      recordings.clear();
+      vi.useRealTimers();
+    }
   });
 
   it('keys the host row under the cleartext swmGraphId (not the numeric id) on first ACK', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -32,6 +32,8 @@ import { DKGAgent } from '../src/index.js';
 
 interface AgentInternals {
   recordCoreHostedPublicCg(cgId: string, swmGraphId?: string): Promise<void>;
+  reconcileChainOrdinal(localCgId: string, onChainCgId: bigint, ordinal: number, headBlock: number | undefined): Promise<{ status: string }>;
+  syncContextGraphFromConnectedPeers(contextGraphId: string, options?: { includeSharedMemory?: boolean; maxPeers?: number; peerRotationKey?: string }): Promise<unknown>;
   runVmReconcileForCg(localCgId: string): Promise<void>;
   runVmReconcileSweep(): Promise<void>;
   subscribedContextGraphs: Map<string, { subscribed: boolean; coreHosted?: boolean; onChainId?: string; lastReconciledOrdinal?: number }>;
@@ -51,6 +53,60 @@ function stubNode(agent: DKGAgent): void {
     peerId: '12D3KooWCoreFillTestPeer',
     libp2p: { getPeers: () => [] },
   };
+}
+
+function emptyCatchupStats() {
+  return {
+    connectedPeers: 1,
+    syncCapablePeers: 1,
+    peersTried: 1,
+    peersSucceeded: 1,
+    dataSynced: 0,
+    sharedMemorySynced: 0,
+    denied: false,
+    diagnostics: {
+      noProtocolPeers: 0,
+      durable: {
+        fetchedMetaTriples: 0,
+        fetchedDataTriples: 0,
+        insertedMetaTriples: 0,
+        insertedDataTriples: 0,
+        bytesReceived: 0,
+        resumedPhases: 0,
+        emptyResponses: 1,
+        metaOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+        rejectedKcs: 0,
+        failedPeers: 0,
+      },
+      sharedMemory: {
+        fetchedMetaTriples: 0,
+        fetchedDataTriples: 0,
+        insertedMetaTriples: 0,
+        insertedDataTriples: 0,
+        bytesReceived: 0,
+        resumedPhases: 0,
+        emptyResponses: 1,
+        droppedDataTriples: 0,
+        failedPeers: 0,
+      },
+    },
+  };
+}
+
+async function insertWorkspaceOperationMeta(
+  store: TripleStore,
+  metaGraph: string,
+  opId: string,
+  rootEntity: string,
+  publishedAt: string,
+): Promise<void> {
+  const subject = `urn:dkg:share:${opId}`;
+  await store.insert([
+    { graph: metaGraph, subject, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+    { graph: metaGraph, subject, predicate: 'http://dkg.io/ontology/rootEntity', object: rootEntity },
+    { graph: metaGraph, subject, predicate: 'http://dkg.io/ontology/publishedAt', object: `"${publishedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+  ]);
 }
 
 /** Seed a local SWM snapshot for one KA under a CG and return its flat-KC root. */
@@ -211,6 +267,150 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(sub!.coreHosted).toBe(true);
     expect(sub!.onChainId).toBe('9');              // rebound to the new graph
     expect(sub!.lastReconciledOrdinal).toBe(0);    // stale watermark dropped
+  });
+});
+
+describe('Phase D - VM reconcile damping', () => {
+  let agent: DKGAgent | null = null;
+
+  afterEach(async () => {
+    if (agent) {
+      await agent.stop().catch(() => undefined);
+      agent = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  async function boot(): Promise<AgentInternals> {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'VmReconcileDamping', chainAdapter: chain });
+    stubNode(agent);
+    return agent as unknown as AgentInternals;
+  }
+
+  function registerUnmatchedKC(chain: MockChainAdapter, kaId: bigint, onChainCgId: bigint): void {
+    chain.__registerKC({
+      kaId,
+      contextGraphId: onChainCgId,
+      merkleRootHex: '0x' + kaId.toString(16).padStart(64, '0'),
+      chunks: [],
+    });
+  }
+
+  it('negative-caches a missing SWM snapshot and skips the expensive scan plus active fetch during backoff', async () => {
+    const internals = await boot();
+    const onChainCgId = 42n;
+    registerUnmatchedKC(internals.chain, 9001n, onChainCgId);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('42', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+
+    expensiveScans = 0;
+    await expect(internals.reconcileChainOrdinal('42', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBe(0);
+  });
+
+  it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
+    const internals = await boot();
+    const onChainCgId = 45n;
+    registerUnmatchedKC(internals.chain, 9005n, onChainCgId);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    let generationReads = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('COUNT(?root) AS ?rootCount')) {
+        generationReads++;
+        if (generationReads <= 2) throw new Error('transient generation read failure');
+      }
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('45', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+
+    expensiveScans = 0;
+    await expect(internals.reconcileChainOrdinal('45', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBe(0);
+    expect(generationReads).toBe(2);
+  });
+
+  it('invalidates the retry cache only for operation changes in the candidate SWM namespace', async () => {
+    const internals = await boot();
+    const onChainCgId = 43n;
+    registerUnmatchedKC(internals.chain, 9002n, onChainCgId);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      contextGraphWorkspaceMetaGraphUri('43'),
+      'existing-root-op',
+      'urn:fact:existing',
+      '2030-01-01T00:00:00.000Z',
+    );
+
+    await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      'did:dkg:context-graph:43/code/_shared_memory_meta',
+      'unrelated-subgraph-op',
+      'urn:fact:unrelated',
+      '2040-01-01T00:00:00.000Z',
+    );
+
+    expensiveScans = 0;
+    await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBe(0);
+
+    await insertWorkspaceOperationMeta(
+      internals.store,
+      contextGraphWorkspaceMetaGraphUri('43'),
+      'candidate-root-op-with-older-timestamp',
+      'urn:fact:candidate',
+      '2020-01-01T00:00:00.000Z',
+    );
+
+    await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+  });
+
+  it('runs at most one active fetch per CG sweep interval across different pending ordinals', async () => {
+    const internals = await boot();
+    const onChainCgId = 44n;
+    registerUnmatchedKC(internals.chain, 9003n, onChainCgId);
+    registerUnmatchedKC(internals.chain, 9004n, onChainCgId);
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+
+    await internals.reconcileChainOrdinal('44', onChainCgId, 0, undefined);
+    await internals.reconcileChainOrdinal('44', onChainCgId, 1, undefined);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -399,6 +399,36 @@ describe('Phase D - VM reconcile damping', () => {
     expect(expensiveScans).toBe(0);
   });
 
+  it('does not reuse a negative cache entry after catchup peer topology changes', async () => {
+    const internals = await boot();
+    const onChainCgId = 54n;
+    registerUnmatchedKC(internals.chain, 9014n, onChainCgId);
+
+    let connectedPeers = ['peer-empty'];
+    (agent as any).node.libp2p.getConnections = () =>
+      connectedPeers.map((peerId) => ({ remotePeer: { toString: () => peerId } }));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('54', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    expensiveScans = 0;
+    connectedPeers = ['peer-empty', 'peer-newly-reachable'];
+
+    await expect(internals.reconcileChainOrdinal('54', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(expensiveScans).toBeGreaterThan(0);
+  });
+
   it('does not reuse a negative cache entry when the same KA has a newer merkle root', async () => {
     const internals = await boot();
     const onChainCgId = 46n;

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -26,7 +26,7 @@ import {
   contextGraphWorkspaceGraphUri,
   contextGraphWorkspaceMetaGraphUri,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import { GraphManager, type TripleStore } from '@origintrail-official/dkg-storage';
 import type { ReplicationEvent, ContextGraphSubscriptionRecord } from '../src/dkg-agent-types.js';
 import { DKGAgent } from '../src/index.js';
 
@@ -171,6 +171,25 @@ async function seedSwmSnapshot(store: TripleStore, localCgId: string, entity: st
   await store.insert([
     { subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: wsGraph },
     { subject: `urn:dkg:share:${entity}`, predicate: 'http://dkg.io/ontology/rootEntity', object: entity, graph: wsMetaGraph },
+  ]);
+  return computeFlatKCRootV10(
+    [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+    [],
+  );
+}
+
+async function seedSwmSnapshotInSubGraph(
+  store: TripleStore,
+  localCgId: string,
+  subGraphName: string,
+  entity: string,
+  value: string,
+): Promise<Uint8Array> {
+  const graphManager = new GraphManager(store);
+  await store.insert([
+    { subject: `urn:test:subgraph-marker:${subGraphName}`, predicate: 'http://schema.org/name', object: '"marker"', graph: graphManager.subGraphUri(localCgId, subGraphName) },
+    { subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: graphManager.sharedMemoryUri(localCgId, subGraphName) },
+    { subject: `urn:dkg:share:${subGraphName}`, predicate: 'http://dkg.io/ontology/rootEntity', object: entity, graph: graphManager.sharedMemoryMetaUri(localCgId, subGraphName) },
   ]);
   return computeFlatKCRootV10(
     [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
@@ -506,6 +525,30 @@ describe('Phase D - VM reconcile damping', () => {
     await insertPrivateMerkleRoot(internals.store, '49', entity, privateRoot);
 
     await expect(internals.reconcileChainOrdinal('49', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
+  it('invalidates a negative cache entry when matching SWM arrives in a new subgraph namespace', async () => {
+    const internals = await boot();
+    const onChainCgId = 53n;
+    const entity = 'urn:fact:new-subgraph-arrival';
+    const value = 'Subgraph SWM arrived after cache';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9013n, onChainCgId, bytesToHex(root));
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+
+    await expect(internals.reconcileChainOrdinal('53', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await seedSwmSnapshotInSubGraph(internals.store, '53', 'code', entity, value);
+
+    await expect(internals.reconcileChainOrdinal('53', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -279,6 +279,37 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect((internals as any).onChainAccessPolicyCache.get('43')).toBe(0);
   });
 
+  it('falls back to ACK-backed policy read when the liveness probe times out', async () => {
+    const internals = await boot();
+    const getContextGraphAccessPolicy = vi.fn(async () => 0);
+    internals.chain.getContextGraphAccessPolicy = getContextGraphAccessPolicy;
+    internals.chain.isContextGraphActiveOnChain = vi.fn(() => new Promise<boolean>(() => undefined));
+
+    vi.useFakeTimers();
+    try {
+      const recorded = internals.recordCoreHostedPublicCg('45');
+      await vi.advanceTimersByTimeAsync(2_500);
+      await recorded;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(getContextGraphAccessPolicy).toHaveBeenCalledWith(45n);
+    expect(internals.subscribedContextGraphs.get('45')?.coreHosted).toBe(true);
+  });
+
+  it('falls back to ACK-backed policy read when the liveness probe rejects', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = vi.fn(async () => 0);
+    internals.chain.isContextGraphActiveOnChain = vi.fn(async () => {
+      throw new Error('rpc unavailable');
+    });
+
+    await internals.recordCoreHostedPublicCg('46');
+
+    expect(internals.subscribedContextGraphs.get('46')?.coreHosted).toBe(true);
+  });
+
   it('bounds ACK-backed access-policy reads when the adapter has no liveness probe', async () => {
     const internals = await boot();
     internals.chain.getContextGraphAccessPolicy = async () => new Promise<number>(() => undefined);

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -265,6 +265,19 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(saved.find((r) => r.id === '43')?.coreHosted).toBe(true);
   });
 
+  it('bounds ACK-backed access-policy reads when the adapter has no liveness probe', async () => {
+    const internals = await boot();
+    internals.chain.getContextGraphAccessPolicy = async () => new Promise<number>(() => undefined);
+    (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+
+    const startedAt = Date.now();
+    await internals.recordCoreHostedPublicCg('44');
+
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    expect(internals.subscribedContextGraphs.get('44')).toBeUndefined();
+    expect(saved.find((r) => r.id === '44')).toBeUndefined();
+  });
+
   it('keys the host row under the cleartext swmGraphId (not the numeric id) on first ACK', async () => {
     // Regression: on the first ACK for a CG we only host, there is no local
     // mapping yet, so without the cleartext hint the row would land under the
@@ -383,7 +396,7 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     expect(((internals as any).recentReconciledUals as { has(key: string): boolean }).has(recentKey)).toBe(false);
   });
 
-  it('clears recent VM reconcile dedupe when stale inactive on-chain ids are re-registered', async () => {
+  it('clears VM reconcile state when stale inactive on-chain ids are re-registered', async () => {
     const internals = await boot();
     const localCgId = 'stale-register';
     const ownerAddr = (internals.chain as unknown as { signerAddress: string }).signerAddress;
@@ -411,13 +424,40 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
     root[31] = 4;
     const recentKey = (internals as any).vmReconcileCacheKey(localCgId, ual, root);
     const recent = (internals as any).recentReconciledUals as { add(key: string): void; has(key: string): boolean };
+    const negativeCache = (internals as any).vmReconcileNegativeCache as Map<string, unknown>;
+    const negativeKeysByCg = (internals as any).vmReconcileNegativeCacheKeysByCg as Map<string, Set<string>>;
+    const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
+    const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
+    const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, unknown>;
+    const reconcileCursors = (internals as any).reconcileCursors as Map<string, unknown>;
     recent.add(recentKey);
+    negativeCache.set(recentKey, {
+      localCgId,
+      failures: 1,
+      nextRetryAt: Date.now() + 60_000,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+    negativeKeysByCg.set(localCgId, new Set([recentKey]));
+    fetchCooldown.set(localCgId, Date.now());
+    peerCursor.set(localCgId, 2);
+    peerOrder.set(localCgId, { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
+    reconcileCursors.set(localCgId, { pending: new Set([0]) });
 
     await expect(internals.registerContextGraph(localCgId, { callerAgentAddress: ownerAddr }))
       .resolves.toMatchObject({ onChainId: expect.any(String) });
 
-    expect(internals.subscribedContextGraphs.get(localCgId)?.onChainId).not.toBe('5');
+    const sub = internals.subscribedContextGraphs.get(localCgId);
+    expect(sub?.onChainId).not.toBe('5');
+    expect(sub?.lastReconciledOrdinal).toBe(0);
     expect(recent.has(recentKey)).toBe(false);
+    expect(negativeCache.has(recentKey)).toBe(false);
+    expect(negativeKeysByCg.has(localCgId)).toBe(false);
+    expect(fetchCooldown.has(localCgId)).toBe(false);
+    expect(peerCursor.has(localCgId)).toBe(false);
+    expect(peerOrder.has(localCgId)).toBe(false);
+    expect(reconcileCursors.has(localCgId)).toBe(false);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -66,6 +66,7 @@ function stubNode(agent: DKGAgent): void {
 function emptyCatchupStats() {
   return {
     connectedPeers: 1,
+    totalPeers: 1,
     syncCapablePeers: 1,
     peersTried: 1,
     peersSucceeded: 1,
@@ -296,6 +297,23 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
 
     expect(getContextGraphAccessPolicy).toHaveBeenCalledWith(45n);
     expect(internals.subscribedContextGraphs.get('45')?.coreHosted).toBe(true);
+  });
+
+  it('ignores late core-host recording completions after recordings are closed', async () => {
+    const internals = await boot();
+    let resolvePolicy!: (value: number) => void;
+    internals.chain.getContextGraphAccessPolicy = vi.fn(() => new Promise<number>((resolve) => {
+      resolvePolicy = resolve;
+    }));
+    (internals.chain as { isContextGraphActiveOnChain?: unknown }).isContextGraphActiveOnChain = undefined;
+
+    const recording = internals.recordCoreHostedPublicCg('48', 'late-hosted');
+    (internals as any).coreHostRecordingsClosed = true;
+    resolvePolicy(0);
+    await recording;
+
+    expect(internals.subscribedContextGraphs.get('late-hosted')).toBeUndefined();
+    expect(saved.find((r) => r.id === 'late-hosted')).toBeUndefined();
   });
 
   it('falls back to ACK-backed policy read when the liveness probe rejects', async () => {
@@ -1189,7 +1207,8 @@ describe('Phase D - VM reconcile damping', () => {
       }
       return {
         ...emptyCatchupStats(),
-        connectedPeers: connectedPeers.length,
+        connectedPeers: 1,
+        totalPeers: connectedPeers.length,
         selectedPeers: 1,
       };
     });
@@ -1206,7 +1225,8 @@ describe('Phase D - VM reconcile damping', () => {
 
     const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue({
       ...emptyCatchupStats(),
-      connectedPeers: 33,
+      connectedPeers: 1,
+      totalPeers: 33,
       selectedPeers: 1,
     });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -952,17 +952,23 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(2);
   });
 
-  it('keeps an unreadable negative-cache generation damped until backoff expires', async () => {
+  it('does not negative-cache an unreadable SWM generation and retries before backoff', async () => {
     const internals = await boot();
     const onChainCgId = 45n;
-    registerUnmatchedKC(internals.chain, 9005n, onChainCgId);
+    const entity = 'urn:fact:after-unreadable';
+    const value = 'Visible right after a probe failure';
+    const root = computeFlatKCRootV10(
+      [{ subject: entity, predicate: 'http://schema.org/name', object: `"${value}"`, graph: '' }],
+      [],
+    );
+    registerUnmatchedKC(internals.chain, 9005n, onChainCgId, bytesToHex(root));
 
     const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
     const originalQuery = internals.store.query.bind(internals.store);
     let expensiveScans = 0;
     let generationReads = 0;
     vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
-      if (sparql.includes('COUNT(?root) AS ?rootCount')) {
+      if (sparql.includes('SELECT ?op ?root ?ts WHERE')) {
         generationReads++;
         if (generationReads <= 2) throw new Error('transient generation read failure');
       }
@@ -973,12 +979,37 @@ describe('Phase D - VM reconcile damping', () => {
     await expect(internals.reconcileChainOrdinal('45', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(expensiveScans).toBeGreaterThan(0);
+    expect(generationReads).toBe(2);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+
+    await seedSwmSnapshot(internals.store, '45', entity, value);
 
     expensiveScans = 0;
-    await expect(internals.reconcileChainOrdinal('45', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    await expect(internals.reconcileChainOrdinal('45', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'reconciled', blockNumber: 0 });
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(expensiveScans).toBe(0);
-    expect(generationReads).toBe(2);
+    expect(expensiveScans).toBeGreaterThan(0);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
+  });
+
+  it('invalidates a negative cache entry when same-count SWM data changes', async () => {
+    const internals = await boot();
+    const storageAddr = await internals.chain.getDKGKnowledgeAssetsAddress();
+    const ual = buildKnowledgeAssetUal(internals.chain.chainId, storageAddr, 9023n);
+    const root = new Uint8Array(32);
+    root[31] = 23;
+    const cacheKey = (internals as any).vmReconcileCacheKey('63', ual, root);
+
+    await insertWorkspaceDataTriple(internals.store, '63', 'urn:fact:same-count', 'old');
+    const stateBefore = await (internals as any).collectVmReconcileSwmCandidateState('63');
+    expect(stateBefore.swmGen).toContain('dataTriples:1');
+
+    (internals as any).recordVmReconcileNegativeCache(cacheKey, '63', stateBefore);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+
+    await replaceWorkspaceDataTriple(internals.store, '63', 'urn:fact:same-count', 'new');
+
+    await expect((internals as any).shouldDeferVmReconcileByNegativeCache(cacheKey, '63')).resolves.toBe(false);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
   it('does not negative-cache misses once candidate SWM operation metadata exists', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -756,6 +756,7 @@ describe('Phase D - VM reconcile damping', () => {
     const freshKey = (internals as any).vmReconcileCacheKey(ual, freshRoot);
     ((internals as any).recentReconciledUals as { add(key: string): void }).add(freshKey);
     ((internals as any).vmReconcileNegativeCache as Map<string, unknown>).set(freshKey, {
+      localCgId: '55',
       failures: 1,
       nextRetryAt: Date.now() + 60_000,
       swmGen: 'empty:0',
@@ -784,9 +785,11 @@ describe('Phase D - VM reconcile damping', () => {
     }>;
     const fetchCooldown = (internals as any).vmReconcileFetchCooldownAt as Map<string, number>;
     const peerCursor = (internals as any).vmReconcileCatchupPeerCursor as Map<string, number>;
+    const peerOrder = (internals as any).vmReconcileCatchupPeerOrder as Map<string, { orderedPeers: string[]; nextPeerId?: string }>;
     const now = Date.now();
 
     negativeCache.set('expired', {
+      localCgId: 'expired-cg',
       failures: 1,
       nextRetryAt: now - 1,
       swmGen: 'empty:0',
@@ -795,6 +798,7 @@ describe('Phase D - VM reconcile damping', () => {
     });
     for (let i = 0; i < DKGAgent.VM_RECONCILE_CACHE_MAX_ENTRIES + 2; i += 1) {
       negativeCache.set(`future-${i}`, {
+        localCgId: `future-cg-${i}`,
         failures: 1,
         nextRetryAt: now + 60_000,
         swmGen: 'empty:0',
@@ -806,6 +810,7 @@ describe('Phase D - VM reconcile damping', () => {
     for (let i = 0; i < DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES + 2; i += 1) {
       fetchCooldown.set(`fetch-${i}`, now);
       peerCursor.set(`cursor-${i}`, i);
+      peerOrder.set(`cursor-${i}`, { orderedPeers: [`peer-${i}`], nextPeerId: `peer-${i}` });
     }
 
     (internals as any).pruneVmReconcileState(now);
@@ -815,20 +820,45 @@ describe('Phase D - VM reconcile damping', () => {
     expect(fetchCooldown.has('expired-cg')).toBe(false);
     expect(fetchCooldown.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
     expect(peerCursor.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
+    expect(peerOrder.size).toBeLessThanOrEqual(DKGAgent.VM_RECONCILE_CG_STATE_MAX_ENTRIES);
 
     internals.subscribedContextGraphs.set('cleanup-cg', { subscribed: true });
+    negativeCache.set('cleanup-cache', {
+      localCgId: 'cleanup-cg',
+      failures: 1,
+      nextRetryAt: now + 60_000,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+    (internals as any).indexVmReconcileNegativeCacheEntry('cleanup-cg', 'cleanup-cache');
     fetchCooldown.set('cleanup-cg', now);
     peerCursor.set('cleanup-cg', 7);
+    peerOrder.set('cleanup-cg', { orderedPeers: ['peer-a'], nextPeerId: 'peer-a' });
     (agent as any).unsubscribeFromContextGraph('cleanup-cg');
+    expect(negativeCache.has('cleanup-cache')).toBe(false);
     expect(fetchCooldown.has('cleanup-cg')).toBe(false);
     expect(peerCursor.has('cleanup-cg')).toBe(false);
+    expect(peerOrder.has('cleanup-cg')).toBe(false);
 
     internals.subscribedContextGraphs.set('hosted-cg', { subscribed: true, coreHosted: true });
+    negativeCache.set('hosted-cache', {
+      localCgId: 'hosted-cg',
+      failures: 1,
+      nextRetryAt: now + 60_000,
+      swmGen: 'empty:0',
+      candidateNamespaces: [],
+      peerTopologyKey: '',
+    });
+    (internals as any).indexVmReconcileNegativeCacheEntry('hosted-cg', 'hosted-cache');
     fetchCooldown.set('hosted-cg', now);
     peerCursor.set('hosted-cg', 3);
+    peerOrder.set('hosted-cg', { orderedPeers: ['peer-b'], nextPeerId: 'peer-b' });
     (agent as any).unsubscribeFromContextGraph('hosted-cg');
+    expect(negativeCache.has('hosted-cache')).toBe(true);
     expect(fetchCooldown.has('hosted-cg')).toBe(true);
     expect(peerCursor.has('hosted-cg')).toBe(true);
+    expect(peerOrder.has('hosted-cg')).toBe(true);
   });
 });
 

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -429,6 +429,35 @@ describe('Phase D - VM reconcile damping', () => {
     expect(expensiveScans).toBeGreaterThan(0);
   });
 
+  it('does not reuse a negative cache entry when catchup ranking changes for the same peer set', async () => {
+    const internals = await boot();
+    const onChainCgId = 56n;
+    registerUnmatchedKC(internals.chain, 9016n, onChainCgId);
+
+    (agent as any).node.libp2p.getConnections = () => [
+      { remotePeer: { toString: () => 'peer-reclassified' } },
+    ];
+
+    const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue(emptyCatchupStats());
+    const originalQuery = internals.store.query.bind(internals.store);
+    let expensiveScans = 0;
+    vi.spyOn(internals.store, 'query').mockImplementation(async (sparql: string) => {
+      if (sparql.includes('SELECT ?op ?root WHERE')) expensiveScans++;
+      return originalQuery(sparql);
+    });
+
+    await expect(internals.reconcileChainOrdinal('56', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(expensiveScans).toBeGreaterThan(0);
+
+    expensiveScans = 0;
+    (internals as any).knownCorePeerIds.add('peer-reclassified');
+
+    await expect(internals.reconcileChainOrdinal('56', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(expensiveScans).toBeGreaterThan(0);
+  });
+
   it('does not reuse a negative cache entry when the same KA has a newer merkle root', async () => {
     const internals = await boot();
     const onChainCgId = 46n;
@@ -464,7 +493,7 @@ describe('Phase D - VM reconcile damping', () => {
     expect(cacheKeys.some((key) => key.includes('22'.repeat(32)))).toBe(true);
   });
 
-  it('invalidates a negative cache entry when SWM data arrives without operation-meta changes', async () => {
+  it('retries an incomplete SWM operation when data arrives without operation-meta changes', async () => {
     const internals = await boot();
     const onChainCgId = 48n;
     const entity = 'urn:fact:data-arrival';
@@ -485,7 +514,7 @@ describe('Phase D - VM reconcile damping', () => {
     );
 
     await expect(internals.reconcileChainOrdinal('48', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
-    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
 
     await insertWorkspaceDataTriple(internals.store, '48', entity, value);
 
@@ -494,7 +523,7 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
-  it('invalidates a negative cache entry when SWM data changes without triple-count changes', async () => {
+  it('retries an incomplete SWM operation when data changes without triple-count changes', async () => {
     const internals = await boot();
     const onChainCgId = 52n;
     const entity = 'urn:fact:data-replacement';
@@ -517,7 +546,7 @@ describe('Phase D - VM reconcile damping', () => {
     await insertWorkspaceDataTriple(internals.store, '52', entity, staleValue);
 
     await expect(internals.reconcileChainOrdinal('52', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
-    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
 
     await replaceWorkspaceDataTriple(internals.store, '52', entity, freshValue);
 
@@ -526,7 +555,7 @@ describe('Phase D - VM reconcile damping', () => {
     expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
   });
 
-  it('invalidates a negative cache entry when private-root metadata arrives without operation-meta changes', async () => {
+  it('retries an incomplete SWM operation when private-root metadata arrives without operation-meta changes', async () => {
     const internals = await boot();
     const onChainCgId = 49n;
     const entity = 'urn:fact:private-arrival';
@@ -550,7 +579,7 @@ describe('Phase D - VM reconcile damping', () => {
     await insertWorkspaceDataTriple(internals.store, '49', entity, value);
 
     await expect(internals.reconcileChainOrdinal('49', onChainCgId, 0, undefined)).resolves.toEqual({ status: 'pending' });
-    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
 
     await insertPrivateMerkleRoot(internals.store, '49', entity, privateRoot);
 
@@ -612,7 +641,7 @@ describe('Phase D - VM reconcile damping', () => {
     expect(generationReads).toBe(2);
   });
 
-  it('invalidates the retry cache only for operation changes in the candidate SWM namespace', async () => {
+  it('does not negative-cache misses once candidate SWM operation metadata exists', async () => {
     const internals = await boot();
     const onChainCgId = 43n;
     registerUnmatchedKC(internals.chain, 9002n, onChainCgId);
@@ -635,6 +664,7 @@ describe('Phase D - VM reconcile damping', () => {
 
     await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(((internals as any).vmReconcileNegativeCache as Map<string, unknown>).size).toBe(0);
 
     await insertWorkspaceOperationMeta(
       internals.store,
@@ -647,7 +677,7 @@ describe('Phase D - VM reconcile damping', () => {
     expensiveScans = 0;
     await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(expensiveScans).toBe(0);
+    expect(expensiveScans).toBeGreaterThan(0);
 
     await insertWorkspaceOperationMeta(
       internals.store,
@@ -657,6 +687,7 @@ describe('Phase D - VM reconcile damping', () => {
       '2020-01-01T00:00:00.000Z',
     );
 
+    expensiveScans = 0;
     await internals.reconcileChainOrdinal('43', onChainCgId, 0, undefined);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(expensiveScans).toBeGreaterThan(0);

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -359,7 +359,9 @@ describe('Phase D — recordCoreHostedPublicCg', () => {
 
     await internals.recordCoreHostedPublicCg('46');
 
+    expect(internals.chain.getContextGraphAccessPolicy).toHaveBeenCalledWith(46n);
     expect(internals.subscribedContextGraphs.get('46')?.coreHosted).toBe(true);
+    expect(saved.find((r) => r.id === '46')?.coreHosted).toBe(true);
   });
 
   it('bounds ACK-backed access-policy reads when the adapter has no liveness probe', async () => {
@@ -1278,7 +1280,7 @@ describe('Phase D - VM reconcile damping', () => {
       }
       return {
         ...emptyCatchupStats(),
-        connectedPeers: connectedPeers.length,
+        connectedPeers: 1,
         totalPeers: connectedPeers.length,
         selectedPeers: 1,
       };
@@ -1296,7 +1298,7 @@ describe('Phase D - VM reconcile damping', () => {
 
     const fetch = vi.spyOn(internals, 'syncContextGraphFromConnectedPeers').mockResolvedValue({
       ...emptyCatchupStats(),
-      connectedPeers: 33,
+      connectedPeers: 1,
       totalPeers: 33,
       selectedPeers: 1,
     });

--- a/packages/agent/test/durable-sync-since-threading.test.ts
+++ b/packages/agent/test/durable-sync-since-threading.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { createOperationContext } from '@origintrail-official/dkg-core';
+import { runDurableSync } from '../src/sync/requester/durable-sync.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+
+interface FetchCall {
+  phase: string;
+  snapshotRef: string | undefined;
+  sinceBatchId: string | undefined;
+}
+
+function makeContext(sinceBatchIdFor?: (cg: string) => string | undefined) {
+  const calls: FetchCall[] = [];
+  const page = (phase: 'data' | 'meta'): SyncPageResult => ({
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: `cp|${phase}`,
+    completed: true,
+    timedOut: false,
+  });
+  return {
+    calls,
+    context: {
+      ctx: createOperationContext('sync'),
+      remotePeerId: 'peerR',
+      contextGraphIds: ['mfacts'],
+      createContextGraphSyncDeadline: () => Date.now() + 10_000,
+      fetchSyncPages: async (
+        _ctx: unknown,
+        _peer: string,
+        _cg: string,
+        _swm: boolean,
+        phase: 'data' | 'meta',
+        _graphUri: string,
+        _deadline: number,
+        snapshotRef?: string,
+        sinceBatchId?: string,
+      ) => {
+        calls.push({ phase, snapshotRef, sinceBatchId });
+        return page(phase);
+      },
+      sinceBatchIdFor,
+      processDurableBatchInWorker: async () => ({
+        verifiedData: [],
+        verifiedMeta: [],
+        totalFetchedDataQuads: 0,
+        totalFetchedMetaQuads: 0,
+        rejectedKcs: 0,
+        emptyResponses: 0,
+        metaOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      storeInsert: async () => undefined,
+      deleteCheckpoint: () => undefined,
+      setCheckpoint: () => undefined,
+      logInfo: () => undefined,
+      logWarn: () => undefined,
+      logDebug: () => undefined,
+    },
+  };
+}
+
+describe('runDurableSync sinceBatchId threading', () => {
+  it('passes sinceBatchIdFor() to the DATA fetch only, not the META fetch', async () => {
+    const { calls, context } = makeContext(() => '7');
+    await runDurableSync(context);
+
+    const meta = calls.find((c) => c.phase === 'meta')!;
+    const data = calls.find((c) => c.phase === 'data')!;
+    expect(meta.sinceBatchId).toBeUndefined();
+    expect(data.sinceBatchId).toBe('7');
+    expect(data.snapshotRef).toBeUndefined();
+  });
+
+  it('passes undefined when no high-water mark resolver is wired', async () => {
+    const { calls, context } = makeContext(undefined);
+    await runDurableSync(context);
+    const data = calls.find((c) => c.phase === 'data')!;
+    expect(data.sinceBatchId).toBeUndefined();
+  });
+
+  it('passes undefined when the resolver returns undefined for the CG', async () => {
+    const { calls, context } = makeContext(() => undefined);
+    await runDurableSync(context);
+    const data = calls.find((c) => c.phase === 'data')!;
+    expect(data.sinceBatchId).toBeUndefined();
+  });
+});

--- a/packages/agent/test/sync-checkpoint-key.test.ts
+++ b/packages/agent/test/sync-checkpoint-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { getSyncCheckpointKey } from '../src/sync/checkpoint/state.js';
+
+describe('getSyncCheckpointKey', () => {
+  it('keeps an unscoped key when no sinceBatchId is given', () => {
+    expect(getSyncCheckpointKey('peerA', 'mfacts', false, 'data')).toBe(
+      'peerA|mfacts|durable|data',
+    );
+  });
+
+  it('distinguishes shared-memory from durable fetches', () => {
+    expect(getSyncCheckpointKey('peerA', 'mfacts', true, 'data')).toBe(
+      'peerA|mfacts|swm|data',
+    );
+  });
+
+  it('appends the snapshotRef only for the snapshot phase', () => {
+    expect(getSyncCheckpointKey('peerA', 'mfacts', false, 'snapshot', 'ref-1')).toBe(
+      'peerA|mfacts|durable|snapshot|ref-1',
+    );
+    expect(getSyncCheckpointKey('peerA', 'mfacts', false, 'data', 'ref-1')).toBe(
+      'peerA|mfacts|durable|data',
+    );
+  });
+
+  it('scopes the key by sinceBatchId so deltas never resume on a full-scan cursor', () => {
+    const full = getSyncCheckpointKey('peerA', 'mfacts', false, 'data');
+    const delta7 = getSyncCheckpointKey('peerA', 'mfacts', false, 'data', undefined, '7');
+    const delta9 = getSyncCheckpointKey('peerA', 'mfacts', false, 'data', undefined, '9');
+
+    expect(delta7).toBe('peerA|mfacts|durable|data|since:7');
+    expect(delta7).not.toBe(full);
+    expect(delta7).not.toBe(delta9);
+  });
+});

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -200,19 +200,21 @@ describe('reconcileWarmCoreConnections', () => {
   });
 
   it('does not count a failed unpin and retains the peer for retry', async () => {
-    let calls = 0;
+    const calls: string[] = [];
     const { deps } = makeDeps({
+      maxCores: 2,
       previouslyWarmed: new Set(['core1', 'core2', 'flaky', 'gone']),
       unpin: async (peerId) => {
-        calls += 1;
+        calls.push(peerId);
         if (peerId === 'flaky') throw new Error('peerStore busy');
       },
     });
 
     const res = await reconcileWarmCoreConnections(deps);
 
-    expect(calls).toBe(2);
-    expect(res.unpinned).toBe(1);
-    expect([...res.warmed].sort()).toEqual(['core1', 'core2', 'flaky']);
+    expect(calls).toEqual(['flaky', 'gone', 'core2']);
+    expect(res.unpinned).toBe(2);
+    expect(res.pinned).toBe(2);
+    expect([...res.warmed].sort()).toEqual(['core1', 'flaky']);
   });
 });

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -199,7 +199,7 @@ describe('reconcileWarmCoreConnections', () => {
     expect(unpinned).toEqual(['core2']);
   });
 
-  it('does not count a failed unpin and retains the peer for retry', async () => {
+  it('does not count a failed unpin or inflate the warmed set', async () => {
     const calls: string[] = [];
     const { deps } = makeDeps({
       maxCores: 2,
@@ -214,8 +214,10 @@ describe('reconcileWarmCoreConnections', () => {
 
     expect(calls).toEqual(['flaky', 'gone']);
     expect(res.unpinned).toBe(1);
-    expect(res.pinned).toBe(3);
-    expect([...res.warmed].sort()).toEqual(['core1', 'core2', 'flaky']);
+    expect(res.unpinFailed).toBe(1);
+    expect(res.pinned).toBe(2);
+    expect([...res.warmed].sort()).toEqual(['core1', 'core2']);
+    expect([...res.failedUnpins]).toEqual(['flaky']);
   });
 
   it('keeps the current best peer when a stale unpin fails at the cap', async () => {
@@ -236,7 +238,48 @@ describe('reconcileWarmCoreConnections', () => {
 
     expect(calls).toEqual(['stale']);
     expect(res.unpinned).toBe(0);
+    expect(res.unpinFailed).toBe(1);
+    expect(res.pinned).toBe(1);
+    expect([...res.warmed]).toEqual(['core1']);
+    expect([...res.failedUnpins]).toEqual(['stale']);
+  });
+
+  it('retries failed unpins separately from the bounded warmed set', async () => {
+    const calls: string[] = [];
+    const { deps } = makeDeps({
+      maxCores: 2,
+      previouslyFailedUnpins: new Set(['flaky']),
+      unpin: async (peerId) => {
+        calls.push(peerId);
+        if (peerId === 'flaky') throw new Error('peerStore busy');
+      },
+    });
+
+    const res = await reconcileWarmCoreConnections(deps);
+
+    expect(calls).toEqual(['flaky']);
+    expect(res.unpinned).toBe(0);
+    expect(res.unpinFailed).toBe(1);
     expect(res.pinned).toBe(2);
-    expect([...res.warmed].sort()).toEqual(['core1', 'stale']);
+    expect([...res.warmed].sort()).toEqual(['core1', 'core2']);
+    expect([...res.failedUnpins]).toEqual(['flaky']);
+  });
+
+  it('bounds the failed-unpin retry set by maxCores', async () => {
+    const { deps } = makeDeps({
+      maxCores: 1,
+      previouslyWarmed: new Set(['stale-a', 'stale-b']),
+      findCoreAgents: async () => [],
+      unpin: async () => {
+        throw new Error('peerStore busy');
+      },
+    });
+
+    const res = await reconcileWarmCoreConnections(deps);
+
+    expect(res.unpinFailed).toBe(2);
+    expect(res.pinned).toBe(0);
+    expect([...res.warmed]).toEqual([]);
+    expect(res.failedUnpins.size).toBe(1);
   });
 });

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -212,9 +212,31 @@ describe('reconcileWarmCoreConnections', () => {
 
     const res = await reconcileWarmCoreConnections(deps);
 
-    expect(calls).toEqual(['flaky', 'gone', 'core2']);
-    expect(res.unpinned).toBe(2);
+    expect(calls).toEqual(['flaky', 'gone']);
+    expect(res.unpinned).toBe(1);
+    expect(res.pinned).toBe(3);
+    expect([...res.warmed].sort()).toEqual(['core1', 'core2', 'flaky']);
+  });
+
+  it('keeps the current best peer when a stale unpin fails at the cap', async () => {
+    const calls: string[] = [];
+    const { deps } = makeDeps({
+      maxCores: 1,
+      previouslyWarmed: new Set(['stale']),
+      findCoreAgents: async () => [
+        { peerId: 'core1', nodeRole: 'core', agentAddress: '0x1' },
+      ],
+      unpin: async (peerId) => {
+        calls.push(peerId);
+        if (peerId === 'stale') throw new Error('peerStore busy');
+      },
+    });
+
+    const res = await reconcileWarmCoreConnections(deps);
+
+    expect(calls).toEqual(['stale']);
+    expect(res.unpinned).toBe(0);
     expect(res.pinned).toBe(2);
-    expect([...res.warmed].sort()).toEqual(['core1', 'flaky']);
+    expect([...res.warmed].sort()).toEqual(['core1', 'stale']);
   });
 });

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -265,7 +265,7 @@ describe('reconcileWarmCoreConnections', () => {
     expect([...res.failedUnpins]).toEqual(['flaky']);
   });
 
-  it('bounds the failed-unpin retry set by maxCores', async () => {
+  it('keeps all failed unpins out of the bounded warmed set', async () => {
     const { deps } = makeDeps({
       maxCores: 1,
       previouslyWarmed: new Set(['stale-a', 'stale-b']),
@@ -280,6 +280,6 @@ describe('reconcileWarmCoreConnections', () => {
     expect(res.unpinFailed).toBe(2);
     expect(res.pinned).toBe(0);
     expect([...res.warmed]).toEqual([]);
-    expect(res.failedUnpins.size).toBe(1);
+    expect([...res.failedUnpins].sort()).toEqual(['stale-a', 'stale-b']);
   });
 });

--- a/packages/agent/test/warm-core-connections.test.ts
+++ b/packages/agent/test/warm-core-connections.test.ts
@@ -198,4 +198,21 @@ describe('reconcileWarmCoreConnections', () => {
     expect(res).toMatchObject({ pinned: 1, skippedGate: 1, unpinned: 1 });
     expect(unpinned).toEqual(['core2']);
   });
+
+  it('does not count a failed unpin and retains the peer for retry', async () => {
+    let calls = 0;
+    const { deps } = makeDeps({
+      previouslyWarmed: new Set(['core1', 'core2', 'flaky', 'gone']),
+      unpin: async (peerId) => {
+        calls += 1;
+        if (peerId === 'flaky') throw new Error('peerStore busy');
+      },
+    });
+
+    const res = await reconcileWarmCoreConnections(deps);
+
+    expect(calls).toBe(2);
+    expect(res.unpinned).toBe(1);
+    expect([...res.warmed].sort()).toEqual(['core1', 'core2', 'flaky']);
+  });
 });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1323,6 +1323,9 @@ export interface ChainAdapter {
    * so the protected/encrypted path is kept). Adapters that implement
    * `getContextGraphAccessPolicy` SHOULD also implement this so they don't
    * silently strand on-chain-public CGs on the encrypted path.
+   * A resolved `false` must mean the chain successfully proved the slot is
+   * inactive; transient RPC/read failures should reject so callers can choose
+   * their own fail-closed or ACK-backed fallback behavior.
    */
   isContextGraphActiveOnChain?(contextGraphId: bigint): Promise<boolean>;
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -137,12 +137,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
   /** True when `contextGraphId` is an active minted CG in ContextGraphStorage. */
   async isContextGraphActiveOnChain(contextGraphId: bigint): Promise<boolean> {
     await this.init();
-    if (!this.contracts.contextGraphStorage) return false;
-    try {
-      return Boolean(await this.contracts.contextGraphStorage.isContextGraphActive(contextGraphId));
-    } catch {
-      return false;
-    }
+    const cgs = this.requireContextGraphStorage();
+    return Boolean(await cgs.isContextGraphActive(contextGraphId));
   }
 
   async createOnChainContextGraph(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult> {

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -261,6 +261,37 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     await expect(a.getContextGraphAccessPolicy(7n)).resolves.toBe(0);
   });
 
+  it('surfaces context graph liveness RPC failures instead of reporting inactive', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    const rpcError = new Error('rpc unavailable');
+    (a as any).init = async () => undefined;
+    (a as any).contracts.contextGraphStorage = {
+      isContextGraphActive: vi.fn(async () => {
+        throw rpcError;
+      }),
+    };
+
+    await expect(a.isContextGraphActiveOnChain(8n)).rejects.toThrow('rpc unavailable');
+  });
+
+  it('returns false for a successful inactive context graph liveness read', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    const isContextGraphActive = vi.fn(async () => false);
+    (a as any).init = async () => undefined;
+    (a as any).contracts.contextGraphStorage = { isContextGraphActive };
+
+    await expect(a.isContextGraphActiveOnChain(9n)).resolves.toBe(false);
+    expect(isContextGraphActive).toHaveBeenCalledWith(9n);
+  });
+
+  it('surfaces missing ContextGraphStorage as unknown instead of reporting inactive', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    (a as any).init = async () => undefined;
+    (a as any).contracts.contextGraphStorage = undefined;
+
+    await expect(a.isContextGraphActiveOnChain(10n)).rejects.toThrow('ContextGraphStorage not deployed');
+  });
+
   it('uses configured tokenAddress without resolving Hub.Token during init', async () => {
     const tokenAddress = ethers.getAddress(`0x${'22'.repeat(20)}`);
     const contractAddress = ethers.getAddress(`0x${'11'.repeat(20)}`);

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1176,6 +1176,8 @@ export class ApiClient {
     catchup?:
       | {
         connectedPeers: number;
+        totalPeers?: number;
+        selectedPeers?: number;
         syncCapablePeers: number;
         peersTried: number;
         peersResponded: number;
@@ -1235,6 +1237,8 @@ export class ApiClient {
     catchup?:
       | {
         connectedPeers: number;
+        totalPeers?: number;
+        selectedPeers?: number;
         syncCapablePeers: number;
         peersTried: number;
         peersResponded: number;
@@ -1298,6 +1302,8 @@ export class ApiClient {
     finishedAt?: number;
     result?: {
       connectedPeers: number;
+      totalPeers?: number;
+      selectedPeers?: number;
       syncCapablePeers: number;
       peersTried: number;
       peersResponded: number;

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -225,6 +225,8 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
 
   return {
     connectedPeers: prepared.connectedPeers,
+    totalPeers: prepared.connectedPeers,
+    selectedPeers: prepared.peerIds.length,
     syncCapablePeers,
     peersTried,
     peersResponded,

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -9,6 +9,8 @@ const SYNC_PROTOCOL_CHECK_DELAY_MS = 500;
 
 export interface CatchupJobResult {
   connectedPeers: number;
+  totalPeers?: number;
+  selectedPeers?: number;
   syncCapablePeers: number;
   peersTried: number;
   /**

--- a/packages/cli/src/cli-helpers.ts
+++ b/packages/cli/src/cli-helpers.ts
@@ -249,8 +249,9 @@ function printCatchupStatus(status: Awaited<ReturnType<ApiClient['catchupStatus'
   if (status.startedAt) console.log(`Started:       ${new Date(status.startedAt).toISOString()}`);
   if (status.finishedAt) console.log(`Finished:      ${new Date(status.finishedAt).toISOString()}`);
   if (status.result) {
+    const totalConnectedPeers = status.result.totalPeers ?? status.result.connectedPeers;
     console.log(
-      `Result:        peers ${status.result.peersTried}/${status.result.syncCapablePeers} (connected ${status.result.connectedPeers}), data ${status.result.dataSynced}, shared memory ${status.result.sharedMemorySynced}`,
+      `Result:        peers ${status.result.peersTried}/${status.result.syncCapablePeers} (connected ${totalConnectedPeers}), data ${status.result.dataSynced}, shared memory ${status.result.sharedMemorySynced}`,
     );
     if (status.result.diagnostics) {
       console.log(
@@ -269,7 +270,8 @@ function printCatchupStatus(status: Awaited<ReturnType<ApiClient['catchupStatus'
   }
   if (
     status.result &&
-    status.result.connectedPeers > 0 &&
+    (status.result.selectedPeers ?? status.result.connectedPeers) >= (status.result.totalPeers ?? status.result.connectedPeers) &&
+    (status.result.totalPeers ?? status.result.connectedPeers) > 0 &&
     status.result.syncCapablePeers === 0 &&
     status.result.dataSynced === 0 &&
     status.result.sharedMemorySynced === 0

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1550,6 +1550,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
         const servedUsableData =
           result.dataSynced > 0 ||
           result.sharedMemorySynced > 0;
+        const totalConnectedPeers = result.totalPeers ?? result.connectedPeers;
+        const selectedConnectedPeers = result.selectedPeers ?? result.connectedPeers;
         const cleanResponse =
           servedUsableData ||
           (d?.emptyResponses ?? 0) > 0 ||
@@ -1583,7 +1585,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           } else if (result.peersTried > 0) {
             job.status = "failed";
             job.error = "Sync did not complete — all reachable peers failed (timeouts or transport errors). Retry once the network is healthier.";
-          } else if (result.connectedPeers > 0 && result.syncCapablePeers === 0) {
+          } else if (totalConnectedPeers > 0 && selectedConnectedPeers >= totalConnectedPeers && result.syncCapablePeers === 0) {
             // Connected to peers, but none speak the sync protocol —
             // i.e. all our connections are non-DKG / mismatched
             // versions. From the joiner's perspective this is the same
@@ -1591,7 +1593,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
             // reuse the dedicated terminal status.
             job.status = "unreachable";
             job.error = "No sync-capable peers found for catch-up — the curator may be offline.";
-          } else if (result.connectedPeers === 0) {
+          } else if (totalConnectedPeers === 0) {
             // No peers connected at all → definitionally unreachable.
             job.status = "unreachable";
             job.error = "No peers connected — couldn't reach the curator. They may be offline, or your node hasn't bootstrapped to the network yet.";
@@ -1600,7 +1602,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
           if (DEBUG_SYNC_TRACE) {
             console.log(
               `[catchup] job=${jobId} contextGraph=${contextGraphId} status=${job.status} ` +
-                `peers=${result.peersTried}/${result.syncCapablePeers} connected=${result.connectedPeers} ` +
+                `peers=${result.peersTried}/${result.syncCapablePeers} connected=${totalConnectedPeers} ` +
                 `data=${result.dataSynced} swm=${result.sharedMemorySynced} denied=${result.denied}`,
             );
           }


### PR DESCRIPTION
## Summary

- Damps the 60 s VM-reconcile loop: a per-UAL negative cache (5 min base, x2, 6 h cap) that scopes recompute with a cheap bound ASK gate instead of CG-wide counters.
- Replaces all-peers-parallel catch-up with a single peer chosen from preferred/core-first ordering, then round-robin, plus a per-CG fetch cooldown.
- Adds optional tombstoning (`DKG_VM_RECONCILE_TOMBSTONE_AFTER_MS`, default OFF) to advance the cursor after sustained max-backoff.
- Folds the still-relevant #934 hardening into A4: transient head-fetch watermark hold, existence-gated core-host recording, tracked core-host persistence on shutdown, deterministic finalization op selection, failed warm-core unpin retry, typed keep-root coverage, and sync checkpoint/since threading tests.

## Related

- Part of #1138 (Track A, PR A4).
- Supersedes #934 for the still-relevant robustness fixes. The #934 parser extraction and publication-provenance fallback were intentionally not folded because integration/A3 and #1155 already supersede those paths.
- Targets `integration/issue-1138`.

## Files changed

| File | What |
|------|------|
| `packages/agent/src/dkg-agent-swm-host.ts` | Negative cache, scoped recompute gate, single-peer round-robin, tombstone, existence-gated core-host recording |
| `packages/agent/src/chain-reconciler.ts` | Hold watermark persistence on transient head-fetch failure |
| `packages/agent/src/dkg-agent-base.ts` | VM reconcile cache state and tracked core-host recording promises |
| `packages/agent/src/dkg-agent-lifecycle.ts` | Track async core-host recording from StorageACK hook |
| `packages/agent/src/dkg-agent.ts` | Flush tracked core-host recording promises during stop |
| `packages/agent/src/finalization-handler.ts` | Deterministic operation selection for merkle-root match |
| `packages/agent/src/p2p/warm-core-connections.ts` | Retry failed warm-core unpins |

Plus focused regression tests for A4 and #934 fold-in behavior.

## Test plan

- [x] `node node_modules/typescript/bin/tsc -p packages/agent/tsconfig.json`
- [x] `node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts test/chain-reconciler.test.ts test/core-fills-gap.test.ts test/warm-core-connections.test.ts test/chain-reconcile-e2e.test.ts test/durable-sync-since-threading.test.ts test/sync-checkpoint-key.test.ts --reporter verbose`
- [x] `node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts test/sync-on-connect-retry.test.ts test/sync-requester-progress.test.ts --reporter verbose`
- [x] `$env:NODE_PATH=(Resolve-Path .\node_modules).Path; node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts test/agent.part-16.test.ts --reporter verbose`

---
Targets `integration/issue-1138` (not `main`) so the heavy overlaps on agent lifecycle/base code are resolved once on the integration branch, which is promoted to `main` in gated waves (see #1138).
