### PR TITLE
B3 — listContextGraphs graceful degradation (policy-closed)

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -814,8 +814,9 @@ export class DKGAgentBase {
       return injectedStoreListCacheAllowed(this.store, this.config.storeConfig);
     }
     const storeConfig = this.config.storeConfig;
-    if (!storeConfig || !isExternalBackend(storeConfig.backend)) return true;
-    return storeConfig.options?.managedByDkg === true;
+    if (!storeConfig) return true;
+    if (isExternalBackend(storeConfig.backend)) return storeConfig.options?.managedByDkg === true;
+    return isLocalOxigraphConfig(storeConfig);
   }
 
   protected invalidateListContextGraphsCache(): void {

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -704,6 +704,10 @@ export class DKGAgentBase {
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_MAX']) || 32);
   static readonly LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS =
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS']) || 200);
+  static readonly LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS =
+    Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS']) || 5_000);
+  static readonly LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS =
+    Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS']) || 5_000);
 
   protected messageHandler: MessageHandler | null = null;
   protected chainPoller: ChainEventPoller | null = null;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -381,6 +381,13 @@ import {
 } from './dkg-agent-swm-state.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+function readNonNegativeNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : fallback;
+}
+
 export class DKGAgentBase {
   readonly wallet: AgentWallet;
   readonly node: DKGNode;
@@ -692,7 +699,7 @@ export class DKGAgentBase {
     Number(process.env['DKG_VM_RECONCILE_CONFIRMATION_DEPTH']) || 5;
 
   static readonly LIST_CONTEXT_GRAPHS_CACHE_TTL_MS =
-    Math.max(0, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS']) || 5_000);
+    readNonNegativeNumberEnv('DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', 5_000);
   static readonly LIST_CONTEXT_GRAPHS_CACHE_MAX =
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_MAX']) || 32);
   static readonly LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS =

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -424,6 +424,76 @@ function injectedStoreListCacheAllowed(store: TripleStore, storeConfig?: TripleS
   return false;
 }
 
+export function createListContextGraphsCacheInvalidatingStore(
+  innerStore: TripleStore,
+  invalidate: () => void,
+): TripleStore {
+  const invalidateAfterMutation = async <T>(work: () => Promise<T>, changed: (result: T) => boolean): Promise<T> => {
+    const result = await work();
+    if (changed(result)) invalidate();
+    return result;
+  };
+  const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
+    innerStore,
+    get queryCancellation() {
+      return innerStore.queryCancellation;
+    },
+    insert(quads) {
+      return invalidateAfterMutation(
+        () => innerStore.insert(quads),
+        () => quads.length > 0,
+      );
+    },
+    delete(quads) {
+      return invalidateAfterMutation(
+        () => innerStore.delete(quads),
+        () => quads.length > 0,
+      );
+    },
+    deleteByPattern(pattern) {
+      return invalidateAfterMutation(
+        () => innerStore.deleteByPattern(pattern),
+        removed => removed > 0,
+      );
+    },
+    query(sparql, options) {
+      return invalidateAfterMutation(
+        () => innerStore.query(sparql, options),
+        () => isSparqlUpdateStatement(sparql),
+      );
+    },
+    hasGraph(graphUri) {
+      return innerStore.hasGraph(graphUri);
+    },
+    createGraph(graphUri) {
+      return innerStore.createGraph(graphUri);
+    },
+    dropGraph(graphUri) {
+      return invalidateAfterMutation(
+        () => innerStore.dropGraph(graphUri),
+        () => true,
+      );
+    },
+    listGraphs(options) {
+      return innerStore.listGraphs(options);
+    },
+    deleteBySubjectPrefix(graphUri, prefix) {
+      return invalidateAfterMutation(
+        () => innerStore.deleteBySubjectPrefix(graphUri, prefix),
+        removed => removed > 0,
+      );
+    },
+    countQuads(graphUri) {
+      return innerStore.countQuads(graphUri);
+    },
+    flush: innerStore.flush ? () => innerStore.flush!() : undefined,
+    close() {
+      return innerStore.close();
+    },
+  };
+  return wrapper;
+}
+
 export class DKGAgentBase {
   readonly wallet: AgentWallet;
   readonly node: DKGNode;
@@ -842,49 +912,6 @@ export class DKGAgentBase {
     this.listContextGraphsCacheGeneration += 1;
     this.listContextGraphsCache.clear();
     this.listContextGraphsInFlight.clear();
-  }
-
-  protected bindListContextGraphsCacheInvalidatingStore(): void {
-    const store = this.store;
-
-    const originalInsert = store.insert.bind(store);
-    store.insert = async (quads: Quad[]): Promise<void> => {
-      await originalInsert(quads);
-      if (quads.length > 0) this.invalidateListContextGraphsCache();
-    };
-
-    const originalDelete = store.delete.bind(store);
-    store.delete = async (quads: Quad[]): Promise<void> => {
-      await originalDelete(quads);
-      if (quads.length > 0) this.invalidateListContextGraphsCache();
-    };
-
-    const originalDeleteByPattern = store.deleteByPattern.bind(store);
-    store.deleteByPattern = async (pattern: Partial<Quad>): Promise<number> => {
-      const removed = await originalDeleteByPattern(pattern);
-      if (removed > 0) this.invalidateListContextGraphsCache();
-      return removed;
-    };
-
-    const originalDeleteBySubjectPrefix = store.deleteBySubjectPrefix.bind(store);
-    store.deleteBySubjectPrefix = async (graphUri: string, prefix: string): Promise<number> => {
-      const removed = await originalDeleteBySubjectPrefix(graphUri, prefix);
-      if (removed > 0) this.invalidateListContextGraphsCache();
-      return removed;
-    };
-
-    const originalDropGraph = store.dropGraph.bind(store);
-    store.dropGraph = async (graphUri: string): Promise<void> => {
-      await originalDropGraph(graphUri);
-      this.invalidateListContextGraphsCache();
-    };
-
-    const originalQuery = store.query.bind(store);
-    store.query = async (...args: Parameters<TripleStore['query']>): ReturnType<TripleStore['query']> => {
-      const result = await originalQuery(...args);
-      if (isSparqlUpdateStatement(args[0])) this.invalidateListContextGraphsCache();
-      return result;
-    };
   }
 
   protected async insertSyncedQuadsAndInvalidateListCache(quads: Quad[]): Promise<void> {
@@ -1313,7 +1340,6 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
-    this.bindListContextGraphsCacheInvalidatingStore();
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -10,6 +10,7 @@
  * be declared; external construction still goes through `DKGAgent.create`.
  */
 import { createHash, randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
@@ -386,6 +387,14 @@ function readNonNegativeNumberEnv(name: string, fallback: number): number {
   if (raw === undefined || raw.trim() === '') return fallback;
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? Math.max(0, parsed) : fallback;
+}
+
+function isSparqlUpdateStatement(sparql: string): boolean {
+  const withoutPrologue = sparql.replace(
+    /^\s*(?:(?:PREFIX\s+[\w-]*:\s*<[^>]+>|BASE\s+<[^>]+>)\s*)*/i,
+    '',
+  );
+  return /^(?:WITH\s+<[^>]+>\s*)?(?:INSERT|DELETE|DROP|CLEAR|CREATE|LOAD|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
 }
 
 export class DKGAgentBase {
@@ -788,11 +797,65 @@ export class DKGAgentBase {
   }>();
   protected readonly listContextGraphsInFlight = new Map<string, Promise<Array<Record<string, unknown>>>>();
   protected listContextGraphsCacheGeneration = 0;
+  protected listContextGraphsCacheNow(): number {
+    return performance.now();
+  }
+
   protected invalidateListContextGraphsCache(): void {
     this.listContextGraphsCacheGeneration += 1;
     this.listContextGraphsCache.clear();
     this.listContextGraphsInFlight.clear();
   }
+
+  protected bindListContextGraphsCacheInvalidatingStore(): void {
+    const store = this.store;
+
+    const originalInsert = store.insert.bind(store);
+    store.insert = async (quads: Quad[]): Promise<void> => {
+      await originalInsert(quads);
+      if (quads.length > 0) this.invalidateListContextGraphsCache();
+    };
+
+    const originalDelete = store.delete.bind(store);
+    store.delete = async (quads: Quad[]): Promise<void> => {
+      await originalDelete(quads);
+      if (quads.length > 0) this.invalidateListContextGraphsCache();
+    };
+
+    const originalDeleteByPattern = store.deleteByPattern.bind(store);
+    store.deleteByPattern = async (pattern: Partial<Quad>): Promise<number> => {
+      const removed = await originalDeleteByPattern(pattern);
+      if (removed > 0) this.invalidateListContextGraphsCache();
+      return removed;
+    };
+
+    const originalDeleteBySubjectPrefix = store.deleteBySubjectPrefix.bind(store);
+    store.deleteBySubjectPrefix = async (graphUri: string, prefix: string): Promise<number> => {
+      const removed = await originalDeleteBySubjectPrefix(graphUri, prefix);
+      if (removed > 0) this.invalidateListContextGraphsCache();
+      return removed;
+    };
+
+    const originalCreateGraph = store.createGraph.bind(store);
+    store.createGraph = async (graphUri: string): Promise<void> => {
+      await originalCreateGraph(graphUri);
+      this.invalidateListContextGraphsCache();
+    };
+
+    const originalDropGraph = store.dropGraph.bind(store);
+    store.dropGraph = async (graphUri: string): Promise<void> => {
+      await originalDropGraph(graphUri);
+      this.invalidateListContextGraphsCache();
+    };
+
+    const originalQuery = store.query.bind(store);
+    store.query = async (...args: Parameters<TripleStore['query']>): ReturnType<TripleStore['query']> => {
+      const result = await originalQuery(...args);
+      if (isSparqlUpdateStatement(args[0])) this.invalidateListContextGraphsCache();
+      return result;
+    };
+  }
+
   protected async insertSyncedQuadsAndInvalidateListCache(quads: Quad[]): Promise<void> {
     await this.store.insert(quads);
     if (quads.length > 0) this.invalidateListContextGraphsCache();
@@ -1219,6 +1282,7 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
+    this.bindListContextGraphsCacheInvalidatingStore();
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { BlazegraphStore, GraphManager, OxigraphStore, OxigraphWorkerStore, PrivateContentStore, SparqlHttpStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -395,33 +395,6 @@ function isSparqlUpdateStatement(sparql: string): boolean {
     '',
   );
   return /^(?:WITH\s+<[^>]+>\s*)?(?:INSERT|DELETE|DROP|CLEAR|CREATE|LOAD|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
-}
-
-function isTripleStoreLike(value: unknown): value is TripleStore {
-  return !!value
-    && typeof (value as TripleStore).query === 'function'
-    && typeof (value as TripleStore).insert === 'function'
-    && typeof (value as TripleStore).listGraphs === 'function';
-}
-
-function unwrapListCacheStore(store: TripleStore, seen = new Set<TripleStore>()): TripleStore {
-  if (seen.has(store)) return store;
-  seen.add(store);
-  const wrapped = store as { innerStore?: unknown; inner?: unknown };
-  const innerStore = wrapped.innerStore ?? wrapped.inner;
-  if (isTripleStoreLike(innerStore)) {
-    return unwrapListCacheStore(innerStore, seen);
-  }
-  return store;
-}
-
-function injectedStoreListCacheAllowed(store: TripleStore, storeConfig?: TripleStoreConfig): boolean {
-  const effectiveStore = unwrapListCacheStore(store);
-  if (effectiveStore instanceof BlazegraphStore || effectiveStore instanceof SparqlHttpStore) {
-    return !!storeConfig && isExternalBackend(storeConfig.backend) && storeConfig.options?.managedByDkg === true;
-  }
-  if (effectiveStore instanceof OxigraphStore || effectiveStore instanceof OxigraphWorkerStore) return true;
-  return false;
 }
 
 export function createListContextGraphsCacheInvalidatingStore(
@@ -900,7 +873,7 @@ export class DKGAgentBase {
 
   protected listContextGraphsCacheAllowed(): boolean {
     if (this.config.store) {
-      return injectedStoreListCacheAllowed(this.store, this.config.storeConfig);
+      return false;
     }
     const storeConfig = this.config.storeConfig;
     if (!storeConfig) return true;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -691,6 +691,13 @@ export class DKGAgentBase {
   static readonly VM_RECONCILE_CONFIRMATION_DEPTH =
     Number(process.env['DKG_VM_RECONCILE_CONFIRMATION_DEPTH']) || 5;
 
+  static readonly LIST_CONTEXT_GRAPHS_CACHE_TTL_MS =
+    Math.max(0, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS']) || 5_000);
+  static readonly LIST_CONTEXT_GRAPHS_CACHE_MAX =
+    Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_MAX']) || 32);
+  static readonly LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS =
+    Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS']) || 200);
+
   protected messageHandler: MessageHandler | null = null;
   protected chainPoller: ChainEventPoller | null = null;
   protected swmCleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -764,6 +771,17 @@ export class DKGAgentBase {
   protected readonly config: DKGAgentConfig;
   protected started = false;
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
+  protected readonly listContextGraphsCache = new Map<string, {
+    expiresAt: number;
+    rows: Array<Record<string, unknown>>;
+  }>();
+  protected readonly listContextGraphsInFlight = new Map<string, Promise<Array<Record<string, unknown>>>>();
+  protected listContextGraphsCacheGeneration = 0;
+  protected invalidateListContextGraphsCache(): void {
+    this.listContextGraphsCacheGeneration += 1;
+    this.listContextGraphsCache.clear();
+    this.listContextGraphsInFlight.clear();
+  }
   protected readonly gossipRegistered = new Set<string>();
   protected readonly sharedMemoryGossipRegistered = new Set<string>();
   protected readonly seenOnChainIds = new Set<string>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -836,12 +836,6 @@ export class DKGAgentBase {
       return removed;
     };
 
-    const originalCreateGraph = store.createGraph.bind(store);
-    store.createGraph = async (graphUri: string): Promise<void> => {
-      await originalCreateGraph(graphUri);
-      this.invalidateListContextGraphsCache();
-    };
-
     const originalDropGraph = store.dropGraph.bind(store);
     store.dropGraph = async (graphUri: string): Promise<void> => {
       await originalDropGraph(graphUri);

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -799,6 +799,12 @@ export class DKGAgentBase {
   protected listContextGraphsCacheGeneration = 0;
   protected listContextGraphsCacheNow(): number {
     return performance.now();
+  }
+
+  protected listContextGraphsCacheAllowed(): boolean {
+    const storeConfig = this.config.storeConfig;
+    if (!storeConfig || !isExternalBackend(storeConfig.backend)) return true;
+    return storeConfig.options?.managedByDkg === true;
   }
 
   protected invalidateListContextGraphsCache(): void {

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -95,7 +95,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { BlazegraphStore, GraphManager, OxigraphStore, OxigraphWorkerStore, PrivateContentStore, SparqlHttpStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -395,6 +395,14 @@ function isSparqlUpdateStatement(sparql: string): boolean {
     '',
   );
   return /^(?:WITH\s+<[^>]+>\s*)?(?:INSERT|DELETE|DROP|CLEAR|CREATE|LOAD|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+}
+
+function injectedStoreListCacheAllowed(store: TripleStore, storeConfig?: TripleStoreConfig): boolean {
+  if (store instanceof BlazegraphStore || store instanceof SparqlHttpStore) {
+    return !!storeConfig && isExternalBackend(storeConfig.backend) && storeConfig.options?.managedByDkg === true;
+  }
+  if (store instanceof OxigraphStore || store instanceof OxigraphWorkerStore) return true;
+  return false;
 }
 
 export class DKGAgentBase {
@@ -802,6 +810,9 @@ export class DKGAgentBase {
   }
 
   protected listContextGraphsCacheAllowed(): boolean {
+    if (this.config.store) {
+      return injectedStoreListCacheAllowed(this.store, this.config.storeConfig);
+    }
     const storeConfig = this.config.storeConfig;
     if (!storeConfig || !isExternalBackend(storeConfig.backend)) return true;
     return storeConfig.options?.managedByDkg === true;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -782,6 +782,10 @@ export class DKGAgentBase {
     this.listContextGraphsCache.clear();
     this.listContextGraphsInFlight.clear();
   }
+  protected async insertSyncedQuadsAndInvalidateListCache(quads: Quad[]): Promise<void> {
+    await this.store.insert(quads);
+    if (quads.length > 0) this.invalidateListContextGraphsCache();
+  }
   protected readonly gossipRegistered = new Set<string>();
   protected readonly sharedMemoryGossipRegistered = new Set<string>();
   protected readonly seenOnChainIds = new Set<string>();

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -397,11 +397,30 @@ function isSparqlUpdateStatement(sparql: string): boolean {
   return /^(?:WITH\s+<[^>]+>\s*)?(?:INSERT|DELETE|DROP|CLEAR|CREATE|LOAD|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
 }
 
+function isTripleStoreLike(value: unknown): value is TripleStore {
+  return !!value
+    && typeof (value as TripleStore).query === 'function'
+    && typeof (value as TripleStore).insert === 'function'
+    && typeof (value as TripleStore).listGraphs === 'function';
+}
+
+function unwrapListCacheStore(store: TripleStore, seen = new Set<TripleStore>()): TripleStore {
+  if (seen.has(store)) return store;
+  seen.add(store);
+  const wrapped = store as { innerStore?: unknown; inner?: unknown };
+  const innerStore = wrapped.innerStore ?? wrapped.inner;
+  if (isTripleStoreLike(innerStore)) {
+    return unwrapListCacheStore(innerStore, seen);
+  }
+  return store;
+}
+
 function injectedStoreListCacheAllowed(store: TripleStore, storeConfig?: TripleStoreConfig): boolean {
-  if (store instanceof BlazegraphStore || store instanceof SparqlHttpStore) {
+  const effectiveStore = unwrapListCacheStore(store);
+  if (effectiveStore instanceof BlazegraphStore || effectiveStore instanceof SparqlHttpStore) {
     return !!storeConfig && isExternalBackend(storeConfig.backend) && storeConfig.options?.managedByDkg === true;
   }
-  if (store instanceof OxigraphStore || store instanceof OxigraphWorkerStore) return true;
+  if (effectiveStore instanceof OxigraphStore || effectiveStore instanceof OxigraphWorkerStore) return true;
   return false;
 }
 

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -416,7 +416,11 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     return owned !== undefined && owned.size > 0;
   }
 
-  async getContextGraphOnChainId(this: DKGAgent, contextGraphId: string): Promise<string | null> {
+  async getContextGraphOnChainId(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string | null> {
     const subscribed = this.subscribedContextGraphs.get(contextGraphId)?.onChainId;
     if (subscribed) return subscribed;
 
@@ -424,6 +428,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     const result = await this.store.query(
       `SELECT ?id WHERE { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> ?id } } LIMIT 1`,
+      { signal: options.signal },
     );
     if (result.type !== 'bindings' || result.bindings.length === 0) return null;
     const value = result.bindings[0]?.['id'];

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -2012,7 +2012,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         cacheable = false;
         return 'unknown';
       }
-      return legacyRead.value ? 'private' : 'unknown';
+      return legacyRead.value ? 'private' : 'public';
     };
     const privacySettled = await Promise.allSettled(rows.map(async (row) => ({
       uri: row.uri,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1986,6 +1986,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       if (seen.has(uri)) continue;
       if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) continue;
 
+      const contentRead = await withBudget(
+        (signal) => this.contextGraphHasLocalContent(id, { signal }),
+        `storage content probe for ${id}`,
+      );
+      if (!contentRead.ok) cacheable = false;
+      if (contentRead.ok && !contentRead.value) continue;
+
       const sub = this.subscribedContextGraphs.get(id);
       const onChainId = sub?.onChainId ?? (await optional(
         (signal) => this.getContextGraphOnChainId(id, { signal }),

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -2052,10 +2052,14 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       if (curatorMatch) {
         return { row: { ...r, callerInvolved: true }, privacy };
       }
+      let usedLiveChainAuth = false;
       const allowlistRead = await withBudget(
-        () => this.callerIsAllowlistedAgentParticipant(r.id, checksum),
+        () => this.callerIsAllowlistedAgentParticipant(r.id, checksum, {
+          onChainLookup: () => { usedLiveChainAuth = true; },
+        }),
         `allowlist lookup for ${r.id}`,
       );
+      if (usedLiveChainAuth) cacheable = false;
       if (!allowlistRead.ok) cacheable = false;
       // `callerInvolved` must reflect ONLY the provided caller wallet.
       // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1990,8 +1990,12 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       'storage context graph scan',
       scanBudgetMs,
     );
-    if (!storedRead.ok) cacheable = false;
-    const storedContextGraphs = storedRead.ok ? storedRead.value : [];
+    if (!storedRead.ok) {
+      throw storedRead.error instanceof Error
+        ? storedRead.error
+        : new Error(`listContextGraphs storage graph scan failed: ${String(storedRead.error)}`);
+    }
+    const storedContextGraphs = storedRead.value;
     for (const id of storedContextGraphs) {
       const uri = `${prefix}${id}`;
       if (seen.has(uri)) continue;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1657,8 +1657,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const cacheKey = checksum
       ? `wallet:${checksum.toLowerCase()}`
       : scopedListing ? 'no-wallet' : 'owner-unscoped';
-    const cacheTtlMs = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
-    if (cacheTtlMs > 0) {
+    const cacheEnabled = this.listContextGraphsCacheAllowed()
+      && DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS > 0;
+    const cacheTtlMs = cacheEnabled ? DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS : 0;
+    if (cacheEnabled) {
       const cached = this.listContextGraphsCache.get(cacheKey);
       if (cached) {
         if (cached.expiresAt > this.listContextGraphsCacheNow()) {
@@ -1670,16 +1672,18 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }
     }
 
-    const inFlight = this.listContextGraphsInFlight.get(cacheKey);
-    if (inFlight) {
-      return cloneRows((await inFlight) as ListContextGraphsRow[]);
+    if (cacheEnabled) {
+      const inFlight = this.listContextGraphsInFlight.get(cacheKey);
+      if (inFlight) {
+        return cloneRows((await inFlight) as ListContextGraphsRow[]);
+      }
     }
 
     const generation = this.listContextGraphsCacheGeneration;
     const task = (async () => {
       const result = await this.listContextGraphsUncached(checksum, scopedListing);
       const rows = result.rows;
-      if (cacheTtlMs > 0 && result.cacheable && this.listContextGraphsCacheGeneration === generation) {
+      if (cacheEnabled && result.cacheable && this.listContextGraphsCacheGeneration === generation) {
         this.listContextGraphsCache.set(cacheKey, {
           expiresAt: this.listContextGraphsCacheNow() + cacheTtlMs,
           rows: cloneRows(rows) as Array<Record<string, unknown>>,
@@ -1693,11 +1697,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       return rows;
     })();
 
-    this.listContextGraphsInFlight.set(cacheKey, task as Promise<Array<Record<string, unknown>>>);
+    if (cacheEnabled) {
+      this.listContextGraphsInFlight.set(cacheKey, task as Promise<Array<Record<string, unknown>>>);
+    }
     try {
       return cloneRows(await task);
     } finally {
-      if (this.listContextGraphsInFlight.get(cacheKey) === task) {
+      if (cacheEnabled && this.listContextGraphsInFlight.get(cacheKey) === task) {
         this.listContextGraphsInFlight.delete(cacheKey);
       }
     }
@@ -1784,8 +1790,12 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       'ontology/agents definition scan',
       scanBudgetMs,
     );
-    if (!initialRead.ok) cacheable = false;
-    const result = initialRead.ok ? initialRead.value : undefined;
+    if (!initialRead.ok) {
+      throw initialRead.error instanceof Error
+        ? initialRead.error
+        : new Error(`listContextGraphs primary definition scan failed: ${String(initialRead.error)}`);
+    }
+    const result = initialRead.value;
 
     const prefix = 'did:dkg:context-graph:';
     const seen = new Map<string, ListContextGraphsRow>();

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -246,6 +246,21 @@ type JoinApprovalRetryEntry = {
   nextAttemptAt: number;
   lastError: string;
 };
+type ListContextGraphsRow = {
+  id: string;
+  uri: string;
+  name: string;
+  description?: string;
+  creator?: string;
+  curator?: string;
+  accessPolicy?: string;
+  createdAt?: string;
+  isSystem: boolean;
+  subscribed: boolean;
+  synced: boolean;
+  onChainId?: string;
+  callerInvolved?: boolean;
+};
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -1611,31 +1626,109 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * With a valid `callerAgentAddress` option, each row includes `callerInvolved`.
    * With no usable caller wallet, omit that field entirely so callers can infer membership from `curator`.
    */
-  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<Array<{
-    id: string;
-    uri: string;
-    name: string;
-    description?: string;
-    creator?: string;
-    /** Wallet-scoped curator DID (from _meta / ontology), if present. */
-    curator?: string;
-    /** Declared access policy literal, e.g. public / private. */
-    accessPolicy?: string;
-    createdAt?: string;
-    isSystem: boolean;
-    subscribed: boolean;
-    synced: boolean;
-    onChainId?: string;
-    /**
-     * When `callerAgentAddress` is omitted or invalid: property is omitted —
-     * clients fall back to comparing `curator` to identity (listing was not scoped to a caller).
-     * When a valid caller is provided: explicit true/false.
-     */
-    callerInvolved?: boolean;
-  }>> {
+  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ListContextGraphsRow[]> {
+    const scopedListing = opts !== undefined;
+    let checksum: string | null = null;
+    const rawCaller = opts?.callerAgentAddress?.trim();
+    if (rawCaller && ethers.isAddress(rawCaller)) {
+      try {
+        checksum = ethers.getAddress(rawCaller);
+      } catch {
+        checksum = null;
+      }
+    }
+
+    const cloneRows = (rows: ListContextGraphsRow[]): ListContextGraphsRow[] => rows.map((row) => ({ ...row }));
+    const cacheKey = checksum
+      ? `wallet:${checksum.toLowerCase()}`
+      : scopedListing ? 'no-wallet' : 'owner-unscoped';
+    const cached = this.listContextGraphsCache.get(cacheKey);
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        this.listContextGraphsCache.delete(cacheKey);
+        this.listContextGraphsCache.set(cacheKey, cached);
+        return cloneRows(cached.rows as ListContextGraphsRow[]);
+      }
+      this.listContextGraphsCache.delete(cacheKey);
+    }
+
+    const inFlight = this.listContextGraphsInFlight.get(cacheKey);
+    if (inFlight) {
+      return cloneRows((await inFlight) as ListContextGraphsRow[]);
+    }
+
+    const generation = this.listContextGraphsCacheGeneration;
+    const task = (async () => {
+      const rows = await this.listContextGraphsUncached(checksum, scopedListing);
+      if (this.listContextGraphsCacheGeneration === generation) {
+        this.listContextGraphsCache.set(cacheKey, {
+          expiresAt: Date.now() + DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS,
+          rows: cloneRows(rows) as Array<Record<string, unknown>>,
+        });
+        while (this.listContextGraphsCache.size > DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_MAX) {
+          const oldest = this.listContextGraphsCache.keys().next().value;
+          if (!oldest) break;
+          this.listContextGraphsCache.delete(oldest);
+        }
+      }
+      return rows;
+    })();
+
+    this.listContextGraphsInFlight.set(cacheKey, task as Promise<Array<Record<string, unknown>>>);
+    try {
+      return cloneRows(await task);
+    } finally {
+      if (this.listContextGraphsInFlight.get(cacheKey) === task) {
+        this.listContextGraphsInFlight.delete(cacheKey);
+      }
+    }
+  }
+
+  protected async listContextGraphsUncached(this: DKGAgent, checksum: string | null, scopedListing: boolean): Promise<ListContextGraphsRow[]> {
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
-    const result = await this.store.query(`
+    const rowBudgetMs = Math.max(1, DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS);
+    const globalBudgetMs = Math.max(
+      rowBudgetMs,
+      Math.min(5_000, rowBudgetMs * Math.max(1, this.subscribedContextGraphs.size + 4)),
+    );
+    const deadlineAt = Date.now() + globalBudgetMs;
+
+    const withBudget = async <T>(
+      work: () => Promise<T>,
+      label: string,
+      budgetMs = rowBudgetMs,
+    ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> => {
+      const remaining = deadlineAt - Date.now();
+      if (remaining <= 0) {
+        return { ok: false, error: new Error(`${label} exceeded listContextGraphs deadline`) };
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} exceeded listContextGraphs row budget`)),
+          Math.min(budgetMs, remaining),
+        );
+        const unref = (timer as { unref?: () => void } | undefined)?.unref;
+        if (typeof unref === 'function') unref.call(timer);
+      });
+      try {
+        const value = await Promise.race([Promise.resolve().then(work), timeout]);
+        return { ok: true, value };
+      } catch (error) {
+        return { ok: false, error };
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+
+    const optional = async <T>(work: () => Promise<T>, label: string): Promise<T | undefined> => {
+      const result = await withBudget(work, label);
+      return result.ok ? result.value : undefined;
+    };
+
+    const initialRead = await withBudget(
+      () => this.store.query(`
       SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem WHERE {
         {
           GRAPH <${ontologyGraph}> {
@@ -1661,16 +1754,22 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           }
         }
       }
-    `);
+    `),
+      'ontology/agents definition scan',
+      globalBudgetMs,
+    );
+    const result = initialRead.ok ? initialRead.value : undefined;
 
     const prefix = 'did:dkg:context-graph:';
-    const seen = new Map<string, {
-      id: string; uri: string; name: string; description?: string;
-      creator?: string; curator?: string; accessPolicy?: string; createdAt?: string; isSystem: boolean;
-      subscribed: boolean; synced: boolean; onChainId?: string;
-    }>();
+    const seen = new Map<string, ListContextGraphsRow>();
+    const policyKnownByUri = new Map<string, boolean>();
+    const rememberRow = (row: ListContextGraphsRow, policyKnown: boolean): void => {
+      if (seen.has(row.uri)) return;
+      seen.set(row.uri, row);
+      policyKnownByUri.set(row.uri, policyKnown);
+    };
 
-    if (result.type === 'bindings') {
+    if (result?.type === 'bindings') {
       const byUri = new Map<string, Record<string, string>>();
       for (const row of result.bindings as Record<string, string>[]) {
         const uri = row['ctxGraph'] ?? '';
@@ -1678,13 +1777,16 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         byUri.set(uri, row);
       }
       // Parallel lookups — sequential await per ontology row multiplied list latency noticeably.
-      await Promise.all([...byUri.values()].map(async (row) => {
+      await Promise.allSettled([...byUri.values()].map(async (row) => {
         const uri = row['ctxGraph'] ?? '';
         if (seen.has(uri)) return;
         const id = uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
         const sub = this.subscribedContextGraphs.get(id);
-        const onChainId = sub?.onChainId ?? (await this.getContextGraphOnChainId(id)) ?? undefined;
-        seen.set(uri, {
+        const onChainId = sub?.onChainId ?? (await optional(
+          () => this.getContextGraphOnChainId(id),
+          `on-chain id lookup for ${id}`,
+        )) ?? undefined;
+        rememberRow({
           id,
           uri,
           name: stripLiteral(row['name'] ?? id),
@@ -1706,7 +1808,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           // `markContextGraphSubscriptionState` at routes/context-graph.ts:1301).
           synced: sub?.synced ?? false,
           ...(onChainId ? { onChainId } : {}),
-        });
+        }, true);
       }));
     }
 
@@ -1719,7 +1821,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
       const metaGraph = contextGraphMetaGraphUri(id);
       const pUri = contextGraphDataGraphUri(id);
-      const metaResult = await this.store.query(`
+      const metaRead = await withBudget(
+        () => this.store.query(`
         SELECT ?name ?desc ?creator ?created ?curator ?access WHERE {
           GRAPH <${metaGraph}> {
             <${pUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
@@ -1731,12 +1834,18 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             OPTIONAL { <${pUri}> <${DKG_ONTOLOGY.DKG_CREATED_AT}> ?created }
           }
         } LIMIT 1
-      `);
+      `),
+        `meta declaration lookup for ${id}`,
+      );
+      const metaResult = metaRead.ok ? metaRead.value : undefined;
 
-      if (metaResult.type === 'bindings' && metaResult.bindings.length > 0) {
+      if (metaResult?.type === 'bindings' && metaResult.bindings.length > 0) {
         const row = metaResult.bindings[0] as Record<string, string>;
-        const onChainId = sub.onChainId ?? (await this.getContextGraphOnChainId(id)) ?? undefined;
-        seen.set(uri, {
+        const onChainId = sub.onChainId ?? (await optional(
+          () => this.getContextGraphOnChainId(id),
+          `on-chain id lookup for ${id}`,
+        )) ?? undefined;
+        rememberRow({
           id,
           uri,
           name: stripLiteral(row['name'] ?? sub.name ?? id),
@@ -1749,7 +1858,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           subscribed: sub.subscribed,
           synced: sub.synced,
           ...(onChainId ? { onChainId } : {}),
-        });
+        }, true);
         continue;
       }
 
@@ -1789,11 +1898,14 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         // only the root caused legitimate synced projects to be
         // hidden as phantoms here (Codex tier-4m follow-up to N29,
         // same issue in a separate call site).
-        const hasContent = await this.contextGraphHasLocalContent(id);
+        const hasContent = await optional(
+          () => this.contextGraphHasLocalContent(id),
+          `local content probe for ${id}`,
+        );
         if (!hasContent) continue;
       }
 
-      seen.set(uri, {
+      rememberRow({
         id,
         uri,
         name: sub.name ?? id,
@@ -1801,27 +1913,41 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         subscribed: sub.subscribed,
         synced: sub.synced,
         ...(sub.onChainId ? { onChainId: sub.onChainId } : {}),
-      });
+      }, metaRead.ok);
     }
 
     const graphManager = new GraphManager(this.store);
-    const storedContextGraphs = await graphManager.listContextGraphs();
+    const storedRead = await withBudget(
+      () => graphManager.listContextGraphs(),
+      'storage context graph scan',
+      globalBudgetMs,
+    );
+    const storedContextGraphs = storedRead.ok ? storedRead.value : [];
     for (const id of storedContextGraphs) {
       const uri = `${prefix}${id}`;
       if (seen.has(uri)) continue;
       if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) continue;
 
       const sub = this.subscribedContextGraphs.get(id);
-      const onChainId = sub?.onChainId ?? (await this.getContextGraphOnChainId(id)) ?? undefined;
-      seen.set(uri, {
+      const onChainId = sub?.onChainId ?? (await optional(
+        () => this.getContextGraphOnChainId(id),
+        `on-chain id lookup for ${id}`,
+      )) ?? undefined;
+      const policyRead = await withBudget(
+        () => this.getExplicitAccessPolicy(id),
+        `access policy lookup for storage row ${id}`,
+      );
+      const accessPolicy = policyRead.ok && policyRead.value ? policyRead.value : undefined;
+      rememberRow({
         id,
         uri,
         name: sub?.name ?? id,
         isSystem: false,
         subscribed: sub?.subscribed ?? false,
         synced: sub?.synced ?? false,
+        ...(accessPolicy ? { accessPolicy } : {}),
         ...(onChainId ? { onChainId } : {}),
-      });
+      }, accessPolicy !== undefined);
     }
 
     let rows = Array.from(seen.values());
@@ -1831,21 +1957,15 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
      * so list rows lack `curator` and the sidebar cannot classify "mine" without a Bearer-scoped pass.
      * Backfill once (parallelised) — also removes duplicate SPARQL in the involvement pass below.
      */
-    rows = await Promise.all(rows.map(async (r) => {
+    const curatorBackfills = await Promise.allSettled(rows.map(async (r) => {
       if (r.curator?.trim()) return r;
-      const c = await this.getContextGraphCurator(r.id);
+      const c = await optional(
+        () => this.getContextGraphCurator(r.id),
+        `curator lookup for ${r.id}`,
+      );
       return c ? { ...r, curator: c } : r;
     }));
-
-    let checksum: string | null = null;
-    const rawCaller = opts?.callerAgentAddress?.trim();
-    if (rawCaller && ethers.isAddress(rawCaller)) {
-      try {
-        checksum = ethers.getAddress(rawCaller);
-      } catch {
-        checksum = null;
-      }
-    }
+    rows = curatorBackfills.map((entry, index) => entry.status === 'fulfilled' ? entry.value : rows[index]);
 
     // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
     // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
@@ -1855,23 +1975,30 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
       return t === 'private';
     };
+    const policyKnown = (row: ListContextGraphsRow): boolean => policyKnownByUri.get(row.uri) !== false;
 
     if (!checksum) {
       // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
       // curator-vs-identity fallback for OPEN graphs.
-      return rows.filter((r) => !isPrivateRow(r.accessPolicy));
+      return rows.filter((r) => (!scopedListing || policyKnown(r)) && !isPrivateRow(r.accessPolicy));
     }
 
-    const annotated = await Promise.all(rows.map(async (r) => {
+    const annotatedSettled = await Promise.allSettled(rows.map(async (r) => {
       const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
-      const allowlisted = await this.callerIsAllowlistedAgentParticipant(r.id, checksum);
+      const allowlisted = await optional(
+        () => this.callerIsAllowlistedAgentParticipant(r.id, checksum),
+        `allowlist lookup for ${r.id}`,
+      ) ?? false;
       // `callerInvolved` must reflect ONLY the provided caller wallet.
       // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
       const involved = curatorMatch || allowlisted;
       return { ...r, callerInvolved: involved };
     }));
+    const annotated = annotatedSettled.map(
+      (entry, index) => entry.status === 'fulfilled' ? entry.value : { ...rows[index], callerInvolved: false },
+    );
 
-    return annotated.filter((r) => !isPrivateRow(r.accessPolicy) || r.callerInvolved === true);
+    return annotated.filter((r) => policyKnown(r) && (!isPrivateRow(r.accessPolicy) || r.callerInvolved === true));
   }
 
 }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1715,6 +1715,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const rowBudgetMs = Math.max(1, DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS);
     const scanBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS);
     const authBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS);
+    const budgetedReadsInterruptible = this.store.queryCancellation === 'interruptible';
     let cacheable = true;
 
     const withBudget = async <T>(
@@ -1722,6 +1723,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       label: string,
       budgetMs = rowBudgetMs,
     ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> => {
+      if (!budgetedReadsInterruptible) {
+        const controller = new AbortController();
+        return { ok: true, value: await work(controller.signal) };
+      }
       let timer: ReturnType<typeof setTimeout> | undefined;
       const controller = new AbortController();
       const timeoutError = new ListContextGraphsBudgetExceeded(label);
@@ -1733,8 +1738,6 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           },
           budgetMs,
         );
-        const unref = (timer as { unref?: () => void } | undefined)?.unref;
-        if (typeof unref === 'function') unref.call(timer);
       });
       try {
         const value = await Promise.race([

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1715,7 +1715,6 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const rowBudgetMs = Math.max(1, DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS);
     const scanBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS);
     const authBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS);
-    const budgetedReadsInterruptible = this.store.queryCancellation === 'interruptible';
     let cacheable = true;
 
     const withBudget = async <T>(
@@ -1723,16 +1722,15 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       label: string,
       budgetMs = rowBudgetMs,
     ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> => {
-      if (!budgetedReadsInterruptible) {
-        const controller = new AbortController();
-        return { ok: true, value: await work(controller.signal) };
-      }
       let timer: ReturnType<typeof setTimeout> | undefined;
       const controller = new AbortController();
       const timeoutError = new ListContextGraphsBudgetExceeded(label);
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
           () => {
+            // For pre-dispatch stores this signal cannot interrupt an in-flight
+            // synchronous native query, but it still bounds async work wrapped in
+            // the same lookup, such as chain/RPC membership checks.
             controller.abort(timeoutError);
             reject(timeoutError);
           },

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -261,6 +261,10 @@ type ListContextGraphsRow = {
   onChainId?: string;
   callerInvolved?: boolean;
 };
+type ListContextGraphsUncachedResult = {
+  rows: ListContextGraphsRow[];
+  cacheable: boolean;
+};
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -1659,8 +1663,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     const generation = this.listContextGraphsCacheGeneration;
     const task = (async () => {
-      const rows = await this.listContextGraphsUncached(checksum, scopedListing);
-      if (this.listContextGraphsCacheGeneration === generation) {
+      const result = await this.listContextGraphsUncached(checksum, scopedListing);
+      const rows = result.rows;
+      if (result.cacheable && this.listContextGraphsCacheGeneration === generation) {
         this.listContextGraphsCache.set(cacheKey, {
           expiresAt: Date.now() + DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS,
           rows: cloneRows(rows) as Array<Record<string, unknown>>,
@@ -1684,30 +1689,26 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     }
   }
 
-  protected async listContextGraphsUncached(this: DKGAgent, checksum: string | null, scopedListing: boolean): Promise<ListContextGraphsRow[]> {
+  protected async listContextGraphsUncached(this: DKGAgent, checksum: string | null, scopedListing: boolean): Promise<ListContextGraphsUncachedResult> {
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const rowBudgetMs = Math.max(1, DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS);
-    const globalBudgetMs = Math.max(
+    const scanBudgetMs = Math.max(
       rowBudgetMs,
       Math.min(5_000, rowBudgetMs * Math.max(1, this.subscribedContextGraphs.size + 4)),
     );
-    const deadlineAt = Date.now() + globalBudgetMs;
+    let cacheable = true;
 
     const withBudget = async <T>(
       work: () => Promise<T>,
       label: string,
       budgetMs = rowBudgetMs,
     ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> => {
-      const remaining = deadlineAt - Date.now();
-      if (remaining <= 0) {
-        return { ok: false, error: new Error(`${label} exceeded listContextGraphs deadline`) };
-      }
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
           () => reject(new Error(`${label} exceeded listContextGraphs row budget`)),
-          Math.min(budgetMs, remaining),
+          budgetMs,
         );
         const unref = (timer as { unref?: () => void } | undefined)?.unref;
         if (typeof unref === 'function') unref.call(timer);
@@ -1724,7 +1725,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     const optional = async <T>(work: () => Promise<T>, label: string): Promise<T | undefined> => {
       const result = await withBudget(work, label);
-      return result.ok ? result.value : undefined;
+      if (result.ok) return result.value;
+      cacheable = false;
+      return undefined;
     };
 
     const initialRead = await withBudget(
@@ -1756,13 +1759,16 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }
     `),
       'ontology/agents definition scan',
-      globalBudgetMs,
+      scanBudgetMs,
     );
+    if (!initialRead.ok) cacheable = false;
     const result = initialRead.ok ? initialRead.value : undefined;
 
     const prefix = 'did:dkg:context-graph:';
     const seen = new Map<string, ListContextGraphsRow>();
     const policyKnownByUri = new Map<string, boolean>();
+    const hasExplicitPolicy = (value: unknown): value is string =>
+      typeof value === 'string' && stripLiteral(value).trim().length > 0;
     const rememberRow = (row: ListContextGraphsRow, policyKnown: boolean): void => {
       if (seen.has(row.uri)) return;
       seen.set(row.uri, row);
@@ -1808,7 +1814,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           // `markContextGraphSubscriptionState` at routes/context-graph.ts:1301).
           synced: sub?.synced ?? false,
           ...(onChainId ? { onChainId } : {}),
-        }, true);
+        }, hasExplicitPolicy(row['access']));
       }));
     }
 
@@ -1837,6 +1843,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       `),
         `meta declaration lookup for ${id}`,
       );
+      if (!metaRead.ok) cacheable = false;
       const metaResult = metaRead.ok ? metaRead.value : undefined;
 
       if (metaResult?.type === 'bindings' && metaResult.bindings.length > 0) {
@@ -1858,7 +1865,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           subscribed: sub.subscribed,
           synced: sub.synced,
           ...(onChainId ? { onChainId } : {}),
-        }, true);
+        }, hasExplicitPolicy(row['access']));
         continue;
       }
 
@@ -1913,15 +1920,16 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         subscribed: sub.subscribed,
         synced: sub.synced,
         ...(sub.onChainId ? { onChainId: sub.onChainId } : {}),
-      }, metaRead.ok);
+      }, false);
     }
 
     const graphManager = new GraphManager(this.store);
     const storedRead = await withBudget(
       () => graphManager.listContextGraphs(),
       'storage context graph scan',
-      globalBudgetMs,
+      scanBudgetMs,
     );
+    if (!storedRead.ok) cacheable = false;
     const storedContextGraphs = storedRead.ok ? storedRead.value : [];
     for (const id of storedContextGraphs) {
       const uri = `${prefix}${id}`;
@@ -1937,6 +1945,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         () => this.getExplicitAccessPolicy(id),
         `access policy lookup for storage row ${id}`,
       );
+      if (!policyRead.ok) cacheable = false;
       const accessPolicy = policyRead.ok && policyRead.value ? policyRead.value : undefined;
       rememberRow({
         id,
@@ -1965,7 +1974,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       );
       return c ? { ...r, curator: c } : r;
     }));
-    rows = curatorBackfills.map((entry, index) => entry.status === 'fulfilled' ? entry.value : rows[index]);
+    rows = curatorBackfills.map((entry, index) => {
+      if (entry.status === 'fulfilled') return entry.value;
+      cacheable = false;
+      return rows[index];
+    });
 
     // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
     // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
@@ -1975,30 +1988,40 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
       return t === 'private';
     };
-    const policyKnown = (row: ListContextGraphsRow): boolean => policyKnownByUri.get(row.uri) !== false;
+    const policyKnown = (row: ListContextGraphsRow): boolean => policyKnownByUri.get(row.uri) === true;
 
     if (!checksum) {
       // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
       // curator-vs-identity fallback for OPEN graphs.
-      return rows.filter((r) => (!scopedListing || policyKnown(r)) && !isPrivateRow(r.accessPolicy));
+      return {
+        rows: rows.filter((r) => (!scopedListing || policyKnown(r)) && !isPrivateRow(r.accessPolicy)),
+        cacheable,
+      };
     }
 
-    const annotatedSettled = await Promise.allSettled(rows.map(async (r) => {
+    const annotatedSettled = await Promise.allSettled(rows.map(async (r): Promise<ListContextGraphsRow> => {
       const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
-      const allowlisted = await optional(
+      const allowlistRead = await withBudget(
         () => this.callerIsAllowlistedAgentParticipant(r.id, checksum),
         `allowlist lookup for ${r.id}`,
-      ) ?? false;
+      );
+      if (!allowlistRead.ok) cacheable = false;
+      const allowlisted = allowlistRead.ok ? allowlistRead.value : false;
       // `callerInvolved` must reflect ONLY the provided caller wallet.
       // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
       const involved = curatorMatch || allowlisted;
       return { ...r, callerInvolved: involved };
     }));
-    const annotated = annotatedSettled.map(
-      (entry, index) => entry.status === 'fulfilled' ? entry.value : { ...rows[index], callerInvolved: false },
-    );
+    const annotated = annotatedSettled.map((entry, index) => {
+      if (entry.status === 'fulfilled') return entry.value;
+      cacheable = false;
+      return { ...rows[index], callerInvolved: false };
+    });
 
-    return annotated.filter((r) => policyKnown(r) && (!isPrivateRow(r.accessPolicy) || r.callerInvolved === true));
+    return {
+      rows: annotated.filter((r) => policyKnown(r) && (!isPrivateRow(r.accessPolicy) || r.callerInvolved === true)),
+      cacheable,
+    };
   }
 
 }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -2052,6 +2052,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const resolveRowPrivacy = async (row: ListContextGraphsRow): Promise<ListContextGraphsPrivacy> => {
       const explicitPrivacy = privacyByUri.get(row.uri) ?? 'unknown';
       if (explicitPrivacy !== 'unknown') return explicitPrivacy;
+      if (!scopedListing) return 'unknown';
       const legacyRead = await withBudget(
         (signal) => this.isPrivateContextGraph(row.id, { signal }),
         `legacy privacy lookup for ${row.id}`,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -265,6 +265,12 @@ type ListContextGraphsUncachedResult = {
   rows: ListContextGraphsRow[];
   cacheable: boolean;
 };
+class ListContextGraphsBudgetExceeded extends Error {
+  constructor(label: string) {
+    super(`${label} exceeded listContextGraphs budget`);
+    this.name = 'ListContextGraphsBudgetExceeded';
+  }
+}
 import { multiaddr } from '@multiformats/multiaddr';
 import { buildCclPolicyQuads, buildPolicyApprovalQuads, buildPolicyRevocationQuads, hashCclPolicy, type CclPolicyRecord, type PolicyApprovalBinding } from './ccl-policy.js';
 import { CclEvaluator, parseCclPolicy, validateCclPolicy, type CclEvaluationResult, type CclFactTuple } from './ccl-evaluator.js';
@@ -1603,7 +1609,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       );
       throwIfSyncAuthAborted(options.signal);
       if (metaResult.quads.length > 0) {
-        await this.store.insert(metaResult.quads);
+        await this.insertSyncedQuadsAndInvalidateListCache(metaResult.quads);
         this.syncCheckpoints.delete(metaResult.checkpointKey);
         this.log.info(ctx, `Meta refresh for "${contextGraphId}": ${metaResult.quads.length} triples from curator ${curatorPeerId.slice(-8)}`);
         return true;
@@ -1707,7 +1713,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new Error(`${label} exceeded listContextGraphs row budget`)),
+          () => reject(new ListContextGraphsBudgetExceeded(label)),
           budgetMs,
         );
         const unref = (timer as { unref?: () => void } | undefined)?.unref;
@@ -1717,6 +1723,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         const value = await Promise.race([Promise.resolve().then(work), timeout]);
         return { ok: true, value };
       } catch (error) {
+        if (!(error instanceof ListContextGraphsBudgetExceeded)) {
+          throw error;
+        }
         return { ok: false, error };
       } finally {
         if (timer) clearTimeout(timer);
@@ -1783,7 +1792,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         byUri.set(uri, row);
       }
       // Parallel lookups — sequential await per ontology row multiplied list latency noticeably.
-      await Promise.allSettled([...byUri.values()].map(async (row) => {
+      const definitionSettled = await Promise.allSettled([...byUri.values()].map(async (row) => {
         const uri = row['ctxGraph'] ?? '';
         if (seen.has(uri)) return;
         const id = uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
@@ -1816,6 +1825,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           ...(onChainId ? { onChainId } : {}),
         }, hasExplicitPolicy(row['access']));
       }));
+      for (const entry of definitionSettled) {
+        if (entry.status === 'rejected') throw entry.reason;
+      }
     }
 
     // Curated CGs store their definition in their own _meta graph, not in
@@ -1976,8 +1988,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     }));
     rows = curatorBackfills.map((entry, index) => {
       if (entry.status === 'fulfilled') return entry.value;
-      cacheable = false;
-      return rows[index];
+      throw entry.reason;
     });
 
     // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
@@ -2014,8 +2025,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     }));
     const annotated = annotatedSettled.map((entry, index) => {
       if (entry.status === 'fulfilled') return entry.value;
-      cacheable = false;
-      return { ...rows[index], callerInvolved: false };
+      throw entry.reason;
     });
 
     return {

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1703,10 +1703,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const rowBudgetMs = Math.max(1, DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS);
-    const scanBudgetMs = Math.max(
-      rowBudgetMs,
-      Math.min(5_000, rowBudgetMs * Math.max(1, this.subscribedContextGraphs.size + 4)),
-    );
+    const scanBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS);
+    const authBudgetMs = Math.max(rowBudgetMs, DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS);
     let cacheable = true;
 
     const withBudget = async <T>(
@@ -2058,6 +2056,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           onChainLookup: () => { usedLiveChainAuth = true; },
         }),
         `allowlist lookup for ${r.id}`,
+        authBudgetMs,
       );
       if (usedLiveChainAuth) cacheable = false;
       if (!allowlistRead.ok) cacheable = false;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -265,6 +265,7 @@ type ListContextGraphsUncachedResult = {
   rows: ListContextGraphsRow[];
   cacheable: boolean;
 };
+type ListContextGraphsPrivacy = 'public' | 'private' | 'unknown';
 class ListContextGraphsBudgetExceeded extends Error {
   constructor(label: string) {
     super(`${label} exceeded listContextGraphs budget`);
@@ -1652,14 +1653,17 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const cacheKey = checksum
       ? `wallet:${checksum.toLowerCase()}`
       : scopedListing ? 'no-wallet' : 'owner-unscoped';
-    const cached = this.listContextGraphsCache.get(cacheKey);
-    if (cached) {
-      if (cached.expiresAt > Date.now()) {
+    const cacheTtlMs = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
+    if (cacheTtlMs > 0) {
+      const cached = this.listContextGraphsCache.get(cacheKey);
+      if (cached) {
+        if (cached.expiresAt > Date.now()) {
+          this.listContextGraphsCache.delete(cacheKey);
+          this.listContextGraphsCache.set(cacheKey, cached);
+          return cloneRows(cached.rows as ListContextGraphsRow[]);
+        }
         this.listContextGraphsCache.delete(cacheKey);
-        this.listContextGraphsCache.set(cacheKey, cached);
-        return cloneRows(cached.rows as ListContextGraphsRow[]);
       }
-      this.listContextGraphsCache.delete(cacheKey);
     }
 
     const inFlight = this.listContextGraphsInFlight.get(cacheKey);
@@ -1671,9 +1675,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const task = (async () => {
       const result = await this.listContextGraphsUncached(checksum, scopedListing);
       const rows = result.rows;
-      if (result.cacheable && this.listContextGraphsCacheGeneration === generation) {
+      if (cacheTtlMs > 0 && result.cacheable && this.listContextGraphsCacheGeneration === generation) {
         this.listContextGraphsCache.set(cacheKey, {
-          expiresAt: Date.now() + DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS,
+          expiresAt: Date.now() + cacheTtlMs,
           rows: cloneRows(rows) as Array<Record<string, unknown>>,
         });
         while (this.listContextGraphsCache.size > DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_MAX) {
@@ -1775,13 +1779,17 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     const prefix = 'did:dkg:context-graph:';
     const seen = new Map<string, ListContextGraphsRow>();
-    const policyKnownByUri = new Map<string, boolean>();
-    const hasExplicitPolicy = (value: unknown): value is string =>
-      typeof value === 'string' && stripLiteral(value).trim().length > 0;
-    const rememberRow = (row: ListContextGraphsRow, policyKnown: boolean): void => {
+    const privacyByUri = new Map<string, ListContextGraphsPrivacy>();
+    const policyPrivacy = (value: unknown): ListContextGraphsPrivacy => {
+      if (typeof value !== 'string') return 'unknown';
+      const normalized = stripLiteral(value).trim().replace(/^["']|["']$/g, '').toLowerCase();
+      if (normalized === 'public' || normalized === 'private') return normalized;
+      return 'unknown';
+    };
+    const rememberRow = (row: ListContextGraphsRow, privacy: ListContextGraphsPrivacy): void => {
       if (seen.has(row.uri)) return;
       seen.set(row.uri, row);
-      policyKnownByUri.set(row.uri, policyKnown);
+      privacyByUri.set(row.uri, privacy);
     };
 
     if (result?.type === 'bindings') {
@@ -1801,6 +1809,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           () => this.getContextGraphOnChainId(id),
           `on-chain id lookup for ${id}`,
         )) ?? undefined;
+        const accessPolicy = row['access'] ? stripLiteral(row['access']) : undefined;
         rememberRow({
           id,
           uri,
@@ -1808,7 +1817,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           description: row['desc'] ? stripLiteral(row['desc']) : undefined,
           creator: row['creator'],
           ...(row['curator'] ? { curator: row['curator'] } : {}),
-          ...(row['access'] ? { accessPolicy: stripLiteral(row['access']) } : {}),
+          ...(accessPolicy ? { accessPolicy } : {}),
           createdAt: row['created'] ? stripLiteral(row['created']) : undefined,
           isSystem: !!row['isSystem'],
           subscribed: sub?.subscribed ?? false,
@@ -1823,7 +1832,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           // `markContextGraphSubscriptionState` at routes/context-graph.ts:1301).
           synced: sub?.synced ?? false,
           ...(onChainId ? { onChainId } : {}),
-        }, hasExplicitPolicy(row['access']));
+        }, policyPrivacy(row['access']));
       }));
       for (const entry of definitionSettled) {
         if (entry.status === 'rejected') throw entry.reason;
@@ -1864,6 +1873,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           () => this.getContextGraphOnChainId(id),
           `on-chain id lookup for ${id}`,
         )) ?? undefined;
+        const accessPolicy = row['access'] ? stripLiteral(row['access']) : undefined;
         rememberRow({
           id,
           uri,
@@ -1871,13 +1881,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           description: row['desc'] ? stripLiteral(row['desc']) : undefined,
           creator: row['creator'],
           ...(row['curator'] ? { curator: row['curator'] } : {}),
-          ...(row['access'] ? { accessPolicy: stripLiteral(row['access']) } : {}),
+          ...(accessPolicy ? { accessPolicy } : {}),
           createdAt: row['created'] ? stripLiteral(row['created']) : undefined,
           isSystem: false,
           subscribed: sub.subscribed,
           synced: sub.synced,
           ...(onChainId ? { onChainId } : {}),
-        }, hasExplicitPolicy(row['access']));
+        }, policyPrivacy(row['access']));
         continue;
       }
 
@@ -1932,7 +1942,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         subscribed: sub.subscribed,
         synced: sub.synced,
         ...(sub.onChainId ? { onChainId: sub.onChainId } : {}),
-      }, false);
+      }, 'unknown');
     }
 
     const graphManager = new GraphManager(this.store);
@@ -1968,7 +1978,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         synced: sub?.synced ?? false,
         ...(accessPolicy ? { accessPolicy } : {}),
         ...(onChainId ? { onChainId } : {}),
-      }, accessPolicy !== undefined);
+      }, accessPolicy ?? 'unknown');
     }
 
     let rows = Array.from(seen.values());
@@ -1991,37 +2001,66 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       throw entry.reason;
     });
 
-    // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
-    // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
-    // keep private rows only when they are curator or allowlisted participant.
-    const isPrivateRow = (ap?: string): boolean => {
-      if (!ap?.trim()) return false;
-      const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
-      return t === 'private';
+    const resolveRowPrivacy = async (row: ListContextGraphsRow): Promise<ListContextGraphsPrivacy> => {
+      const explicitPrivacy = privacyByUri.get(row.uri) ?? 'unknown';
+      if (explicitPrivacy !== 'unknown') return explicitPrivacy;
+      const legacyRead = await withBudget(
+        () => this.isPrivateContextGraph(row.id),
+        `legacy privacy lookup for ${row.id}`,
+      );
+      if (!legacyRead.ok) {
+        cacheable = false;
+        return 'unknown';
+      }
+      return legacyRead.value ? 'private' : 'unknown';
     };
-    const policyKnown = (row: ListContextGraphsRow): boolean => policyKnownByUri.get(row.uri) === true;
+    const privacySettled = await Promise.allSettled(rows.map(async (row) => ({
+      uri: row.uri,
+      privacy: await resolveRowPrivacy(row),
+    })));
+    const resolvedPrivacyByUri = new Map<string, ListContextGraphsPrivacy>();
+    for (const entry of privacySettled) {
+      if (entry.status === 'fulfilled') {
+        resolvedPrivacyByUri.set(entry.value.uri, entry.value.privacy);
+      } else {
+        throw entry.reason;
+      }
+    }
+    const rowPrivacy = (row: ListContextGraphsRow): ListContextGraphsPrivacy =>
+      resolvedPrivacyByUri.get(row.uri) ?? 'unknown';
 
     if (!checksum) {
       // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
       // curator-vs-identity fallback for OPEN graphs.
       return {
-        rows: rows.filter((r) => (!scopedListing || policyKnown(r)) && !isPrivateRow(r.accessPolicy)),
+        rows: rows.filter((r) => {
+          const privacy = rowPrivacy(r);
+          if (privacy === 'private') return false;
+          if (privacy === 'unknown') return !scopedListing;
+          return true;
+        }),
         cacheable,
       };
     }
 
-    const annotatedSettled = await Promise.allSettled(rows.map(async (r): Promise<ListContextGraphsRow> => {
+    const annotatedSettled = await Promise.allSettled(rows.map(async (r): Promise<{
+      row: ListContextGraphsRow;
+      privacy: ListContextGraphsPrivacy;
+    }> => {
+      const privacy = rowPrivacy(r);
       const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
+      if (curatorMatch) {
+        return { row: { ...r, callerInvolved: true }, privacy };
+      }
       const allowlistRead = await withBudget(
         () => this.callerIsAllowlistedAgentParticipant(r.id, checksum),
         `allowlist lookup for ${r.id}`,
       );
       if (!allowlistRead.ok) cacheable = false;
-      const allowlisted = allowlistRead.ok ? allowlistRead.value : false;
       // `callerInvolved` must reflect ONLY the provided caller wallet.
       // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
-      const involved = curatorMatch || allowlisted;
-      return { ...r, callerInvolved: involved };
+      if (!allowlistRead.ok) return { row: r, privacy };
+      return { row: { ...r, callerInvolved: allowlistRead.value }, privacy };
     }));
     const annotated = annotatedSettled.map((entry, index) => {
       if (entry.status === 'fulfilled') return entry.value;
@@ -2029,7 +2068,14 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     });
 
     return {
-      rows: annotated.filter((r) => policyKnown(r) && (!isPrivateRow(r.accessPolicy) || r.callerInvolved === true)),
+      rows: annotated
+        .filter(({ row, privacy }) => {
+          if (row.callerInvolved === true) return true;
+          if (privacy === 'unknown') return false;
+          if (privacy === 'private') return false;
+          return true;
+        })
+        .map(({ row }) => row),
       cacheable,
     };
   }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -464,7 +464,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * content is the normal state for any non-trivial project so the root
    * data graph is routinely empty.
    */
-  async contextGraphHasLocalContent(this: DKGAgent, contextGraphId: string): Promise<boolean> {
+  async contextGraphHasLocalContent(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
     const prefix = `did:dkg:context-graph:${contextGraphId}`;
     // ASK is cheap on Oxigraph; the FILTER keeps us inside this CG's
     // namespace and excludes `_meta` / `_shared_memory_meta` bookkeeping
@@ -475,7 +479,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       FILTER(!STRENDS(STR(?g), "/_meta"))
       FILTER(!STRENDS(STR(?g), "/_shared_memory_meta"))
     }`;
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { signal: options.signal });
     if (result.type === 'boolean') return result.value;
     return result.type === 'bindings' && result.bindings.length > 0;
   }
@@ -1708,21 +1712,29 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let cacheable = true;
 
     const withBudget = async <T>(
-      work: () => Promise<T>,
+      work: (signal: AbortSignal) => Promise<T>,
       label: string,
       budgetMs = rowBudgetMs,
     ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> => {
       let timer: ReturnType<typeof setTimeout> | undefined;
+      const controller = new AbortController();
+      const timeoutError = new ListContextGraphsBudgetExceeded(label);
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new ListContextGraphsBudgetExceeded(label)),
+          () => {
+            controller.abort(timeoutError);
+            reject(timeoutError);
+          },
           budgetMs,
         );
         const unref = (timer as { unref?: () => void } | undefined)?.unref;
         if (typeof unref === 'function') unref.call(timer);
       });
       try {
-        const value = await Promise.race([Promise.resolve().then(work), timeout]);
+        const value = await Promise.race([
+          Promise.resolve().then(() => work(controller.signal)),
+          timeout,
+        ]);
         return { ok: true, value };
       } catch (error) {
         if (!(error instanceof ListContextGraphsBudgetExceeded)) {
@@ -1734,7 +1746,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }
     };
 
-    const optional = async <T>(work: () => Promise<T>, label: string): Promise<T | undefined> => {
+    const optional = async <T>(work: (signal: AbortSignal) => Promise<T>, label: string): Promise<T | undefined> => {
       const result = await withBudget(work, label);
       if (result.ok) return result.value;
       cacheable = false;
@@ -1742,7 +1754,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     };
 
     const initialRead = await withBudget(
-      () => this.store.query(`
+      (signal) => this.store.query(`
       SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem WHERE {
         {
           GRAPH <${ontologyGraph}> {
@@ -1768,7 +1780,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
           }
         }
       }
-    `),
+    `, { signal }),
       'ontology/agents definition scan',
       scanBudgetMs,
     );
@@ -1804,7 +1816,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         const id = uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
         const sub = this.subscribedContextGraphs.get(id);
         const onChainId = sub?.onChainId ?? (await optional(
-          () => this.getContextGraphOnChainId(id),
+          (signal) => this.getContextGraphOnChainId(id, { signal }),
           `on-chain id lookup for ${id}`,
         )) ?? undefined;
         const accessPolicy = row['access'] ? stripLiteral(row['access']) : undefined;
@@ -1847,7 +1859,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const metaGraph = contextGraphMetaGraphUri(id);
       const pUri = contextGraphDataGraphUri(id);
       const metaRead = await withBudget(
-        () => this.store.query(`
+        (signal) => this.store.query(`
         SELECT ?name ?desc ?creator ?created ?curator ?access WHERE {
           GRAPH <${metaGraph}> {
             <${pUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
@@ -1859,7 +1871,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
             OPTIONAL { <${pUri}> <${DKG_ONTOLOGY.DKG_CREATED_AT}> ?created }
           }
         } LIMIT 1
-      `),
+      `, { signal }),
         `meta declaration lookup for ${id}`,
       );
       if (!metaRead.ok) cacheable = false;
@@ -1868,7 +1880,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       if (metaResult?.type === 'bindings' && metaResult.bindings.length > 0) {
         const row = metaResult.bindings[0] as Record<string, string>;
         const onChainId = sub.onChainId ?? (await optional(
-          () => this.getContextGraphOnChainId(id),
+          (signal) => this.getContextGraphOnChainId(id, { signal }),
           `on-chain id lookup for ${id}`,
         )) ?? undefined;
         const accessPolicy = row['access'] ? stripLiteral(row['access']) : undefined;
@@ -1925,11 +1937,12 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         // only the root caused legitimate synced projects to be
         // hidden as phantoms here (Codex tier-4m follow-up to N29,
         // same issue in a separate call site).
-        const hasContent = await optional(
-          () => this.contextGraphHasLocalContent(id),
+        const contentRead = await withBudget(
+          (signal) => this.contextGraphHasLocalContent(id, { signal }),
           `local content probe for ${id}`,
         );
-        if (!hasContent) continue;
+        if (!contentRead.ok) cacheable = false;
+        if (contentRead.ok && !contentRead.value) continue;
       }
 
       rememberRow({
@@ -1943,9 +1956,26 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }, 'unknown');
     }
 
-    const graphManager = new GraphManager(this.store);
     const storedRead = await withBudget(
-      () => graphManager.listContextGraphs(),
+      async (signal) => {
+        const graphs = await this.store.listGraphs({ signal });
+        const contextGraphs = new Set<string>();
+        for (const graph of graphs) {
+          if (!graph.startsWith(prefix)) continue;
+          const rest = graph.slice(prefix.length);
+          const id = rest.endsWith('/_meta')
+            ? rest.slice(0, -6)
+            : rest.endsWith('/_private')
+              ? rest.slice(0, -9)
+              : rest.endsWith('/_shared_memory_meta')
+                ? rest.slice(0, -20)
+                : rest.endsWith('/_shared_memory')
+                  ? rest.slice(0, -15)
+                  : rest;
+          if (!id.includes('/')) contextGraphs.add(id);
+        }
+        return [...contextGraphs];
+      },
       'storage context graph scan',
       scanBudgetMs,
     );
@@ -1958,11 +1988,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
       const sub = this.subscribedContextGraphs.get(id);
       const onChainId = sub?.onChainId ?? (await optional(
-        () => this.getContextGraphOnChainId(id),
+        (signal) => this.getContextGraphOnChainId(id, { signal }),
         `on-chain id lookup for ${id}`,
       )) ?? undefined;
       const policyRead = await withBudget(
-        () => this.getExplicitAccessPolicy(id),
+        (signal) => this.getExplicitAccessPolicy(id, { signal }),
         `access policy lookup for storage row ${id}`,
       );
       if (!policyRead.ok) cacheable = false;
@@ -1989,7 +2019,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     const curatorBackfills = await Promise.allSettled(rows.map(async (r) => {
       if (r.curator?.trim()) return r;
       const c = await optional(
-        () => this.getContextGraphCurator(r.id),
+        (signal) => this.getContextGraphCurator(r.id, { signal }),
         `curator lookup for ${r.id}`,
       );
       return c ? { ...r, curator: c } : r;
@@ -2003,7 +2033,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const explicitPrivacy = privacyByUri.get(row.uri) ?? 'unknown';
       if (explicitPrivacy !== 'unknown') return explicitPrivacy;
       const legacyRead = await withBudget(
-        () => this.isPrivateContextGraph(row.id),
+        (signal) => this.isPrivateContextGraph(row.id, { signal }),
         `legacy privacy lookup for ${row.id}`,
       );
       if (!legacyRead.ok) {
@@ -2052,8 +2082,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       }
       let usedLiveChainAuth = false;
       const allowlistRead = await withBudget(
-        () => this.callerIsAllowlistedAgentParticipant(r.id, checksum, {
+        (signal) => this.callerIsAllowlistedAgentParticipant(r.id, checksum, {
           onChainLookup: () => { usedLiveChainAuth = true; },
+          signal,
         }),
         `allowlist lookup for ${r.id}`,
         authBudgetMs,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1661,7 +1661,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     if (cacheTtlMs > 0) {
       const cached = this.listContextGraphsCache.get(cacheKey);
       if (cached) {
-        if (cached.expiresAt > Date.now()) {
+        if (cached.expiresAt > this.listContextGraphsCacheNow()) {
           this.listContextGraphsCache.delete(cacheKey);
           this.listContextGraphsCache.set(cacheKey, cached);
           return cloneRows(cached.rows as ListContextGraphsRow[]);
@@ -1681,7 +1681,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const rows = result.rows;
       if (cacheTtlMs > 0 && result.cacheable && this.listContextGraphsCacheGeneration === generation) {
         this.listContextGraphsCache.set(cacheKey, {
-          expiresAt: Date.now() + cacheTtlMs,
+          expiresAt: this.listContextGraphsCacheNow() + cacheTtlMs,
           rows: cloneRows(rows) as Array<Record<string, unknown>>,
         });
         while (this.listContextGraphsCache.size > DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_MAX) {

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -652,6 +652,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     );
 
     await this.store.insert(quads);
+    this.invalidateListContextGraphsCache();
     await gm.ensureContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
@@ -911,6 +912,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
       ]);
+      this.invalidateListContextGraphsCache();
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);
       return curatorDid;
     };
@@ -1400,6 +1402,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       // topic without re-reading the chain event.
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
     ]);
+    this.invalidateListContextGraphsCache();
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
@@ -1526,6 +1529,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     });
 
     await this.store.insert(quadsToInsert);
+    this.invalidateListContextGraphsCache();
 
     // Issue #865 — log a clear warning AFTER the allowlist quad has
     // landed on a CG with an explicit `accessPolicy="public"` triple.
@@ -1688,6 +1692,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     }
 
     await this.store.insert(quadsToInsert);
+    this.invalidateListContextGraphsCache();
 
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
@@ -1778,6 +1783,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT,
       object: `"${agentAddress}"`,
     }]);
+    this.invalidateListContextGraphsCache();
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
     this.queueSharedMemoryGossipSubscription(contextGraphId);
     // Drop any cached sender-key send state for this CG so the next
@@ -1855,6 +1861,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: ontologyGraph },
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: cgMetaGraph },
     ]);
+    this.invalidateListContextGraphsCache();
 
     this.log.info(ctx, `Renamed context graph "${contextGraphId}" to "${trimmed}"`);
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3548,6 +3548,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     next: ContextGraphSub,
     options?: { persist?: boolean },
   ): ContextGraphSub {
+    this.invalidateListContextGraphsCache();
     this.subscribedContextGraphs.set(contextGraphId, next);
     if (!next.subscribed && !next.coreHosted) {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
@@ -3574,6 +3575,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   persistContextGraphSubscription(this: DKGAgent, contextGraphId: string): void {
+    this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
     const sub = this.subscribedContextGraphs.get(contextGraphId);

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2798,7 +2798,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       fetchSyncPages: this.fetchSyncPages.bind(this),
       sinceBatchIdFor,
       processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
-      storeInsert: (quads) => this.store.insert(quads),
+      storeInsert: (quads) => this.insertSyncedQuadsAndInvalidateListCache(quads),
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -2954,7 +2954,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const graphManager = new GraphManager(this.store);
         await graphManager.ensureContextGraph(contextGraphId);
       },
-      storeInsert: (quads) => this.store.insert(quads),
+      storeInsert: (quads) => this.insertSyncedQuadsAndInvalidateListCache(quads),
       publicSnapshotStore: this.publicSnapshotStore,
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3529,15 +3529,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if (!sub) continue;
       if (await this.hasConfirmedMetaState(contextGraphId)) {
         if (sub.metaSynced !== true) {
-          sub.metaSynced = true;
-          this.persistContextGraphSubscription(contextGraphId);
+          this.setContextGraphSubscription(contextGraphId, { ...sub, metaSynced: true });
         }
         if (sub.pendingMeta) {
           // Meta arrived; the freshly-joined "waiting for sync" state
           // (set by the join-approved handler) no longer applies — the
           // CG will now surface via the normal `_meta` branch in
           // `listContextGraphs`.
-          sub.pendingMeta = false;
+          const current = this.subscribedContextGraphs.get(contextGraphId) ?? sub;
+          this.setContextGraphSubscription(contextGraphId, {
+            ...current,
+            metaSynced: true,
+            pendingMeta: false,
+          });
         }
         this.queueSharedMemoryGossipSubscription(contextGraphId);
       }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1355,17 +1355,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             // would no-op on this without a pre-existing record, so
             // upsert a minimal stub first.
             if (!this.subscribedContextGraphs.has(hashLower)) {
-              this.subscribedContextGraphs.set(hashLower, {
+              this.setContextGraphSubscription(hashLower, {
                 subscribed: false,
                 synced: false,
                 onChainId: contextGraphId,
                 onChainHash: hashLower,
                 pendingMeta: true,
-              });
+              }, { persist: false });
             } else {
-              const existing = this.subscribedContextGraphs.get(hashLower)!;
-              this.bindSubscriptionOnChainId(hashLower, existing, contextGraphId);
-              existing.onChainHash = hashLower;
+              const next = { ...this.subscribedContextGraphs.get(hashLower)! };
+              this.bindSubscriptionOnChainId(hashLower, next, contextGraphId);
+              next.onChainHash = hashLower;
+              this.setContextGraphSubscription(hashLower, next, { persist: false });
             }
             this.recordCgWireId(hashLower, hashLower);
 
@@ -3570,6 +3571,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
   }
 
+  deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
+    this.invalidateListContextGraphsCache();
+    this.forceClearVmReconcileStateForContextGraph(contextGraphId);
+    return this.subscribedContextGraphs.delete(contextGraphId);
+  }
+
   persistContextGraphSubscriptionState(this: DKGAgent, contextGraphId: string): void {
     this.persistContextGraphSubscription(contextGraphId);
   }
@@ -3851,8 +3858,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       } catch {
         /* best-effort teardown */
       }
-      this.forceClearVmReconcileStateForContextGraph(id);
-      this.subscribedContextGraphs.delete(id);
+      this.deleteContextGraphSubscription(id);
     }
 
     // Delete the persisted USER rows (active + dormant). Selective — never the

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -699,7 +699,11 @@ export class OwnershipMethods extends DKGAgentBase {
     return deriveCuratorDidFromCgId(contextGraphId);
   }
 
-  async getContextGraphCurator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
+  async getContextGraphCurator(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<string | null> {
     const cgMetaGraph = contextGraphMetaUri(contextGraphId);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     // Multi-curator scenario: peer-to-peer sync of CG `_meta` triples
@@ -725,7 +729,7 @@ export class OwnershipMethods extends DKGAgentBase {
           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
         }
       }
-    `);
+    `, { signal: options.signal });
     if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
       return null;
     }
@@ -783,9 +787,9 @@ export class OwnershipMethods extends DKGAgentBase {
     this: DKGAgent,
     contextGraphId: string,
     checksumAddress: string,
-    options: { onChainLookup?: () => void } = {},
+    options: { onChainLookup?: () => void; signal?: AbortSignal } = {},
   ): Promise<boolean> {
-    const participants = await this.getPrivateContextGraphParticipants(contextGraphId);
+    const participants = await this.getPrivateContextGraphParticipants(contextGraphId, { signal: options.signal });
     if (!participants?.length) return false;
 
     for (const raw of participants) {

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -779,7 +779,12 @@ export class OwnershipMethods extends DKGAgentBase {
    * Whether the wallet is on the CG allowlist (participant / allowed-agent) or tied to a
    * listed on-chain identity ID. Does not consult curator — compose with curator checks separately.
    */
-  public async callerIsAllowlistedAgentParticipant(this: DKGAgent, contextGraphId: string, checksumAddress: string): Promise<boolean> {
+  public async callerIsAllowlistedAgentParticipant(
+    this: DKGAgent,
+    contextGraphId: string,
+    checksumAddress: string,
+    options: { onChainLookup?: () => void } = {},
+  ): Promise<boolean> {
     const participants = await this.getPrivateContextGraphParticipants(contextGraphId);
     if (!participants?.length) return false;
 
@@ -791,6 +796,7 @@ export class OwnershipMethods extends DKGAgentBase {
       }
       if (/^\d+$/.test(p) && this.chain.isOperationalWalletRegistered) {
         try {
+          options.onChainLookup?.();
           if (await this.chain.isOperationalWalletRegistered(BigInt(p), checksumAddress)) return true;
         } catch {
           // ignore chain read errors — treat as non-participant

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -1378,15 +1378,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
     // the CG, so `recordCgWireId(wireId, wireId)` is the right
     // identity-translation entry.
     if (!this.subscribedContextGraphs.has(wireId)) {
-      this.subscribedContextGraphs.set(wireId, {
+      this.setContextGraphSubscription(wireId, {
         subscribed: false,
         synced: false,
         onChainHash: wireId,
         pendingMeta: true,
-      });
+      }, { persist: false });
     } else {
       const existing = this.subscribedContextGraphs.get(wireId)!;
-      existing.onChainHash = wireId;
+      this.setContextGraphSubscription(wireId, { ...existing, onChainHash: wireId }, { persist: false });
     }
     this.recordCgWireId(wireId, wireId);
 

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -811,6 +811,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           // `dkg:curator` (wallet DID) is for local authorization only.
           getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
+          setContextGraphSubscription: (id, next, options) => this.setContextGraphSubscription(id, next, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -815,6 +815,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
+        { requireContextGraphSubscriptionSetter: true },
       );
     }
     return this.gossipPublishHandler;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -372,7 +372,7 @@ import {
   deserializeSwmSenderReceiveState,
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
-import { DKGAgentBase } from './dkg-agent-base.js';
+import { DKGAgentBase, createListContextGraphsCacheInvalidatingStore } from './dkg-agent-base.js';
 import { reconcileAndAllocateKaNumber } from './allocator.js';
 import { applyMixins } from './dkg-agent-apply-mixins.js';
 import { OwnershipMethods } from './dkg-agent-ownership.js';
@@ -571,8 +571,13 @@ export class DKGAgent extends DKGAgentBase {
       !adapterCanPublishFromAdvertisedSigner &&
       (!configuredPublisherAddress || publisherAddressMatchesLegacyKey),
     );
+    let agentRef: DKGAgent | undefined;
+    const agentStore = createListContextGraphsCacheInvalidatingStore(store, () => {
+      agentRef?.invalidateListContextGraphsCache();
+    });
+
     const publisher = new DKGPublisher({
-      store,
+      store: agentStore,
       chain,
       eventBus,
       keypair,
@@ -618,12 +623,14 @@ export class DKGAgent extends DKGAgentBase {
       log.warn(createOperationContext('init'), `Failed to migrate SWM attribution to agent DID, continuing without: ${err instanceof Error ? err.message : String(err)}`);
     }
 
-    const queryEngine = new DKGQueryEngine(store);
+    const queryEngine = new DKGQueryEngine(agentStore);
 
-    return new DKGAgent(
-      config, wallet, node, store, publisher, queryEngine, eventBus, chain,
+    const agent = new DKGAgent(
+      config, wallet, node, agentStore, publisher, queryEngine, eventBus, chain,
       workspaceOwnedEntities, writeLocks, publicSnapshotStore,
     );
+    agentRef = agent;
+    return agent;
   }
 
   public getACKSignerCandidateWallets(ctx: OperationContext): ethers.Wallet[] {

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -22,6 +22,7 @@ export interface GossipPublishHandlerCallbacks {
   contextGraphExists: (id: string) => Promise<boolean>;
   getContextGraphOwner: (id: string) => Promise<string | null>;
   subscribeToContextGraph: (id: string, options?: { trackSyncScope?: boolean; persist?: boolean }) => void;
+  setContextGraphSubscription: (id: string, next: any, options?: { persist?: boolean }) => void;
   /**
    * Same semantics as `DKGAgent#hasConfirmedMetaState`: returns true when the
    * local store already has a trustworthy public announcement for this CG
@@ -166,7 +167,7 @@ export class GossipPublishHandler {
               q.subject === `${contextGraphPrefix}${newId}` && q.predicate === DKG_ONTOLOGY.SCHEMA_NAME,
             );
             const name = nameQuad ? stripLiteral(nameQuad.object) : newId;
-            this.subscribedContextGraphs.set(newId, {
+            const next = {
               name,
               subscribed: true,
               // `synced: false` — we just got the definition triple via
@@ -177,7 +178,8 @@ export class GossipPublishHandler {
               synced: false,
               metaSynced: false,
               onChainId: this.subscribedContextGraphs.get(newId)?.onChainId,
-            });
+            };
+            this.callbacks.setContextGraphSubscription(newId, next, { persist: false });
             this.callbacks.subscribeToContextGraph(newId, { trackSyncScope: true });
             this.log.info(ctx, `Discovered context graph "${name}" (${newId}) via gossip — auto-subscribed (sync-enabled)`);
           }

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -23,7 +23,7 @@ export interface GossipPublishHandlerCallbacks {
   contextGraphExists: (id: string) => Promise<boolean>;
   getContextGraphOwner: (id: string) => Promise<string | null>;
   subscribeToContextGraph: (id: string, options?: { trackSyncScope?: boolean; persist?: boolean }) => void;
-  setContextGraphSubscription: (id: string, next: ContextGraphSub, options?: { persist?: boolean }) => void;
+  setContextGraphSubscription?: (id: string, next: ContextGraphSub, options?: { persist?: boolean }) => void;
   /**
    * Same semantics as `DKGAgent#hasConfirmedMetaState`: returns true when the
    * local store already has a trustworthy public announcement for this CG
@@ -58,6 +58,19 @@ export class GossipPublishHandler {
     this.chain = chain;
     this.subscribedContextGraphs = subscribedContextGraphs;
     this.callbacks = callbacks;
+  }
+
+  private setContextGraphSubscription(
+    id: string,
+    next: ContextGraphSub,
+    options?: { persist?: boolean },
+  ): void {
+    const setter = this.callbacks.setContextGraphSubscription;
+    if (setter) {
+      setter(id, next, options);
+      return;
+    }
+    this.subscribedContextGraphs.set(id, next);
   }
 
   async handlePublishMessage(data: Uint8Array, contextGraphId: string, onPhase?: GossipPhaseCallback, fromPeerId?: string): Promise<void> {
@@ -180,7 +193,7 @@ export class GossipPublishHandler {
               metaSynced: false,
               onChainId: this.subscribedContextGraphs.get(newId)?.onChainId,
             };
-            this.callbacks.setContextGraphSubscription(newId, next, { persist: false });
+            this.setContextGraphSubscription(newId, next, { persist: false });
             this.callbacks.subscribeToContextGraph(newId, { trackSyncScope: true });
             this.log.info(ctx, `Discovered context graph "${name}" (${newId}) via gossip — auto-subscribed (sync-enabled)`);
           }
@@ -225,7 +238,7 @@ export class GossipPublishHandler {
               ? await this.callbacks.hasConfirmedMetaState(request.contextGraphId)
               : false;
             if (confirmed) {
-              this.callbacks.setContextGraphSubscription(request.contextGraphId, { ...sub, metaSynced: true });
+              this.setContextGraphSubscription(request.contextGraphId, { ...sub, metaSynced: true });
             } else {
               this.log.warn(ctx, `Gossip publish deferred: context graph "${request.contextGraphId}" _meta not yet synced — defaulting to deny`);
               return;

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -15,6 +15,7 @@ import {
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import type { ContextGraphSub } from './dkg-agent-types.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
 
@@ -22,7 +23,7 @@ export interface GossipPublishHandlerCallbacks {
   contextGraphExists: (id: string) => Promise<boolean>;
   getContextGraphOwner: (id: string) => Promise<string | null>;
   subscribeToContextGraph: (id: string, options?: { trackSyncScope?: boolean; persist?: boolean }) => void;
-  setContextGraphSubscription: (id: string, next: any, options?: { persist?: boolean }) => void;
+  setContextGraphSubscription: (id: string, next: ContextGraphSub, options?: { persist?: boolean }) => void;
   /**
    * Same semantics as `DKGAgent#hasConfirmedMetaState`: returns true when the
    * local store already has a trustworthy public announcement for this CG
@@ -43,14 +44,14 @@ export interface GossipPublishHandlerCallbacks {
 export class GossipPublishHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
-  private readonly subscribedContextGraphs: Map<string, any>;
+  private readonly subscribedContextGraphs: Map<string, ContextGraphSub>;
   private readonly callbacks: GossipPublishHandlerCallbacks;
   private readonly log = new Logger('GossipPublishHandler');
 
   constructor(
     store: TripleStore,
     chain: ChainAdapter | undefined,
-    subscribedContextGraphs: Map<string, any>,
+    subscribedContextGraphs: Map<string, ContextGraphSub>,
     callbacks: GossipPublishHandlerCallbacks,
   ) {
     this.store = store;

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -41,6 +41,16 @@ export interface GossipPublishHandlerCallbacks {
   onPhase?: GossipPhaseCallback;
 }
 
+export interface GossipPublishHandlerOptions {
+  /**
+   * Agent-backed handlers require the invalidating subscription setter so
+   * gossip state changes keep listContextGraphs cache and durable subscription
+   * bookkeeping coherent. Standalone/legacy handlers can omit the callback and
+   * keep the historical in-memory map fallback.
+   */
+  requireContextGraphSubscriptionSetter?: boolean;
+}
+
 export class GossipPublishHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
@@ -53,7 +63,11 @@ export class GossipPublishHandler {
     chain: ChainAdapter | undefined,
     subscribedContextGraphs: Map<string, ContextGraphSub>,
     callbacks: GossipPublishHandlerCallbacks,
+    options: GossipPublishHandlerOptions = {},
   ) {
+    if (options.requireContextGraphSubscriptionSetter && !callbacks.setContextGraphSubscription) {
+      throw new Error('GossipPublishHandler requires setContextGraphSubscription for agent-backed subscription state');
+    }
     this.store = store;
     this.chain = chain;
     this.subscribedContextGraphs = subscribedContextGraphs;

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -213,7 +213,7 @@ export class GossipPublishHandler {
         // confirmable from the local store (system contextGraph, populated
         // `_meta`, or `<cg> rdf:type dkg:ContextGraph` in ontology — the same
         // check Viktor introduced in `hasConfirmedMetaState`). If yes,
-        // flip the flag in place and proceed; if no, keep the strict
+        // update the flag through the agent subscription setter and proceed; if no, keep the strict
         // deny behavior so curated CGs without a synced allowlist can't
         // leak through.
         if (allowedPeers === null
@@ -225,8 +225,7 @@ export class GossipPublishHandler {
               ? await this.callbacks.hasConfirmedMetaState(request.contextGraphId)
               : false;
             if (confirmed) {
-              sub.metaSynced = true;
-              this.callbacks.persistContextGraphSubscription?.(request.contextGraphId);
+              this.callbacks.setContextGraphSubscription(request.contextGraphId, { ...sub, metaSynced: true });
             } else {
               this.log.warn(ctx, `Gossip publish deferred: context graph "${request.contextGraphId}" _meta not yet synced — defaulting to deny`);
               return;

--- a/packages/agent/test/adversarial-determinism.test.ts
+++ b/packages/agent/test/adversarial-determinism.test.ts
@@ -80,6 +80,7 @@ describe('Gossip (03 §10–11): malformed publish broadcast', () => {
       contextGraphExists: async () => false,
       getContextGraphOwner: async () => null,
       subscribeToContextGraph: () => {},
+      setContextGraphSubscription: () => {},
     });
     const countBefore = await totalQuadCount(store);
 
@@ -97,6 +98,7 @@ describe('Gossip (03 §10–11): malformed publish broadcast', () => {
       contextGraphExists: async () => true,
       getContextGraphOwner: async () => null,
       subscribeToContextGraph: () => {},
+      setContextGraphSubscription: () => {},
     });
     const countBefore = await totalQuadCount(store);
 
@@ -131,6 +133,7 @@ describe('Gossip (03 §10–11): malformed publish broadcast', () => {
       contextGraphExists: async () => true,
       getContextGraphOwner: async () => null,
       subscribeToContextGraph: () => {},
+      setContextGraphSubscription: () => {},
     });
     const countBefore = await totalQuadCount(store);
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1091,6 +1091,29 @@ describe('listContextGraphs merge', () => {
     expect((await agent.listContextGraphs()).find(p => p.id === droppedId)).toBeUndefined();
   }, 15000);
 
+  it('does not list empty named graphs created by graph ensure calls', async () => {
+    const originalTtl = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+      value: 0,
+      configurable: true,
+    });
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'empty-created-graph-cg';
+      await result.store.createGraph(contextGraphDataGraphUri(id));
+
+      expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeUndefined();
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+        value: originalTtl,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('expires cached list rows using monotonic time when wall clock moves backwards', async () => {
     const originalTtl = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
     Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1463,7 +1463,7 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
-  it('does not downgrade budgeted reads for pre-dispatch stores', async () => {
+  it('does not downgrade synchronous pre-dispatch store reads', async () => {
     const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
     const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;
     Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
@@ -1485,7 +1485,10 @@ describe('listContextGraphs merge', () => {
       const originalQuery = store.query.bind(store);
       vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
         if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
-          await new Promise(resolve => setTimeout(resolve, 20));
+          const startedAt = performance.now();
+          while (performance.now() - startedAt < 8) {
+            // Simulate the default native Oxigraph path blocking the event loop.
+          }
           expect(options?.signal?.aborted).toBe(false);
           return {
             type: 'bindings',
@@ -1508,6 +1511,66 @@ describe('listContextGraphs merge', () => {
       });
       Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
         value: originalScanBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
+  it('still applies auth budget to async membership work on pre-dispatch stores', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalAuthBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    try {
+      const result = await createTestAgent({ store: new OxigraphStore() });
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'pre-dispatch-auth-budget-cg';
+      const member = ethers.Wallet.createRandom().address;
+      await agent.createContextGraph({
+        id,
+        name: 'Pre Dispatch Auth Budget',
+        accessPolicy: 1,
+        allowedAgents: [agent.getDefaultAgentAddress()!],
+      });
+
+      const originalAllowlist = agent.callerIsAllowlistedAgentParticipant.bind(agent);
+      let targetCalls = 0;
+      let signalSeen: AbortSignal | undefined;
+      vi.spyOn(agent, 'callerIsAllowlistedAgentParticipant').mockImplementation(async (contextGraphId, caller, options) => {
+        if (contextGraphId === id && ethers.getAddress(caller) === ethers.getAddress(member)) {
+          targetCalls += 1;
+          signalSeen = options?.signal;
+          return new Promise<boolean>(() => {});
+        }
+        return originalAllowlist(contextGraphId, caller, options);
+      });
+
+      const timeout = { timedOut: true as const };
+      const rows = await Promise.race([
+        agent.listContextGraphs({ callerAgentAddress: member }),
+        new Promise<typeof timeout>(resolve => setTimeout(() => resolve(timeout), 100)),
+      ]);
+
+      expect(rows).not.toBe(timeout);
+      if (rows === timeout) return;
+      expect(rows.find(p => p.id === id)).toBeUndefined();
+      expect(targetCalls).toBe(1);
+      expect(signalSeen?.aborted).toBe(true);
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+        value: originalAuthBudget,
         configurable: true,
       });
     }

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -960,6 +960,55 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
+  it('uses a catalog scan budget that is independent from the per-row enrichment budget', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+      value: 80,
+      configurable: true,
+    });
+    try {
+      const store = new OxigraphStore();
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'slow-catalog-scan-cg';
+      const uri = contextGraphDataGraphUri(id);
+      const originalQuery = store.query.bind(store);
+      vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
+          await new Promise(resolve => setTimeout(resolve, 20));
+          return {
+            type: 'bindings',
+            bindings: [{
+              ctxGraph: uri,
+              name: '"Slow Catalog Scan"',
+              access: '"public"',
+            }],
+          } as any;
+        }
+        return originalQuery(query, options);
+      });
+
+      const rows = await agent.listContextGraphs({ callerAgentAddress: null });
+      expect(rows.find(p => p.id === id)).toBeDefined();
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+        value: originalScanBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('does not cache private membership misses when allowlist lookup degrades', async () => {
     const result = await createTestAgent();
     agent = result.agent;
@@ -1010,6 +1059,7 @@ describe('listContextGraphs merge', () => {
       registrationCalls += 1;
       expect(actualIdentityId).toBe(identityId);
       expect(ethers.getAddress(actualAddress)).toBe(ethers.getAddress(member));
+      await new Promise(resolve => setTimeout(resolve, 20));
       return registered;
     });
 
@@ -1026,14 +1076,35 @@ describe('listContextGraphs merge', () => {
       graph: contextGraphMetaGraphUri(id),
     }]);
 
-    const before = await agent.listContextGraphs({ callerAgentAddress: member });
-    expect(before.find(p => p.id === id)).toBeDefined();
-    expect(registrationCalls).toBe(1);
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalAuthBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+      value: 80,
+      configurable: true,
+    });
+    try {
+      const before = await agent.listContextGraphs({ callerAgentAddress: member });
+      expect(before.find(p => p.id === id)).toBeDefined();
+      expect(registrationCalls).toBe(1);
 
-    registered = false;
-    const after = await agent.listContextGraphs({ callerAgentAddress: member });
-    expect(after.find(p => p.id === id)).toBeUndefined();
-    expect(registrationCalls).toBe(2);
+      registered = false;
+      const after = await agent.listContextGraphs({ callerAgentAddress: member });
+      expect(after.find(p => p.id === id)).toBeUndefined();
+      expect(registrationCalls).toBe(2);
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+        value: originalAuthBudget,
+        configurable: true,
+      });
+    }
   }, 15000);
 
   it('rejects scoped list calls when allowlist lookup fails with a real error', async () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1034,6 +1034,125 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
+  it('invalidates cached list rows after delete and drop graph writes', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const renamedId = 'delete-invalidates-list-cache-cg';
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const renamedUri = contextGraphDataGraphUri(renamedId);
+    await result.store.insert([
+      {
+        subject: renamedUri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: renamedUri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Delete Invalidates List Cache"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: renamedUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+    ]);
+
+    const first = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(first.find(p => p.id === renamedId)?.name).toBe('Delete Invalidates List Cache');
+
+    await result.store.deleteByPattern({
+      graph: ontologyGraph,
+      subject: renamedUri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+    });
+
+    const second = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(second.find(p => p.id === renamedId)?.name).toBe(renamedId);
+
+    const droppedId = 'drop-invalidates-list-cache-cg';
+    const droppedGraph = contextGraphDataGraphUri(droppedId);
+    await result.store.insert([{
+      subject: `${droppedGraph}#seed`,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: droppedGraph,
+    }]);
+
+    expect((await agent.listContextGraphs()).find(p => p.id === droppedId)).toBeDefined();
+
+    await result.store.dropGraph(droppedGraph);
+
+    expect((await agent.listContextGraphs()).find(p => p.id === droppedId)).toBeUndefined();
+  }, 15000);
+
+  it('expires cached list rows using monotonic time when wall clock moves backwards', async () => {
+    const originalTtl = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+      value: 50,
+      configurable: true,
+    });
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    try {
+      const store = new OxigraphStore();
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'monotonic-list-cache-cg';
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const uri = contextGraphDataGraphUri(id);
+      await store.insert([
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Monotonic List Cache"',
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
+          graph: ontologyGraph,
+        },
+      ]);
+
+      let monotonicNow = 1_000;
+      vi.spyOn(agent as any, 'listContextGraphsCacheNow').mockImplementation(() => monotonicNow);
+      const originalQuery = store.query.bind(store);
+      let definitionScans = 0;
+      vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access')) {
+          definitionScans += 1;
+        }
+        return originalQuery(query, options);
+      });
+
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+      dateNow.mockReturnValue(1);
+      monotonicNow += 51;
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+      expect(definitionScans).toBe(2);
+    } finally {
+      dateNow.mockRestore();
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+        value: originalTtl,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('uses a catalog scan budget that is independent from the per-row enrichment budget', async () => {
     const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
     const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -55,18 +55,17 @@ async function createTestAgent(opts?: {
   storeConfig?: TripleStoreConfig;
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
 }) {
-  const store = opts?.store ?? new OxigraphStore();
   const agent = await DKGAgent.create({
-      kaNumberAllocator: makeTestKaNumberAllocator(),
+    kaNumberAllocator: makeTestKaNumberAllocator(),
     name: 'ContextGraphTestAgent',
     listenPort: 0,
     listenHost: '127.0.0.1',
-    store,
-    storeConfig: opts?.storeConfig,
+    ...(opts?.store ? { store: opts.store } : {}),
+    ...(opts?.storeConfig ? { storeConfig: opts.storeConfig } : {}),
     chainAdapter: opts?.chainAdapter ?? createEVMAdapter(HARDHAT_KEYS.CORE_OP),
     contextGraphSubscriptionStore: opts?.contextGraphSubscriptionStore,
   });
-  return { agent, store };
+  return { agent, store: opts?.store ?? agent.store };
 }
 
 describe('ensureContextGraphLocal', () => {
@@ -1033,10 +1032,10 @@ describe('listContextGraphs merge', () => {
       configurable: true,
     });
     try {
-      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
-      const result = await createTestAgent({ store });
+      const result = await createTestAgent();
       agent = result.agent;
       await agent.start();
+      const store = result.store;
 
       const id = 'zero-cache-ttl-cg';
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
@@ -1187,19 +1186,19 @@ describe('listContextGraphs merge', () => {
     expect((agent as any).listContextGraphsCache.size).toBe(0);
   }, 15000);
 
-  it('allows list cache for injected large-literal wrappers around local stores', async () => {
+  it('bypasses list cache for injected local wrapper stores', async () => {
     const blobDir = await mkdtemp(join(tmpdir(), 'dkg-list-cache-'));
     try {
       const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 1 });
       const result = await createTestAgent({ store });
       agent = result.agent;
       await agent.start();
-      expect((agent as any).listContextGraphsCacheAllowed()).toBe(true);
+      expect((agent as any).listContextGraphsCacheAllowed()).toBe(false);
 
       const id = 'wrapped-local-cache-cg';
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
       const uri = contextGraphDataGraphUri(id);
-      await agent.store.insert([
+      await store.insert([
         {
           subject: uri,
           predicate: DKG_ONTOLOGY.RDF_TYPE,
@@ -1220,7 +1219,19 @@ describe('listContextGraphs merge', () => {
         },
       ]);
 
+      const originalQuery = store.query.bind(store);
+      let definitionScans = 0;
+      vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access')) {
+          definitionScans += 1;
+        }
+        return originalQuery(query, options);
+      });
+
       expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeDefined();
+      expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeDefined();
+      expect(definitionScans).toBe(2);
+      expect((agent as any).listContextGraphsCache.size).toBe(0);
     } finally {
       await rm(blobDir, { recursive: true, force: true });
     }
@@ -1315,10 +1326,10 @@ describe('listContextGraphs merge', () => {
     });
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(10_000);
     try {
-      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
-      const result = await createTestAgent({ store });
+      const result = await createTestAgent();
       agent = result.agent;
       await agent.start();
+      const store = result.store;
 
       const id = 'monotonic-list-cache-cg';
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
@@ -1788,25 +1799,24 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('single-flights same-scope list calls, caches results, and invalidates on subscription changes', async () => {
-    const store = new OxigraphStore();
-    const result = await createTestAgent({ store });
+    const result = await createTestAgent();
     agent = result.agent;
     await agent.start();
 
-    const originalQuery = store.query.bind(store);
+    const originalQuery = result.store.query.bind(result.store);
     let releaseDefinitionScan: (() => void) | undefined;
     const definitionScanGate = new Promise<void>((resolve) => {
       releaseDefinitionScan = resolve;
     });
     let definitionScans = 0;
-    vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
+    vi.spyOn(result.store, 'query').mockImplementation(async (query: string, options?: any) => {
       if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
         definitionScans += 1;
         if (definitionScans === 1) {
           await definitionScanGate;
         }
       }
-      return originalQuery(query);
+      return originalQuery(query, options);
     });
 
     const first = agent.listContextGraphs({ callerAgentAddress: null });
@@ -1821,7 +1831,7 @@ describe('listContextGraphs merge', () => {
 
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const invalidatedUri = contextGraphDataGraphUri('cache-invalidated-cg');
-    await store.insert([
+    await result.store.insert([
       {
         subject: invalidatedUri,
         predicate: DKG_ONTOLOGY.RDF_TYPE,

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1,8 +1,11 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
-import { OxigraphStore, SparqlHttpStore, registerTripleStoreAdapter, type TripleStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, SharedMemoryLiteralBlobStore, SparqlHttpStore, registerTripleStoreAdapter, type TripleStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
 import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -858,6 +861,25 @@ describe('listContextGraphs merge', () => {
     expect(ownerLocal.find(p => p.id === id)).toBeDefined();
   }, 15000);
 
+  it('skips legacy privacy fallback for unscoped owner list rows', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'unscoped-no-legacy-fallback';
+    (agent as any).setContextGraphSubscription(id, {
+      name: 'Unscoped No Legacy Fallback',
+      subscribed: true,
+      synced: false,
+      onChainId: '0xabc123',
+    } satisfies ContextGraphSub, { persist: false });
+
+    const legacyPrivacy = vi.spyOn(agent, 'isPrivateContextGraph');
+    const rows = await agent.listContextGraphs();
+    expect(rows.find(p => p.id === id)).toBeDefined();
+    expect(legacyPrivacy.mock.calls.filter(([contextGraphId]) => contextGraphId === id)).toHaveLength(0);
+  }, 15000);
+
   it('drops storage-only rows from scoped output when policy enrichment times out', async () => {
     const store = sparqlHttpStoreBackedBy(new OxigraphStore());
     const result = await createTestAgent({ store });
@@ -1163,6 +1185,45 @@ describe('listContextGraphs merge', () => {
     expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
     expect(definitionScans).toBe(2);
     expect((agent as any).listContextGraphsCache.size).toBe(0);
+  }, 15000);
+
+  it('allows list cache for injected large-literal wrappers around local stores', async () => {
+    const blobDir = await mkdtemp(join(tmpdir(), 'dkg-list-cache-'));
+    try {
+      const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 1 });
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+      expect((agent as any).listContextGraphsCacheAllowed()).toBe(true);
+
+      const id = 'wrapped-local-cache-cg';
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const uri = contextGraphDataGraphUri(id);
+      await agent.store.insert([
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Wrapped Local Cache"',
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
+          graph: ontologyGraph,
+        },
+      ]);
+
+      expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeDefined();
+    } finally {
+      await rm(blobDir, { recursive: true, force: true });
+    }
   }, 15000);
 
   it('invalidates cached list rows after delete and drop graph writes', async () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -597,6 +597,12 @@ describe('listContextGraphs merge', () => {
         graph: ontologyGraph,
       },
       {
+        subject: contextGraphDataGraphUri('healthy-enrichment-row'),
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+      {
         subject: contextGraphDataGraphUri('broken-enrichment-row'),
         predicate: DKG_ONTOLOGY.RDF_TYPE,
         object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
@@ -606,6 +612,12 @@ describe('listContextGraphs merge', () => {
         subject: contextGraphDataGraphUri('broken-enrichment-row'),
         predicate: DKG_ONTOLOGY.SCHEMA_NAME,
         object: '"Broken Row"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri('broken-enrichment-row'),
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
         graph: ontologyGraph,
       },
     ]);
@@ -672,6 +684,29 @@ describe('listContextGraphs merge', () => {
     expect(noWallet.find(p => p.id === id)).toBeUndefined();
   }, 15000);
 
+  it('drops map-state tail rows from scoped output when no policy literal was read', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'policy-unknown-tail-cg';
+    (agent as any).subscribedContextGraphs.set(id, {
+      name: 'Policy Unknown Tail',
+      subscribed: true,
+      synced: false,
+      onChainId: '0xabc123',
+    } satisfies ContextGraphSub);
+
+    const scoped = await agent.listContextGraphs({ callerAgentAddress: ethers.Wallet.createRandom().address });
+    expect(scoped.find(p => p.id === id)).toBeUndefined();
+
+    const explicitNoWallet = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(explicitNoWallet.find(p => p.id === id)).toBeUndefined();
+
+    const ownerLocal = await agent.listContextGraphs();
+    expect(ownerLocal.find(p => p.id === id)).toBeDefined();
+  }, 15000);
+
   it('drops storage-only rows from scoped output when policy enrichment fails', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });
@@ -722,6 +757,41 @@ describe('listContextGraphs merge', () => {
 
     const ownerLocal = await agent.listContextGraphs();
     expect(ownerLocal.find(p => p.id === 'policy-absent-storage')).toBeDefined();
+  }, 15000);
+
+  it('does not cache private membership misses when allowlist lookup degrades', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'allowlist-unknown-cache-cg';
+    const member = ethers.Wallet.createRandom().address;
+    await agent.createContextGraph({
+      id,
+      name: 'Allowlist Unknown Cache',
+      accessPolicy: 1,
+      allowedAgents: [member],
+    });
+
+    const originalAllowlist = agent.callerIsAllowlistedAgentParticipant.bind(agent);
+    let targetCalls = 0;
+    vi.spyOn(agent, 'callerIsAllowlistedAgentParticipant').mockImplementation(async (contextGraphId, caller) => {
+      if (contextGraphId === id && ethers.getAddress(caller) === ethers.getAddress(member)) {
+        targetCalls += 1;
+        if (targetCalls === 1) throw new Error('simulated allowlist timeout');
+        return true;
+      }
+      return originalAllowlist(contextGraphId, caller);
+    });
+
+    const first = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(first.find(p => p.id === id)).toBeUndefined();
+
+    const second = await agent.listContextGraphs({ callerAgentAddress: member });
+    const entry = second.find(p => p.id === id);
+    expect(entry).toBeDefined();
+    expect(entry!.callerInvolved).toBe(true);
+    expect(targetCalls).toBe(2);
   }, 15000);
 
   it('invalidates wallet-scoped cached list results after agent revocation', async () => {
@@ -801,6 +871,22 @@ describe('listContextGraphs merge', () => {
     await agent.listContextGraphs({ callerAgentAddress: null });
     expect(definitionScans).toBe(1);
 
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const invalidatedUri = contextGraphDataGraphUri('cache-invalidated-cg');
+    await store.insert([
+      {
+        subject: invalidatedUri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: invalidatedUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+    ]);
     (agent as any).setContextGraphSubscription('cache-invalidated-cg', {
       name: 'Cache Invalidated',
       subscribed: true,

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
-import { OxigraphStore, SparqlHttpStore, type TripleStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, SparqlHttpStore, registerTripleStoreAdapter, type TripleStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
 import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -23,6 +23,10 @@ afterAll(async () => {
 
 function sparqlHttpStoreBackedBy(backing: OxigraphStore): TripleStore {
   const store = new SparqlHttpStore({ queryEndpoint: 'http://127.0.0.1:9999/sparql' }) as TripleStore;
+  Object.defineProperty(store, 'queryCancellation', {
+    value: 'interruptible',
+    configurable: true,
+  });
   const methods: Array<keyof TripleStore> = [
     'insert',
     'delete',
@@ -510,7 +514,7 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('keeps phantom-candidate subscriptions when local content probe times out', async () => {
-    const result = await createTestAgent();
+    const result = await createTestAgent({ store: sparqlHttpStoreBackedBy(new OxigraphStore()) });
     agent = result.agent;
     await agent.start();
 
@@ -624,7 +628,7 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('does not reject the whole list when one row enrichment fails', async () => {
-    const store = new OxigraphStore();
+    const store = sparqlHttpStoreBackedBy(new OxigraphStore());
     const result = await createTestAgent({ store });
     agent = result.agent;
     await agent.start();
@@ -680,7 +684,7 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('drops subscribed rows from scoped output when policy enrichment times out', async () => {
-    const store = new OxigraphStore();
+    const store = sparqlHttpStoreBackedBy(new OxigraphStore());
     const result = await createTestAgent({ store });
     agent = result.agent;
     await agent.start();
@@ -855,7 +859,7 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('drops storage-only rows from scoped output when policy enrichment times out', async () => {
-    const store = new OxigraphStore();
+    const store = sparqlHttpStoreBackedBy(new OxigraphStore());
     const result = await createTestAgent({ store });
     agent = result.agent;
     await agent.start();
@@ -956,7 +960,7 @@ describe('listContextGraphs merge', () => {
   }, 15000);
 
   it('omits callerInvolved instead of reporting false when public allowlist lookup times out', async () => {
-    const store = new OxigraphStore();
+    const store = sparqlHttpStoreBackedBy(new OxigraphStore());
     const result = await createTestAgent({ store });
     agent = result.agent;
     await agent.start();
@@ -1007,7 +1011,7 @@ describe('listContextGraphs merge', () => {
       configurable: true,
     });
     try {
-      const store = new OxigraphStore();
+      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
       const result = await createTestAgent({ store });
       agent = result.agent;
       await agent.start();
@@ -1108,6 +1112,59 @@ describe('listContextGraphs merge', () => {
     expect((agent as any).listContextGraphsCache.size).toBe(0);
   }, 15000);
 
+  it('bypasses list cache for unknown configured store backends', async () => {
+    const backend = 'test-remote-list-cache-backend';
+    registerTripleStoreAdapter(backend, async () => new OxigraphStore());
+    const created = await DKGAgent.create({
+      kaNumberAllocator: makeTestKaNumberAllocator(),
+      name: 'ContextGraphTestAgent',
+      listenPort: 0,
+      listenHost: '127.0.0.1',
+      storeConfig: { backend },
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+    });
+    agent = created;
+    await agent.start();
+
+    const id = 'unknown-backend-no-cache-cg';
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const uri = contextGraphDataGraphUri(id);
+    await agent.store.insert([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Unknown Backend No Cache"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+    ]);
+
+    const originalQuery = agent.store.query.bind(agent.store);
+    let definitionScans = 0;
+    vi.spyOn(agent.store, 'query').mockImplementation(async (query: string, options?: any) => {
+      if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access')) {
+        definitionScans += 1;
+      }
+      return originalQuery(query, options);
+    });
+
+    expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+    expect(definitionScans).toBe(2);
+    expect((agent as any).listContextGraphsCache.size).toBe(0);
+  }, 15000);
+
   it('invalidates cached list rows after delete and drop graph writes', async () => {
     const result = await createTestAgent();
     agent = result.agent;
@@ -1196,7 +1253,7 @@ describe('listContextGraphs merge', () => {
     });
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(10_000);
     try {
-      const store = new OxigraphStore();
+      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
       const result = await createTestAgent({ store });
       agent = result.agent;
       await agent.start();
@@ -1311,27 +1368,27 @@ describe('listContextGraphs merge', () => {
       configurable: true,
     });
     try {
-      const store = new OxigraphStore();
+      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
       const result = await createTestAgent({ store });
       agent = result.agent;
       await agent.start();
 
       const originalQuery = store.query.bind(store);
       let sawAbort = false;
+      let scanSettled: Promise<void> | undefined;
       vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
         if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
-          return new Promise<any>((_resolve, reject) => {
-            options?.signal?.addEventListener('abort', () => {
-              sawAbort = true;
-              reject(options.signal.reason);
-            }, { once: true });
-          });
+          scanSettled = new Promise(resolve => setTimeout(resolve, 20));
+          await scanSettled;
+          sawAbort = options?.signal?.aborted === true;
+          return { type: 'bindings', bindings: [] } as any;
         }
         return originalQuery(query, options);
       });
 
       await expect(agent.listContextGraphs({ callerAgentAddress: null }))
         .rejects.toThrow('ontology/agents definition scan');
+      await scanSettled;
       expect(sawAbort).toBe(true);
     } finally {
       Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
@@ -1345,8 +1402,58 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
+  it('does not downgrade budgeted reads for pre-dispatch stores', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    try {
+      const store = new OxigraphStore();
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'pre-dispatch-budget-cg';
+      const uri = contextGraphDataGraphUri(id);
+      const originalQuery = store.query.bind(store);
+      vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
+          await new Promise(resolve => setTimeout(resolve, 20));
+          expect(options?.signal?.aborted).toBe(false);
+          return {
+            type: 'bindings',
+            bindings: [{
+              ctxGraph: uri,
+              name: '"Pre Dispatch Budget"',
+              access: '"public"',
+            }],
+          } as any;
+        }
+        return originalQuery(query, options);
+      });
+
+      const rows = await agent.listContextGraphs({ callerAgentAddress: null });
+      expect(rows.find(p => p.id === id)).toBeDefined();
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+        value: originalScanBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('does not cache private membership misses when allowlist lookup degrades', async () => {
-    const result = await createTestAgent();
+    const result = await createTestAgent({ store: sparqlHttpStoreBackedBy(new OxigraphStore()) });
     agent = result.agent;
     await agent.start();
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -699,7 +699,10 @@ describe('listContextGraphs merge', () => {
     } satisfies ContextGraphSub);
 
     const first = await agent.listContextGraphs({ callerAgentAddress: null });
-    expect(first.find(p => p.id === id)).toBeUndefined();
+    const firstEntry = first.find(p => p.id === id);
+    expect(firstEntry).toBeDefined();
+    expect(firstEntry!.name).toBe('Remote Meta Cache');
+    expect(firstEntry!.accessPolicy).toBeUndefined();
 
     const uri = contextGraphDataGraphUri(id);
     const metaGraph = contextGraphMetaGraphUri(id);
@@ -712,6 +715,12 @@ describe('listContextGraphs merge', () => {
       },
       {
         subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Remote Meta Cache Synced"',
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
         predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
         object: '"public"',
         graph: metaGraph,
@@ -719,10 +728,13 @@ describe('listContextGraphs merge', () => {
     ]);
 
     const second = await agent.listContextGraphs({ callerAgentAddress: null });
-    expect(second.find(p => p.id === id)).toBeDefined();
+    const secondEntry = second.find(p => p.id === id);
+    expect(secondEntry).toBeDefined();
+    expect(secondEntry!.name).toBe('Remote Meta Cache Synced');
+    expect(secondEntry!.accessPolicy).toBe('public');
   }, 15000);
 
-  it('drops map-state tail rows from scoped output when no policy literal was read', async () => {
+  it('keeps map-state tail rows in scoped output when legacy privacy lookup confirms public', async () => {
     const result = await createTestAgent();
     agent = result.agent;
     await agent.start();
@@ -736,10 +748,10 @@ describe('listContextGraphs merge', () => {
     } satisfies ContextGraphSub);
 
     const scoped = await agent.listContextGraphs({ callerAgentAddress: ethers.Wallet.createRandom().address });
-    expect(scoped.find(p => p.id === id)).toBeUndefined();
+    expect(scoped.find(p => p.id === id)).toBeDefined();
 
     const explicitNoWallet = await agent.listContextGraphs({ callerAgentAddress: null });
-    expect(explicitNoWallet.find(p => p.id === id)).toBeUndefined();
+    expect(explicitNoWallet.find(p => p.id === id)).toBeDefined();
 
     const ownerLocal = await agent.listContextGraphs();
     expect(ownerLocal.find(p => p.id === id)).toBeDefined();
@@ -775,7 +787,7 @@ describe('listContextGraphs merge', () => {
     expect(ownerLocal.find(p => p.id === 'policy-unknown-storage')).toBeDefined();
   }, 15000);
 
-  it('drops storage-only rows from scoped output when no explicit policy exists', async () => {
+  it('keeps storage-only rows in scoped output when legacy privacy lookup confirms public', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });
     agent = result.agent;
@@ -791,7 +803,7 @@ describe('listContextGraphs merge', () => {
     ]);
 
     const explicitNoWallet = await agent.listContextGraphs({ callerAgentAddress: null });
-    expect(explicitNoWallet.find(p => p.id === 'policy-absent-storage')).toBeUndefined();
+    expect(explicitNoWallet.find(p => p.id === 'policy-absent-storage')).toBeDefined();
 
     const ownerLocal = await agent.listContextGraphs();
     expect(ownerLocal.find(p => p.id === 'policy-absent-storage')).toBeDefined();

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -486,6 +486,29 @@ describe('listContextGraphs merge', () => {
     expect(contextGraphs.find(p => p.id === 'phantom-cg')).toBeUndefined();
   }, 15000);
 
+  it('keeps phantom-candidate subscriptions when local content probe times out', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    (agent as any).setContextGraphSubscription('slow-local-content-cg', {
+      name: 'Slow Local Content',
+      subscribed: true,
+      synced: false,
+    } satisfies ContextGraphSub, { persist: false });
+    vi.spyOn(agent, 'contextGraphHasLocalContent').mockImplementation(async (contextGraphId) => {
+      if (contextGraphId === 'slow-local-content-cg') {
+        return new Promise<boolean>(() => {});
+      }
+      return false;
+    });
+
+    const contextGraphs = await agent.listContextGraphs();
+    const entry = contextGraphs.find(p => p.id === 'slow-local-content-cg');
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe('Slow Local Content');
+  }, 15000);
+
   it('marks SPARQL-only contextGraphs (not in registry) as subscribed=false', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });
@@ -731,6 +754,57 @@ describe('listContextGraphs merge', () => {
     const secondEntry = second.find(p => p.id === id);
     expect(secondEntry).toBeDefined();
     expect(secondEntry!.name).toBe('Remote Meta Cache Synced');
+    expect(secondEntry!.accessPolicy).toBe('public');
+  }, 15000);
+
+  it('invalidates pending-meta cached rows when meta sync flags refresh', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'pending-meta-refresh-cache-cg';
+    (agent as any).setContextGraphSubscription(id, {
+      name: 'Pending Meta Cache',
+      subscribed: true,
+      synced: false,
+      pendingMeta: true,
+      metaSynced: false,
+    } satisfies ContextGraphSub, { persist: false });
+
+    const first = await agent.listContextGraphs({ callerAgentAddress: null });
+    const firstEntry = first.find(p => p.id === id);
+    expect(firstEntry).toBeDefined();
+    expect(firstEntry!.name).toBe('Pending Meta Cache');
+
+    const uri = contextGraphDataGraphUri(id);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await result.store.insert([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Pending Meta Cache Synced"',
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: metaGraph,
+      },
+    ]);
+
+    await (agent as any).refreshMetaSyncedFlags([id]);
+
+    const second = await agent.listContextGraphs({ callerAgentAddress: null });
+    const secondEntry = second.find(p => p.id === id);
+    expect(secondEntry).toBeDefined();
+    expect(secondEntry!.name).toBe('Pending Meta Cache Synced');
     expect(secondEntry!.accessPolicy).toBe('public');
   }, 15000);
 
@@ -997,6 +1071,51 @@ describe('listContextGraphs merge', () => {
 
       const rows = await agent.listContextGraphs({ callerAgentAddress: null });
       expect(rows.find(p => p.id === id)).toBeDefined();
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+        value: originalScanBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
+  it('aborts budgeted catalog scans after timeout', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    try {
+      const store = new OxigraphStore();
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      const originalQuery = store.query.bind(store);
+      let sawAbort = false;
+      vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
+          return new Promise<any>((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              sawAbort = true;
+              reject(options.signal.reason);
+            }, { once: true });
+          });
+        }
+        return originalQuery(query, options);
+      });
+
+      await agent.listContextGraphs({ callerAgentAddress: null });
+      expect(sawAbort).toBe(true);
     } finally {
       Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
         value: originalRowBudget,

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -995,6 +995,47 @@ describe('listContextGraphs merge', () => {
     expect(targetCalls).toBe(2);
   }, 15000);
 
+  it('does not cache wallet-scoped visibility when membership comes from live chain identity state', async () => {
+    const chainAdapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const result = await createTestAgent({ chainAdapter });
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'chain-auth-cache-cg';
+    const member = ethers.Wallet.createRandom().address;
+    const identityId = 424242n;
+    let registered = true;
+    let registrationCalls = 0;
+    vi.spyOn(chainAdapter, 'isOperationalWalletRegistered').mockImplementation(async (actualIdentityId, actualAddress) => {
+      registrationCalls += 1;
+      expect(actualIdentityId).toBe(identityId);
+      expect(ethers.getAddress(actualAddress)).toBe(ethers.getAddress(member));
+      return registered;
+    });
+
+    await agent.createContextGraph({
+      id,
+      name: 'Chain Auth Cache',
+      accessPolicy: 1,
+      allowedAgents: [agent.getDefaultAgentAddress()!],
+    });
+    await result.store.insert([{
+      subject: contextGraphDataGraphUri(id),
+      predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+      object: `"${identityId.toString()}"`,
+      graph: contextGraphMetaGraphUri(id),
+    }]);
+
+    const before = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(before.find(p => p.id === id)).toBeDefined();
+    expect(registrationCalls).toBe(1);
+
+    registered = false;
+    const after = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(after.find(p => p.id === id)).toBeUndefined();
+    expect(registrationCalls).toBe(2);
+  }, 15000);
+
   it('rejects scoped list calls when allowlist lookup fails with a real error', async () => {
     const result = await createTestAgent();
     agent = result.agent;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
-import { OxigraphStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, SparqlHttpStore, type TripleStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
 import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -21,9 +21,30 @@ afterAll(async () => {
   await revertSnapshot(_fileSnapshot);
 });
 
+function sparqlHttpStoreBackedBy(backing: OxigraphStore): TripleStore {
+  const store = new SparqlHttpStore({ queryEndpoint: 'http://127.0.0.1:9999/sparql' }) as TripleStore;
+  const methods: Array<keyof TripleStore> = [
+    'insert',
+    'delete',
+    'deleteByPattern',
+    'query',
+    'hasGraph',
+    'createGraph',
+    'dropGraph',
+    'listGraphs',
+    'deleteBySubjectPrefix',
+    'countQuads',
+    'close',
+  ];
+  for (const method of methods) {
+    (store as any)[method] = (backing as any)[method].bind(backing);
+  }
+  return store;
+}
+
 async function createTestAgent(opts?: {
   chainAdapter?: ChainAdapter;
-  store?: OxigraphStore;
+  store?: TripleStore;
   storeConfig?: TripleStoreConfig;
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
 }) {
@@ -1036,13 +1057,13 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
-  it('bypasses list cache for unmanaged external store configurations', async () => {
-    const store = new OxigraphStore();
+  it('bypasses list cache for injected unmanaged external stores', async () => {
+    const backing = new OxigraphStore();
+    const store = sparqlHttpStoreBackedBy(backing);
     const result = await createTestAgent({
       store,
       storeConfig: {
-        backend: 'sparql-http',
-        options: { queryEndpoint: 'http://127.0.0.1:9999/sparql' },
+        backend: 'oxigraph',
       },
     });
     agent = result.agent;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -575,6 +575,243 @@ describe('listContextGraphs merge', () => {
     const unauthenticated = await agent.listContextGraphs();
     expect(unauthenticated.find(p => p.id === 'my-curated')).toBeUndefined();
   }, 15000);
+
+  it('does not reject the whole list when one row enrichment fails', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    await store.insert([
+      {
+        subject: contextGraphDataGraphUri('healthy-enrichment-row'),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri('healthy-enrichment-row'),
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Healthy Row"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri('broken-enrichment-row'),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri('broken-enrichment-row'),
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Broken Row"',
+        graph: ontologyGraph,
+      },
+    ]);
+
+    vi.spyOn(agent as any, 'getContextGraphOnChainId').mockImplementation(async (id: string) => {
+      if (id === 'broken-enrichment-row') throw new Error('simulated enrichment failure');
+      return undefined;
+    });
+
+    const contextGraphs = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(contextGraphs.find(p => p.id === 'healthy-enrichment-row')).toBeDefined();
+    expect(contextGraphs.find(p => p.id === 'broken-enrichment-row')).toBeDefined();
+  }, 15000);
+
+  it('drops subscribed rows from scoped output when policy enrichment fails', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'degraded-private-cg';
+    const metaGraph = contextGraphMetaGraphUri(id);
+    const contextGraphUri = contextGraphDataGraphUri(id);
+    await store.insert([
+      {
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: metaGraph,
+      },
+      {
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Degraded Private"',
+        graph: metaGraph,
+      },
+      {
+        subject: contextGraphUri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: metaGraph,
+      },
+    ]);
+    (agent as any).subscribedContextGraphs.set(id, {
+      name: 'Degraded Private',
+      subscribed: true,
+      synced: false,
+      pendingMeta: true,
+    } satisfies ContextGraphSub);
+
+    const originalQuery = store.query.bind(store);
+    vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
+      if (query.includes(`<${metaGraph}>`) && query.includes('SELECT ?name ?desc ?creator ?created ?curator ?access')) {
+        throw new Error('simulated policy read failure');
+      }
+      return originalQuery(query);
+    });
+
+    const stranger = ethers.Wallet.createRandom().address;
+    const fromStranger = await agent.listContextGraphs({ callerAgentAddress: stranger });
+    expect(fromStranger.find(p => p.id === id)).toBeUndefined();
+
+    const noWallet = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(noWallet.find(p => p.id === id)).toBeUndefined();
+  }, 15000);
+
+  it('drops storage-only rows from scoped output when policy enrichment fails', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    await store.insert([
+      {
+        subject: 'urn:workspace-only:policy-unknown',
+        predicate: 'http://schema.org/name',
+        object: '"Policy Unknown"',
+        graph: contextGraphSharedMemoryUri('policy-unknown-storage'),
+      },
+    ]);
+
+    const originalQuery = store.query.bind(store);
+    vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
+      if (query.includes('SELECT ?policy WHERE') && query.includes(DKG_ONTOLOGY.DKG_ACCESS_POLICY)) {
+        throw new Error('simulated storage-tail policy read failure');
+      }
+      return originalQuery(query);
+    });
+
+    const explicitNoWallet = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(explicitNoWallet.find(p => p.id === 'policy-unknown-storage')).toBeUndefined();
+
+    const ownerLocal = await agent.listContextGraphs();
+    expect(ownerLocal.find(p => p.id === 'policy-unknown-storage')).toBeDefined();
+  }, 15000);
+
+  it('drops storage-only rows from scoped output when no explicit policy exists', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    await store.insert([
+      {
+        subject: 'urn:workspace-only:policy-absent',
+        predicate: 'http://schema.org/name',
+        object: '"Policy Absent"',
+        graph: contextGraphSharedMemoryUri('policy-absent-storage'),
+      },
+    ]);
+
+    const explicitNoWallet = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(explicitNoWallet.find(p => p.id === 'policy-absent-storage')).toBeUndefined();
+
+    const ownerLocal = await agent.listContextGraphs();
+    expect(ownerLocal.find(p => p.id === 'policy-absent-storage')).toBeDefined();
+  }, 15000);
+
+  it('invalidates wallet-scoped cached list results after agent revocation', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const owner = agent.getDefaultAgentAddress()!;
+    const member = ethers.Wallet.createRandom().address;
+    await agent.createContextGraph({
+      id: 'cached-revoke-cg',
+      name: 'Cached Revoke',
+      accessPolicy: 1,
+      allowedAgents: [member],
+    });
+
+    const before = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(before.find(p => p.id === 'cached-revoke-cg')).toBeDefined();
+
+    await agent.removeAgentFromContextGraph('cached-revoke-cg', member, owner);
+
+    const after = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(after.find(p => p.id === 'cached-revoke-cg')).toBeUndefined();
+  }, 15000);
+
+  it('invalidates wallet-scoped cached misses after agent invitation', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const owner = agent.getDefaultAgentAddress()!;
+    const member = ethers.Wallet.createRandom().address;
+    await agent.createContextGraph({
+      id: 'cached-invite-cg',
+      name: 'Cached Invite',
+      accessPolicy: 1,
+    });
+
+    const before = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(before.find(p => p.id === 'cached-invite-cg')).toBeUndefined();
+
+    await agent.inviteAgentToContextGraph('cached-invite-cg', member, owner);
+
+    const after = await agent.listContextGraphs({ callerAgentAddress: member });
+    expect(after.find(p => p.id === 'cached-invite-cg')).toBeDefined();
+  }, 15000);
+
+  it('single-flights same-scope list calls, caches results, and invalidates on subscription changes', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    const originalQuery = store.query.bind(store);
+    let releaseDefinitionScan: (() => void) | undefined;
+    const definitionScanGate = new Promise<void>((resolve) => {
+      releaseDefinitionScan = resolve;
+    });
+    let definitionScans = 0;
+    vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
+      if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access ?isSystem')) {
+        definitionScans += 1;
+        if (definitionScans === 1) {
+          await definitionScanGate;
+        }
+      }
+      return originalQuery(query);
+    });
+
+    const first = agent.listContextGraphs({ callerAgentAddress: null });
+    const second = agent.listContextGraphs({ callerAgentAddress: null });
+    await Promise.resolve();
+    expect(definitionScans).toBe(1);
+    releaseDefinitionScan?.();
+    await Promise.all([first, second]);
+
+    await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(definitionScans).toBe(1);
+
+    (agent as any).setContextGraphSubscription('cache-invalidated-cg', {
+      name: 'Cache Invalidated',
+      subscribed: true,
+      synced: false,
+      onChainId: '0xabc123',
+    } satisfies ContextGraphSub, { persist: false });
+
+    const afterInvalidation = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(definitionScans).toBe(2);
+    expect(afterInvalidation.find(p => p.id === 'cache-invalidated-cg')).toBeDefined();
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -623,7 +623,7 @@ describe('listContextGraphs merge', () => {
     ]);
 
     vi.spyOn(agent as any, 'getContextGraphOnChainId').mockImplementation(async (id: string) => {
-      if (id === 'broken-enrichment-row') throw new Error('simulated enrichment failure');
+      if (id === 'broken-enrichment-row') return new Promise<undefined>(() => {});
       return undefined;
     });
 
@@ -632,7 +632,7 @@ describe('listContextGraphs merge', () => {
     expect(contextGraphs.find(p => p.id === 'broken-enrichment-row')).toBeDefined();
   }, 15000);
 
-  it('drops subscribed rows from scoped output when policy enrichment fails', async () => {
+  it('drops subscribed rows from scoped output when policy enrichment times out', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });
     agent = result.agent;
@@ -671,7 +671,7 @@ describe('listContextGraphs merge', () => {
     const originalQuery = store.query.bind(store);
     vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
       if (query.includes(`<${metaGraph}>`) && query.includes('SELECT ?name ?desc ?creator ?created ?curator ?access')) {
-        throw new Error('simulated policy read failure');
+        return new Promise<any>(() => {});
       }
       return originalQuery(query);
     });
@@ -682,6 +682,43 @@ describe('listContextGraphs merge', () => {
 
     const noWallet = await agent.listContextGraphs({ callerAgentAddress: null });
     expect(noWallet.find(p => p.id === id)).toBeUndefined();
+  }, 15000);
+
+  it('invalidates cached scoped results when remote meta sync writes policy metadata', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'remote-meta-cache-cg';
+    (agent as any).subscribedContextGraphs.set(id, {
+      name: 'Remote Meta Cache',
+      subscribed: true,
+      synced: false,
+      pendingMeta: true,
+    } satisfies ContextGraphSub);
+
+    const first = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(first.find(p => p.id === id)).toBeUndefined();
+
+    const uri = contextGraphDataGraphUri(id);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await (agent as any).insertSyncedQuadsAndInvalidateListCache([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: metaGraph,
+      },
+    ]);
+
+    const second = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(second.find(p => p.id === id)).toBeDefined();
   }, 15000);
 
   it('drops map-state tail rows from scoped output when no policy literal was read', async () => {
@@ -707,7 +744,7 @@ describe('listContextGraphs merge', () => {
     expect(ownerLocal.find(p => p.id === id)).toBeDefined();
   }, 15000);
 
-  it('drops storage-only rows from scoped output when policy enrichment fails', async () => {
+  it('drops storage-only rows from scoped output when policy enrichment times out', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });
     agent = result.agent;
@@ -725,7 +762,7 @@ describe('listContextGraphs merge', () => {
     const originalQuery = store.query.bind(store);
     vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
       if (query.includes('SELECT ?policy WHERE') && query.includes(DKG_ONTOLOGY.DKG_ACCESS_POLICY)) {
-        throw new Error('simulated storage-tail policy read failure');
+        return new Promise<any>(() => {});
       }
       return originalQuery(query);
     });
@@ -778,7 +815,7 @@ describe('listContextGraphs merge', () => {
     vi.spyOn(agent, 'callerIsAllowlistedAgentParticipant').mockImplementation(async (contextGraphId, caller) => {
       if (contextGraphId === id && ethers.getAddress(caller) === ethers.getAddress(member)) {
         targetCalls += 1;
-        if (targetCalls === 1) throw new Error('simulated allowlist timeout');
+        if (targetCalls === 1) return new Promise<boolean>(() => {});
         return true;
       }
       return originalAllowlist(contextGraphId, caller);
@@ -792,6 +829,31 @@ describe('listContextGraphs merge', () => {
     expect(entry).toBeDefined();
     expect(entry!.callerInvolved).toBe(true);
     expect(targetCalls).toBe(2);
+  }, 15000);
+
+  it('rejects scoped list calls when allowlist lookup fails with a real error', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'allowlist-real-error-cg';
+    const stranger = ethers.Wallet.createRandom().address;
+    await agent.createContextGraph({
+      id,
+      name: 'Allowlist Real Error',
+      accessPolicy: 1,
+      allowedAgents: [agent.getDefaultAgentAddress()!],
+    });
+
+    vi.spyOn(agent, 'callerIsAllowlistedAgentParticipant').mockImplementation(async (contextGraphId, caller) => {
+      if (contextGraphId === id && ethers.getAddress(caller) === ethers.getAddress(stranger)) {
+        throw new Error('simulated store failure');
+      }
+      return false;
+    });
+
+    await expect(agent.listContextGraphs({ callerAgentAddress: stranger }))
+      .rejects.toThrow('simulated store failure');
   }, 15000);
 
   it('invalidates wallet-scoped cached list results after agent revocation', async () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1230,6 +1230,7 @@ describe('listContextGraphs merge', () => {
     const result = await createTestAgent();
     agent = result.agent;
     await agent.start();
+    const agentStore = (agent as any).store as TripleStore;
 
     const renamedId = 'delete-invalidates-list-cache-cg';
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
@@ -1258,7 +1259,7 @@ describe('listContextGraphs merge', () => {
     const first = await agent.listContextGraphs({ callerAgentAddress: null });
     expect(first.find(p => p.id === renamedId)?.name).toBe('Delete Invalidates List Cache');
 
-    await result.store.deleteByPattern({
+    await agentStore.deleteByPattern({
       graph: ontologyGraph,
       subject: renamedUri,
       predicate: DKG_ONTOLOGY.SCHEMA_NAME,
@@ -1278,7 +1279,7 @@ describe('listContextGraphs merge', () => {
 
     expect((await agent.listContextGraphs()).find(p => p.id === droppedId)).toBeDefined();
 
-    await result.store.dropGraph(droppedGraph);
+    await agentStore.dropGraph(droppedGraph);
 
     expect((await agent.listContextGraphs()).find(p => p.id === droppedId)).toBeUndefined();
   }, 15000);
@@ -1449,6 +1450,48 @@ describe('listContextGraphs merge', () => {
 
       await expect(agent.listContextGraphs({ callerAgentAddress: null }))
         .rejects.toThrow('ontology/agents definition scan');
+      await scanSettled;
+      expect(sawAbort).toBe(true);
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+        value: originalScanBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
+  it('rejects when the budgeted storage graph scan times out', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalScanBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_SCAN_BUDGET_MS', {
+      value: 1,
+      configurable: true,
+    });
+    try {
+      const store = sparqlHttpStoreBackedBy(new OxigraphStore());
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      let sawAbort = false;
+      let scanSettled: Promise<void> | undefined;
+      vi.spyOn(store, 'listGraphs').mockImplementation(async (options?: any) => {
+        scanSettled = new Promise(resolve => setTimeout(resolve, 20));
+        await scanSettled;
+        sawAbort = options?.signal?.aborted === true;
+        return [];
+      });
+
+      await expect(agent.listContextGraphs({ callerAgentAddress: null }))
+        .rejects.toThrow('storage context graph scan');
       await scanSettled;
       expect(sawAbort).toBe(true);
     } finally {
@@ -1802,6 +1845,23 @@ describe('listContextGraphs merge', () => {
     const afterInvalidation = await agent.listContextGraphs({ callerAgentAddress: null });
     expect(definitionScans).toBe(2);
     expect(afterInvalidation.find(p => p.id === 'cache-invalidated-cg')).toBeDefined();
+  }, 15000);
+
+  it('does not rewrite the caller-provided store when binding list cache invalidation', async () => {
+    const store = new OxigraphStore();
+    const originalInsert = store.insert;
+    const originalDelete = store.delete;
+    const originalQuery = store.query;
+
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    expect(store.insert).toBe(originalInsert);
+    expect(store.delete).toBe(originalDelete);
+    expect(store.query).toBe(originalQuery);
+    expect((agent as any).store).not.toBe(store);
+    expect((agent as any).store.innerStore).toBe(store);
   }, 15000);
 });
 

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
 import { DKGAgentBase } from '../src/dkg-agent-base.js';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, type TripleStoreConfig } from '@origintrail-official/dkg-storage';
 import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
@@ -24,6 +24,7 @@ afterAll(async () => {
 async function createTestAgent(opts?: {
   chainAdapter?: ChainAdapter;
   store?: OxigraphStore;
+  storeConfig?: TripleStoreConfig;
   contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
 }) {
   const store = opts?.store ?? new OxigraphStore();
@@ -33,6 +34,7 @@ async function createTestAgent(opts?: {
     listenPort: 0,
     listenHost: '127.0.0.1',
     store,
+    storeConfig: opts?.storeConfig,
     chainAdapter: opts?.chainAdapter ?? createEVMAdapter(HARDHAT_KEYS.CORE_OP),
     contextGraphSubscriptionStore: opts?.contextGraphSubscriptionStore,
   });
@@ -1034,6 +1036,57 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
+  it('bypasses list cache for unmanaged external store configurations', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({
+      store,
+      storeConfig: {
+        backend: 'sparql-http',
+        options: { queryEndpoint: 'http://127.0.0.1:9999/sparql' },
+      },
+    });
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'external-store-no-cache-cg';
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const uri = contextGraphDataGraphUri(id);
+    await store.insert([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"External Store No Cache"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+    ]);
+
+    const originalQuery = store.query.bind(store);
+    let definitionScans = 0;
+    vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+      if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access')) {
+        definitionScans += 1;
+      }
+      return originalQuery(query, options);
+    });
+
+    expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+    expect(definitionScans).toBe(2);
+    expect((agent as any).listContextGraphsCache.size).toBe(0);
+  }, 15000);
+
   it('invalidates cached list rows after delete and drop graph writes', async () => {
     const result = await createTestAgent();
     agent = result.agent;
@@ -1256,7 +1309,8 @@ describe('listContextGraphs merge', () => {
         return originalQuery(query, options);
       });
 
-      await agent.listContextGraphs({ callerAgentAddress: null });
+      await expect(agent.listContextGraphs({ callerAgentAddress: null }))
+        .rejects.toThrow('ontology/agents definition scan');
       expect(sawAbort).toBe(true);
     } finally {
       Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent, type ContextGraphSub, type ContextGraphSubscriptionStore } from '../src/index.js';
+import { DKGAgentBase } from '../src/dkg-agent-base.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY, contextGraphDataGraphUri, contextGraphSharedMemoryUri, contextGraphMetaGraphUri, Logger } from '@origintrail-official/dkg-core';
 import { type ChainAdapter, type ContextGraphOnChain } from '@origintrail-official/dkg-chain';
@@ -794,6 +795,157 @@ describe('listContextGraphs merge', () => {
 
     const ownerLocal = await agent.listContextGraphs();
     expect(ownerLocal.find(p => p.id === 'policy-absent-storage')).toBeDefined();
+  }, 15000);
+
+  it('preserves legacy allowlist privacy for scoped list callers without explicit policy', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'legacy-allowlist-no-policy';
+    const member = ethers.Wallet.createRandom().address;
+    const stranger = ethers.Wallet.createRandom().address;
+    const uri = contextGraphDataGraphUri(id);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await store.insert([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Legacy Allowlist"',
+        graph: metaGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${member}"`,
+        graph: metaGraph,
+      },
+    ]);
+    (agent as any).subscribedContextGraphs.set(id, {
+      name: 'Legacy Allowlist',
+      subscribed: true,
+      synced: true,
+    } satisfies ContextGraphSub);
+
+    const memberRows = await agent.listContextGraphs({ callerAgentAddress: member });
+    const memberEntry = memberRows.find(p => p.id === id);
+    expect(memberEntry).toBeDefined();
+    expect(memberEntry!.callerInvolved).toBe(true);
+
+    const strangerRows = await agent.listContextGraphs({ callerAgentAddress: stranger });
+    expect(strangerRows.find(p => p.id === id)).toBeUndefined();
+
+    const noWalletRows = await agent.listContextGraphs({ callerAgentAddress: null });
+    expect(noWalletRows.find(p => p.id === id)).toBeUndefined();
+  }, 15000);
+
+  it('omits callerInvolved instead of reporting false when public allowlist lookup times out', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'public-allowlist-timeout';
+    const caller = ethers.Wallet.createRandom().address;
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const uri = contextGraphDataGraphUri(id);
+    await store.insert([
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: '"Public Allowlist Timeout"',
+        graph: ontologyGraph,
+      },
+      {
+        subject: uri,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"public"',
+        graph: ontologyGraph,
+      },
+    ]);
+
+    const originalAllowlist = agent.callerIsAllowlistedAgentParticipant.bind(agent);
+    vi.spyOn(agent, 'callerIsAllowlistedAgentParticipant').mockImplementation(async (contextGraphId, wallet) => {
+      if (contextGraphId === id && ethers.getAddress(wallet) === ethers.getAddress(caller)) {
+        return new Promise<boolean>(() => {});
+      }
+      return originalAllowlist(contextGraphId, wallet);
+    });
+
+    const rows = await agent.listContextGraphs({ callerAgentAddress: caller });
+    const entry = rows.find(p => p.id === id);
+    expect(entry).toBeDefined();
+    expect(entry!.callerInvolved).toBeUndefined();
+  }, 15000);
+
+  it('bypasses list cache when the configured TTL is zero', async () => {
+    const originalTtl = DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+      value: 0,
+      configurable: true,
+    });
+    try {
+      const store = new OxigraphStore();
+      const result = await createTestAgent({ store });
+      agent = result.agent;
+      await agent.start();
+
+      const id = 'zero-cache-ttl-cg';
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const uri = contextGraphDataGraphUri(id);
+      await store.insert([
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Zero Cache TTL"',
+          graph: ontologyGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"public"',
+          graph: ontologyGraph,
+        },
+      ]);
+
+      const originalQuery = store.query.bind(store);
+      let definitionScans = 0;
+      vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
+        if (query.includes('SELECT ?ctxGraph ?name ?desc ?creator ?created ?curator ?access')) {
+          definitionScans += 1;
+        }
+        return originalQuery(query);
+      });
+
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === id)).toBeDefined();
+      expect(definitionScans).toBe(2);
+      expect((agent as any).listContextGraphsCache.size).toBe(0);
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', {
+        value: originalTtl,
+        configurable: true,
+      });
+    }
   }, 15000);
 
   it('does not cache private membership misses when allowlist lookup degrades', async () => {

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -209,6 +209,23 @@ describe('GossipPublishHandler', () => {
     });
   });
 
+  it('requires the invalidating subscription setter for agent-backed handlers', () => {
+    const store = new OxigraphStore();
+    const subscriptions = new Map<string, ContextGraphSub>();
+
+    expect(() => new GossipPublishHandler(
+      store,
+      undefined,
+      subscriptions,
+      {
+        contextGraphExists: async () => false,
+        getContextGraphOwner: async () => null,
+        subscribeToContextGraph: () => {},
+      },
+      { requireContextGraphSubscriptionSetter: true },
+    )).toThrow('requires setContextGraphSubscription');
+  });
+
   it('rejects forged ontology policy approvals from non-owners', async () => {
     const { store, handler } = createHandler(undefined, {
       getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { GossipPublishHandler } from '../src/gossip-publish-handler.js';
+import type { ContextGraphSub } from '../src/index.js';
 
 const CONTEXT_GRAPH = 'test-gossip-handler';
 
@@ -34,10 +35,10 @@ function createHandler(store?: OxigraphStore, callbacks?: Partial<{
   contextGraphExists: (id: string) => Promise<boolean>;
   getContextGraphOwner: (id: string) => Promise<string | null>;
   subscribeToContextGraph: (id: string) => void;
-  setContextGraphSubscription: (id: string, next: any) => void;
+  setContextGraphSubscription: (id: string, next: ContextGraphSub) => void;
 }>) {
   const s = store ?? new OxigraphStore();
-  const subscriptions = new Map<string, any>();
+  const subscriptions = new Map<string, ContextGraphSub>();
   return {
     store: s,
     handler: new GossipPublishHandler(

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -30,18 +30,25 @@ function makePublishMessage(opts: {
   });
 }
 
-function createHandler(store?: OxigraphStore, callbacks?: Partial<{ contextGraphExists: (id: string) => Promise<boolean>; getContextGraphOwner: (id: string) => Promise<string | null>; subscribeToContextGraph: (id: string) => void }>) {
+function createHandler(store?: OxigraphStore, callbacks?: Partial<{
+  contextGraphExists: (id: string) => Promise<boolean>;
+  getContextGraphOwner: (id: string) => Promise<string | null>;
+  subscribeToContextGraph: (id: string) => void;
+  setContextGraphSubscription: (id: string, next: any) => void;
+}>) {
   const s = store ?? new OxigraphStore();
+  const subscriptions = new Map<string, any>();
   return {
     store: s,
     handler: new GossipPublishHandler(
       s,
       undefined,
-      new Map<string, any>(),
+      subscriptions,
       {
         contextGraphExists: callbacks?.contextGraphExists ?? (async () => false),
         getContextGraphOwner: callbacks?.getContextGraphOwner ?? (async () => null),
         subscribeToContextGraph: callbacks?.subscribeToContextGraph ?? (() => {}),
+        setContextGraphSubscription: callbacks?.setContextGraphSubscription ?? ((id, next) => { subscriptions.set(id, next); }),
       },
     ),
   };

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -176,6 +176,39 @@ describe('GossipPublishHandler', () => {
     expect(bindings.length).toBeGreaterThan(0);
   });
 
+  it('keeps legacy subscription-map fallback when setContextGraphSubscription is omitted', async () => {
+    const store = new OxigraphStore();
+    const subscriptions = new Map<string, ContextGraphSub>();
+    const handler = new GossipPublishHandler(
+      store,
+      undefined,
+      subscriptions,
+      {
+        contextGraphExists: async () => false,
+        getContextGraphOwner: async () => null,
+        subscribeToContextGraph: () => {},
+      },
+    );
+
+    const id = 'legacy-callback-discovery';
+    const data = makePublishMessage({
+      contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      nquads: [
+        `<did:dkg:context-graph:${id}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> <did:dkg:context-graph:${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}> .`,
+        `<did:dkg:context-graph:${id}> <${DKG_ONTOLOGY.SCHEMA_NAME}> "Legacy Callback Discovery" <did:dkg:context-graph:${SYSTEM_CONTEXT_GRAPHS.ONTOLOGY}> .`,
+      ].join('\n'),
+    });
+
+    await handler.handlePublishMessage(data, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+
+    expect(subscriptions.get(id)).toMatchObject({
+      name: 'Legacy Callback Discovery',
+      subscribed: true,
+      synced: false,
+      metaSynced: false,
+    });
+  });
+
   it('rejects forged ontology policy approvals from non-owners', async () => {
     const { store, handler } = createHandler(undefined, {
       getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,

--- a/packages/agent/test/phase-sequences.test.ts
+++ b/packages/agent/test/phase-sequences.test.ts
@@ -41,7 +41,12 @@ describe('Gossip handler phase-sequence contract', () => {
     const store = new OxigraphStore();
     const handler = new GossipPublishHandler(
       store, undefined, new Map(),
-      { contextGraphExists: async () => false, subscribeToContextGraph: () => {} },
+      {
+        contextGraphExists: async () => false,
+        getContextGraphOwner: async () => null,
+        subscribeToContextGraph: () => {},
+        setContextGraphSubscription: () => {},
+      },
     );
 
     const { calls, fn } = recorder();
@@ -63,7 +68,12 @@ describe('Gossip handler phase-sequence contract', () => {
     const store = new OxigraphStore();
     const handler = new GossipPublishHandler(
       store, undefined, new Map(),
-      { contextGraphExists: async () => false, subscribeToContextGraph: () => {} },
+      {
+        contextGraphExists: async () => false,
+        getContextGraphOwner: async () => null,
+        subscribeToContextGraph: () => {},
+        setContextGraphSubscription: () => {},
+      },
     );
 
     const msg = encodePublishRequest({
@@ -96,7 +106,12 @@ describe('Gossip handler phase-sequence contract', () => {
     const store = new OxigraphStore();
     const handler = new GossipPublishHandler(
       store, undefined, new Map(),
-      { contextGraphExists: async () => false, subscribeToContextGraph: () => {} },
+      {
+        contextGraphExists: async () => false,
+        getContextGraphOwner: async () => null,
+        subscribeToContextGraph: () => {},
+        setContextGraphSubscription: () => {},
+      },
     );
 
     const { calls, fn } = recorder();

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -33,6 +33,7 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.queryCancellation;
   }
 
+  readonly innerStore: TripleStore;
   private readonly inner: TripleStore;
   private readonly blobDir: string;
   private readonly thresholdBytes: number;
@@ -46,6 +47,7 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
       throw new Error('SharedMemoryLiteralBlobStore requires a non-negative integer thresholdBytes');
     }
     this.inner = inner;
+    this.innerStore = inner;
     this.blobDir = options.blobDir;
     this.thresholdBytes = options.thresholdBytes;
   }


### PR DESCRIPTION
## Summary

- Makes `listContextGraphs()` degrade gracefully instead of failing the whole call: per-row error isolation (`Promise.allSettled`), an enrichment deadline with map-state-only tail rows, single-flight, and an interim caller-scoped result cache.
- **Degrade closed on policy:** any row whose `accessPolicy` can't be read within the budget is dropped from scoped output (a map-state-only row has no policy and would otherwise pass `isPrivateRow`, leaking a declared-private CG to non-member bearer callers).

## Related

- Part of #1138 (Track B, PR B3). Refines (does not gate) the checkpoint. Retired later by C3.
- **Merge order:** Wave 1.5 — after the checkpoint, before C3 (which replaces this interim cache).

## Files changed

| File | What |
|------|------|
| `agent/src/dkg-agent-cg-resolve.ts` | Per-row isolation, deadline, single-flight, policy-closed degrade |
| `agent/src/dkg-agent-base.ts` | Interim caller-scoped cache |
| `agent/src/dkg-agent-context-graph.ts`, `dkg-agent-lifecycle.ts` | Cache invalidation hooks |

Plus 1 test file.

## Test plan

- [ ] `pnpm -F dkg-agent test`
- [ ] Merge-gate fixture: declared-private CG + enrichment deadline tripped → row absent from `/api/context-graph/list` for non-members
- [ ] Partial enrichment failure degrades that row only, never the whole call
- [ ] `pnpm build` + lint

---
**Wave 2 — opened as draft.** Gated behind the Wave-1 live-node checkpoint (#1138, Verification): A1-A4 + B0-B2 must merge into `integration/issue-1138` and pass the field repro (sustained CPU < 1 core, VM publish < 1 s) before this is un-drafted/merged. Targets `integration/issue-1138`.