### PR TITLE
B2 — bounded CG-registry chain scan (deploy-anchor + breaker)

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -945,6 +945,8 @@ export interface DKGAgentConfig {
      * (`'per-publish'`, bounded-per-publish with on-chain 1n floor).
      */
     approvalPolicy?: ApprovalPolicy;
+    /** Optional ContextGraphNameRegistry `eth_getLogs` block-window tuning. */
+    cgRegistryScanPageSize?: number;
   };
   /** Cross-agent query access configuration. */
   queryAccess?: QueryAccessConfig;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1020,6 +1020,10 @@ export class DKGAgent extends DKGAgentBase {
     return discovered;
   }
 
+  async hasContextGraphRegistryScanWatermark(): Promise<boolean> {
+    return await this.chain.hasContextGraphRegistryScanWatermark?.() ?? false;
+  }
+
   /**
    * Query the on-chain registry for all registered context graphs and
    * auto-subscribe to any not yet in the subscription registry.
@@ -1060,8 +1064,9 @@ export class DKGAgent extends DKGAgentBase {
       } else {
         this.chainContextGraphScanFailure.count += 1;
       }
-      if (options.throwOnChainScanFailure) throw err;
-      if (!isContextGraphChainScanPartialError(err)) return 0;
+      const partialError = isContextGraphChainScanPartialError(err);
+      if (options.throwOnChainScanFailure && !partialError) throw err;
+      if (!partialError) return 0;
       partialChainScan = true;
       onChainContextGraphs = err.partialResults;
     }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1044,6 +1044,7 @@ export class DKGAgent extends DKGAgentBase {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const signature = message
+        .replace(/stopped after block \d+/g, 'stopped after block N')
         .replace(/\[\d+,\s*\d+\]/g, '[range]')
         .replace(/\b\d+\s+eth_getLogs calls/g, 'N eth_getLogs calls');
       if (this.chainContextGraphScanFailure?.signature !== signature) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -85,7 +85,7 @@ import {
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -443,6 +443,17 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
   kaNumber?: string;
   /** did:dkg:<chainId>/<agentAddrLower>/<number> reserved at finalize. */
   reservedUal?: string;
+}
+
+function isContextGraphChainScanPartialError(
+  err: unknown,
+): err is Error & { partialResults: ContextGraphOnChain[] } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { name?: unknown }).name === 'ContextGraphChainScanPartialError' &&
+    Array.isArray((err as { partialResults?: unknown }).partialResults)
+  );
 }
 
 /**
@@ -1027,6 +1038,7 @@ export class DKGAgent extends DKGAgentBase {
     }
 
     let onChainContextGraphs;
+    let partialChainScan = false;
     try {
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, { incremental: true });
     } catch (err) {
@@ -1040,9 +1052,11 @@ export class DKGAgent extends DKGAgentBase {
       } else {
         this.chainContextGraphScanFailure.count += 1;
       }
-      return 0;
+      if (!isContextGraphChainScanPartialError(err)) return 0;
+      partialChainScan = true;
+      onChainContextGraphs = err.partialResults;
     }
-    if (this.chainContextGraphScanFailure) {
+    if (!partialChainScan && this.chainContextGraphScanFailure) {
       this.log.info(
         ctx,
         `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -85,7 +85,7 @@ import {
   ENTITY_PRED_ALT,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -443,17 +443,6 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
   kaNumber?: string;
   /** did:dkg:<chainId>/<agentAddrLower>/<number> reserved at finalize. */
   reservedUal?: string;
-}
-
-function isContextGraphChainScanPartialError(
-  err: unknown,
-): err is Error & { partialResults: ContextGraphOnChain[] } {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    (err as { name?: unknown }).name === 'ContextGraphChainScanPartialError' &&
-    Array.isArray((err as { partialResults?: unknown }).partialResults)
-  );
 }
 
 export interface DiscoverContextGraphsFromChainOptions {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -457,6 +457,9 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
  *   await agent.stop();
  */
 export class DKGAgent extends DKGAgentBase {
+  private chainContextGraphScanFailure:
+    | { signature: string; count: number }
+    | undefined;
 
   static async create(config: DKGAgentConfig): Promise<DKGAgent> {
     let wallet: DKGAgentWallet;
@@ -510,6 +513,7 @@ export class DKGAgent extends DKGAgentBase {
         tokenAddress: config.chainConfig.tokenAddress,
         chainId: config.chainConfig.chainId,
         approvalPolicy: config.chainConfig.approvalPolicy,
+        cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
       };
       if (config.chainConfig.adminPrivateKey) {
         chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
@@ -1024,10 +1028,26 @@ export class DKGAgent extends DKGAgentBase {
 
     let onChainContextGraphs;
     try {
-      onChainContextGraphs = await this.chain.listContextGraphsFromChain();
+      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, { incremental: true });
     } catch (err) {
-      this.log.warn(ctx, `Chain context graph scan failed: ${err instanceof Error ? err.message : String(err)}`);
+      const message = err instanceof Error ? err.message : String(err);
+      const signature = message
+        .replace(/\[\d+,\s*\d+\]/g, '[range]')
+        .replace(/\b\d+\s+eth_getLogs calls/g, 'N eth_getLogs calls');
+      if (this.chainContextGraphScanFailure?.signature !== signature) {
+        this.log.warn(ctx, `Chain context graph scan failed: ${message}`);
+        this.chainContextGraphScanFailure = { signature, count: 1 };
+      } else {
+        this.chainContextGraphScanFailure.count += 1;
+      }
       return 0;
+    }
+    if (this.chainContextGraphScanFailure) {
+      this.log.info(
+        ctx,
+        `Chain context graph scan recovered after ${this.chainContextGraphScanFailure.count} failed attempt(s)`,
+      );
+      this.chainContextGraphScanFailure = undefined;
     }
 
     // Build a set of all known on-chain IDs (stored and computed) for fast dedup

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -448,6 +448,7 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
+  throwOnChainScanFailure?: boolean;
 }
 
 /**
@@ -1059,6 +1060,7 @@ export class DKGAgent extends DKGAgentBase {
       } else {
         this.chainContextGraphScanFailure.count += 1;
       }
+      if (options.throwOnChainScanFailure) throw err;
       if (!isContextGraphChainScanPartialError(err)) return 0;
       partialChainScan = true;
       onChainContextGraphs = err.partialResults;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1045,6 +1045,7 @@ export class DKGAgent extends DKGAgentBase {
 
     let onChainContextGraphs;
     let partialChainScan = false;
+    let partialChainScanError: unknown;
     try {
       const scanOptions = options.incremental
         ? { incremental: true }
@@ -1068,6 +1069,7 @@ export class DKGAgent extends DKGAgentBase {
       if (options.throwOnChainScanFailure && !partialError) throw err;
       if (!partialError) return 0;
       partialChainScan = true;
+      partialChainScanError = err;
       onChainContextGraphs = err.partialResults;
     }
     if (!partialChainScan && this.chainContextGraphScanFailure) {
@@ -1142,6 +1144,7 @@ export class DKGAgent extends DKGAgentBase {
     if (discovered > 0) {
       this.log.info(ctx, `Discovered ${discovered} new context graph(s) from chain`);
     }
+    if (options.throwOnChainScanFailure && partialChainScanError) throw partialChainScanError;
     return discovered;
   }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -447,6 +447,7 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 
 export interface DiscoverContextGraphsFromChainOptions {
   incremental?: boolean;
+  seedIncrementalWatermark?: boolean;
 }
 
 /**
@@ -1040,7 +1041,11 @@ export class DKGAgent extends DKGAgentBase {
     let onChainContextGraphs;
     let partialChainScan = false;
     try {
-      const scanOptions = options.incremental ? { incremental: true } : undefined;
+      const scanOptions = options.incremental
+        ? { incremental: true }
+        : options.seedIncrementalWatermark
+          ? { seedIncrementalWatermark: true }
+          : undefined;
       onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -456,6 +456,10 @@ function isContextGraphChainScanPartialError(
   );
 }
 
+export interface DiscoverContextGraphsFromChainOptions {
+  incremental?: boolean;
+}
+
 /**
  * High-level facade that ties together all DKG agent capabilities:
  * identity, networking, publishing, querying, discovery, and messaging.
@@ -1028,9 +1032,16 @@ export class DKGAgent extends DKGAgentBase {
   /**
    * Query the on-chain registry for all registered context graphs and
    * auto-subscribe to any not yet in the subscription registry.
+   *
+   * Defaults to a full scan so SDK callers can rebuild missing local state.
+   * Background daemon loops may opt into incremental scans to reuse the
+   * in-memory chain adapter watermark.
+   *
    * Returns the number of newly discovered context graphs.
    */
-  async discoverContextGraphsFromChain(): Promise<number> {
+  async discoverContextGraphsFromChain(
+    options: DiscoverContextGraphsFromChainOptions = {},
+  ): Promise<number> {
     const ctx = createOperationContext('system');
     if (!this.chain.listContextGraphsFromChain) {
       this.log.info(ctx, 'Chain adapter does not support listContextGraphsFromChain — skipping');
@@ -1040,7 +1051,8 @@ export class DKGAgent extends DKGAgentBase {
     let onChainContextGraphs;
     let partialChainScan = false;
     try {
-      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, { incremental: true });
+      const scanOptions = options.incremental ? { incremental: true } : undefined;
+      onChainContextGraphs = await this.chain.listContextGraphsFromChain(undefined, scanOptions);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const signature = message

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -809,10 +809,10 @@ describe('discoverContextGraphsFromChain', () => {
       agent = result.agent;
       await agent.start();
 
-      expect(await agent.discoverContextGraphsFromChain({
+      await expect(agent.discoverContextGraphsFromChain({
         incremental: true,
         throwOnChainScanFailure: true,
-      })).toBe(1);
+      })).rejects.toThrow('partial ContextGraphNameRegistry scan');
       expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     } finally {
       Logger.setSink(null);

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
+import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
@@ -697,6 +697,37 @@ describe('discoverContextGraphsFromChain', () => {
 
     const discovered = await agent.discoverContextGraphsFromChain();
     expect(discovered).toBe(0);
+  }, 15000);
+
+  it('warns once for repeated chain scan failures and logs recovery', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    let fail = true;
+    (chain as any).listContextGraphsFromChain = async () => {
+      if (fail) throw new Error('range too wide [0, 1999]');
+      return [];
+    };
+    const entries: Array<{ level: string; message: string }> = [];
+    Logger.setSink((entry) => entries.push({ level: entry.level, message: entry.message }));
+    try {
+      const result = await createTestAgent({ chainAdapter: chain });
+      agent = result.agent;
+      await agent.start();
+
+      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+      fail = false;
+      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+    } finally {
+      Logger.setSink(null);
+    }
+
+    const warnings = entries.filter((entry) =>
+      entry.level === 'warn' && entry.message.includes('Chain context graph scan failed'),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(entries.some((entry) =>
+      entry.level === 'info' && entry.message.includes('Chain context graph scan recovered after 2 failed attempt(s)'),
+    )).toBe(true);
   }, 15000);
 });
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -699,6 +699,24 @@ describe('discoverContextGraphsFromChain', () => {
     expect(discovered).toBe(0);
   }, 15000);
 
+  it('keeps full chain discovery as the default and makes incremental opt-in', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const calls: unknown[] = [];
+    (chain as any).listContextGraphsFromChain = async (_fromBlock?: number, options?: unknown) => {
+      calls.push(options);
+      return [];
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+
+    expect(calls).toEqual([undefined, { incremental: true }]);
+  }, 15000);
+
   it('warns once for repeated chain scan failures and logs recovery', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     let fail = true;
@@ -770,8 +788,8 @@ describe('discoverContextGraphsFromChain', () => {
       agent = result.agent;
       await agent.start();
 
-      expect(await agent.discoverContextGraphsFromChain()).toBe(1);
-      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+      expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(1);
+      expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     } finally {
       Logger.setSink(null);
     }

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -732,9 +732,15 @@ describe('discoverContextGraphsFromChain', () => {
 
   it('processes partial chain scan prefixes without marking the scan recovered', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    let calls = 0;
     (chain as any).listContextGraphsFromChain = async () => {
+      calls += 1;
+      const stopped = calls === 1 ? 1_999 : 3_999;
+      const failedFrom = calls === 1 ? 2_000 : 4_000;
+      const failedTo = calls === 1 ? 3_999 : 5_999;
       const err = new Error(
-        'partial ContextGraphNameRegistry scan stopped after block 1999; failed page [2000, 3999]: range too wide',
+        `partial ContextGraphNameRegistry scan stopped after block ${stopped}; ` +
+          `failed page [${failedFrom}, ${failedTo}]: range too wide`,
       ) as Error & {
         partialResults: ContextGraphOnChain[];
         scannedToBlock: number;
@@ -752,9 +758,9 @@ describe('discoverContextGraphsFromChain', () => {
           metadataRevealed: true,
         },
       ];
-      err.scannedToBlock = 1_999;
-      err.failedFromBlock = 2_000;
-      err.failedToBlock = 3_999;
+      err.scannedToBlock = stopped;
+      err.failedFromBlock = failedFrom;
+      err.failedToBlock = failedTo;
       throw err;
     };
     const entries: Array<{ level: string; message: string }> = [];
@@ -765,6 +771,7 @@ describe('discoverContextGraphsFromChain', () => {
       await agent.start();
 
       expect(await agent.discoverContextGraphsFromChain()).toBe(1);
+      expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     } finally {
       Logger.setSink(null);
     }
@@ -772,10 +779,11 @@ describe('discoverContextGraphsFromChain', () => {
     const entry = agent!.getSubscribedContextGraphs().get('partial-revealed');
     expect(entry).toBeDefined();
     expect(entry!.onChainId).toBe('0xfeedbeef00000000000000000000000000000000000000000000000000000001');
-    expect((agent as any).chainContextGraphScanFailure?.count).toBe(1);
-    expect(entries.some((entry) =>
+    expect((agent as any).chainContextGraphScanFailure?.count).toBe(2);
+    const warnings = entries.filter((entry) =>
       entry.level === 'warn' && entry.message.includes('Chain context graph scan failed'),
-    )).toBe(true);
+    );
+    expect(warnings).toHaveLength(1);
     expect(entries.some((entry) =>
       entry.level === 'info' && entry.message.includes('Chain context graph scan recovered'),
     )).toBe(false);

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -809,7 +809,10 @@ describe('discoverContextGraphsFromChain', () => {
       agent = result.agent;
       await agent.start();
 
-      expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(1);
+      expect(await agent.discoverContextGraphsFromChain({
+        incremental: true,
+        throwOnChainScanFailure: true,
+      })).toBe(1);
       expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
     } finally {
       Logger.setSink(null);

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -729,6 +729,57 @@ describe('discoverContextGraphsFromChain', () => {
       entry.level === 'info' && entry.message.includes('Chain context graph scan recovered after 2 failed attempt(s)'),
     )).toBe(true);
   }, 15000);
+
+  it('processes partial chain scan prefixes without marking the scan recovered', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    (chain as any).listContextGraphsFromChain = async () => {
+      const err = new Error(
+        'partial ContextGraphNameRegistry scan stopped after block 1999; failed page [2000, 3999]: range too wide',
+      ) as Error & {
+        partialResults: ContextGraphOnChain[];
+        scannedToBlock: number;
+        failedFromBlock: number;
+        failedToBlock: number;
+      };
+      err.name = 'ContextGraphChainScanPartialError';
+      err.partialResults = [
+        {
+          contextGraphId: '0xfeedbeef00000000000000000000000000000000000000000000000000000001',
+          name: 'partial-revealed',
+          creator: '0x1234',
+          accessPolicy: 0,
+          blockNumber: 100,
+          metadataRevealed: true,
+        },
+      ];
+      err.scannedToBlock = 1_999;
+      err.failedFromBlock = 2_000;
+      err.failedToBlock = 3_999;
+      throw err;
+    };
+    const entries: Array<{ level: string; message: string }> = [];
+    Logger.setSink((entry) => entries.push({ level: entry.level, message: entry.message }));
+    try {
+      const result = await createTestAgent({ chainAdapter: chain });
+      agent = result.agent;
+      await agent.start();
+
+      expect(await agent.discoverContextGraphsFromChain()).toBe(1);
+    } finally {
+      Logger.setSink(null);
+    }
+
+    const entry = agent!.getSubscribedContextGraphs().get('partial-revealed');
+    expect(entry).toBeDefined();
+    expect(entry!.onChainId).toBe('0xfeedbeef00000000000000000000000000000000000000000000000000000001');
+    expect((agent as any).chainContextGraphScanFailure?.count).toBe(1);
+    expect(entries.some((entry) =>
+      entry.level === 'warn' && entry.message.includes('Chain context graph scan failed'),
+    )).toBe(true);
+    expect(entries.some((entry) =>
+      entry.level === 'info' && entry.message.includes('Chain context graph scan recovered'),
+    )).toBe(false);
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromStore', () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -713,8 +713,9 @@ describe('discoverContextGraphsFromChain', () => {
 
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ incremental: true })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ seedIncrementalWatermark: true })).toBe(0);
 
-    expect(calls).toEqual([undefined, { incremental: true }]);
+    expect(calls).toEqual([undefined, { incremental: true }, { seedIncrementalWatermark: true }]);
   }, 15000);
 
   it('warns once for repeated chain scan failures and logs recovery', async () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -749,6 +749,26 @@ describe('discoverContextGraphsFromChain', () => {
     )).toBe(true);
   }, 15000);
 
+  it('can surface chain scan failures for daemon seed retries without changing the default contract', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const failure = new Error('seed scan failed');
+    (chain as any).listContextGraphsFromChain = async () => {
+      throw failure;
+    };
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    expect(await agent.discoverContextGraphsFromChain()).toBe(0);
+    await expect(
+      agent.discoverContextGraphsFromChain({
+        seedIncrementalWatermark: true,
+        throwOnChainScanFailure: true,
+      }),
+    ).rejects.toThrow('seed scan failed');
+  }, 15000);
+
   it('processes partial chain scan prefixes without marking the scan recovered', async () => {
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     let calls = 0;

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -248,6 +248,48 @@ export interface ContextGraphOnChain {
   description?: string;
 }
 
+export class ContextGraphChainScanPartialError extends Error {
+  readonly partialResults: ContextGraphOnChain[];
+  readonly scannedToBlock: number;
+  readonly failedFromBlock: number;
+  readonly failedToBlock: number;
+
+  constructor(
+    message: string,
+    opts: {
+      partialResults: ContextGraphOnChain[];
+      scannedToBlock: number;
+      failedFromBlock: number;
+      failedToBlock: number;
+      cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = 'ContextGraphChainScanPartialError';
+    this.partialResults = opts.partialResults;
+    this.scannedToBlock = opts.scannedToBlock;
+    this.failedFromBlock = opts.failedFromBlock;
+    this.failedToBlock = opts.failedToBlock;
+    if (opts.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = opts.cause;
+    }
+  }
+}
+
+export function isContextGraphChainScanPartialError(
+  err: unknown,
+): err is ContextGraphChainScanPartialError {
+  return (
+    err instanceof ContextGraphChainScanPartialError ||
+    (
+      typeof err === 'object' &&
+      err !== null &&
+      (err as { name?: unknown }).name === 'ContextGraphChainScanPartialError' &&
+      Array.isArray((err as { partialResults?: unknown }).partialResults)
+    )
+  );
+}
+
 export interface ContextGraphChainScanOptions {
   /**
    * When true and `fromBlock` is omitted, adapters may resume from an

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -811,6 +811,8 @@ export interface ChainAdapter {
   revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
   /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
   listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
+  /** True when the adapter has a registry scan watermark for its currently bound ContextGraphNameRegistry. */
+  hasContextGraphRegistryScanWatermark?(): Promise<boolean>;
 
   /**
    * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -248,6 +248,15 @@ export interface ContextGraphOnChain {
   description?: string;
 }
 
+export interface ContextGraphChainScanOptions {
+  /**
+   * When true and `fromBlock` is omitted, adapters may resume from an
+   * in-memory watermark with a reorg buffer. The default preserves public
+   * list-all semantics for SDK callers.
+   */
+  incremental?: boolean;
+}
+
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 
 /**
@@ -753,7 +762,7 @@ export interface ChainAdapter {
   /** Reveal cleartext name+description on-chain for a context graph you created. Optional. */
   revealContextGraphMetadata?(contextGraphId: string, name: string, description: string): Promise<TxResult>;
   /** List context graphs from chain via `NameClaimed` events. Optional; not supported on no-chain/mock. */
-  listContextGraphsFromChain?(fromBlock?: number): Promise<ContextGraphOnChain[]>;
+  listContextGraphsFromChain?(fromBlock?: number, options?: ContextGraphChainScanOptions): Promise<ContextGraphOnChain[]>;
 
   /**
    * Live owner lookup for a PCA NFT — wraps `DKGPublishingConvictionNFT.ownerOf(accountId)`.

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -297,6 +297,12 @@ export interface ContextGraphChainScanOptions {
    * list-all semantics for SDK callers.
    */
   incremental?: boolean;
+  /**
+   * When true on a successful full scan, adapters may seed the in-memory
+   * incremental watermark for later daemon background scans. This is opt-in so
+   * public SDK list-all calls remain side-effect free by default.
+   */
+  seedIncrementalWatermark?: boolean;
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -90,6 +90,12 @@ const KA_HIGH_WATER_MAX_SCAN_PAGES = 1_500;
 /** Default pre-10.0.4 fallback eth_getLogs window — the smallest common cap. */
 const KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2_000;
 
+const CG_REGISTRY_DEFAULT_PAGE_SIZE = 2_000;
+
+export const CG_REGISTRY_MAX_SCAN_PAGES = 1_500;
+
+export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
+
 /**
  * Per-backend timeout for a single KnowledgeAssetCreated scan page before
  * failing over to the next eligible backend — generous enough for a slow
@@ -98,6 +104,14 @@ const KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2_000;
  * front of the line for subsequent pages).
  */
 const KA_HIGH_WATER_PAGE_TIMEOUT_MS = 15_000;
+
+type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
+
+function normalizeScanPageSize(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 1
+    ? Math.floor(value)
+    : fallback;
+}
 
 /**
  * True for the UNAMBIGUOUS "the deployed DKGKnowledgeAssets has no
@@ -451,13 +465,17 @@ export class EVMChainAdapterBase {
   protected cachedMinRequiredSignatures: { value: number; cachedAt: number } | undefined;
 
   /**
-   * Cached deploy block of the resolved DKGKnowledgeAssets storage contract,
-   * keyed by address. Anchors the pre-10.0.4 KnowledgeAssetCreated fallback scan
-   * at the contract's birth instead of genesis (a from-0 scan is ~21k eth_getLogs
-   * calls under Base Sepolia's 2,000-block cap — #1080 redux). A contract's
+   * Cached deploy blocks, keyed by lowercase contract address. Anchors long
+   * event-log scans at the contract's birth instead of genesis. A contract's
    * deploy block is immutable, so this needs no TTL.
    */
-  protected cachedKaStorageDeployBlock: { value: number; address: string } | undefined;
+  protected readonly cachedContractDeployBlocks: Map<string, number> = new Map();
+
+  /**
+   * Next unbuffered block for ContextGraphNameRegistry scans, keyed by lowercase
+   * registry address. Read with a reorg buffer; duplicate delivery is harmless.
+   */
+  protected readonly contextGraphRegistryScanWatermarks: Map<string, number> = new Map();
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -465,6 +483,8 @@ export class EVMChainAdapterBase {
    * values fall back to KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2,000).
    */
   protected readonly kaHighWaterScanPageSize: number;
+
+  protected readonly cgRegistryScanPageSize: number;
 
   /**
    * Reset the PR3 publish-preflight cache. Public so daemon code that
@@ -477,7 +497,8 @@ export class EVMChainAdapterBase {
     this.cachedChainId = undefined;
     this.cachedKav10Address = undefined;
     this.cachedMinRequiredSignatures = undefined;
-    this.cachedKaStorageDeployBlock = undefined;
+    this.cachedContractDeployBlocks.clear();
+    this.contextGraphRegistryScanWatermarks.clear();
   }
 
   protected static preflightCacheFresh(
@@ -493,12 +514,14 @@ export class EVMChainAdapterBase {
     // Floor a finite `>= 1` value (so e.g. 10000.5 -> 10000, preserving the
     // window); only a `< 1` (or non-finite) value falls back to the default — a
     // fractional value in (0,1) must NOT floor to 0 (which makes pages Infinity).
-    this.kaHighWaterScanPageSize =
-      typeof config.kaHighWaterScanPageSize === 'number' &&
-      Number.isFinite(config.kaHighWaterScanPageSize) &&
-      config.kaHighWaterScanPageSize >= 1
-        ? Math.floor(config.kaHighWaterScanPageSize)
-        : KA_HIGH_WATER_DEFAULT_PAGE_SIZE;
+    this.kaHighWaterScanPageSize = normalizeScanPageSize(
+      config.kaHighWaterScanPageSize,
+      KA_HIGH_WATER_DEFAULT_PAGE_SIZE,
+    );
+    this.cgRegistryScanPageSize = normalizeScanPageSize(
+      config.cgRegistryScanPageSize,
+      CG_REGISTRY_DEFAULT_PAGE_SIZE,
+    );
     // BUG-022 root-cause fix: force ethers' `PollingEventSubscriber`
     // (eth_getLogs over a sliding block window) instead of the default
     // `FilterIdEventSubscriber` (eth_newFilter + eth_getFilterChanges).
@@ -1576,8 +1599,30 @@ export class EVMChainAdapterBase {
     filter: unknown,
     lo: number,
     hi: number,
-    scanProviders: ReadonlyArray<{ provider: JsonRpcProvider; backendHead: number }>,
+    scanProviders: ReadonlyArray<ScanProvider>,
     connected: Map<JsonRpcProvider, Contract>,
+    preferred?: JsonRpcProvider,
+  ): Promise<{ logs: ReadonlyArray<ethers.EventLog | ethers.Log>; provider: JsonRpcProvider }> {
+    return this.queryEventLogsPage(
+      storage,
+      filter,
+      lo,
+      hi,
+      scanProviders,
+      connected,
+      'getMaxKaNumberForAuthor KnowledgeAssetCreated',
+      preferred,
+    );
+  }
+
+  protected async queryEventLogsPage(
+    baseContract: Contract,
+    filter: unknown,
+    lo: number,
+    hi: number,
+    scanProviders: ReadonlyArray<ScanProvider>,
+    connected: Map<JsonRpcProvider, Contract>,
+    label: string,
     preferred?: JsonRpcProvider,
   ): Promise<{ logs: ReadonlyArray<ethers.EventLog | ethers.Log>; provider: JsonRpcProvider }> {
     // Eligible backends (tip covers the page), with the sticky preferred one moved
@@ -1595,14 +1640,14 @@ export class EVMChainAdapterBase {
     for (const { provider } of ordered) {
       let contract = connected.get(provider);
       if (!contract) {
-        contract = storage.connect(provider) as Contract;
+        contract = baseContract.connect(provider) as Contract;
         connected.set(provider, contract);
       }
       try {
         const logs = await withTimeout(
           contract.queryFilter(filter as any, lo, hi),
           KA_HIGH_WATER_PAGE_TIMEOUT_MS,
-          `getMaxKaNumberForAuthor KnowledgeAssetCreated getLogs [${lo}, ${hi}]`,
+          `${label} getLogs [${lo}, ${hi}]`,
         );
         return { logs, provider };
       } catch (err) {
@@ -1610,8 +1655,8 @@ export class EVMChainAdapterBase {
       }
     }
     throw new Error(
-      `getMaxKaNumberForAuthor: no configured RPC could serve the KnowledgeAssetCreated ` +
-        `log range [${lo}, ${hi}]${pageError ? `: ${errorMessage(pageError)}` : ''}.`,
+      `${label}: no configured RPC could serve the log range [${lo}, ${hi}]` +
+        `${pageError ? `: ${errorMessage(pageError)}` : ''}.`,
       pageError ? { cause: pageError } : undefined,
     );
   }
@@ -1648,14 +1693,58 @@ export class EVMChainAdapterBase {
   ): Promise<{
     fromBlock: number;
     head: number;
-    scanProviders: ReadonlyArray<{ provider: JsonRpcProvider; backendHead: number }>;
+    scanProviders: ReadonlyArray<ScanProvider>;
+  }> {
+    return this.resolveContractDeployBlock(
+      address,
+      'getMaxKaNumberForAuthor',
+      'DKGKnowledgeAssets',
+    );
+  }
+
+  protected async resolveLogScanHead(
+    operationLabel: string,
+  ): Promise<{
+    head: number;
+    scanProviders: ReadonlyArray<ScanProvider>;
+  }> {
+    let probeError: unknown;
+    const reachable: ScanProvider[] = [];
+    for (const provider of this.providers) {
+      try {
+        const backendHead = await withTimeout(
+          provider.getBlockNumber(),
+          RPC_READ_STALL_TIMEOUT_MS,
+          `${operationLabel} backend head probe`,
+        );
+        reachable.push({ provider, backendHead });
+      } catch (err) {
+        if (!isHistoricalStateUnavailable(err)) probeError = err;
+      }
+    }
+    if (reachable.length === 0) {
+      if (probeError !== undefined) throw probeError;
+      throw new Error(`${operationLabel}: no RPC backend returned a block number to anchor the log scan.`);
+    }
+    reachable.sort((a, b) => b.backendHead - a.backendHead);
+    return { head: reachable[0].backendHead, scanProviders: reachable };
+  }
+
+  protected async resolveContractDeployBlock(
+    address: string,
+    operationLabel: string,
+    contractLabel: string,
+  ): Promise<{
+    fromBlock: number;
+    head: number;
+    scanProviders: ReadonlyArray<ScanProvider>;
   }> {
     // 1. Probe every reachable backend for its head; order freshest-first. A
     //    head-probe failure on an UNREACHABLE backend is kept separate — it only
     //    matters when NO backend is reachable at all; it must NOT force a throw
     //    when a reachable (e.g. pruned) backend could still degrade to the scan.
     let probeError: unknown;
-    const reachable: Array<{ provider: JsonRpcProvider; backendHead: number }> = [];
+    const reachable: ScanProvider[] = [];
     for (const provider of this.providers) {
       try {
         // Bound the probe: these are direct per-backend reads (not via the
@@ -1665,7 +1754,7 @@ export class EVMChainAdapterBase {
         const backendHead = await withTimeout(
           provider.getBlockNumber(),
           RPC_READ_STALL_TIMEOUT_MS,
-          'getMaxKaNumberForAuthor backend head probe',
+          `${operationLabel} backend head probe`,
         );
         reachable.push({ provider, backendHead });
       } catch (err) {
@@ -1674,7 +1763,7 @@ export class EVMChainAdapterBase {
     }
     if (reachable.length === 0) {
       if (probeError !== undefined) throw probeError;
-      throw new Error('getMaxKaNumberForAuthor: no RPC backend returned a block number to anchor the pre-10.0.4 fallback.');
+      throw new Error(`${operationLabel}: no RPC backend returned a block number to anchor the log scan.`);
     }
     reachable.sort((a, b) => b.backendHead - a.backendHead);
     // `head` is the FRESHEST backend's tip. The caller crawls each page on the
@@ -1687,26 +1776,39 @@ export class EVMChainAdapterBase {
     // 2. Deploy block (immutable): cache hit, else binary-search a backend that
     //    serves historical getCode — each search uses ITS OWN head (self-
     //    consistent); fail over across backends, freshest-first.
-    const cached = this.cachedKaStorageDeployBlock;
-    if (cached?.address === address) return { fromBlock: cached.value, head, scanProviders: reachable };
+    const cacheKey = address.toLowerCase();
+    const cached = this.cachedContractDeployBlocks.get(cacheKey);
+    if (cached !== undefined) return { fromBlock: cached, head, scanProviders: reachable };
     let throttle: unknown; // a transient rate-limit/throttle seen during the search
     const throttledProviders = new Set<JsonRpcProvider>();
     for (const { provider: searchProvider, backendHead } of reachable) {
       try {
         // Verify code at this backend's head before searching it; a head BEFORE
         // deploy on this backend is skipped (would otherwise cache a stale value).
-        if ((await this.getContractCodeAtBlock(searchProvider, address, backendHead)) === '0x') {
+        if ((await this.getContractCodeAtBlock(
+          searchProvider,
+          address,
+          backendHead,
+          operationLabel,
+          contractLabel,
+        )) === '0x') {
           continue;
         }
         let lo = 0;
         let hi = backendHead;
         while (lo < hi) {
           const mid = lo + Math.floor((hi - lo) / 2);
-          const codeAtMid = await this.getContractCodeAtBlock(searchProvider, address, mid);
+          const codeAtMid = await this.getContractCodeAtBlock(
+            searchProvider,
+            address,
+            mid,
+            operationLabel,
+            contractLabel,
+          );
           if (codeAtMid !== '0x') hi = mid;
           else lo = mid + 1;
         }
-        this.cachedKaStorageDeployBlock = { address, value: lo };
+        this.cachedContractDeployBlocks.set(cacheKey, lo);
         // Drop any backend that throttled earlier in this search from the scan too
         // (same rationale as the degraded path below — a throttled endpoint must not
         // be re-queried by the log scan). The backend that just pinned the deploy
@@ -1754,7 +1856,13 @@ export class EVMChainAdapterBase {
    * diagnose it — degrade only for historical-state-unavailable, surface real
    * outages/auth/timeouts.
    */
-  private async getContractCodeAtBlock(provider: JsonRpcProvider, address: string, block: number): Promise<string> {
+  private async getContractCodeAtBlock(
+    provider: JsonRpcProvider,
+    address: string,
+    block: number,
+    operationLabel: string,
+    contractLabel: string,
+  ): Promise<string> {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
@@ -1770,7 +1878,7 @@ export class EVMChainAdapterBase {
         const code = await withTimeout(
           provider.getCode(address, block),
           RPC_READ_STALL_TIMEOUT_MS,
-          `getMaxKaNumberForAuthor eth_getCode at block ${block}`,
+          `${operationLabel} eth_getCode at block ${block}`,
         );
         return code && code !== '0x' ? code : '0x';
       } catch (err) {
@@ -1778,7 +1886,7 @@ export class EVMChainAdapterBase {
       }
     }
     throw new Error(
-      `getMaxKaNumberForAuthor: eth_getCode for DKGKnowledgeAssets ${address} at block ${block} ` +
+      `${operationLabel}: eth_getCode for ${contractLabel} ${address} at block ${block} ` +
         `failed after 3 attempts: ${errorMessage(lastErr)}`,
       { cause: lastErr },
     );

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1749,6 +1749,7 @@ export class EVMChainAdapterBase {
     fromBlock: number;
     head: number;
     scanProviders: ReadonlyArray<ScanProvider>;
+    degradedFromGenesis?: boolean;
   }> {
     // 1. Probe every reachable backend for its head; order freshest-first. A
     //    head-probe failure on an UNREACHABLE backend is kept separate — it only
@@ -1854,7 +1855,7 @@ export class EVMChainAdapterBase {
     // surfaced by the scan (page-1 throw with cause). The degraded `0` is not cached.
     const scanProviders = reachable.filter((r) => !throttledProviders.has(r.provider));
     if (scanProviders.length === 0) throw throttle;
-    return { fromBlock: 0, head, scanProviders };
+    return { fromBlock: 0, head, scanProviders, degradedFromGenesis: true };
   }
 
   /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -93,9 +93,17 @@ const KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2_000;
 const CG_REGISTRY_DEFAULT_PAGE_SIZE = 2_000;
 
 const CG_REGISTRY_LEGACY_PAGE_SIZE = 9_000;
+const CG_REGISTRY_LEGACY_MAX_SCAN_PAGES = 1_500;
 
-/** Preserve the old default registry scan span while using smaller RPC-safe pages. */
-export const CG_REGISTRY_MAX_SCAN_BLOCKS = CG_REGISTRY_LEGACY_PAGE_SIZE * 1_500;
+/**
+ * Preserve the old default registry scan span while using smaller RPC-safe
+ * pages. Larger configured page windows extend the block span at the same call
+ * budget.
+ */
+export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
+  (CG_REGISTRY_LEGACY_PAGE_SIZE * CG_REGISTRY_LEGACY_MAX_SCAN_PAGES) /
+  CG_REGISTRY_DEFAULT_PAGE_SIZE,
+);
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -92,7 +92,10 @@ const KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2_000;
 
 const CG_REGISTRY_DEFAULT_PAGE_SIZE = 2_000;
 
-export const CG_REGISTRY_MAX_SCAN_PAGES = 1_500;
+const CG_REGISTRY_LEGACY_PAGE_SIZE = 9_000;
+
+/** Preserve the old default registry scan span while using smaller RPC-safe pages. */
+export const CG_REGISTRY_MAX_SCAN_BLOCKS = CG_REGISTRY_LEGACY_PAGE_SIZE * 1_500;
 
 export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -123,7 +123,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
               'ContextGraphNameRegistry',
             )
         : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
-    const { fromBlock: deployBlock, head, scanProviders } = scan;
+    const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
     const start = fromBlock ?? (
       incremental && watermark !== undefined
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
@@ -134,7 +134,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (!degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -100,6 +100,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return { hash: receipt.hash, blockNumber: receipt.blockNumber, txIndex: receipt.index, success: true };
   }
 
+  async hasContextGraphRegistryScanWatermark(): Promise<boolean> {
+    await this.init();
+    const registry = this.contracts.contextGraphNameRegistry;
+    if (!registry) return false;
+    const registryAddress = (await registry.getAddress()).toLowerCase();
+    return this.contextGraphRegistryScanWatermarks.has(registryAddress);
+  }
+
   async listContextGraphsFromChain(
     fromBlock?: number,
     options?: ContextGraphChainScanOptions,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -134,9 +134,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (!degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (incremental && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
-        `listContextGraphsFromChain: ContextGraphNameRegistry scan would need ` +
+        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
           `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
           `${blockBudget} blocks). ` +

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -9,7 +9,7 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_BLOCKS, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
+import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
@@ -133,14 +133,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
-    const scanBlocks = head - start + 1;
-    const pageBudget = Math.ceil(CG_REGISTRY_MAX_SCAN_BLOCKS / pageSize);
-    if (scanBlocks > CG_REGISTRY_MAX_SCAN_BLOCKS) {
+    const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
+    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
-          `${pageSize}-block window (budget ${pageBudget} pages / ` +
-          `${CG_REGISTRY_MAX_SCAN_BLOCKS} blocks). ` +
+          `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
+          `${blockBudget} blocks). ` +
           `Use an RPC that can anchor the registry deploy block and serve the ` +
           `requested log range, or increase cgRegistryScanPageSize for an RPC ` +
           `known to support larger ranges.`,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -11,7 +11,7 @@
 
 import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import type { CreateContextGraphParams, TxResult, ContextGraphOnChain, ContextGraphChainScanOptions, CreateOnChainContextGraphParams, CreateOnChainContextGraphResult, VerifyParams, PublishToContextGraphParams, OnChainPublishResult } from './chain-adapter.js';
+import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
@@ -166,7 +166,20 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         logs = page.logs;
         preferred = page.provider;
       } catch (err) {
-        if (incremental && scannedAnyPage) return results;
+        if (incremental && scannedAnyPage) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new ContextGraphChainScanPartialError(
+            `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
+              `stopped after block ${lo - 1}; failed page [${lo}, ${hi}]: ${message}`,
+            {
+              partialResults: results,
+              scannedToBlock: lo - 1,
+              failedFromBlock: lo,
+              failedToBlock: hi,
+              cause: err,
+            },
+          );
+        }
         throw err;
       }
       scannedAnyPage = true;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -9,9 +9,9 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase } from './evm-adapter-base.js';
-import { ethers, Contract } from 'ethers';
-import type { CreateContextGraphParams, TxResult, ContextGraphOnChain, CreateOnChainContextGraphParams, CreateOnChainContextGraphResult, VerifyParams, PublishToContextGraphParams, OnChainPublishResult } from './chain-adapter.js';
+import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
+import { ethers, Contract, type JsonRpcProvider } from 'ethers';
+import type { CreateContextGraphParams, TxResult, ContextGraphOnChain, ContextGraphChainScanOptions, CreateOnChainContextGraphParams, CreateOnChainContextGraphResult, VerifyParams, PublishToContextGraphParams, OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
@@ -100,20 +100,79 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return { hash: receipt.hash, blockNumber: receipt.blockNumber, txIndex: receipt.index, success: true };
   }
 
-  async listContextGraphsFromChain(fromBlock?: number): Promise<ContextGraphOnChain[]> {
+  async listContextGraphsFromChain(
+    fromBlock?: number,
+    options?: ContextGraphChainScanOptions,
+  ): Promise<ContextGraphOnChain[]> {
     await this.init();
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return [];
     const eventFilter = registry.filters.NameClaimed();
-    const head = await this.provider.getBlockNumber();
-    const PAGE = 9_000;
-    const start = fromBlock ?? 0;
-    const results: ContextGraphOnChain[] = [];
+    const registryAddress = (await registry.getAddress()).toLowerCase();
+    const scan =
+      fromBlock === undefined
+        ? await this.resolveContractDeployBlock(
+            registryAddress,
+            'listContextGraphsFromChain',
+            'ContextGraphNameRegistry',
+          )
+        : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
+    const { fromBlock: deployBlock, head, scanProviders } = scan;
+    const incremental = options?.incremental === true && fromBlock === undefined;
+    const watermark = incremental
+      ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
+      : undefined;
+    const start = fromBlock ?? (
+      !incremental || watermark === undefined
+        ? deployBlock
+        : Math.max(deployBlock, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
+    );
+    if (start > head) return [];
 
-    // Paginate in PAGE-sized chunks to stay within RPC range limits.
-    for (let lo = start; lo <= head; lo += PAGE) {
-      const hi = Math.min(lo + PAGE - 1, head);
-      const logs = await registry.queryFilter(eventFilter, lo, hi);
+    const pageSize = this.cgRegistryScanPageSize;
+    const pages = Math.ceil((head - start + 1) / pageSize);
+    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+      throw new Error(
+        `listContextGraphsFromChain: ContextGraphNameRegistry scan would need ` +
+          `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
+          `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages). ` +
+          `Use an RPC that can anchor the registry deploy block and serve the ` +
+          `requested log range, or increase cgRegistryScanPageSize for an RPC ` +
+          `known to support larger ranges.`,
+      );
+    }
+
+    const results: ContextGraphOnChain[] = [];
+    const connected = new Map<JsonRpcProvider, Contract>();
+    let preferred: JsonRpcProvider | undefined;
+    let scannedAnyPage = false;
+
+    // Incremental daemon scans can resume from the scanned prefix after a later
+    // page failure. Public list-all calls should remain all-or-error.
+    for (let lo = start; lo <= head; lo += pageSize) {
+      const hi = Math.min(lo + pageSize - 1, head);
+      let logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
+      try {
+        const page = await this.queryEventLogsPage(
+          registry,
+          eventFilter,
+          lo,
+          hi,
+          scanProviders,
+          connected,
+          'listContextGraphsFromChain NameClaimed',
+          preferred,
+        );
+        logs = page.logs;
+        preferred = page.provider;
+      } catch (err) {
+        if (incremental && scannedAnyPage) return results;
+        throw err;
+      }
+      scannedAnyPage = true;
+      if (incremental) {
+        this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
+      }
       for (const log of logs) {
         const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
         if (!parsed || parsed.name !== 'NameClaimed') continue;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -151,7 +151,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     // page failure. Public list-all calls should remain all-or-error.
     for (let lo = start; lo <= head; lo += pageSize) {
       const hi = Math.min(lo + pageSize - 1, head);
-      let logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
       try {
         const page = await this.queryEventLogsPage(
           registry,
@@ -163,8 +162,24 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           'listContextGraphsFromChain NameClaimed',
           preferred,
         );
-        logs = page.logs;
         preferred = page.provider;
+        const pageResults: ContextGraphOnChain[] = [];
+        for (const log of page.logs) {
+          const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
+          if (!parsed || parsed.name !== 'NameClaimed') continue;
+          pageResults.push({
+            contextGraphId: String(parsed.args.nameHash),
+            creator: String(parsed.args.creator),
+            accessPolicy: Number(parsed.args.accessPolicy),
+            blockNumber: log.blockNumber,
+            metadataRevealed: false,
+          });
+        }
+        results.push(...pageResults);
+        scannedAnyPage = true;
+        if (incremental) {
+          this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
+        }
       } catch (err) {
         if (incremental && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
@@ -181,21 +196,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           );
         }
         throw err;
-      }
-      scannedAnyPage = true;
-      if (incremental) {
-        this.contextGraphRegistryScanWatermarks.set(registryAddress, hi + 1);
-      }
-      for (const log of logs) {
-        const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed || parsed.name !== 'NameClaimed') continue;
-        results.push({
-          contextGraphId: String(parsed.args.nameHash),
-          creator: String(parsed.args.creator),
-          accessPolicy: Number(parsed.args.accessPolicy),
-          blockNumber: log.blockNumber,
-          metadataRevealed: false,
-        });
       }
     }
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -9,7 +9,7 @@
  * via applyMixins(); see evm-adapter.ts for the assembly.
  */
 
-import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
+import { EVMChainAdapterBase, CG_REGISTRY_MAX_SCAN_BLOCKS, CG_REGISTRY_REORG_BUFFER_BLOCKS } from './evm-adapter-base.js';
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
@@ -109,33 +109,38 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     if (!registry) return [];
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const scan =
-      fromBlock === undefined
-        ? await this.resolveContractDeployBlock(
-            registryAddress,
-            'listContextGraphsFromChain',
-            'ContextGraphNameRegistry',
-          )
-        : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
-    const { fromBlock: deployBlock, head, scanProviders } = scan;
     const incremental = options?.incremental === true && fromBlock === undefined;
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
+    const scan =
+      fromBlock === undefined
+        ? incremental && watermark !== undefined
+          ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
+          : await this.resolveContractDeployBlock(
+              registryAddress,
+              'listContextGraphsFromChain',
+              'ContextGraphNameRegistry',
+            )
+        : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
+    const { fromBlock: deployBlock, head, scanProviders } = scan;
     const start = fromBlock ?? (
-      !incremental || watermark === undefined
-        ? deployBlock
-        : Math.max(deployBlock, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
+      incremental && watermark !== undefined
+        ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
+        : deployBlock
     );
     if (start > head) return [];
 
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
-    if (pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    const scanBlocks = head - start + 1;
+    const pageBudget = Math.ceil(CG_REGISTRY_MAX_SCAN_BLOCKS / pageSize);
+    if (scanBlocks > CG_REGISTRY_MAX_SCAN_BLOCKS) {
       throw new Error(
         `listContextGraphsFromChain: ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
-          `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages). ` +
+          `${pageSize}-block window (budget ${pageBudget} pages / ` +
+          `${CG_REGISTRY_MAX_SCAN_BLOCKS} blocks). ` +
           `Use an RPC that can anchor the registry deploy block and serve the ` +
           `requested log range, or increase cgRegistryScanPageSize for an RPC ` +
           `known to support larger ranges.`,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -110,6 +110,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const eventFilter = registry.filters.NameClaimed();
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const incremental = options?.incremental === true && fromBlock === undefined;
+    const seedIncrementalWatermark =
+      options?.seedIncrementalWatermark === true && !incremental && fromBlock === undefined;
     const watermark = incremental
       ? this.contextGraphRegistryScanWatermarks.get(registryAddress)
       : undefined;
@@ -129,7 +131,12 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         ? Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
         : deployBlock
     );
-    if (start > head) return [];
+    if (start > head) {
+      if (seedIncrementalWatermark) {
+        this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
+      }
+      return [];
+    }
 
     const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
@@ -201,6 +208,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
         throw err;
       }
+    }
+
+    if (seedIncrementalWatermark) {
+      this.contextGraphRegistryScanWatermarks.set(registryAddress, head + 1);
     }
 
     return results;

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -55,6 +55,13 @@ export interface EVMAdapterBaseConfig {
    * O(1) view is used).
    */
   kaHighWaterScanPageSize?: number;
+  /**
+   * Adapter/SDK-level tuning for the ContextGraphNameRegistry discovery scan:
+   * the `eth_getLogs` block-window, in blocks. Default 2,000, matching the
+   * smallest common provider cap. A finite value `>= 1` is floored; a
+   * non-finite or `< 1` value falls back to the default.
+   */
+  cgRegistryScanPageSize?: number;
 }
 
 export interface EVMAdapterConfig extends EVMAdapterBaseConfig {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -470,6 +470,10 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
+  async hasContextGraphRegistryScanWatermark(): Promise<boolean> {
+    return false;
+  }
+
   // --- V10 Publishing Conviction NFT (DKGPublishingConvictionNFT) ---
   // In-memory parity: account map + agent reverse map + owner-gating.
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -463,7 +463,10 @@ export class MockChainAdapter implements ChainAdapter {
     return this.txResult(true);
   }
 
-  async listContextGraphsFromChain(): Promise<import('./chain-adapter.js').ContextGraphOnChain[]> {
+  async listContextGraphsFromChain(
+    _fromBlock?: number,
+    _options?: import('./chain-adapter.js').ContextGraphChainScanOptions,
+  ): Promise<import('./chain-adapter.js').ContextGraphOnChain[]> {
     return [];
   }
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
+import { CG_REGISTRY_MAX_SCAN_BLOCKS, CG_REGISTRY_REORG_BUFFER_BLOCKS } from '../src/evm-adapter-base.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
@@ -196,11 +197,40 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     ]);
   });
 
-  it('throws before queryFilter when the bounded registry scan would exceed the page budget', async () => {
+  it('resumes incremental scans from the watermark without deploy-block probing', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100);
+    provider.getCode = vi.fn(async () => {
+      throw new Error('eth_getCode should not be called');
+    });
+    registry.queryFilter.mockResolvedValue([]);
+    (adapter as any).contextGraphRegistryScanWatermarks.set(REGISTRY.toLowerCase(), 2_050);
+
+    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+
+    expect(provider.getCode).not.toHaveBeenCalled();
+    expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [2_050 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 2_100],
+    ]);
+  });
+
+  it('allows default registry scans beyond the old 3M page-count cap', async () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000_000);
+    registry.queryFilter.mockResolvedValue([]);
 
-    await expect(adapter.listContextGraphsFromChain()).rejects.toThrow(/ContextGraphNameRegistry scan would need/);
+    await expect(adapter.listContextGraphsFromChain()).resolves.toEqual([]);
+
+    expect(registry.queryFilter).toHaveBeenCalledTimes(Math.ceil((4_000_000 + 1) / 2_000));
+  });
+
+  it('throws before queryFilter when the bounded registry scan would exceed the block-span budget', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, CG_REGISTRY_MAX_SCAN_BLOCKS);
+
+    await expect(adapter.listContextGraphsFromChain()).rejects.toThrow(
+      new RegExp(`ContextGraphNameRegistry scan would need.*${CG_REGISTRY_MAX_SCAN_BLOCKS} blocks`),
+    );
     expect(registry.queryFilter).not.toHaveBeenCalled();
   });
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+const REGISTRY = '0x3333333333333333333333333333333333333333';
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    ...overrides,
+  };
+}
+
+function makeRegistry(overrides: Record<string, unknown> = {}) {
+  return {
+    getAddress: vi.fn(async () => REGISTRY),
+    filters: { NameClaimed: vi.fn(() => 'NameClaimedFilter') },
+    interface: {
+      parseLog: vi.fn(({ data }: { data: string }) => {
+        if (data === '0x01') {
+          return {
+            name: 'NameClaimed',
+            args: {
+              nameHash: '0xaaa0000000000000000000000000000000000000000000000000000000000001',
+              creator: '0x1111111111111111111111111111111111111111',
+              accessPolicy: 0,
+            },
+          };
+        }
+        return null;
+      }),
+    },
+    queryFilter: vi.fn(async () => []),
+    connect: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+function makeAdapter(registry: any, head = 0, config: Partial<EVMAdapterConfig> = {}) {
+  const adapter = new EVMChainAdapter(minimalConfig(config));
+  registry.connect = vi.fn(() => registry);
+  const provider = {
+    getBlockNumber: vi.fn(async () => head),
+    getCode: vi.fn(async (_address: string, block?: number) =>
+      block === undefined || block >= 0 ? '0x6000' : '0x',
+    ),
+  };
+  (adapter as any).contracts = { contextGraphNameRegistry: registry };
+  (adapter as any).initialized = true;
+  (adapter as any).provider = provider;
+  (adapter as any).providers = [provider];
+  return { adapter, provider };
+}
+
+describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
+  it('anchors at the registry deploy block and paginates with the 2,000-block default', async () => {
+    const deployBlock = 1_500;
+    const head = 5_500;
+    const registry = makeRegistry({
+      queryFilter: vi.fn(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= 3_500 && 3_500 <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: 3_500 }]
+          : [],
+      ),
+    });
+    const { adapter, provider } = makeAdapter(registry, head);
+    provider.getCode = vi.fn(async (_address: string, block?: number) =>
+      block === undefined || block >= deployBlock ? '0x6000' : '0x',
+    );
+
+    const results = await adapter.listContextGraphsFromChain();
+
+    expect(results).toEqual([
+      {
+        contextGraphId: '0xaaa0000000000000000000000000000000000000000000000000000000000001',
+        creator: '0x1111111111111111111111111111111111111111',
+        accessPolicy: 0,
+        blockNumber: 3_500,
+        metadataRevealed: false,
+      },
+    ]);
+    expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [1_500, 3_499],
+      [3_500, 5_499],
+      [5_500, 5_500],
+    ]);
+  });
+
+  it('returns scanned-prefix results on a later page failure and resumes with a reorg buffer', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 4_999);
+    provider.getBlockNumber
+      .mockResolvedValueOnce(4_999)
+      .mockResolvedValueOnce(2_100);
+    registry.queryFilter
+      .mockResolvedValueOnce([{ topics: [], data: '0x01', blockNumber: 10 }])
+      .mockRejectedValueOnce(new Error('range too wide'));
+
+    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+
+    expect(partial).toHaveLength(1);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+
+    registry.queryFilter.mockReset();
+    registry.queryFilter.mockResolvedValue([]);
+    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+
+    expect(registry.queryFilter.mock.calls[0][1]).toBe(1_950);
+    expect(registry.queryFilter.mock.calls[0][2]).toBe(2_100);
+  });
+
+  it('preserves public list-all semantics unless the caller opts into incremental scans', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100);
+    provider.getBlockNumber
+      .mockResolvedValueOnce(2_100)
+      .mockResolvedValueOnce(2_100);
+    registry.queryFilter.mockResolvedValue([]);
+
+    await adapter.listContextGraphsFromChain();
+    await adapter.listContextGraphsFromChain();
+
+    expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 1_999],
+      [2_000, 2_100],
+      [0, 1_999],
+      [2_000, 2_100],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+  });
+
+  it('rethrows later page failures for public list-all scans', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100);
+    provider.getBlockNumber.mockResolvedValueOnce(2_100);
+    registry.queryFilter.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error('range too wide'));
+
+    await expect(adapter.listContextGraphsFromChain()).rejects.toThrow('range too wide');
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
+  });
+
+  it('does not require deploy-block probing when fromBlock is explicit', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 2_100);
+    provider.getCode = vi.fn(async () => {
+      throw new Error('eth_getCode should not be called');
+    });
+    registry.queryFilter.mockResolvedValue([]);
+
+    await adapter.listContextGraphsFromChain(1_234);
+
+    expect(provider.getCode).not.toHaveBeenCalled();
+    expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [1_234, 2_100],
+    ]);
+  });
+
+  it('throws before queryFilter when the bounded registry scan would exceed the page budget', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_000_000);
+
+    await expect(adapter.listContextGraphsFromChain()).rejects.toThrow(/ContextGraphNameRegistry scan would need/);
+    expect(registry.queryFilter).not.toHaveBeenCalled();
+  });
+
+  it('honors cgRegistryScanPageSize and defaults invalid values', () => {
+    const tuned = new EVMChainAdapter(minimalConfig({ cgRegistryScanPageSize: 10_000.5 }));
+    expect((tuned as any).cgRegistryScanPageSize).toBe(10_000);
+
+    const defaulted = new EVMChainAdapter(minimalConfig({ cgRegistryScanPageSize: 0.5 }));
+    expect((defaulted as any).cgRegistryScanPageSize).toBe(2_000);
+  });
+});

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
@@ -91,7 +92,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     ]);
   });
 
-  it('returns scanned-prefix results on a later page failure and resumes with a reorg buffer', async () => {
+  it('throws explicit partial scan failures with scanned-prefix results and resumes with a reorg buffer', async () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 4_999);
     provider.getBlockNumber
@@ -101,9 +102,13 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       .mockResolvedValueOnce([{ topics: [], data: '0x01', blockNumber: 10 }])
       .mockRejectedValueOnce(new Error('range too wide'));
 
-    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
 
-    expect(partial).toHaveLength(1);
+    expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(partial.partialResults).toHaveLength(1);
+    expect(partial.scannedToBlock).toBe(1_999);
+    expect(partial.failedFromBlock).toBe(2_000);
+    expect(partial.failedToBlock).toBe(3_999);
     expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
 
     registry.queryFilter.mockReset();

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -236,14 +236,26 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter).toHaveBeenCalledTimes(Math.ceil((head + 1) / pageSize));
   });
 
-  it('throws before queryFilter when the bounded registry scan would exceed the page budget', async () => {
+  it('keeps public list-all scans complete beyond the incremental page budget', async () => {
+    const registry = makeRegistry();
+    const defaultPageSize = 2_000;
+    const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
+    const { adapter } = makeAdapter(registry, defaultBlockBudget);
+    registry.queryFilter.mockResolvedValue([]);
+
+    await expect(adapter.listContextGraphsFromChain()).resolves.toEqual([]);
+
+    expect(registry.queryFilter).toHaveBeenCalledTimes(CG_REGISTRY_MAX_SCAN_PAGES + 1);
+  });
+
+  it('throws before queryFilter when an incremental registry scan would exceed the page budget', async () => {
     const registry = makeRegistry();
     const defaultPageSize = 2_000;
     const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
     const { adapter } = makeAdapter(registry, defaultBlockBudget);
 
-    await expect(adapter.listContextGraphsFromChain()).rejects.toThrow(
-      new RegExp(`ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
+    await expect(adapter.listContextGraphsFromChain(undefined, { incremental: true })).rejects.toThrow(
+      new RegExp(`incremental ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
     );
     expect(registry.queryFilter).not.toHaveBeenCalled();
   });

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -176,9 +176,12 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const { adapter, provider } = makeAdapter(registry, 4_000);
     registry.queryFilter.mockResolvedValue([]);
 
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
+
     await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
 
     expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(4_001);
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
 
     provider.getCode = vi.fn(async () => {
       throw new Error('eth_getCode should not be called after watermark seeding');
@@ -191,6 +194,19 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
       [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
     ]);
+  });
+
+  it('reports no registry scan watermark after preflight cache invalidation', async () => {
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 4_000);
+    registry.queryFilter.mockResolvedValue([]);
+
+    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+
+    adapter.invalidatePublishPreflightCache();
+
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(false);
   });
 
   it('rethrows later page failures for public list-all scans', async () => {

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -248,6 +248,21 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter).not.toHaveBeenCalled();
   });
 
+  it('keeps degraded non-archive genesis fallback complete beyond the page budget', async () => {
+    const registry = makeRegistry();
+    const defaultPageSize = 2_000;
+    const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
+    const { adapter, provider } = makeAdapter(registry, defaultBlockBudget);
+    provider.getCode = vi.fn(async () => {
+      throw new Error('missing trie node (pruned node)');
+    });
+    registry.queryFilter.mockResolvedValue([]);
+
+    await expect(adapter.listContextGraphsFromChain()).resolves.toEqual([]);
+
+    expect(registry.queryFilter).toHaveBeenCalledTimes(CG_REGISTRY_MAX_SCAN_PAGES + 1);
+  });
+
   it('honors cgRegistryScanPageSize and defaults invalid values', () => {
     const tuned = new EVMChainAdapter(minimalConfig({ cgRegistryScanPageSize: 10_000.5 }));
     expect((tuned as any).cgRegistryScanPageSize).toBe(10_000);

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -171,6 +171,28 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBeUndefined();
   });
 
+  it('can seed the incremental watermark from an explicit successful full scan', async () => {
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 4_000);
+    registry.queryFilter.mockResolvedValue([]);
+
+    await adapter.listContextGraphsFromChain(undefined, { seedIncrementalWatermark: true });
+
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(4_001);
+
+    provider.getCode = vi.fn(async () => {
+      throw new Error('eth_getCode should not be called after watermark seeding');
+    });
+    registry.queryFilter.mockClear();
+
+    await adapter.listContextGraphsFromChain(undefined, { incremental: true });
+
+    expect(provider.getCode).not.toHaveBeenCalled();
+    expect(registry.queryFilter.mock.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [4_001 - CG_REGISTRY_REORG_BUFFER_BLOCKS, 4_000],
+    ]);
+  });
+
   it('rethrows later page failures for public list-all scans', async () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 2_100);

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import { ContextGraphChainScanPartialError } from '../src/chain-adapter.js';
-import { CG_REGISTRY_MAX_SCAN_BLOCKS, CG_REGISTRY_REORG_BUFFER_BLOCKS } from '../src/evm-adapter-base.js';
+import { CG_REGISTRY_MAX_SCAN_PAGES, CG_REGISTRY_REORG_BUFFER_BLOCKS } from '../src/evm-adapter-base.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
@@ -224,12 +224,26 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter).toHaveBeenCalledTimes(Math.ceil((4_000_000 + 1) / 2_000));
   });
 
-  it('throws before queryFilter when the bounded registry scan would exceed the block-span budget', async () => {
+  it('lets larger cgRegistryScanPageSize extend the block span at the same page budget', async () => {
     const registry = makeRegistry();
-    const { adapter } = makeAdapter(registry, CG_REGISTRY_MAX_SCAN_BLOCKS);
+    const head = 20_000_000;
+    const pageSize = 10_000;
+    const { adapter } = makeAdapter(registry, head, { cgRegistryScanPageSize: pageSize });
+    registry.queryFilter.mockResolvedValue([]);
+
+    await expect(adapter.listContextGraphsFromChain()).resolves.toEqual([]);
+
+    expect(registry.queryFilter).toHaveBeenCalledTimes(Math.ceil((head + 1) / pageSize));
+  });
+
+  it('throws before queryFilter when the bounded registry scan would exceed the page budget', async () => {
+    const registry = makeRegistry();
+    const defaultPageSize = 2_000;
+    const defaultBlockBudget = CG_REGISTRY_MAX_SCAN_PAGES * defaultPageSize;
+    const { adapter } = makeAdapter(registry, defaultBlockBudget);
 
     await expect(adapter.listContextGraphsFromChain()).rejects.toThrow(
-      new RegExp(`ContextGraphNameRegistry scan would need.*${CG_REGISTRY_MAX_SCAN_BLOCKS} blocks`),
+      new RegExp(`ContextGraphNameRegistry scan would need.*budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages`),
     );
     expect(registry.queryFilter).not.toHaveBeenCalled();
   });

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -119,6 +119,37 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(registry.queryFilter.mock.calls[0][2]).toBe(2_100);
   });
 
+  it('does not advance the incremental watermark when parsing a later page fails', async () => {
+    const registry = makeRegistry({
+      interface: {
+        parseLog: vi.fn(({ data }: { data: string }) => {
+          if (data === '0xbad') throw new Error('bad registry log');
+          return {
+            name: 'NameClaimed',
+            args: {
+              nameHash: '0xaaa0000000000000000000000000000000000000000000000000000000000001',
+              creator: '0x1111111111111111111111111111111111111111',
+              accessPolicy: 0,
+            },
+          };
+        }),
+      },
+    });
+    const { adapter, provider } = makeAdapter(registry, 2_100);
+    provider.getBlockNumber.mockResolvedValueOnce(2_100);
+    registry.queryFilter
+      .mockResolvedValueOnce([{ topics: [], data: '0x01', blockNumber: 10 }])
+      .mockResolvedValueOnce([{ topics: [], data: '0xbad', blockNumber: 2_000 }]);
+
+    const partial = await adapter.listContextGraphsFromChain(undefined, { incremental: true }).catch((err) => err);
+
+    expect(partial).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(partial.partialResults).toHaveLength(1);
+    expect(partial.failedFromBlock).toBe(2_000);
+    expect(partial.failedToBlock).toBe(2_100);
+    expect((adapter as any).contextGraphRegistryScanWatermarks.get(REGISTRY.toLowerCase())).toBe(2_000);
+  });
+
   it('preserves public list-all semantics unless the caller opts into incremental scans', async () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 2_100);

--- a/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
+++ b/packages/chain/test/getmaxkanumberforauthor.unit.test.ts
@@ -425,7 +425,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     await a.getMaxKaNumberForAuthor(AUTHOR);
     const searchCalls1 = getCode.mock.calls.filter((c) => c.length === 2).length;
     expect(searchCalls1).toBeGreaterThan(0); // first call binary-searches
-    expect((a as any).cachedKaStorageDeployBlock).toEqual({ address: storage.target, value: deployBlock });
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBe(deployBlock);
 
     getCode.mockClear();
     await a.getMaxKaNumberForAuthor(AUTHOR);
@@ -469,7 +469,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
 
     expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n); // still scans — pruned RPCs serve queryFilter
     expect((queryFilter.mock.calls[0] as unknown as [unknown, number, number])[1]).toBe(0); // genesis (safe lower bound, never above deploy)
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined(); // degraded anchor not cached
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined(); // degraded anchor not cached
   });
 
   it('rethrows a transient throttle during the deploy-block search immediately (no degrade that would worsen the throttle)', async () => {
@@ -487,7 +487,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     // access/plan/archive denial would instead degrade — see the degrade cases.)
     await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow('Too Many Requests');
     expect(queryFilter).not.toHaveBeenCalled(); // not degraded into a log crawl
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined();
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined();
   });
 
   it('surfaces a DEEPLY-NESTED 429 status even when the message text looks like pruned state (#1111 review)', async () => {
@@ -509,7 +509,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     });
     await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow(); // surfaced, not degraded
     expect(queryFilter).not.toHaveBeenCalled(); // NOT degraded into a log sweep despite the "missing trie node" text
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined();
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined();
   });
 
   it('does NOT silently mask a BARE "header not found" — it is not historical-state, so it surfaces via the scan (#1111 review)', async () => {
@@ -531,7 +531,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     });
     await expect(a.getMaxKaNumberForAuthor(AUTHOR)).rejects.toThrow('header not found'); // surfaced by the scan
     expect(queryFilter).toHaveBeenCalledTimes(1); // fails on page 1, no large sweep
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined();
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined();
   });
 
   it('still degrades when "header not found" is accompanied by a genuine pruned-state phrase (#1111 review)', async () => {
@@ -547,7 +547,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
     });
     expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n); // degraded to a genesis-anchored scan
     expect((queryFilter.mock.calls[0] as unknown as [unknown, number, number])[1]).toBe(0); // safe genesis lower bound
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined();
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined();
   });
 
   it('degrades to genesis (never caches a stale head as the deploy block) when a backend head is behind the deploy block', async () => {
@@ -559,7 +559,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
       block === undefined ? '0x6000' : '0x',
     );
     expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(-1n);
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined(); // stale head NOT cached as deploy block
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined(); // stale head NOT cached as deploy block
     expect((queryFilter.mock.calls[0] as unknown as [unknown, number, number])[1]).toBe(0); // safe genesis lower bound
   });
 
@@ -659,7 +659,7 @@ describe('EVMChainAdapter.getMaxKaNumberForAuthor — view + bounded fallback (#
 
     expect(await a.getMaxKaNumberForAuthor(AUTHOR)).toBe(7n); // degraded + scanned, not aborted
     expect((queryFilter.mock.calls[0] as unknown as [unknown, number, number])[1]).toBe(0); // genesis lower bound
-    expect((a as any).cachedKaStorageDeployBlock).toBeUndefined(); // degraded anchor not cached
+    expect((a as any).cachedContractDeployBlocks.get(storage.target.toLowerCase())).toBeUndefined(); // degraded anchor not cached
   });
 
   it('does not abort on a denied freshest backend — a healthy archive secondary still pins the deploy block (#1111 review)', async () => {

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -202,12 +202,15 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // 2,000-block eth_getLogs cap). EVM-only — the mock's getMaxKaNumberForAuthor
   // is an in-memory scan with no chain, deploy block, or eth_getCode to resolve.
   'resolveKaStorageDeployBlock',
+  'resolveContractDeployBlock',
+  'resolveLogScanHead',
   // companion retry-wrapper for the deploy-block binary search's historical
   // eth_getCode probes — EVM-only, same rationale as resolveKaStorageDeployBlock.
   'getContractCodeAtBlock',
   // per-page KnowledgeAssetCreated log-scan with cross-backend failover — EVM-only
   // (the mock's getMaxKaNumberForAuthor is an in-memory scan, no providers).
   'queryKaCreatedPage',
+  'queryEventLogsPage',
 ]);
 
 const NO_CHAIN_EXEMPT_FROM_EVM = new Set<string>([

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -131,6 +131,11 @@ export interface NetworkConfig {
     hubAddress: string;
     tokenAddress?: string;
     chainId: string;
+    /**
+     * ContextGraphNameRegistry discovery scan `eth_getLogs` block-window.
+     * Defaults to the EVM adapter's 2,000-block common provider cap.
+     */
+    cgRegistryScanPageSize?: number;
   };
   faucet?: {
     url: string;
@@ -220,6 +225,11 @@ export interface ChainConfig {
    * `packages/cli/skills/dkg-node/SKILL.md` §8 for the operator guide.
    */
   approvalPolicy?: ApprovalPolicyConfig;
+  /**
+   * ContextGraphNameRegistry discovery scan `eth_getLogs` block-window.
+   * Defaults to the EVM adapter's 2,000-block common provider cap.
+   */
+  cgRegistryScanPageSize?: number;
 }
 
 export interface LargeLiteralStorageConfig {
@@ -962,6 +972,8 @@ export function resolveChainConfig(
   if (tokenAddress !== undefined) merged.tokenAddress = tokenAddress;
   const chainId = cfg?.chainId ?? net?.chainId;
   if (chainId !== undefined) merged.chainId = chainId;
+  const cgRegistryScanPageSize = cfg?.cgRegistryScanPageSize ?? net?.cgRegistryScanPageSize;
+  if (cgRegistryScanPageSize !== undefined) merged.cgRegistryScanPageSize = cgRegistryScanPageSize;
   if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;
   return merged;
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -594,6 +594,14 @@ export function shouldUseIncrementalChainDiscoveryScan(input: {
   );
 }
 
+export function chainDiscoveryScanOptions(incremental: boolean):
+  | { incremental: true }
+  | { seedIncrementalWatermark: true; throwOnChainScanFailure: true } {
+  return incremental
+    ? { incremental: true }
+    : { seedIncrementalWatermark: true, throwOnChainScanFailure: true };
+}
+
 export interface PromoteWorkerDaemonLifecycle {
   waitForStartup(): Promise<void>;
   stop(reason?: string | null): Promise<void>;
@@ -1754,7 +1762,7 @@ export async function runDaemonInner(
         fullScanEvery: CHAIN_FULL_SCAN_EVERY,
       });
       const found = await agent.discoverContextGraphsFromChain(
-        incremental ? { incremental: true } : { seedIncrementalWatermark: true },
+        chainDiscoveryScanOptions(incremental),
       );
       if (!incremental) chainScanWatermarkSeeded = true;
       if (found > 0)

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -582,6 +582,18 @@ export function mergePreferredRelays(input: {
   };
 }
 
+export function shouldUseIncrementalChainDiscoveryScan(input: {
+  run: number;
+  watermarkSeeded: boolean;
+  fullScanEvery: number;
+}): boolean {
+  return (
+    input.watermarkSeeded &&
+    input.run !== 0 &&
+    input.run % input.fullScanEvery !== 0
+  );
+}
+
 export interface PromoteWorkerDaemonLifecycle {
   waitForStartup(): Promise<void>;
   stop(reason?: string | null): Promise<void>;
@@ -1732,13 +1744,19 @@ export async function runDaemonInner(
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
   let chainScanRuns = 0;
+  let chainScanWatermarkSeeded = false;
   const runChainDiscoveryScan = async () => {
     try {
       const run = chainScanRuns++;
-      const incremental = run !== 0 && run % CHAIN_FULL_SCAN_EVERY !== 0;
+      const incremental = shouldUseIncrementalChainDiscoveryScan({
+        run,
+        watermarkSeeded: chainScanWatermarkSeeded,
+        fullScanEvery: CHAIN_FULL_SCAN_EVERY,
+      });
       const found = await agent.discoverContextGraphsFromChain(
         incremental ? { incremental: true } : { seedIncrementalWatermark: true },
       );
+      if (!incremental) chainScanWatermarkSeeded = true;
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1752,19 +1752,17 @@ export async function runDaemonInner(
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
   let chainScanRuns = 0;
-  let chainScanWatermarkSeeded = false;
   const runChainDiscoveryScan = async () => {
     try {
       const run = chainScanRuns++;
       const incremental = shouldUseIncrementalChainDiscoveryScan({
         run,
-        watermarkSeeded: chainScanWatermarkSeeded,
+        watermarkSeeded: await agent.hasContextGraphRegistryScanWatermark(),
         fullScanEvery: CHAIN_FULL_SCAN_EVERY,
       });
       const found = await agent.discoverContextGraphsFromChain(
         chainDiscoveryScanOptions(incremental),
       );
-      if (!incremental) chainScanWatermarkSeeded = true;
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1730,24 +1730,23 @@ export async function runDaemonInner(
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
-  setTimeout(async () => {
+  const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+  let chainScanRuns = 0;
+  const runChainDiscoveryScan = async () => {
     try {
-      const found = await agent.discoverContextGraphsFromChain({ incremental: true });
+      const run = chainScanRuns++;
+      const incremental = run !== 0 && run % CHAIN_FULL_SCAN_EVERY !== 0;
+      const found = await agent.discoverContextGraphsFromChain(
+        incremental ? { incremental: true } : undefined,
+      );
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {
       /* non-critical */
     }
-  }, 15_000);
-  const chainScanTimer = setInterval(async () => {
-    try {
-      const found = await agent.discoverContextGraphsFromChain({ incremental: true });
-      if (found > 0)
-        log(`Chain scan: discovered ${found} new context graph(s)`);
-    } catch {
-      /* non-critical */
-    }
-  }, CHAIN_SCAN_INTERVAL_MS);
+  };
+  setTimeout(runChainDiscoveryScan, 15_000);
+  const chainScanTimer = setInterval(runChainDiscoveryScan, CHAIN_SCAN_INTERVAL_MS);
   if (chainScanTimer.unref) chainScanTimer.unref();
 
   // Periodic peer health ping (every 2 minutes)

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1737,7 +1737,7 @@ export async function runDaemonInner(
       const run = chainScanRuns++;
       const incremental = run !== 0 && run % CHAIN_FULL_SCAN_EVERY !== 0;
       const found = await agent.discoverContextGraphsFromChain(
-        incremental ? { incremental: true } : undefined,
+        incremental ? { incremental: true } : { seedIncrementalWatermark: true },
       );
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1732,7 +1732,7 @@ export async function runDaemonInner(
   const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   setTimeout(async () => {
     try {
-      const found = await agent.discoverContextGraphsFromChain();
+      const found = await agent.discoverContextGraphsFromChain({ incremental: true });
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {
@@ -1741,7 +1741,7 @@ export async function runDaemonInner(
   }, 15_000);
   const chainScanTimer = setInterval(async () => {
     try {
-      const found = await agent.discoverContextGraphsFromChain();
+      const found = await agent.discoverContextGraphsFromChain({ incremental: true });
       if (found > 0)
         log(`Chain scan: discovered ${found} new context graph(s)`);
     } catch {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1243,6 +1243,7 @@ export async function runDaemonInner(
       operationalKeys: opWallets.wallets.map((w) => w.privateKey),
       chainId: chainBase.chainId,
       approvalPolicy: resolveApprovalPolicy(chainBase.approvalPolicy) as ApprovalPolicy | undefined,
+      cgRegistryScanPageSize: chainBase.cgRegistryScanPageSize,
     } : undefined,
     sharedMemoryTtlMs: resolveSharedMemoryTtlMs(config),
     // RFC ka-metadata-trim P3.3 — lifecycle PROV event writes (default true).

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUseIncrementalChainDiscoveryScan } from '../src/daemon/lifecycle.js';
+
+describe('shouldUseIncrementalChainDiscoveryScan', () => {
+  it('starts with a full scan before any watermark seed exists', () => {
+    expect(
+      shouldUseIncrementalChainDiscoveryScan({
+        run: 0,
+        watermarkSeeded: false,
+        fullScanEvery: 48,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps retrying full scans until a watermark seed succeeds', () => {
+    expect(
+      shouldUseIncrementalChainDiscoveryScan({
+        run: 1,
+        watermarkSeeded: false,
+        fullScanEvery: 48,
+      }),
+    ).toBe(false);
+  });
+
+  it('uses incremental scans after a successful watermark seed', () => {
+    expect(
+      shouldUseIncrementalChainDiscoveryScan({
+        run: 1,
+        watermarkSeeded: true,
+        fullScanEvery: 48,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the scheduled full-resync cadence after a watermark seed', () => {
+    expect(
+      shouldUseIncrementalChainDiscoveryScan({
+        run: 48,
+        watermarkSeeded: true,
+        fullScanEvery: 48,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { shouldUseIncrementalChainDiscoveryScan } from '../src/daemon/lifecycle.js';
+import {
+  chainDiscoveryScanOptions,
+  shouldUseIncrementalChainDiscoveryScan,
+} from '../src/daemon/lifecycle.js';
 
 describe('shouldUseIncrementalChainDiscoveryScan', () => {
   it('starts with a full scan before any watermark seed exists', () => {
@@ -40,5 +43,18 @@ describe('shouldUseIncrementalChainDiscoveryScan', () => {
         fullScanEvery: 48,
       }),
     ).toBe(false);
+  });
+});
+
+describe('chainDiscoveryScanOptions', () => {
+  it('uses failure-throwing watermark seeding for full daemon scans', () => {
+    expect(chainDiscoveryScanOptions(false)).toEqual({
+      seedIncrementalWatermark: true,
+      throwOnChainScanFailure: true,
+    });
+  });
+
+  it('keeps steady-state daemon scans incremental-only', () => {
+    expect(chainDiscoveryScanOptions(true)).toEqual({ incremental: true });
   });
 });

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -486,6 +486,20 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged?.chainId).toBe(fullNetworkChain.chainId);
   });
 
+  it('merges cgRegistryScanPageSize with operator precedence', () => {
+    const inherited = resolveChainConfig(
+      {},
+      { chain: { ...fullNetworkChain, cgRegistryScanPageSize: 10_000 } },
+    );
+    expect(inherited?.cgRegistryScanPageSize).toBe(10_000);
+
+    const overridden = resolveChainConfig(
+      { chain: { cgRegistryScanPageSize: 4_000 } },
+      { chain: { ...fullNetworkChain, cgRegistryScanPageSize: 10_000 } },
+    );
+    expect(overridden?.cgRegistryScanPageSize).toBe(4_000);
+  });
+
   it('dedupes primary + backups while preserving operator priority', () => {
     const merged = resolveChainConfig(
       {

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           // timeout attribution regressions in the fast unit lane too.
           'test/daemon-openclaw.test.ts',
           'test/daemon-hermes.test.ts',
+          'test/chain-discovery-scan-mode.test.ts',
         ],
     testTimeout: runsDaemonHttpBehavior ? 120_000 : 60_000,
     globalSetup: runsDaemonHttpBehavior ? ['../chain/test/hardhat-global-setup.ts'] : [],


### PR DESCRIPTION
## Summary

- Repairs the CG-registry chain scan that fails every 30 min with "query exceeds max block range 2000": deploy-block anchoring (generalized `resolveContractDeployBlock`), a 2,000-block page default knob, a page budget + actionable error, per-chunk retry then partial return with an in-memory watermark (+50-block reorg buffer), and a failure circuit breaker that warns on state change only.
- Scope note: the EVM path reads only `NameClaimed` (no `MetadataRevealed`), so the consumer can't yet subscribe from scan results — B2's user-visible value is killing the failure loop / log noise; a follow-up that reads metadata-reveal makes discovery actionable.

## Related

- Part of #1138 (Track B, PR B2). Independent. Mirrors the reviewed KA-path pattern (#1108; #1111 merged 2026-06-11 — re-anchor to the post-#1111 helper).
- **Merge order:** Wave 1 (parallel; shares `cli/daemon/lifecycle.ts`).

## Files changed

| File | What |
|------|------|
| `chain/src/evm-adapter-context-graph.ts` | Deploy-anchor + capped pages + budget + watermark |
| `chain/src/evm-adapter-base.ts`, `evm-adapter-types.ts`, `chain-adapter.ts`, `mock-adapter.ts` | Generalized deploy-block resolver + config |
| `agent/src/dkg-agent.ts` | Discovery circuit breaker |
| `cli/src/config.ts`, `cli/src/daemon/lifecycle.ts` | `cgRegistryScanPageSize` knob |

Plus 5 test files.

## Test plan

- [ ] `pnpm -F @origintrail-official/dkg-chain -F dkg-agent test`
- [ ] Mock provider rejecting > 2,000-block spans → scan succeeds in capped chunks; partial-on-failure advances watermark only past scanned chunks
- [ ] Breaker: repeated failures → at most one warn per escalation per hour
- [ ] `pnpm build` + lint

---
*Targets `integration/issue-1138` (not `main`) so the heavy overlaps on `dkg-agent-lifecycle.ts` / `dkg-agent-base.ts` are resolved once on the integration branch, which is promoted to `main` in two gated waves (see #1138, Coordination). Single squashed commit off `main`.*