### PR TITLE
B0 — cheap context-graph metrics count (drop the 30s composite sweep)

### DIFF
--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1869,7 +1869,7 @@ export async function runDaemonInner(
       )) {
         knownContextGraphIds.add(contextGraphId);
       }
-      const declarationQuery = buildContextGraphDeclarationsSparql(graphUris);
+      const declarationQuery = buildContextGraphDeclarationsSparql(graphUris, knownContextGraphIds);
       const declarationResult = declarationQuery
         ? await agent.store.query(declarationQuery)
         : null;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -22,6 +22,7 @@ import {
   countContextGraphsFromGraphUris,
   GET_TOTAL_TRIPLES_SPARQL,
   parseRdfInt,
+  shadowContextGraphIdsFromMetricSubscriptionCandidates,
 } from "./metrics-queries.js";
 import {
   appendFile,
@@ -1862,10 +1863,15 @@ export async function runDaemonInner(
         agent.listContextGraphs(),
       ]);
       const knownContextGraphIds = new Set<string>();
-      for (const contextGraph of contextGraphs) {
-        if (contextGraph.id) knownContextGraphIds.add(contextGraph.id);
-      }
       const subscribedContextGraphs = agent.getSubscribedContextGraphs();
+      const shadowContextGraphIds = new Set(
+        shadowContextGraphIdsFromMetricSubscriptionCandidates(subscribedContextGraphs.entries()),
+      );
+      for (const contextGraph of contextGraphs) {
+        if (contextGraph.id && !shadowContextGraphIds.has(contextGraph.id)) {
+          knownContextGraphIds.add(contextGraph.id);
+        }
+      }
       for (const contextGraphId of contextGraphIdsFromMetricSubscriptionCandidates(
         subscribedContextGraphs.entries(),
       )) {
@@ -1875,7 +1881,7 @@ export async function runDaemonInner(
         graphUris,
         subscribedContextGraphs.keys(),
       )) {
-        knownContextGraphIds.add(contextGraphId);
+        if (!shadowContextGraphIds.has(contextGraphId)) knownContextGraphIds.add(contextGraphId);
       }
       const declarationQuery = buildContextGraphDeclarationsSparql(graphUris, knownContextGraphIds);
       const declarationResult = declarationQuery
@@ -1885,7 +1891,7 @@ export async function runDaemonInner(
         for (const contextGraphId of contextGraphIdsFromDeclarationBindings(
           declarationResult.bindings as Record<string, string>[],
         )) {
-          knownContextGraphIds.add(contextGraphId);
+          if (!shadowContextGraphIds.has(contextGraphId)) knownContextGraphIds.add(contextGraphId);
         }
       }
       return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1894,7 +1894,7 @@ export async function runDaemonInner(
           if (!shadowContextGraphIds.has(contextGraphId)) knownContextGraphIds.add(contextGraphId);
         }
       }
-      return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds);
+      return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds, shadowContextGraphIds);
     },
     // The count getters below each issue a data-proportional full-scan COUNT,
     // but the only caller is the 30 s metrics tick (metricsSource is consumed

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -17,6 +17,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   buildContextGraphDeclarationsSparql,
   contextGraphIdsFromDeclarationBindings,
+  contextGraphIdsFromLocalRootMetaGraphs,
   contextGraphIdsFromMetricSubscriptionCandidates,
   countContextGraphsFromGraphUris,
   GET_TOTAL_TRIPLES_SPARQL,
@@ -1864,8 +1865,15 @@ export async function runDaemonInner(
       for (const contextGraph of contextGraphs) {
         if (contextGraph.id) knownContextGraphIds.add(contextGraph.id);
       }
+      const subscribedContextGraphs = agent.getSubscribedContextGraphs();
       for (const contextGraphId of contextGraphIdsFromMetricSubscriptionCandidates(
-        agent.getSubscribedContextGraphs().entries(),
+        subscribedContextGraphs.entries(),
+      )) {
+        knownContextGraphIds.add(contextGraphId);
+      }
+      for (const contextGraphId of contextGraphIdsFromLocalRootMetaGraphs(
+        graphUris,
+        subscribedContextGraphs.keys(),
       )) {
         knownContextGraphIds.add(contextGraphId);
       }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -14,7 +14,14 @@ import {
   type ServerResponse,
 } from "node:http";
 import { createHash, randomUUID } from "node:crypto";
-import { countContextGraphsFromGraphUris, GET_TOTAL_TRIPLES_SPARQL, parseRdfInt } from "./metrics-queries.js";
+import {
+  contextGraphIdsFromDeclarationBindings,
+  contextGraphIdsFromMetricSubscriptionCandidates,
+  countContextGraphsFromGraphUris,
+  GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL,
+  GET_TOTAL_TRIPLES_SPARQL,
+  parseRdfInt,
+} from "./metrics-queries.js";
 import {
   appendFile,
   chmod,
@@ -1849,13 +1856,26 @@ export async function runDaemonInner(
       }
     },
     getContextGraphCount: async () => {
-      const [graphUris, contextGraphs] = await Promise.all([
+      const [graphUris, contextGraphs, declarationResult] = await Promise.all([
         agent.store.listGraphs(),
         agent.listContextGraphs(),
+        agent.store.query(GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL),
       ]);
-      const knownContextGraphIds = new Set(agent.getSubscribedContextGraphs().keys());
+      const knownContextGraphIds = new Set<string>();
       for (const contextGraph of contextGraphs) {
         if (contextGraph.id) knownContextGraphIds.add(contextGraph.id);
+      }
+      for (const contextGraphId of contextGraphIdsFromMetricSubscriptionCandidates(
+        agent.getSubscribedContextGraphs().entries(),
+      )) {
+        knownContextGraphIds.add(contextGraphId);
+      }
+      if (declarationResult.type === "bindings") {
+        for (const contextGraphId of contextGraphIdsFromDeclarationBindings(
+          declarationResult.bindings as Record<string, string>[],
+        )) {
+          knownContextGraphIds.add(contextGraphId);
+        }
       }
       return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds);
     },
@@ -1865,8 +1885,9 @@ export async function runDaemonInner(
     // already re-reads the store fresh and there is nothing concurrent to
     // coalesce. They are intentionally left uncached so a snapshot never serves
     // a stale count and can't mask a store outage. The context-graph count
-    // merges listContextGraphs() IDs with the store graph inventory, then
-    // dedupes local layer graphs. It intentionally includes private CG graphs.
+    // merges filtered listContextGraphs() rows, locally declared CG metadata,
+    // and backed subscription rows with the store graph inventory, then dedupes
+    // local layer graphs. It intentionally includes private CG graphs.
     // These COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
     getTotalTriples: async () => {
       const r = await agent.query(GET_TOTAL_TRIPLES_SPARQL);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -15,10 +15,10 @@ import {
 } from "node:http";
 import { createHash, randomUUID } from "node:crypto";
 import {
+  buildContextGraphDeclarationsSparql,
   contextGraphIdsFromDeclarationBindings,
   contextGraphIdsFromMetricSubscriptionCandidates,
   countContextGraphsFromGraphUris,
-  GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL,
   GET_TOTAL_TRIPLES_SPARQL,
   parseRdfInt,
 } from "./metrics-queries.js";
@@ -1856,10 +1856,9 @@ export async function runDaemonInner(
       }
     },
     getContextGraphCount: async () => {
-      const [graphUris, contextGraphs, declarationResult] = await Promise.all([
+      const [graphUris, contextGraphs] = await Promise.all([
         agent.store.listGraphs(),
         agent.listContextGraphs(),
-        agent.store.query(GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL),
       ]);
       const knownContextGraphIds = new Set<string>();
       for (const contextGraph of contextGraphs) {
@@ -1870,7 +1869,11 @@ export async function runDaemonInner(
       )) {
         knownContextGraphIds.add(contextGraphId);
       }
-      if (declarationResult.type === "bindings") {
+      const declarationQuery = buildContextGraphDeclarationsSparql(graphUris);
+      const declarationResult = declarationQuery
+        ? await agent.store.query(declarationQuery)
+        : null;
+      if (declarationResult?.type === "bindings") {
         for (const contextGraphId of contextGraphIdsFromDeclarationBindings(
           declarationResult.bindings as Record<string, string>[],
         )) {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1858,20 +1858,12 @@ export async function runDaemonInner(
       }
     },
     getContextGraphCount: async () => {
-      const [graphUris, contextGraphs] = await Promise.all([
-        agent.store.listGraphs(),
-        agent.listContextGraphs(),
-      ]);
+      const graphUris = await agent.store.listGraphs();
       const knownContextGraphIds = new Set<string>();
       const subscribedContextGraphs = agent.getSubscribedContextGraphs();
       const shadowContextGraphIds = new Set(
         shadowContextGraphIdsFromMetricSubscriptionCandidates(subscribedContextGraphs.entries()),
       );
-      for (const contextGraph of contextGraphs) {
-        if (contextGraph.id && !shadowContextGraphIds.has(contextGraph.id)) {
-          knownContextGraphIds.add(contextGraph.id);
-        }
-      }
       for (const contextGraphId of contextGraphIdsFromMetricSubscriptionCandidates(
         subscribedContextGraphs.entries(),
       )) {
@@ -1902,9 +1894,10 @@ export async function runDaemonInner(
     // already re-reads the store fresh and there is nothing concurrent to
     // coalesce. They are intentionally left uncached so a snapshot never serves
     // a stale count and can't mask a store outage. The context-graph count
-    // merges filtered listContextGraphs() rows, locally declared CG metadata,
-    // and backed subscription rows with the store graph inventory, then dedupes
-    // local layer graphs. It intentionally includes private CG graphs.
+    // avoids the composite context-graph listing enrichment path. It uses the
+    // cached store graph inventory plus backed subscription/declaration evidence,
+    // then dedupes local layer graphs. It intentionally includes private CG graphs
+    // that are backed by local subscription/declaration state.
     // These COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
     getTotalTriples: async () => {
       const r = await agent.query(GET_TOTAL_TRIPLES_SPARQL);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1848,20 +1848,25 @@ export async function runDaemonInner(
         return 0;
       }
     },
-    getContextGraphCount: async () =>
-      countContextGraphsFromGraphUris(
-        await agent.store.listGraphs(),
-        agent.getSubscribedContextGraphs().keys(),
-      ),
+    getContextGraphCount: async () => {
+      const [graphUris, contextGraphs] = await Promise.all([
+        agent.store.listGraphs(),
+        agent.listContextGraphs(),
+      ]);
+      const knownContextGraphIds = new Set(agent.getSubscribedContextGraphs().keys());
+      for (const contextGraph of contextGraphs) {
+        if (contextGraph.id) knownContextGraphIds.add(contextGraph.id);
+      }
+      return countContextGraphsFromGraphUris(graphUris, knownContextGraphIds);
+    },
     // The count getters below each issue a data-proportional full-scan COUNT,
     // but the only caller is the 30 s metrics tick (metricsSource is consumed
     // solely by MetricsCollector — no on-demand /api/status path), so each tick
     // already re-reads the store fresh and there is nothing concurrent to
     // coalesce. They are intentionally left uncached so a snapshot never serves
-    // a stale count and can't mask a store outage. The context-graph count uses
-    // the store graph inventory directly instead of the composite
-    // listContextGraphs() enrichment path; managed local stores serve this from
-    // the R6-A listGraphs cache. It intentionally includes private CG graphs.
+    // a stale count and can't mask a store outage. The context-graph count
+    // merges listContextGraphs() IDs with the store graph inventory, then
+    // dedupes local layer graphs. It intentionally includes private CG graphs.
     // These COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
     getTotalTriples: async () => {
       const r = await agent.query(GET_TOTAL_TRIPLES_SPARQL);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -14,7 +14,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { createHash, randomUUID } from "node:crypto";
-import { GET_TOTAL_TRIPLES_SPARQL, parseRdfInt } from "./metrics-queries.js";
+import { countContextGraphsFromGraphUris, GET_TOTAL_TRIPLES_SPARQL, parseRdfInt } from "./metrics-queries.js";
 import {
   appendFile,
   chmod,
@@ -1848,15 +1848,21 @@ export async function runDaemonInner(
         return 0;
       }
     },
-    getContextGraphCount: async () => (await agent.listContextGraphs()).length,
+    getContextGraphCount: async () =>
+      countContextGraphsFromGraphUris(
+        await agent.store.listGraphs(),
+        agent.getSubscribedContextGraphs().keys(),
+      ),
     // The count getters below each issue a data-proportional full-scan COUNT,
     // but the only caller is the 30 s metrics tick (metricsSource is consumed
     // solely by MetricsCollector — no on-demand /api/status path), so each tick
     // already re-reads the store fresh and there is nothing concurrent to
     // coalesce. They are intentionally left uncached so a snapshot never serves
-    // a stale count and can't mask a store outage. The one heavy metrics read,
-    // getContextGraphCount, is relieved at the chokepoint by R6-A's listGraphs
-    // cache; these COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
+    // a stale count and can't mask a store outage. The context-graph count uses
+    // the store graph inventory directly instead of the composite
+    // listContextGraphs() enrichment path; managed local stores serve this from
+    // the R6-A listGraphs cache. It intentionally includes private CG graphs.
+    // These COUNTs are cheap (~0.015 CPU-s/tick on a 75k-triple store).
     getTotalTriples: async () => {
       const r = await agent.query(GET_TOTAL_TRIPLES_SPARQL);
       return parseRdfInt(r?.bindings?.[0]?.c);

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -14,6 +14,24 @@
 export const GET_TOTAL_TRIPLES_SPARQL =
   'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';
 
+const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
+const CONTEXT_GRAPH_LAYER_MARKERS = [
+  '/_shared_memory/',
+  '/_shared_memory_snapshots/',
+  '/_verifiable_memory/',
+  '/_working_memory/',
+  '/assertion/',
+  '/context/',
+] as const;
+const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
+  '/_shared_memory_meta',
+  '/_shared_memory',
+  '/_private',
+  '/_rules',
+  '/_meta',
+] as const;
+const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+/;
+
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
  * integer literal (e.g. `"1000"^^<…#integer>`) or a bare `1000`; missing or
@@ -26,4 +44,71 @@ export function parseRdfInt(raw: string | undefined): number {
   if (m) return parseInt(m[1], 10);
   const n = parseInt(raw, 10);
   return isNaN(n) ? 0 : n;
+}
+
+function normalizeMetricContextGraphCandidates(knownContextGraphIds?: Iterable<string>): string[] {
+  return [...new Set(knownContextGraphIds ?? [])]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+}
+
+export function contextGraphIdFromGraphUriForMetrics(
+  graphUri: string,
+  knownContextGraphIds?: Iterable<string>,
+): string | null {
+  return contextGraphIdFromGraphUriForMetricsWithCandidates(
+    graphUri,
+    normalizeMetricContextGraphCandidates(knownContextGraphIds),
+  );
+}
+
+function contextGraphIdFromGraphUriForMetricsWithCandidates(
+  graphUri: string,
+  knownContextGraphIds: readonly string[],
+): string | null {
+  if (!graphUri.startsWith(CONTEXT_GRAPH_URI_PREFIX)) return null;
+  let rest = graphUri.slice(CONTEXT_GRAPH_URI_PREFIX.length);
+  if (!rest) return null;
+
+  for (const knownId of knownContextGraphIds) {
+    if (rest === knownId || rest.startsWith(`${knownId}/`)) return knownId;
+  }
+
+  for (const marker of CONTEXT_GRAPH_LAYER_MARKERS) {
+    const markerIndex = rest.indexOf(marker);
+    if (markerIndex > 0) {
+      rest = rest.slice(0, markerIndex);
+      break;
+    }
+  }
+
+  for (const suffix of CONTEXT_GRAPH_RESERVED_SUFFIXES) {
+    if (rest.endsWith(suffix)) {
+      rest = rest.slice(0, -suffix.length);
+      if (!rest) return null;
+      break;
+    }
+  }
+
+  const walletScoped = rest.match(WALLET_SCOPED_CONTEXT_GRAPH_RE)?.[0];
+  if (walletScoped) return walletScoped;
+
+  const slash = rest.indexOf('/');
+  return slash === -1 ? rest : rest.slice(0, slash);
+}
+
+export function countContextGraphsFromGraphUris(
+  graphUris: readonly string[],
+  knownContextGraphIds?: Iterable<string>,
+): number {
+  const knownCandidates = normalizeMetricContextGraphCandidates(knownContextGraphIds);
+  const contextGraphIds = new Set<string>();
+  for (const graphUri of graphUris) {
+    const contextGraphId = contextGraphIdFromGraphUriForMetricsWithCandidates(
+      graphUri,
+      knownCandidates,
+    );
+    if (contextGraphId) contextGraphIds.add(contextGraphId);
+  }
+  return contextGraphIds.size;
 }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -154,7 +154,20 @@ export function contextGraphIdsFromLocalRootMetaGraphs(
 export function contextGraphIdsFromMetricSubscriptionCandidates(
   subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
 ): string[] {
+  return selectMetricSubscriptionCandidateIds(subscriptions).selected;
+}
+
+export function shadowContextGraphIdsFromMetricSubscriptionCandidates(
+  subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
+): string[] {
+  return selectMetricSubscriptionCandidateIds(subscriptions).shadows;
+}
+
+function selectMetricSubscriptionCandidateIds(
+  subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
+): { selected: string[]; shadows: string[] } {
   const contextGraphIdsByIdentity = new Map<string, string>();
+  const contextGraphIdsByStableIdentity = new Map<string, Set<string>>();
   for (const [id, sub] of subscriptions) {
     if (!id) continue;
     if (SYSTEM_CONTEXT_GRAPH_IDS.has(id)) continue;
@@ -168,16 +181,29 @@ export function contextGraphIdsFromMetricSubscriptionCandidates(
     ) {
       const identity = sub.onChainId
         ? `chain:${sub.onChainId}`
-        : sub.onChainHash
-          ? `wire:${sub.onChainHash.toLowerCase()}`
-          : `local:${id}`;
+          : sub.onChainHash
+            ? `wire:${sub.onChainHash.toLowerCase()}`
+            : `local:${id}`;
+      let idsForIdentity = contextGraphIdsByStableIdentity.get(identity);
+      if (!idsForIdentity) {
+        idsForIdentity = new Set<string>();
+        contextGraphIdsByStableIdentity.set(identity, idsForIdentity);
+      }
+      idsForIdentity.add(id);
       const existingId = contextGraphIdsByIdentity.get(identity);
       if (!existingId || shouldPreferMetricContextGraphId(id, existingId)) {
         contextGraphIdsByIdentity.set(identity, id);
       }
     }
   }
-  return [...contextGraphIdsByIdentity.values()];
+  const shadows: string[] = [];
+  for (const [identity, ids] of contextGraphIdsByStableIdentity) {
+    const selected = contextGraphIdsByIdentity.get(identity);
+    for (const id of ids) {
+      if (id !== selected) shadows.push(id);
+    }
+  }
+  return { selected: [...contextGraphIdsByIdentity.values()], shadows };
 }
 
 function shouldPreferMetricContextGraphId(candidateId: string, existingId: string): boolean {
@@ -188,17 +214,6 @@ function shouldPreferMetricContextGraphId(candidateId: string, existingId: strin
   const existingIsWalletScoped = WALLET_SCOPED_CONTEXT_GRAPH_RE.test(existingId);
   if (candidateIsWalletScoped !== existingIsWalletScoped) return candidateIsWalletScoped;
   return candidateId.length < existingId.length;
-}
-
-function canonicalizeMetricContextGraphIds(contextGraphIds: Iterable<string>): string[] {
-  const ids = [...new Set(contextGraphIds)].filter((id) => !SYSTEM_CONTEXT_GRAPH_IDS.has(id));
-  const walletScopedIds = ids.filter((id) => WALLET_SCOPED_CONTEXT_GRAPH_RE.test(id));
-  const shadowAliases = new Set<string>();
-  for (const id of walletScopedIds) {
-    const suffix = id.slice(id.indexOf('/') + 1);
-    if (suffix) shadowAliases.add(suffix);
-  }
-  return ids.filter((id) => !shadowAliases.has(id) || WALLET_SCOPED_CONTEXT_GRAPH_RE.test(id));
 }
 
 export function contextGraphIdFromGraphUriForMetrics(
@@ -252,5 +267,5 @@ export function countContextGraphsFromGraphUris(
     );
     if (contextGraphId) contextGraphIds.add(contextGraphId);
   }
-  return canonicalizeMetricContextGraphIds(contextGraphIds).length;
+  return contextGraphIds.size;
 }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -43,6 +43,10 @@ type MetricSubscriptionCandidate = {
 };
 
 const HASH_CONTEXT_GRAPH_ID_RE = /^0x[a-fA-F0-9]{64}$/;
+const SYSTEM_CONTEXT_GRAPH_IDS = new Set<string>([
+  SYSTEM_CONTEXT_GRAPHS.AGENTS,
+  SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+]);
 
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
@@ -60,12 +64,13 @@ export function parseRdfInt(raw: string | undefined): number {
 
 function normalizeMetricContextGraphCandidates(knownContextGraphIds?: Iterable<string>): string[] {
   return [...new Set(knownContextGraphIds ?? [])]
-    .filter(Boolean)
+    .filter((id) => Boolean(id) && !SYSTEM_CONTEXT_GRAPH_IDS.has(id))
     .sort((a, b) => b.length - a.length);
 }
 
 function unambiguousMetricContextGraphId(candidate: string): string | null {
   if (!candidate) return null;
+  if (SYSTEM_CONTEXT_GRAPH_IDS.has(candidate)) return null;
   if (!candidate.includes('/')) return candidate;
   return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
 }
@@ -116,7 +121,22 @@ export function contextGraphIdsFromDeclarationBindings(
     const uri = row.ctxGraph;
     if (uri?.startsWith(CONTEXT_GRAPH_URI_PREFIX)) {
       const id = uri.slice(CONTEXT_GRAPH_URI_PREFIX.length);
-      if (id) contextGraphIds.add(id);
+      if (id && !SYSTEM_CONTEXT_GRAPH_IDS.has(id)) contextGraphIds.add(id);
+    }
+  }
+  return [...contextGraphIds];
+}
+
+export function contextGraphIdsFromLocalRootMetaGraphs(
+  graphUris: readonly string[],
+  candidateContextGraphIds: Iterable<string>,
+): string[] {
+  const graphUriSet = new Set(graphUris);
+  const contextGraphIds = new Set<string>();
+  for (const id of candidateContextGraphIds) {
+    if (!id || SYSTEM_CONTEXT_GRAPH_IDS.has(id)) continue;
+    if (graphUriSet.has(`${CONTEXT_GRAPH_URI_PREFIX}${id}/_meta`)) {
+      contextGraphIds.add(id);
     }
   }
   return [...contextGraphIds];
@@ -128,6 +148,7 @@ export function contextGraphIdsFromMetricSubscriptionCandidates(
   const contextGraphIdsByIdentity = new Map<string, string>();
   for (const [id, sub] of subscriptions) {
     if (!id) continue;
+    if (SYSTEM_CONTEXT_GRAPH_IDS.has(id)) continue;
     if (
       sub.onChainId
       || sub.pendingMeta === true

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -50,8 +50,6 @@ const SYSTEM_CONTEXT_GRAPH_IDS = new Set<string>([
 const NON_ROOT_DECLARATION_META_SEGMENTS = [
   '/_verifiable_memory/',
   '/_shared_memory_snapshots/',
-  '/assertion/',
-  '/context/',
 ] as const;
 
 /**

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -112,6 +112,8 @@ export function buildContextGraphDeclarationsSparql(
   const declarationGraphs = declarationGraphUrisFromGraphUris(graphUris, knownContextGraphIds);
   if (declarationGraphs.length === 0) return null;
   const values = declarationGraphs.map((graphUri) => sparqlIri(graphUri)).join(' ');
+  const agentsGraph = `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.AGENTS}`;
+  const ontologyGraph = `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}`;
   return `
     SELECT DISTINCT ?ctxGraph WHERE {
       VALUES ?g { ${values} }
@@ -119,6 +121,11 @@ export function buildContextGraphDeclarationsSparql(
         ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
       }
       FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_URI_PREFIX}"))
+      FILTER(
+        ?g = ${sparqlIri(agentsGraph)}
+        || ?g = ${sparqlIri(ontologyGraph)}
+        || STR(?g) = CONCAT(STR(?ctxGraph), "/_meta")
+      )
     }
   `;
 }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -70,20 +70,31 @@ function unambiguousMetricContextGraphId(candidate: string): string | null {
   return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
 }
 
-function declarationGraphUrisFromGraphUris(graphUris: readonly string[]): string[] {
+function declarationGraphUrisFromGraphUris(
+  graphUris: readonly string[],
+  knownContextGraphIds?: Iterable<string>,
+): string[] {
   const declarationGraphs = new Set<string>([
     `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}`,
     `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.AGENTS}`,
   ]);
+  const knownCandidates = new Set(normalizeMetricContextGraphCandidates(knownContextGraphIds));
   for (const graphUri of graphUris) {
     if (!graphUri.startsWith(CONTEXT_GRAPH_URI_PREFIX)) continue;
-    if (graphUri.endsWith('/_meta')) declarationGraphs.add(graphUri);
+    if (!graphUri.endsWith('/_meta')) continue;
+    const id = graphUri.slice(CONTEXT_GRAPH_URI_PREFIX.length, -'/_meta'.length);
+    if (unambiguousMetricContextGraphId(id) === id || knownCandidates.has(id)) {
+      declarationGraphs.add(graphUri);
+    }
   }
   return [...declarationGraphs].sort();
 }
 
-export function buildContextGraphDeclarationsSparql(graphUris: readonly string[]): string | null {
-  const declarationGraphs = declarationGraphUrisFromGraphUris(graphUris);
+export function buildContextGraphDeclarationsSparql(
+  graphUris: readonly string[],
+  knownContextGraphIds?: Iterable<string>,
+): string | null {
+  const declarationGraphs = declarationGraphUrisFromGraphUris(graphUris, knownContextGraphIds);
   if (declarationGraphs.length === 0) return null;
   const values = declarationGraphs.map((graphUri) => sparqlIri(graphUri)).join(' ');
   return `

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -51,6 +51,7 @@ const NON_ROOT_DECLARATION_META_SEGMENTS = [
   '/_verifiable_memory/',
   '/_shared_memory_snapshots/',
   '/assertion/',
+  '/context/',
 ] as const;
 
 /**
@@ -179,11 +180,11 @@ function selectMetricSubscriptionCandidateIds(
       || sub.sharedMemorySynced === true
       || sub.coreHosted === true
     ) {
-      const identity = sub.onChainId
-        ? `chain:${sub.onChainId}`
-          : sub.onChainHash
-            ? `wire:${sub.onChainHash.toLowerCase()}`
-            : `local:${id}`;
+      const identity = sub.onChainHash
+        ? `wire:${sub.onChainHash.toLowerCase()}`
+        : sub.onChainId
+          ? `chain:${sub.onChainId}`
+          : `local:${id}`;
       let idsForIdentity = contextGraphIdsByStableIdentity.get(identity);
       if (!idsForIdentity) {
         idsForIdentity = new Set<string>();

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -78,7 +78,7 @@ function unambiguousMetricContextGraphId(candidate: string): string | null {
   if (!candidate) return null;
   if (SYSTEM_CONTEXT_GRAPH_IDS.has(candidate)) return null;
   if (!candidate.includes('/')) return candidate;
-  return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
+  return null;
 }
 
 function declarationGraphUrisFromGraphUris(

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -15,13 +15,11 @@ export const GET_TOTAL_TRIPLES_SPARQL =
   'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';
 
 const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
-const CONTEXT_GRAPH_LAYER_MARKERS = [
+const CONTEXT_GRAPH_UNAMBIGUOUS_LAYER_MARKERS = [
   '/_shared_memory/',
   '/_shared_memory_snapshots/',
   '/_verifiable_memory/',
   '/_working_memory/',
-  '/assertion/',
-  '/context/',
 ] as const;
 const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
   '/_shared_memory_meta',
@@ -30,7 +28,7 @@ const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
   '/_rules',
   '/_meta',
 ] as const;
-const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+/;
+const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+$/;
 
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
@@ -50,6 +48,12 @@ function normalizeMetricContextGraphCandidates(knownContextGraphIds?: Iterable<s
   return [...new Set(knownContextGraphIds ?? [])]
     .filter(Boolean)
     .sort((a, b) => b.length - a.length);
+}
+
+function unambiguousMetricContextGraphId(candidate: string): string | null {
+  if (!candidate) return null;
+  if (!candidate.includes('/')) return candidate;
+  return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
 }
 
 export function contextGraphIdFromGraphUriForMetrics(
@@ -74,27 +78,20 @@ function contextGraphIdFromGraphUriForMetricsWithCandidates(
     if (rest === knownId || rest.startsWith(`${knownId}/`)) return knownId;
   }
 
-  for (const marker of CONTEXT_GRAPH_LAYER_MARKERS) {
-    const markerIndex = rest.indexOf(marker);
-    if (markerIndex > 0) {
-      rest = rest.slice(0, markerIndex);
-      break;
-    }
-  }
-
   for (const suffix of CONTEXT_GRAPH_RESERVED_SUFFIXES) {
     if (rest.endsWith(suffix)) {
-      rest = rest.slice(0, -suffix.length);
-      if (!rest) return null;
-      break;
+      return unambiguousMetricContextGraphId(rest.slice(0, -suffix.length));
     }
   }
 
-  const walletScoped = rest.match(WALLET_SCOPED_CONTEXT_GRAPH_RE)?.[0];
-  if (walletScoped) return walletScoped;
+  for (const marker of CONTEXT_GRAPH_UNAMBIGUOUS_LAYER_MARKERS) {
+    const markerIndex = rest.indexOf(marker);
+    if (markerIndex > 0) {
+      return unambiguousMetricContextGraphId(rest.slice(0, markerIndex));
+    }
+  }
 
-  const slash = rest.indexOf('/');
-  return slash === -1 ? rest : rest.slice(0, slash);
+  return unambiguousMetricContextGraphId(rest);
 }
 
 export function countContextGraphsFromGraphUris(
@@ -102,7 +99,7 @@ export function countContextGraphsFromGraphUris(
   knownContextGraphIds?: Iterable<string>,
 ): number {
   const knownCandidates = normalizeMetricContextGraphCandidates(knownContextGraphIds);
-  const contextGraphIds = new Set<string>();
+  const contextGraphIds = new Set<string>(knownCandidates);
   for (const graphUri of graphUris) {
     const contextGraphId = contextGraphIdFromGraphUriForMetricsWithCandidates(
       graphUri,

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -1,18 +1,11 @@
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+
 // Canonical SPARQL + result parsing for the daemon's metrics reads.
 //
 // Extracted so cross-package consumers — currently the
 // `bench/store-read-latency` benchmark (regression guard for #939) — can
 // measure the EXACT production read path (both the query AND how its result is
 // parsed) instead of duplicated copies that could silently drift.
-
-/**
- * Total triples across the default graph and all named graphs. Run on the 30s
- * metrics-collector cadence via `getTotalTriples` (see the metrics source in
- * `lifecycle.ts`). It is the heaviest read the collector issues and the one the
- * store-read-latency benchmark tracks.
- */
-export const GET_TOTAL_TRIPLES_SPARQL =
-  'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';
 
 const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
 const CONTEXT_GRAPH_UNAMBIGUOUS_LAYER_MARKERS = [
@@ -29,6 +22,33 @@ const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
   '/_meta',
 ] as const;
 const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+$/;
+
+/**
+ * Total triples across the default graph and all named graphs. Run on the 30s
+ * metrics-collector cadence via `getTotalTriples` (see the metrics source in
+ * `lifecycle.ts`). It is the heaviest read the collector issues and the one the
+ * store-read-latency benchmark tracks.
+ */
+export const GET_TOTAL_TRIPLES_SPARQL =
+  'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';
+
+export const GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL = `
+  SELECT DISTINCT ?ctxGraph WHERE {
+    GRAPH ?g {
+      ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+    }
+    FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_URI_PREFIX}"))
+  }
+`;
+
+type MetricSubscriptionCandidate = {
+  onChainId?: string;
+  pendingMeta?: boolean;
+  synced?: boolean;
+  metaSynced?: boolean;
+  sharedMemorySynced?: boolean;
+  coreHosted?: boolean;
+};
 
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
@@ -54,6 +74,40 @@ function unambiguousMetricContextGraphId(candidate: string): string | null {
   if (!candidate) return null;
   if (!candidate.includes('/')) return candidate;
   return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
+}
+
+export function contextGraphIdsFromDeclarationBindings(
+  bindings: readonly Record<string, string>[] | undefined,
+): string[] {
+  const contextGraphIds = new Set<string>();
+  for (const row of bindings ?? []) {
+    const uri = row.ctxGraph;
+    if (uri?.startsWith(CONTEXT_GRAPH_URI_PREFIX)) {
+      const id = uri.slice(CONTEXT_GRAPH_URI_PREFIX.length);
+      if (id) contextGraphIds.add(id);
+    }
+  }
+  return [...contextGraphIds];
+}
+
+export function contextGraphIdsFromMetricSubscriptionCandidates(
+  subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
+): string[] {
+  const contextGraphIds = new Set<string>();
+  for (const [id, sub] of subscriptions) {
+    if (!id) continue;
+    if (
+      sub.onChainId
+      || sub.pendingMeta === true
+      || sub.synced === true
+      || sub.metaSynced === true
+      || sub.sharedMemorySynced === true
+      || sub.coreHosted === true
+    ) {
+      contextGraphIds.add(id);
+    }
+  }
+  return [...contextGraphIds];
 }
 
 export function contextGraphIdFromGraphUriForMetrics(

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -1,4 +1,4 @@
-import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { DKG_ONTOLOGY, sparqlIri, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 
 // Canonical SPARQL + result parsing for the daemon's metrics reads.
 //
@@ -32,23 +32,17 @@ const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+$/;
 export const GET_TOTAL_TRIPLES_SPARQL =
   'SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }';
 
-export const GET_CONTEXT_GRAPH_DECLARATIONS_SPARQL = `
-  SELECT DISTINCT ?ctxGraph WHERE {
-    GRAPH ?g {
-      ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
-    }
-    FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_URI_PREFIX}"))
-  }
-`;
-
 type MetricSubscriptionCandidate = {
   onChainId?: string;
+  onChainHash?: string;
   pendingMeta?: boolean;
   synced?: boolean;
   metaSynced?: boolean;
   sharedMemorySynced?: boolean;
   coreHosted?: boolean;
 };
+
+const HASH_CONTEXT_GRAPH_ID_RE = /^0x[a-fA-F0-9]{64}$/;
 
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
@@ -76,6 +70,33 @@ function unambiguousMetricContextGraphId(candidate: string): string | null {
   return WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidate) ? candidate : null;
 }
 
+function declarationGraphUrisFromGraphUris(graphUris: readonly string[]): string[] {
+  const declarationGraphs = new Set<string>([
+    `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}`,
+    `${CONTEXT_GRAPH_URI_PREFIX}${SYSTEM_CONTEXT_GRAPHS.AGENTS}`,
+  ]);
+  for (const graphUri of graphUris) {
+    if (!graphUri.startsWith(CONTEXT_GRAPH_URI_PREFIX)) continue;
+    if (graphUri.endsWith('/_meta')) declarationGraphs.add(graphUri);
+  }
+  return [...declarationGraphs].sort();
+}
+
+export function buildContextGraphDeclarationsSparql(graphUris: readonly string[]): string | null {
+  const declarationGraphs = declarationGraphUrisFromGraphUris(graphUris);
+  if (declarationGraphs.length === 0) return null;
+  const values = declarationGraphs.map((graphUri) => sparqlIri(graphUri)).join(' ');
+  return `
+    SELECT DISTINCT ?ctxGraph WHERE {
+      VALUES ?g { ${values} }
+      GRAPH ?g {
+        ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+      }
+      FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_URI_PREFIX}"))
+    }
+  `;
+}
+
 export function contextGraphIdsFromDeclarationBindings(
   bindings: readonly Record<string, string>[] | undefined,
 ): string[] {
@@ -93,7 +114,7 @@ export function contextGraphIdsFromDeclarationBindings(
 export function contextGraphIdsFromMetricSubscriptionCandidates(
   subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
 ): string[] {
-  const contextGraphIds = new Set<string>();
+  const contextGraphIdsByIdentity = new Map<string, string>();
   for (const [id, sub] of subscriptions) {
     if (!id) continue;
     if (
@@ -104,10 +125,25 @@ export function contextGraphIdsFromMetricSubscriptionCandidates(
       || sub.sharedMemorySynced === true
       || sub.coreHosted === true
     ) {
-      contextGraphIds.add(id);
+      const identity = sub.onChainId
+        ? `chain:${sub.onChainId}`
+        : sub.onChainHash
+          ? `wire:${sub.onChainHash.toLowerCase()}`
+          : `local:${id}`;
+      const existingId = contextGraphIdsByIdentity.get(identity);
+      if (!existingId || shouldPreferMetricContextGraphId(id, existingId)) {
+        contextGraphIdsByIdentity.set(identity, id);
+      }
     }
   }
-  return [...contextGraphIds];
+  return [...contextGraphIdsByIdentity.values()];
+}
+
+function shouldPreferMetricContextGraphId(candidateId: string, existingId: string): boolean {
+  const candidateIsHash = HASH_CONTEXT_GRAPH_ID_RE.test(candidateId);
+  const existingIsHash = HASH_CONTEXT_GRAPH_ID_RE.test(existingId);
+  if (candidateIsHash !== existingIsHash) return !candidateIsHash;
+  return candidateId.length < existingId.length;
 }
 
 export function contextGraphIdFromGraphUriForMetrics(

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -265,15 +265,20 @@ function contextGraphIdFromGraphUriForMetricsWithCandidates(
 export function countContextGraphsFromGraphUris(
   graphUris: readonly string[],
   knownContextGraphIds?: Iterable<string>,
+  excludedContextGraphIds?: Iterable<string>,
 ): number {
-  const knownCandidates = normalizeMetricContextGraphCandidates(knownContextGraphIds);
+  const excludedContextGraphIdSet = new Set(excludedContextGraphIds ?? []);
+  const knownCandidates = normalizeMetricContextGraphCandidates(knownContextGraphIds)
+    .filter((contextGraphId) => !excludedContextGraphIdSet.has(contextGraphId));
   const contextGraphIds = new Set<string>(knownCandidates);
   for (const graphUri of graphUris) {
     const contextGraphId = contextGraphIdFromGraphUriForMetricsWithCandidates(
       graphUri,
       knownCandidates,
     );
-    if (contextGraphId) contextGraphIds.add(contextGraphId);
+    if (contextGraphId && !excludedContextGraphIdSet.has(contextGraphId)) {
+      contextGraphIds.add(contextGraphId);
+    }
   }
   return contextGraphIds.size;
 }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -175,6 +175,9 @@ function shouldPreferMetricContextGraphId(candidateId: string, existingId: strin
   const candidateIsHash = HASH_CONTEXT_GRAPH_ID_RE.test(candidateId);
   const existingIsHash = HASH_CONTEXT_GRAPH_ID_RE.test(existingId);
   if (candidateIsHash !== existingIsHash) return !candidateIsHash;
+  const candidateIsWalletScoped = WALLET_SCOPED_CONTEXT_GRAPH_RE.test(candidateId);
+  const existingIsWalletScoped = WALLET_SCOPED_CONTEXT_GRAPH_RE.test(existingId);
+  if (candidateIsWalletScoped !== existingIsWalletScoped) return candidateIsWalletScoped;
   return candidateId.length < existingId.length;
 }
 

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -21,7 +21,7 @@ const CONTEXT_GRAPH_RESERVED_SUFFIXES = [
   '/_rules',
   '/_meta',
 ] as const;
-const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/[^/]+$/;
+const WALLET_SCOPED_CONTEXT_GRAPH_RE = /^0x[a-fA-F0-9]{40}\/.+$/;
 
 /**
  * Total triples across the default graph and all named graphs. Run on the 30s

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -47,6 +47,11 @@ const SYSTEM_CONTEXT_GRAPH_IDS = new Set<string>([
   SYSTEM_CONTEXT_GRAPHS.AGENTS,
   SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
 ]);
+const NON_ROOT_DECLARATION_META_SEGMENTS = [
+  '/_verifiable_memory/',
+  '/_shared_memory_snapshots/',
+  '/assertion/',
+] as const;
 
 /**
  * Parse a SPARQL `COUNT` binding into a number. The value arrives as an RDF
@@ -87,8 +92,12 @@ function declarationGraphUrisFromGraphUris(
   for (const graphUri of graphUris) {
     if (!graphUri.startsWith(CONTEXT_GRAPH_URI_PREFIX)) continue;
     if (!graphUri.endsWith('/_meta')) continue;
-    const id = graphUri.slice(CONTEXT_GRAPH_URI_PREFIX.length, -'/_meta'.length);
-    if (unambiguousMetricContextGraphId(id) === id || knownCandidates.has(id)) {
+    const rest = graphUri.slice(CONTEXT_GRAPH_URI_PREFIX.length);
+    const id = rest.slice(0, -'/_meta'.length);
+    if (
+      knownCandidates.has(id)
+      || !NON_ROOT_DECLARATION_META_SEGMENTS.some((segment) => rest.includes(segment))
+    ) {
       declarationGraphs.add(graphUri);
     }
   }
@@ -181,6 +190,17 @@ function shouldPreferMetricContextGraphId(candidateId: string, existingId: strin
   return candidateId.length < existingId.length;
 }
 
+function canonicalizeMetricContextGraphIds(contextGraphIds: Iterable<string>): string[] {
+  const ids = [...new Set(contextGraphIds)].filter((id) => !SYSTEM_CONTEXT_GRAPH_IDS.has(id));
+  const walletScopedIds = ids.filter((id) => WALLET_SCOPED_CONTEXT_GRAPH_RE.test(id));
+  const shadowAliases = new Set<string>();
+  for (const id of walletScopedIds) {
+    const suffix = id.slice(id.indexOf('/') + 1);
+    if (suffix) shadowAliases.add(suffix);
+  }
+  return ids.filter((id) => !shadowAliases.has(id) || WALLET_SCOPED_CONTEXT_GRAPH_RE.test(id));
+}
+
 export function contextGraphIdFromGraphUriForMetrics(
   graphUri: string,
   knownContextGraphIds?: Iterable<string>,
@@ -232,5 +252,5 @@ export function countContextGraphsFromGraphUris(
     );
     if (contextGraphId) contextGraphIds.add(contextGraphId);
   }
-  return contextGraphIds.size;
+  return canonicalizeMetricContextGraphIds(contextGraphIds).length;
 }

--- a/packages/cli/src/daemon/metrics-queries.ts
+++ b/packages/cli/src/daemon/metrics-queries.ts
@@ -41,6 +41,11 @@ type MetricSubscriptionCandidate = {
   sharedMemorySynced?: boolean;
   coreHosted?: boolean;
 };
+type MetricSubscriptionRecord = {
+  id: string;
+  onChainId?: string;
+  onChainHash?: string;
+};
 
 const HASH_CONTEXT_GRAPH_ID_RE = /^0x[a-fA-F0-9]{64}$/;
 const SYSTEM_CONTEXT_GRAPH_IDS = new Set<string>([
@@ -95,7 +100,7 @@ function declarationGraphUrisFromGraphUris(
     const id = rest.slice(0, -'/_meta'.length);
     if (
       knownCandidates.has(id)
-      || !NON_ROOT_DECLARATION_META_SEGMENTS.some((segment) => rest.includes(segment))
+      && !NON_ROOT_DECLARATION_META_SEGMENTS.some((segment) => rest.includes(segment))
     ) {
       declarationGraphs.add(graphUri);
     }
@@ -172,8 +177,9 @@ export function shadowContextGraphIdsFromMetricSubscriptionCandidates(
 function selectMetricSubscriptionCandidateIds(
   subscriptions: Iterable<readonly [string, MetricSubscriptionCandidate]>,
 ): { selected: string[]; shadows: string[] } {
-  const contextGraphIdsByIdentity = new Map<string, string>();
-  const contextGraphIdsByStableIdentity = new Map<string, Set<string>>();
+  const groupsByIdentity = new Map<string, Set<string>>();
+  const groups: Set<string>[] = [];
+  const recordsById = new Map<string, MetricSubscriptionRecord>();
   for (const [id, sub] of subscriptions) {
     if (!id) continue;
     if (SYSTEM_CONTEXT_GRAPH_IDS.has(id)) continue;
@@ -185,31 +191,112 @@ function selectMetricSubscriptionCandidateIds(
       || sub.sharedMemorySynced === true
       || sub.coreHosted === true
     ) {
-      const identity = sub.onChainHash
-        ? `wire:${sub.onChainHash.toLowerCase()}`
-        : sub.onChainId
-          ? `chain:${sub.onChainId}`
-          : `local:${id}`;
-      let idsForIdentity = contextGraphIdsByStableIdentity.get(identity);
-      if (!idsForIdentity) {
-        idsForIdentity = new Set<string>();
-        contextGraphIdsByStableIdentity.set(identity, idsForIdentity);
-      }
-      idsForIdentity.add(id);
-      const existingId = contextGraphIdsByIdentity.get(identity);
-      if (!existingId || shouldPreferMetricContextGraphId(id, existingId)) {
-        contextGraphIdsByIdentity.set(identity, id);
-      }
+      recordsById.set(id, {
+        id,
+        ...(sub.onChainId ? { onChainId: sub.onChainId } : {}),
+        ...(sub.onChainHash ? { onChainHash: sub.onChainHash.toLowerCase() } : {}),
+      });
+      const identities = metricSubscriptionStableIdentities(id, sub);
+      mergeMetricSubscriptionIdIntoGroup(id, identities, groups, groupsByIdentity);
     }
   }
+  foldChainOnlyAliasesIntoWireGroups(groups, groupsByIdentity, recordsById);
+  const selected: string[] = [];
   const shadows: string[] = [];
-  for (const [identity, ids] of contextGraphIdsByStableIdentity) {
-    const selected = contextGraphIdsByIdentity.get(identity);
+  for (const ids of groups) {
+    const preferred = [...ids].reduce((current, candidate) =>
+      shouldPreferMetricContextGraphId(candidate, current) ? candidate : current,
+    );
+    selected.push(preferred);
     for (const id of ids) {
-      if (id !== selected) shadows.push(id);
+      if (id !== preferred) shadows.push(id);
     }
   }
-  return { selected: [...contextGraphIdsByIdentity.values()], shadows };
+  return { selected, shadows };
+}
+
+function mergeMetricSubscriptionIdIntoGroup(
+  id: string,
+  identities: readonly string[],
+  groups: Set<string>[],
+  groupsByIdentity: Map<string, Set<string>>,
+): Set<string> {
+  const matchingGroups = [...new Set(
+    identities
+      .map((identity) => groupsByIdentity.get(identity))
+      .filter((group): group is Set<string> => Boolean(group)),
+  )];
+  let group = matchingGroups[0];
+  if (!group) {
+    group = new Set<string>();
+    groups.push(group);
+  }
+  for (const otherGroup of matchingGroups.slice(1)) {
+    mergeMetricSubscriptionGroups(group, otherGroup, groups, groupsByIdentity);
+  }
+  group.add(id);
+  for (const identity of identities) groupsByIdentity.set(identity, group);
+  return group;
+}
+
+function mergeMetricSubscriptionGroups(
+  target: Set<string>,
+  source: Set<string>,
+  groups: Set<string>[],
+  groupsByIdentity: Map<string, Set<string>>,
+): void {
+  if (target === source) return;
+  for (const otherId of source) target.add(otherId);
+  const sourceIndex = groups.indexOf(source);
+  if (sourceIndex >= 0) groups.splice(sourceIndex, 1);
+  for (const [identity, group] of groupsByIdentity) {
+    if (group === source) groupsByIdentity.set(identity, target);
+  }
+}
+
+function foldChainOnlyAliasesIntoWireGroups(
+  groups: Set<string>[],
+  groupsByIdentity: Map<string, Set<string>>,
+  recordsById: ReadonlyMap<string, MetricSubscriptionRecord>,
+): void {
+  const wireGroupsByChainId = new Map<string, Set<Set<string>>>();
+  for (const group of groups) {
+    for (const id of group) {
+      const record = recordsById.get(id);
+      if (!record?.onChainId || !record.onChainHash) continue;
+      let chainGroups = wireGroupsByChainId.get(record.onChainId);
+      if (!chainGroups) {
+        chainGroups = new Set<Set<string>>();
+        wireGroupsByChainId.set(record.onChainId, chainGroups);
+      }
+      chainGroups.add(group);
+    }
+  }
+
+  for (const group of [...groups]) {
+    if (![...group].every((id) => !recordsById.get(id)?.onChainHash)) continue;
+    const chainIds = [...new Set(
+      [...group]
+        .map((id) => recordsById.get(id)?.onChainId)
+        .filter((chainId): chainId is string => Boolean(chainId)),
+    )];
+    if (chainIds.length !== 1) continue;
+    const wireGroups = wireGroupsByChainId.get(chainIds[0]);
+    if (wireGroups?.size !== 1) continue;
+    mergeMetricSubscriptionGroups([...wireGroups][0], group, groups, groupsByIdentity);
+  }
+}
+
+function metricSubscriptionStableIdentities(
+  id: string,
+  sub: MetricSubscriptionCandidate,
+): string[] {
+  const identities: string[] = [];
+  if (sub.onChainHash) identities.push(`wire:${sub.onChainHash.toLowerCase()}`);
+  if (!sub.onChainHash && sub.onChainId) identities.push(`chain:${sub.onChainId}`);
+  if (!sub.onChainHash && /^\d+$/.test(id)) identities.push(`chain:${id}`);
+  if (identities.length === 0) identities.push(`local:${id}`);
+  return identities;
 }
 
 function shouldPreferMetricContextGraphId(candidateId: string, existingId: string): boolean {

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -7,6 +7,7 @@ import {
   contextGraphIdFromGraphUriForMetrics,
   countContextGraphsFromGraphUris,
   parseRdfInt,
+  shadowContextGraphIdsFromMetricSubscriptionCandidates,
 } from '../src/daemon/metrics-queries.js';
 
 // Guards the shared COUNT parser the daemon's metric getters depend on. The
@@ -115,12 +116,12 @@ describe('countContextGraphsFromGraphUris', () => {
     ], declared)).toBe(1);
   });
 
-  it('collapses bare shadow aliases when a wallet-scoped canonical id is present', () => {
+  it('does not collapse suffix-matching ids without proven shared identity', () => {
     const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
     expect(countContextGraphsFromGraphUris([
       'did:dkg:context-graph:tuesday-cg/_meta',
       `did:dkg:context-graph:${walletScoped}/_meta`,
-    ], ['tuesday-cg', walletScoped])).toBe(1);
+    ], ['tuesday-cg', walletScoped])).toBe(2);
   });
 
   it('uses exact local root meta graphs to back subscribed slash ids', () => {
@@ -153,6 +154,10 @@ describe('countContextGraphsFromGraphUris', () => {
       ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
       [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
     ])).toEqual(['cleartext-cg', 'wire-only-clear', walletScoped]);
+    expect(shadowContextGraphIdsFromMetricSubscriptionCandidates([
+      ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
+      [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
+    ])).toEqual(['tuesday-cg']);
   });
 
   it('builds declaration queries from known declaration graphs only', () => {

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildContextGraphDeclarationsSparql,
   contextGraphIdsFromDeclarationBindings,
   contextGraphIdsFromMetricSubscriptionCandidates,
   contextGraphIdFromGraphUriForMetrics,
@@ -111,5 +112,31 @@ describe('countContextGraphsFromGraphUris', () => {
       ['local-sync/slash-id', { metaSynced: true }],
       ['core-hosted', { coreHosted: true }],
     ])).toEqual(['chain-backed', 'pending-meta', 'local-sync/slash-id', 'core-hosted']);
+  });
+
+  it('dedupes subscription candidates by stable chain or wire identity', () => {
+    const hashKey = `0x${'a'.repeat(64)}`;
+    const wireOnlyHash = `0x${'b'.repeat(64)}`;
+    expect(contextGraphIdsFromMetricSubscriptionCandidates([
+      [hashKey, { onChainId: '7', onChainHash: hashKey, coreHosted: true }],
+      ['cleartext-cg', { onChainId: '7', onChainHash: hashKey, synced: true }],
+      [wireOnlyHash, { onChainHash: wireOnlyHash, coreHosted: true }],
+      ['wire-only-clear', { onChainHash: wireOnlyHash, synced: true }],
+    ])).toEqual(['cleartext-cg', 'wire-only-clear']);
+  });
+
+  it('builds declaration queries from known declaration graphs only', () => {
+    const query = buildContextGraphDeclarationsSparql([
+      'did:dkg:context-graph:team/context/alpha/_meta',
+      'did:dkg:context-graph:agents/_shared_memory',
+      'did:dkg:context-graph:plain-cg',
+    ]);
+
+    expect(query).toContain('VALUES ?g');
+    expect(query).toContain('<did:dkg:context-graph:team/context/alpha/_meta>');
+    expect(query).toContain('<did:dkg:context-graph:ontology>');
+    expect(query).toContain('<did:dkg:context-graph:agents>');
+    expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');
+    expect(query).not.toContain('<did:dkg:context-graph:agents/_shared_memory>');
   });
 });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -128,14 +128,22 @@ describe('countContextGraphsFromGraphUris', () => {
   it('builds declaration queries from known declaration graphs only', () => {
     const query = buildContextGraphDeclarationsSparql([
       'did:dkg:context-graph:team/context/alpha/_meta',
+      'did:dkg:context-graph:team/context/beta/_meta',
+      'did:dkg:context-graph:plain-cg/code/_meta',
+      'did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta',
       'did:dkg:context-graph:agents/_shared_memory',
       'did:dkg:context-graph:plain-cg',
-    ]);
+      'did:dkg:context-graph:plain-cg/_meta',
+    ], ['team/context/alpha']);
 
     expect(query).toContain('VALUES ?g');
     expect(query).toContain('<did:dkg:context-graph:team/context/alpha/_meta>');
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');
+    expect(query).toContain('<did:dkg:context-graph:plain-cg/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:team/context/beta/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');
     expect(query).not.toContain('<did:dkg:context-graph:agents/_shared_memory>');
   });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -192,7 +192,7 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');
     expect(query).toContain('<did:dkg:context-graph:plain-cg/_meta>');
-    expect(query).not.toContain('<did:dkg:context-graph:team/context/beta/_meta>');
+    expect(query).toContain('<did:dkg:context-graph:team/context/beta/_meta>');
     expect(query).toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -175,6 +175,7 @@ describe('countContextGraphsFromGraphUris', () => {
     ], ['team/context/alpha']);
 
     expect(query).toContain('VALUES ?g');
+    expect(query).toContain('STR(?g) = CONCAT(STR(?ctxGraph), "/_meta")');
     expect(query).toContain('<did:dkg:context-graph:team/context/alpha/_meta>');
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+  contextGraphIdsFromDeclarationBindings,
+  contextGraphIdsFromMetricSubscriptionCandidates,
   contextGraphIdFromGraphUriForMetrics,
   countContextGraphsFromGraphUris,
   parseRdfInt,
@@ -85,5 +87,29 @@ describe('countContextGraphsFromGraphUris', () => {
       'did:dkg:context-graph:agents/_meta',
       'did:dkg:context-graph:agents/_shared_memory',
     ], ['agents', 'joined-before-first-sync'])).toBe(2);
+  });
+
+  it('uses declaration metadata to count backed slash-bearing context graphs', () => {
+    const declared = contextGraphIdsFromDeclarationBindings([
+      { ctxGraph: 'did:dkg:context-graph:team/context/alpha' },
+      { ctxGraph: 'did:dkg:context-graph:agents' },
+      { ctxGraph: 'urn:not-a-context-graph' },
+    ]);
+
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:team/context/alpha/_meta',
+      'did:dkg:context-graph:team/context/alpha/_private',
+      'did:dkg:context-graph:agents/_shared_memory',
+    ], declared)).toBe(2);
+  });
+
+  it('excludes phantom subscription keys from metric candidates', () => {
+    expect(contextGraphIdsFromMetricSubscriptionCandidates([
+      ['phantom', { synced: false }],
+      ['chain-backed', { onChainId: '42' }],
+      ['pending-meta', { pendingMeta: true }],
+      ['local-sync/slash-id', { metaSynced: true }],
+      ['core-hosted', { coreHosted: true }],
+    ])).toEqual(['chain-backed', 'pending-meta', 'local-sync/slash-id', 'core-hosted']);
   });
 });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -120,6 +120,14 @@ describe('countContextGraphsFromGraphUris', () => {
     ], declared)).toBe(1);
   });
 
+  it('includes private context graphs when they are backed by known local state', () => {
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:curated-private/_meta',
+      'did:dkg:context-graph:curated-private/_private',
+      'did:dkg:context-graph:curated-private/_shared_memory',
+    ], ['curated-private'])).toBe(1);
+  });
+
   it('does not collapse suffix-matching ids without proven shared identity', () => {
     const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
     expect(countContextGraphsFromGraphUris([
@@ -159,6 +167,7 @@ describe('countContextGraphsFromGraphUris', () => {
     const wireOnlyHash = `0x${'b'.repeat(64)}`;
     const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
     const reusedSlotHash = `0x${'d'.repeat(64)}`;
+    const sharedIdentityHash = `0x${'f'.repeat(64)}`;
     expect(contextGraphIdsFromMetricSubscriptionCandidates([
       [hashKey, { onChainId: '7', onChainHash: hashKey, coreHosted: true }],
       ['cleartext-cg', { onChainId: '7', onChainHash: hashKey, synced: true }],
@@ -168,11 +177,34 @@ describe('countContextGraphsFromGraphUris', () => {
       [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
       ['reused-slot-old', { onChainId: '11', onChainHash: reusedSlotHash, synced: true }],
       ['reused-slot-new', { onChainId: '11', onChainHash: `0x${'e'.repeat(64)}`, synced: true }],
-    ])).toEqual(['cleartext-cg', 'wire-only-clear', walletScoped, 'reused-slot-old', 'reused-slot-new']);
+      ['13', { onChainId: '13', synced: true }],
+      ['bare-wallet-cg', { onChainId: '13', onChainHash: sharedIdentityHash, synced: true }],
+      ['0xE5B8896800000000000000000000000000000000/bare-wallet-cg', {
+        onChainId: '13',
+        onChainHash: sharedIdentityHash,
+        synced: true,
+      }],
+    ])).toEqual([
+      'cleartext-cg',
+      'wire-only-clear',
+      walletScoped,
+      'reused-slot-old',
+      'reused-slot-new',
+      '0xE5B8896800000000000000000000000000000000/bare-wallet-cg',
+    ]);
     expect(shadowContextGraphIdsFromMetricSubscriptionCandidates([
       ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
       [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
     ])).toEqual(['tuesday-cg']);
+    expect(shadowContextGraphIdsFromMetricSubscriptionCandidates([
+      ['13', { onChainId: '13', synced: true }],
+      ['bare-wallet-cg', { onChainId: '13', onChainHash: sharedIdentityHash, synced: true }],
+      ['0xE5B8896800000000000000000000000000000000/bare-wallet-cg', {
+        onChainId: '13',
+        onChainHash: sharedIdentityHash,
+        synced: true,
+      }],
+    ])).toEqual(['bare-wallet-cg', '13']);
   });
 
   it('builds declaration queries from known declaration graphs only', () => {
@@ -191,11 +223,23 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(query).toContain('<did:dkg:context-graph:team/context/alpha/_meta>');
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');
-    expect(query).toContain('<did:dkg:context-graph:plain-cg/_meta>');
-    expect(query).toContain('<did:dkg:context-graph:team/context/beta/_meta>');
-    expect(query).toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:team/context/beta/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');
     expect(query).not.toContain('<did:dkg:context-graph:agents/_shared_memory>');
+  });
+
+  it('does not add foreign curated metadata graphs to the declaration query', () => {
+    const query = buildContextGraphDeclarationsSparql([
+      'did:dkg:context-graph:joined/slash-cg/_meta',
+      'did:dkg:context-graph:foreign/slash-cg/_meta',
+      'did:dkg:context-graph:foreign-plain/_meta',
+    ], ['joined/slash-cg']);
+
+    expect(query).toContain('<did:dkg:context-graph:joined/slash-cg/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:foreign/slash-cg/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:foreign-plain/_meta>');
   });
 });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildContextGraphDeclarationsSparql,
   contextGraphIdsFromDeclarationBindings,
+  contextGraphIdsFromLocalRootMetaGraphs,
   contextGraphIdsFromMetricSubscriptionCandidates,
   contextGraphIdFromGraphUriForMetrics,
   countContextGraphsFromGraphUris,
@@ -23,15 +24,15 @@ describe('parseRdfInt', () => {
 describe('countContextGraphsFromGraphUris', () => {
   it('counts bare context graphs once across reserved layer graphs', () => {
     expect(countContextGraphsFromGraphUris([
-      'did:dkg:context-graph:agents',
-      'did:dkg:context-graph:agents/_meta',
-      'did:dkg:context-graph:agents/_private',
-      'did:dkg:context-graph:agents/_shared_memory',
-      'did:dkg:context-graph:agents/_shared_memory_meta',
-      'did:dkg:context-graph:agents/_verifiable_memory/1',
-      'did:dkg:context-graph:agents/context/1/_meta',
-      'did:dkg:context-graph:agents/code',
-      'did:dkg:context-graph:agents/code/_shared_memory',
+      'did:dkg:context-graph:project',
+      'did:dkg:context-graph:project/_meta',
+      'did:dkg:context-graph:project/_private',
+      'did:dkg:context-graph:project/_shared_memory',
+      'did:dkg:context-graph:project/_shared_memory_meta',
+      'did:dkg:context-graph:project/_verifiable_memory/1',
+      'did:dkg:context-graph:project/context/1/_meta',
+      'did:dkg:context-graph:project/code',
+      'did:dkg:context-graph:project/code/_shared_memory',
     ])).toBe(1);
   });
 
@@ -39,7 +40,7 @@ describe('countContextGraphsFromGraphUris', () => {
     const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
     const nestedSlashId = `${walletScoped}/phase-two`;
     const reservedSegmentId = 'team/context/alpha';
-    const knownContextGraphs = [walletScoped, nestedSlashId, reservedSegmentId, 'agents'];
+    const knownContextGraphs = [walletScoped, nestedSlashId, reservedSegmentId, 'project'];
 
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${walletScoped}/_meta`,
@@ -76,18 +77,28 @@ describe('countContextGraphsFromGraphUris', () => {
       `did:dkg:context-graph:${nestedSlashId}/_meta`,
       `did:dkg:context-graph:${reservedSegmentId}`,
       `did:dkg:context-graph:${reservedSegmentId}/_meta`,
-      'did:dkg:context-graph:agents/code',
-      'did:dkg:context-graph:agents/code/_shared_memory',
-      'did:dkg:context-graph:agents',
+      'did:dkg:context-graph:project/code',
+      'did:dkg:context-graph:project/code/_shared_memory',
+      'did:dkg:context-graph:project',
       'urn:not-a-context-graph',
     ], knownContextGraphs)).toBe(4);
   });
 
   it('counts known context graphs that do not have a local graph yet', () => {
     expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:project/_meta',
+      'did:dkg:context-graph:project/_shared_memory',
+    ], ['project', 'joined-before-first-sync'])).toBe(2);
+  });
+
+  it('does not count system context graphs as user context graphs', () => {
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:agents',
       'did:dkg:context-graph:agents/_meta',
-      'did:dkg:context-graph:agents/_shared_memory',
-    ], ['agents', 'joined-before-first-sync'])).toBe(2);
+      'did:dkg:context-graph:ontology',
+      'did:dkg:context-graph:ontology/_meta',
+      'did:dkg:context-graph:project/_meta',
+    ], ['agents', 'ontology', 'project'])).toBe(1);
   });
 
   it('uses declaration metadata to count backed slash-bearing context graphs', () => {
@@ -101,7 +112,15 @@ describe('countContextGraphsFromGraphUris', () => {
       'did:dkg:context-graph:team/context/alpha/_meta',
       'did:dkg:context-graph:team/context/alpha/_private',
       'did:dkg:context-graph:agents/_shared_memory',
-    ], declared)).toBe(2);
+    ], declared)).toBe(1);
+  });
+
+  it('uses exact local root meta graphs to back subscribed slash ids', () => {
+    expect(contextGraphIdsFromLocalRootMetaGraphs([
+      'did:dkg:context-graph:team/context/alpha/_meta',
+      'did:dkg:context-graph:team/context/beta/_meta',
+      'did:dkg:context-graph:project/code/_meta',
+    ], ['team/context/alpha', 'missing/slash', 'agents'])).toEqual(['team/context/alpha']);
   });
 
   it('excludes phantom subscription keys from metric candidates', () => {

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -115,6 +115,14 @@ describe('countContextGraphsFromGraphUris', () => {
     ], declared)).toBe(1);
   });
 
+  it('collapses bare shadow aliases when a wallet-scoped canonical id is present', () => {
+    const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:tuesday-cg/_meta',
+      `did:dkg:context-graph:${walletScoped}/_meta`,
+    ], ['tuesday-cg', walletScoped])).toBe(1);
+  });
+
   it('uses exact local root meta graphs to back subscribed slash ids', () => {
     expect(contextGraphIdsFromLocalRootMetaGraphs([
       'did:dkg:context-graph:team/context/alpha/_meta',
@@ -163,8 +171,8 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');
     expect(query).toContain('<did:dkg:context-graph:plain-cg/_meta>');
-    expect(query).not.toContain('<did:dkg:context-graph:team/context/beta/_meta>');
-    expect(query).not.toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
+    expect(query).toContain('<did:dkg:context-graph:team/context/beta/_meta>');
+    expect(query).toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');
     expect(query).not.toContain('<did:dkg:context-graph:agents/_shared_memory>');

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -124,6 +124,14 @@ describe('countContextGraphsFromGraphUris', () => {
     ], ['tuesday-cg', walletScoped])).toBe(2);
   });
 
+  it('skips graph-derived ids that are proven subscription shadows', () => {
+    const hashKey = `0x${'a'.repeat(64)}`;
+    expect(countContextGraphsFromGraphUris([
+      `did:dkg:context-graph:${hashKey}/_meta`,
+      'did:dkg:context-graph:cleartext-cg/_meta',
+    ], ['cleartext-cg'], [hashKey])).toBe(1);
+  });
+
   it('uses exact local root meta graphs to back subscribed slash ids', () => {
     expect(contextGraphIdsFromLocalRootMetaGraphs([
       'did:dkg:context-graph:team/context/alpha/_meta',

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -136,12 +136,15 @@ describe('countContextGraphsFromGraphUris', () => {
   it('dedupes subscription candidates by stable chain or wire identity', () => {
     const hashKey = `0x${'a'.repeat(64)}`;
     const wireOnlyHash = `0x${'b'.repeat(64)}`;
+    const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
     expect(contextGraphIdsFromMetricSubscriptionCandidates([
       [hashKey, { onChainId: '7', onChainHash: hashKey, coreHosted: true }],
       ['cleartext-cg', { onChainId: '7', onChainHash: hashKey, synced: true }],
       [wireOnlyHash, { onChainHash: wireOnlyHash, coreHosted: true }],
       ['wire-only-clear', { onChainHash: wireOnlyHash, synced: true }],
-    ])).toEqual(['cleartext-cg', 'wire-only-clear']);
+      ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
+      [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
+    ])).toEqual(['cleartext-cg', 'wire-only-clear', walletScoped]);
   });
 
   it('builds declaration queries from known declaration graphs only', () => {

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -61,7 +61,7 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${nestedSlashId}/_meta`,
     ))
-      .toBe(nestedSlashId);
+      .toBeNull();
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${reservedSegmentId}/_meta`,
     ))
@@ -69,7 +69,11 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${walletScoped}/_meta`,
     ))
-      .toBe(walletScoped);
+      .toBeNull();
+    expect(countContextGraphsFromGraphUris([
+      `did:dkg:context-graph:${walletScoped}/_meta`,
+      `did:dkg:context-graph:${walletScoped}/child/_meta`,
+    ], [walletScoped])).toBe(1);
     expect(countContextGraphsFromGraphUris([
       `did:dkg:context-graph:${walletScoped}`,
       `did:dkg:context-graph:${walletScoped}/_meta`,

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -53,6 +53,18 @@ describe('countContextGraphsFromGraphUris', () => {
       knownContextGraphs,
     ))
       .toBe(reservedSegmentId);
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${nestedSlashId}/_meta`,
+    ))
+      .toBeNull();
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${reservedSegmentId}/_meta`,
+    ))
+      .toBeNull();
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${walletScoped}/_meta`,
+    ))
+      .toBe(walletScoped);
     expect(countContextGraphsFromGraphUris([
       `did:dkg:context-graph:${walletScoped}`,
       `did:dkg:context-graph:${walletScoped}/_meta`,
@@ -66,5 +78,12 @@ describe('countContextGraphsFromGraphUris', () => {
       'did:dkg:context-graph:agents',
       'urn:not-a-context-graph',
     ], knownContextGraphs)).toBe(4);
+  });
+
+  it('counts known context graphs that do not have a local graph yet', () => {
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:agents/_meta',
+      'did:dkg:context-graph:agents/_shared_memory',
+    ], ['agents', 'joined-before-first-sync'])).toBe(2);
   });
 });

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -146,6 +146,7 @@ describe('countContextGraphsFromGraphUris', () => {
     const hashKey = `0x${'a'.repeat(64)}`;
     const wireOnlyHash = `0x${'b'.repeat(64)}`;
     const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
+    const reusedSlotHash = `0x${'d'.repeat(64)}`;
     expect(contextGraphIdsFromMetricSubscriptionCandidates([
       [hashKey, { onChainId: '7', onChainHash: hashKey, coreHosted: true }],
       ['cleartext-cg', { onChainId: '7', onChainHash: hashKey, synced: true }],
@@ -153,7 +154,9 @@ describe('countContextGraphsFromGraphUris', () => {
       ['wire-only-clear', { onChainHash: wireOnlyHash, synced: true }],
       ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
       [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
-    ])).toEqual(['cleartext-cg', 'wire-only-clear', walletScoped]);
+      ['reused-slot-old', { onChainId: '11', onChainHash: reusedSlotHash, synced: true }],
+      ['reused-slot-new', { onChainId: '11', onChainHash: `0x${'e'.repeat(64)}`, synced: true }],
+    ])).toEqual(['cleartext-cg', 'wire-only-clear', walletScoped, 'reused-slot-old', 'reused-slot-new']);
     expect(shadowContextGraphIdsFromMetricSubscriptionCandidates([
       ['tuesday-cg', { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
       [walletScoped, { onChainId: '9', onChainHash: `0x${'c'.repeat(64)}`, synced: true }],
@@ -176,7 +179,7 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(query).toContain('<did:dkg:context-graph:ontology>');
     expect(query).toContain('<did:dkg:context-graph:agents>');
     expect(query).toContain('<did:dkg:context-graph:plain-cg/_meta>');
-    expect(query).toContain('<did:dkg:context-graph:team/context/beta/_meta>');
+    expect(query).not.toContain('<did:dkg:context-graph:team/context/beta/_meta>');
     expect(query).toContain('<did:dkg:context-graph:plain-cg/code/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg/_verifiable_memory/1/_meta>');
     expect(query).not.toContain('<did:dkg:context-graph:plain-cg>');

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -59,7 +59,7 @@ describe('countContextGraphsFromGraphUris', () => {
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${nestedSlashId}/_meta`,
     ))
-      .toBeNull();
+      .toBe(nestedSlashId);
     expect(contextGraphIdFromGraphUriForMetrics(
       `did:dkg:context-graph:${reservedSegmentId}/_meta`,
     ))

--- a/packages/cli/test/metrics-queries.test.ts
+++ b/packages/cli/test/metrics-queries.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseRdfInt } from '../src/daemon/metrics-queries.js';
+import {
+  contextGraphIdFromGraphUriForMetrics,
+  countContextGraphsFromGraphUris,
+  parseRdfInt,
+} from '../src/daemon/metrics-queries.js';
 
 // Guards the shared COUNT parser the daemon's metric getters depend on. The
 // getters themselves are intentionally uncached (metricsSource is consumed only
@@ -10,5 +14,57 @@ describe('parseRdfInt', () => {
     expect(parseRdfInt('42')).toBe(42);
     expect(parseRdfInt(undefined)).toBe(0);
     expect(parseRdfInt('not-a-number')).toBe(0);
+  });
+});
+
+describe('countContextGraphsFromGraphUris', () => {
+  it('counts bare context graphs once across reserved layer graphs', () => {
+    expect(countContextGraphsFromGraphUris([
+      'did:dkg:context-graph:agents',
+      'did:dkg:context-graph:agents/_meta',
+      'did:dkg:context-graph:agents/_private',
+      'did:dkg:context-graph:agents/_shared_memory',
+      'did:dkg:context-graph:agents/_shared_memory_meta',
+      'did:dkg:context-graph:agents/_verifiable_memory/1',
+      'did:dkg:context-graph:agents/context/1/_meta',
+      'did:dkg:context-graph:agents/code',
+      'did:dkg:context-graph:agents/code/_shared_memory',
+    ])).toBe(1);
+  });
+
+  it('keeps known slash-bearing context graph ids without counting subgraphs', () => {
+    const walletScoped = '0xE5B8896800000000000000000000000000000000/tuesday-cg';
+    const nestedSlashId = `${walletScoped}/phase-two`;
+    const reservedSegmentId = 'team/context/alpha';
+    const knownContextGraphs = [walletScoped, nestedSlashId, reservedSegmentId, 'agents'];
+
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${walletScoped}/_meta`,
+      knownContextGraphs,
+    ))
+      .toBe(walletScoped);
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${nestedSlashId}/_meta`,
+      knownContextGraphs,
+    ))
+      .toBe(nestedSlashId);
+    expect(contextGraphIdFromGraphUriForMetrics(
+      `did:dkg:context-graph:${reservedSegmentId}/_meta`,
+      knownContextGraphs,
+    ))
+      .toBe(reservedSegmentId);
+    expect(countContextGraphsFromGraphUris([
+      `did:dkg:context-graph:${walletScoped}`,
+      `did:dkg:context-graph:${walletScoped}/_meta`,
+      `did:dkg:context-graph:${walletScoped}/assertion/0x0000000000000000000000000000000000000001/draft`,
+      `did:dkg:context-graph:${nestedSlashId}`,
+      `did:dkg:context-graph:${nestedSlashId}/_meta`,
+      `did:dkg:context-graph:${reservedSegmentId}`,
+      `did:dkg:context-graph:${reservedSegmentId}/_meta`,
+      'did:dkg:context-graph:agents/code',
+      'did:dkg:context-graph:agents/code/_shared_memory',
+      'did:dkg:context-graph:agents',
+      'urn:not-a-context-graph',
+    ], knownContextGraphs)).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary

- Re-points `getContextGraphCount` off the full `agent.listContextGraphs()` composite (which ran every 30 s on every node role, also via `GET /api/metrics`) onto one cheap count source that keeps wallet-scoped (`<addr>/<slug>`) ids — not `GraphManager.listContextGraphs().length` (drops slashed ids) and not the boot-capped `subscribedContextGraphs.size`.
- States the accepted delta vs today (private CGs now counted; the metric is a never-rendered diagnostic gauge).

## Related

- Part of #1138 (Track B, PR B0). Do-first, ~half-day, isolated.
- **Merge order:** Wave 1 (parallel with A-track; shares only `cli/daemon/lifecycle.ts`).

## Files changed

| File | What |
|------|------|
| `cli/src/daemon/metrics-queries.ts` | New cheap context-graph count |
| `cli/src/daemon/lifecycle.ts` | `getContextGraphCount` re-pointed |

Plus 1 test file.

## Test plan

- [ ] `pnpm -F @origintrail-official/dkg-cli test`
- [ ] Count includes wallet-scoped CGs; no full composite fan-out on the 30 s tick
- [ ] `pnpm build` + lint

---
*Targets `integration/issue-1138` (not `main`) so the heavy overlaps on `dkg-agent-lifecycle.ts` / `dkg-agent-base.ts` are resolved once on the integration branch, which is promoted to `main` in two gated waves (see #1138, Coordination). Single squashed commit off `main`.*