### PR TITLE
C1 — GraphSetIndexStore (resolve-by-key graph enumeration)

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -901,7 +901,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     // Drop assertion graphs under the sub-graph prefix
     const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, sgPrefix);
     for (const g of allGraphs) {
       if (g.startsWith(sgPrefix)) {
         try { await this.store.dropGraph(g); } catch { /* graph may not exist */ }
@@ -1093,4 +1093,10 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
   // ── ENDORSE ─���────────────────────────────────────────────────────────
 
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3800,7 +3800,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           }
 
           // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + bucket.
-          const wsGraphs = (await this.store.listGraphs()).filter(g => g === wsGraph || g.startsWith(`${wsGraph}/`));
+          const wsGraphs = await listGraphFamily(this.store, wsGraph);
           for (const re of rootEntities) {
             for (const g of wsGraphs) {
               // Exact root only; then skolemized descendants only (prefix would over-delete e.g. urn:foo vs urn:foobar)
@@ -3843,4 +3843,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return totalDeleted;
   }
 
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -347,6 +347,12 @@ export interface QueryAccessConfig {
   rateLimitPerMinute?: number;
 }
 
+export interface GraphSetIndexConfig {
+  enabled?: boolean;
+  /** Revalidate the named-graph index after this many milliseconds. 0 means every read. */
+  revalidateMs?: number;
+}
+
 export interface DkgConfig {
   name: string;
   relay?: string;
@@ -445,7 +451,7 @@ export interface DkgConfig {
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
-  store?: { backend: string; options?: Record<string, unknown> };
+  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
   /**
    * Cap on how many persisted context-graph subscriptions a node ACTIVATES on
    * boot (gossip + sync). A large stale backlog otherwise fans out store work

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1212,6 +1212,7 @@ export async function runDaemonInner(
     storeConfig: runtimeStore ? {
       backend: runtimeStore.backend,
       options: runtimeStore.options,
+      graphSetIndex: runtimeStore.graphSetIndex,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -49,6 +49,10 @@ export function resolveManagedOxigraphPort(
 interface StoreConfigLike {
   backend?: unknown;
   options?: Record<string, unknown>;
+  graphSetIndex?: boolean | {
+    enabled?: boolean;
+    revalidateMs?: number;
+  };
 }
 
 interface ConfigLike {
@@ -79,6 +83,7 @@ export interface ManagedOxigraphPlan {
   storeConfigTemplate: {
     backend: 'sparql-http';
     options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
   };
   /**
    * largeLiteralStorage to apply when the operator didn't configure one.
@@ -140,16 +145,22 @@ export function planManagedOxigraph(
         }
       : undefined;
 
+  const graphSetIndex = config.store?.graphSetIndex;
+  const storeConfigTemplate: ManagedOxigraphPlan['storeConfigTemplate'] = {
+    backend: 'sparql-http',
+    // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
+    // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
+    options: { managedByDkg: true },
+  };
+  if (graphSetIndex !== undefined) {
+    storeConfigTemplate.graphSetIndex = graphSetIndex;
+  }
+
   return {
     port,
     location,
     cacheDir,
-    storeConfigTemplate: {
-      backend: 'sparql-http',
-      // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
-      // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
-      options: { managedByDkg: true },
-    },
+    storeConfigTemplate,
     largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage,
   };
@@ -158,7 +169,11 @@ export function planManagedOxigraph(
 export interface ManagedOxigraphResult {
   handle: OxigraphServerHandle;
   /** Drop-in replacement for `config.store`. */
-  storeConfig: { backend: 'sparql-http'; options: Record<string, unknown> };
+  storeConfig: {
+    backend: 'sparql-http';
+    options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
+  };
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
   /** Set only when the operator enabled the feature (else leave config as-is). */
   sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
@@ -206,16 +221,21 @@ export async function startManagedOxigraph(
     io: opts.serverIo,
   });
 
+  const storeConfig: ManagedOxigraphResult['storeConfig'] = {
+    backend: 'sparql-http',
+    options: {
+      ...plan.storeConfigTemplate.options,
+      queryEndpoint: handle.queryEndpoint,
+      updateEndpoint: handle.updateEndpoint,
+    },
+  };
+  if (plan.storeConfigTemplate.graphSetIndex !== undefined) {
+    storeConfig.graphSetIndex = plan.storeConfigTemplate.graphSetIndex;
+  }
+
   return {
     handle,
-    storeConfig: {
-      backend: 'sparql-http',
-      options: {
-        ...plan.storeConfigTemplate.options,
-        queryEndpoint: handle.queryEndpoint,
-        updateEndpoint: handle.updateEndpoint,
-      },
-    },
+    storeConfig,
     largeLiteralStorage: plan.largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: plan.sharedMemoryPublicSnapshotStorage,
   };

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -7,6 +7,7 @@
  * loopback endpoints + managedByDkg) without touching disk or processes.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 
 vi.mock('../src/daemon/oxigraph-binary.js', () => ({
   ensureOxigraphBinary: vi.fn(async () => '/cache/oxigraph-v0.5.8'),
@@ -43,12 +44,12 @@ describe('planManagedOxigraph', () => {
     const plan = planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data');
     expect(plan).not.toBeNull();
     expect(plan!.port).toBe(DEFAULT_OXIGRAPH_PORT);
-    expect(plan!.location).toBe('/data/oxigraph-data');
-    expect(plan!.cacheDir).toBe('/data/oxigraph');
+    expect(plan!.location).toBe(join('/data', 'oxigraph-data'));
+    expect(plan!.cacheDir).toBe(join('/data', 'oxigraph'));
     expect(plan!.largeLiteralStorage).toEqual({
       enabled: true,
       thresholdBytes: undefined,
-      directory: '/data/literal-blobs',
+      directory: join('/data', 'literal-blobs'),
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
@@ -99,6 +100,19 @@ describe('planManagedOxigraph', () => {
     });
   });
 
+  it('preserves graphSetIndex options through the managed store rewrite plan', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: { enabled: true, revalidateMs: 5_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.storeConfigTemplate.graphSetIndex).toEqual({ enabled: true, revalidateMs: 5_000 });
+  });
+
   it('leaves sharedMemoryPublicSnapshotStorage undefined when disabled/absent', () => {
     expect(
       planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data')!
@@ -125,7 +139,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.sharedMemoryPublicSnapshotStorage).toEqual({
       enabled: true,
-      directory: '/data/swm-public-snapshots',
+      directory: join('/data', 'swm-public-snapshots'),
     });
   });
 
@@ -176,6 +190,19 @@ describe('startManagedOxigraph', () => {
         updateEndpoint: `http://127.0.0.1:${DEFAULT_OXIGRAPH_PORT}/update`,
       },
     });
-    expect(result!.largeLiteralStorage.directory).toBe('/data/literal-blobs');
+    expect(result!.largeLiteralStorage.directory).toBe(join('/data', 'literal-blobs'));
+  });
+
+  it('preserves graphSetIndex options when starting the managed store', async () => {
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: false,
+        },
+      },
+      dataDir: '/data',
+    });
+    expect(result!.storeConfig.graphSetIndex).toBe(false);
   });
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -64,6 +64,20 @@ export {
 
 const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
 
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
 /**
  * Minimal structural view of the OT-RFC-43 Option-1 KA-number allocator the
  * publisher needs to mint deterministic packed ids. The concrete
@@ -3519,25 +3533,35 @@ export class DKGPublisher implements Publisher {
     const SWM_META_SUFFIX = '/_shared_memory_meta';
     const CG_PREFIX = 'did:dkg:context-graph:';
     try {
-      const contextGraphs = await this.graphManager.listContextGraphs();
+      const allContextGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       let total = 0;
 
       // Build list of (ownershipKey, swmMetaGraphUri) pairs: root + sub-graph scoped
       const targets: Array<{ ownershipKey: string; swmMetaGraph: string }> = [];
-      const allGraphs = await this.store.listGraphs();
-      for (const cgId of contextGraphs) {
-        targets.push({ ownershipKey: cgId, swmMetaGraph: this.graphManager.sharedMemoryMetaUri(cgId) });
-
-        // Discover sub-graph SWM meta graphs: did:dkg:context-graph:{cgId}/{sgName}/_shared_memory_meta
-        const sgPrefix = `${CG_PREFIX}${cgId}/`;
-        for (const g of allGraphs) {
-          if (g.startsWith(sgPrefix) && g.endsWith(SWM_META_SUFFIX)) {
-            const middle = g.slice(sgPrefix.length, g.length - SWM_META_SUFFIX.length);
-            if (middle && !middle.includes('/')) {
-              targets.push({ ownershipKey: `${cgId}\0${middle}`, swmMetaGraph: g });
-            }
-          }
-        }
+      const targetKeys = new Set<string>();
+      const swmMetaGraphs = allContextGraphs
+        .filter((graph) => graph.endsWith(SWM_META_SUFFIX))
+        .map((graph) => ({
+          graph,
+          cgPath: graph.slice(CG_PREFIX.length, graph.length - SWM_META_SUFFIX.length),
+        }))
+        .filter(({ cgPath }) => cgPath.length > 0);
+      for (const { graph, cgPath } of swmMetaGraphs) {
+        const slash = cgPath.lastIndexOf('/');
+        const rootId = slash > 0 ? cgPath.slice(0, slash) : '';
+        const subGraphName = slash > 0 ? cgPath.slice(slash + 1) : '';
+        const isRegisteredSubGraph =
+          rootId.length > 0 &&
+          subGraphName.length > 0 &&
+          !subGraphName.includes('/') &&
+          await this.isSubGraphRegistered(rootId, subGraphName);
+        const ownershipKey =
+          isRegisteredSubGraph
+            ? `${rootId}\0${subGraphName}`
+            : cgPath;
+        if (targetKeys.has(ownershipKey)) continue;
+        targetKeys.add(ownershipKey);
+        targets.push({ ownershipKey, swmMetaGraph: graph });
       }
 
       for (const { ownershipKey, swmMetaGraph } of targets) {
@@ -3758,9 +3782,9 @@ export class DKGPublisher implements Publisher {
 
     try {
       const peerToAddress = new Map<string, string | null>();
-      const allGraphs = await this.store.listGraphs();
+      const allGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       // GH #748 Codex round 6 (user report): enumerate `_shared_memory_meta`
-      // graphs directly via `store.listGraphs()`. The earlier approach used
+      // graphs directly from the store's context-graph prefix. The earlier approach used
       // `graphManager.listContextGraphs()`, but that helper filters out CG
       // IDs containing a slash (storage/graph-manager.ts:104) to dedupe
       // sub-graph paths — which also excludes legitimate curated CGs of the
@@ -4202,8 +4226,7 @@ export class DKGPublisher implements Publisher {
    * graph is intentionally excluded — it is not under the `/` prefix).
    */
   private async swmGraphsUnder(bucketGraph: string): Promise<string[]> {
-    const all = await this.store.listGraphs();
-    return all.filter((g) => g === bucketGraph || g.startsWith(`${bucketGraph}/`));
+    return listGraphFamily(this.store, bucketGraph);
   }
 
   async assertionCreate(

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -189,7 +189,7 @@ export class PublishHandler {
       const swmGraph = this.graphManager.sharedMemoryUri(pending.contextGraphId);
       const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(pending.contextGraphId);
       // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + the bucket.
-      const swmGraphs = (await this.store.listGraphs()).filter(g => g === swmGraph || g.startsWith(`${swmGraph}/`));
+      const swmGraphs = await listGraphFamily(this.store, swmGraph);
       const rootEntities = new Set(pending.dataQuads.map(q => q.subject));
       for (const rootEntity of rootEntities) {
         for (const g of swmGraphs) {
@@ -574,6 +574,20 @@ export class PublishHandler {
       rejectionReason: reason,
     });
   }
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }
 
 // ── Helpers ──

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -581,6 +581,107 @@ describe('Workspace: ownership persistence and reconstruction', () => {
     expect(freshOwned.get(CONTEXT_GRAPH)?.get(entity2)).toBe('peerB');
   });
 
+  it('reconstructs ownership for slash-shaped context graph ids from SWM meta graph names', async () => {
+    const curatedContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const curatedEntity = 'urn:test:entity:curated';
+    const swmMetaGraph = `did:dkg:context-graph:${curatedContextGraph}/_shared_memory_meta`;
+    const op = 'urn:test:op:curated';
+    await store.insert([
+      q('urn:test:root-marker', 'http://schema.org/name', '"Root"', WORKSPACE_META_GRAPH),
+      q(curatedEntity, 'http://dkg.io/ontology/workspaceOwner', '"peerCurated"', swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', curatedEntity, swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerCurated"', swmMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(curatedContextGraph)?.get(curatedEntity)).toBe('peerCurated');
+  });
+
+  it('reconstructs registered sub-graph ownership under the sub-graph key', async () => {
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:registered-subgraph';
+    const op = 'urn:test:op:registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${CONTEXT_GRAPH}\0${subGraphName}`)?.get(entity)).toBe('peerSubGraph');
+  });
+
+  it('reconstructs registered sub-graph ownership under slash-shaped context graph ids', async () => {
+    const slashContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${slashContextGraph}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:slash-registered-subgraph';
+    const op = 'urn:test:op:slash-registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSlashSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSlashSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${slashContextGraph}\0${subGraphName}`)?.get(entity)).toBe('peerSlashSubGraph');
+    expect(freshOwned.get(`${slashContextGraph}/${subGraphName}`)?.get(entity)).toBeUndefined();
+  });
+
   it('clears ownership quads on publishFromSharedMemory with clearSharedMemoryAfter', async () => {
     const quads = [q(ENTITY, 'http://schema.org/name', '"Enshrine"')];
     await publisher.share(CONTEXT_GRAPH, quads, { publisherPeerId: 'peer1' });

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -564,7 +564,7 @@ export class DKGQueryEngine implements QueryEngine {
   }
 
   private async discoverGraphsByPrefix(prefix: string): Promise<string[]> {
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );
@@ -646,7 +646,7 @@ export class DKGQueryEngine implements QueryEngine {
       : await this.discoverRegisteredSubGraphNames(contextGraphId);
     const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(contextGraphId);
     const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(contextGraphId);
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphFamily(this.store, `did:dkg:context-graph:${contextGraphId}`);
 
     for (const graph of allGraphs) {
       if (
@@ -934,6 +934,20 @@ function assertNoCallerDatasetClauses(sparql: string): void {
       'FROM clauses are not allowed on scoped local queries',
     );
   }
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
 }
 
 function hasCallerDatasetClause(sparql: string): boolean {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -30,26 +30,6 @@ import type {
   AskResult,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
-import { performance } from 'node:perf_hooks';
-
-/**
- * Monotonic clock for the listGraphs cache TTL. Unlike `Date.now()`,
- * `performance.now()` never moves backwards on an NTP step / VM resume / manual
- * clock change, so the TTL can't be silently extended past its window (which
- * would defeat the outage re-validation guarantee).
- */
-const monotonicNow = (): number => performance.now();
-
-/**
- * R6-A: how long a managed-endpoint `listGraphs()` result may be served from
- * cache before it is re-validated against the store. The cache is also cleared
- * eagerly on every local write, so this TTL only bounds *non-write* staleness:
- * it collapses the peer-churn-driven burst of reconcile enumerations to at most
- * one scan per window (the actual CPU win) while guaranteeing the graph set is
- * re-read at least this often — so a managed-store outage/restart surfaces
- * within the window instead of being masked indefinitely (review round 1).
- */
-export const LIST_GRAPHS_CACHE_TTL_MS = 30_000;
 
 export interface SparqlHttpStoreOptions {
   /** SPARQL query endpoint URL (required). */
@@ -61,24 +41,14 @@ export interface SparqlHttpStoreOptions {
   /** Optional Authorization header value (e.g. "Bearer <token>" or "Basic <base64>"). */
   auth?: string;
   /**
-   * True when the daemon owns this endpoint end-to-end (a CLI-managed local
-   * `oxigraph-server`, signalled by `oxigraph-managed.ts`). When set, no
-   * external writer can mutate the store behind our back, so `listGraphs()`
-   * is served from an in-memory cache that is invalidated on every local
-   * write AND expires after {@link LIST_GRAPHS_CACHE_TTL_MS}. This kills the
-   * data-proportional `SELECT DISTINCT ?g` full scan that the 30 s host-mode
-   * reconcile (and on-demand CG enumeration) would otherwise re-run every
-   * cycle on an idle, data-rich node (R6-A).
-   *
-   * Leave false/undefined for operator-provided endpoints: a shared/external
-   * SPARQL server can gain graphs we did not write, which the cache would
-   * miss — so caching is unsafe there and `listGraphs()` always queries.
+   * Marker used by higher-level daemon flows to distinguish daemon-owned
+   * endpoints from operator-provided URLs. Graph-list indexing is handled by
+   * GraphSetIndexStore rather than this adapter.
    */
   managedByDkg?: boolean;
   /**
-   * Clock for the `listGraphs()` cache TTL. Test seam only; defaults to the
-   * monotonic {@link monotonicNow} (`performance.now`), never `Date.now`, so a
-   * backwards wall-clock jump can't extend the cache past its TTL.
+   * Deprecated compatibility option. Graph-list revalidation clocks are owned
+   * by GraphSetIndexStore.
    */
   now?: () => number;
 }
@@ -89,38 +59,6 @@ export class SparqlHttpStore implements TripleStore {
   private readonly timeout: number;
   private readonly headers: Record<string, string>;
 
-  /** R6-A: cache `listGraphs()` only for daemon-owned (managed) endpoints. */
-  private readonly cacheGraphList: boolean;
-  /** Monotonic clock for the cache TTL (defaults to performance.now). */
-  private readonly now: () => number;
-  /** Cached graph-name list; null = not built / invalidated by a write. */
-  private graphListCache: string[] | null = null;
-  /** Wall-clock (via {@link now}) when {@link graphListCache} was last built. */
-  private graphListCacheAt = 0;
-  /**
-   * Bumped on every local write. `listGraphs()` captures it before its
-   * async query and only stores the result if it is unchanged on return —
-   * so a write that lands while a rebuild is in flight discards the
-   * possibly-stale result instead of caching it.
-   */
-  private graphListCacheGen = 0;
-  /**
-   * In-flight rebuild promise (managed endpoints). Concurrent callers on a
-   * cold/expired cache share this single scan instead of each issuing their
-   * own `SELECT DISTINCT ?g` — without it, a burst of overlapping enumerations
-   * (reconcile + metrics CG-count + status) at startup or each TTL boundary
-   * would still run duplicate full scans, the exact load this fix targets.
-   */
-  private graphListInflight: Promise<string[]> | null = null;
-  /**
-   * The generation {@link graphListInflight} was started at. A caller may only
-   * join the in-flight scan when this still equals {@link graphListCacheGen};
-   * a write that bumps the generation mid-scan means the in-flight result is
-   * pre-write, so a later caller must start a fresh scan rather than observe a
-   * stale graph set (read-your-writes).
-   */
-  private graphListInflightGen = -1;
-
   constructor(options: SparqlHttpStoreOptions) {
     if (!options.queryEndpoint?.trim()) {
       throw new Error('sparql-http adapter requires options.queryEndpoint');
@@ -128,8 +66,6 @@ export class SparqlHttpStore implements TripleStore {
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? 30_000;
-    this.cacheGraphList = options.managedByDkg === true;
-    this.now = options.now ?? monotonicNow;
     // Content-Type is set per-request in postQuery/postUpdate (direct POST:
     // application/sparql-query | application/sparql-update). Only shared
     // headers (e.g. Authorization) belong here.
@@ -137,18 +73,6 @@ export class SparqlHttpStore implements TripleStore {
     if (options.auth) {
       this.headers['Authorization'] = options.auth;
     }
-  }
-
-  /**
-   * Invalidate the cached graph list after a local write. A no-op when
-   * caching is disabled (external endpoints). Bumping the generation also
-   * causes any concurrently in-flight `listGraphs()` rebuild to drop its
-   * result rather than cache a pre-write snapshot.
-   */
-  private invalidateGraphListCache(): void {
-    if (!this.cacheGraphList) return;
-    this.graphListCache = null;
-    this.graphListCacheGen++;
   }
 
   private async postQuery(sparql: string, accept: string): Promise<Response> {
@@ -204,7 +128,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP insert failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a new graph may have appeared
   }
 
   async delete(quads: DKGQuad[]): Promise<void> {
@@ -223,7 +146,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP delete failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a graph may now be empty (gone from listGraphs)
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {
@@ -246,7 +168,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteByPattern failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a graph may now be empty (gone from listGraphs)
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -260,7 +181,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteBySubjectPrefix failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // the graph may now be empty (gone from listGraphs)
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -327,70 +247,11 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP dropGraph failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // the graph is gone from listGraphs
   }
 
   async listGraphs(): Promise<string[]> {
-    // R6-A: on a managed (daemon-owned) endpoint the graph set only changes
-    // when *we* write, so serve a warm cache and skip the full
-    // `SELECT DISTINCT ?g` quad-store scan — the dominant idle-node CPU cost
-    // on a data-rich node (re-run by the 30 s host-mode reconcile and every
-    // on-demand CG enumeration). The cache is cleared on every write and also
-    // expires after LIST_GRAPHS_CACHE_TTL_MS, so the burst of churn-driven
-    // re-enumerations collapses to one scan per window while a store
-    // outage/restart still surfaces within the TTL. Returns a copy so callers
-    // can't mutate it.
-    if (
-      this.cacheGraphList &&
-      this.graphListCache !== null &&
-      this.now() - this.graphListCacheAt < LIST_GRAPHS_CACHE_TTL_MS
-    ) {
-      return [...this.graphListCache];
-    }
-    // External (non-managed) endpoint: never cache (an outside writer could
-    // add a graph we'd miss), so just scan.
-    if (!this.cacheGraphList) {
-      return [...(await this.scanGraphs(this.graphListCacheGen))];
-    }
-    // Managed, cold/expired cache: coalesce concurrent callers onto one
-    // in-flight scan so a startup or TTL-boundary burst doesn't fan out into
-    // duplicate full scans (the very load this fix removes) — but only while no
-    // write has invalidated the cache since that scan started. A caller
-    // arriving after a write must not join the pre-write scan (it would observe
-    // a stale graph set); it starts a fresh one instead.
-    if (this.graphListInflight && this.graphListInflightGen === this.graphListCacheGen) {
-      return [...(await this.graphListInflight)];
-    }
-    const startGen = this.graphListCacheGen;
-    const scan = this.scanGraphs(startGen);
-    this.graphListInflight = scan;
-    this.graphListInflightGen = startGen;
-    try {
-      return [...(await scan)];
-    } finally {
-      // Clear only if a newer scan hasn't already replaced this one, so a
-      // post-write rebuild started while this scan was resolving isn't lost.
-      if (this.graphListInflight === scan) {
-        this.graphListInflight = null;
-        this.graphListInflightGen = -1;
-      }
-    }
-  }
-
-  /**
-   * Run the `SELECT DISTINCT ?g` enumeration and (for managed endpoints) cache
-   * the result, unless a write landed during the scan — the generation guard
-   * (`startGen` vs the current generation) discards a snapshot that may predate
-   * that write so the next call rebuilds.
-   */
-  private async scanGraphs(startGen: number): Promise<string[]> {
     const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
-    const graphs = r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
-    if (this.cacheGraphList && startGen === this.graphListCacheGen) {
-      this.graphListCache = graphs;
-      this.graphListCacheAt = this.now();
-    }
-    return graphs;
+    return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
   }
 
   async countQuads(graphUri?: string): Promise<number> {

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -15,6 +15,12 @@ import {
 
 const CG_PREFIX = 'did:dkg:context-graph:';
 
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
 export class ContextGraphManager {
   private readonly store: TripleStore;
   private readonly ensuredContextGraphs = new Set<string>();
@@ -87,7 +93,7 @@ export class ContextGraphManager {
   }
 
   async listContextGraphs(): Promise<string[]> {
-    const graphs = await this.store.listGraphs();
+    const graphs = await listGraphsByPrefix(this.store, CG_PREFIX);
     const contextGraphs = new Set<string>();
     for (const g of graphs) {
       if (g.startsWith(CG_PREFIX)) {
@@ -116,7 +122,7 @@ export class ContextGraphManager {
    */
   async listSubGraphs(contextGraphId: string): Promise<string[]> {
     const prefix = `${CG_PREFIX}${contextGraphId}/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     const subGraphNames = new Set<string>();
     const reservedPrefixes = ['_', 'assertion/', 'draft/', 'context/'];
     for (const g of allGraphs) {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,0 +1,267 @@
+import { performance } from 'node:perf_hooks';
+import type { Quad, QueryResult, TripleStore } from './triple-store.js';
+
+export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
+
+export type GraphSetMutationSource =
+  | 'seed'
+  | 'revalidate'
+  | 'insert'
+  | 'delete'
+  | 'deleteByPattern'
+  | 'deleteBySubjectPrefix'
+  | 'dropGraph'
+  | 'query';
+
+type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query';
+
+export type GraphSetMutationEvent =
+  | {
+      type: 'graph-added';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-removed';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-set-revalidated';
+      added: string[];
+      removed: string[];
+      source: GraphSetRefreshSource;
+    };
+
+export interface GraphSetIndexStoreOptions {
+  enabled?: boolean;
+  /** Revalidate after this interval. Use 0 to revalidate on every read. */
+  revalidateMs?: number;
+  now?: () => number;
+  onMutation?: (event: GraphSetMutationEvent) => void;
+}
+
+/**
+ * Write-through named-graph index for stores whose `listGraphs()` implementation
+ * is a full-store scan. The index follows the repo's existing graph semantics:
+ * only graphs containing at least one quad are listed; empty `createGraph()`
+ * calls are not visible until data is inserted.
+ */
+export class GraphSetIndexStore implements TripleStore {
+  private readonly inner: TripleStore;
+  private readonly revalidateMs: number;
+  private readonly now: () => number;
+  private readonly onMutation?: (event: GraphSetMutationEvent) => void;
+
+  private graphs: Set<string> | null = null;
+  private validatedAt = 0;
+  private mutationGeneration = 0;
+  private refreshInFlight: Promise<Set<string>> | null = null;
+
+  constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
+    this.inner = inner;
+    this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
+    this.now = options.now ?? (() => performance.now());
+    this.onMutation = options.onMutation;
+  }
+
+  async insert(quads: Quad[]): Promise<void> {
+    await this.inner.insert(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    this.addGraphs(touched, 'insert');
+  }
+
+  async delete(quads: Quad[]): Promise<void> {
+    await this.inner.delete(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'delete'));
+  }
+
+  async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    const removed = await this.inner.deleteByPattern(pattern);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    const graph = pattern.graph;
+    if (graph) {
+      await this.maintainIndex(() => this.refreshTouchedGraphs([graph], 'deleteByPattern'));
+    } else {
+      await this.maintainIndex(() => this.refreshIndex('deleteByPattern'));
+    }
+    return removed;
+  }
+
+  async query(sparql: string): Promise<QueryResult> {
+    const result = await this.inner.query(sparql);
+    if (isSparqlUpdate(sparql)) {
+      this.bumpMutation();
+      if (this.graphs || this.refreshInFlight) {
+        await this.maintainIndex(() => this.refreshIndex('query'));
+      }
+    }
+    return result;
+  }
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    const hasGraph = await this.inner.hasGraph(graphUri);
+    const indexed = this.graphs?.has(graphUri);
+    if (this.graphs && indexed !== hasGraph) {
+      this.bumpMutation();
+      if (hasGraph) this.addGraphs([graphUri], 'revalidate');
+      else this.removeGraphs([graphUri], 'revalidate');
+    }
+    return hasGraph;
+  }
+
+  async createGraph(graphUri: string): Promise<void> {
+    await this.inner.createGraph(graphUri);
+  }
+
+  async dropGraph(graphUri: string): Promise<void> {
+    await this.inner.dropGraph(graphUri);
+    this.bumpMutation();
+    this.removeGraphs([graphUri], 'dropGraph');
+  }
+
+  async listGraphs(): Promise<string[]> {
+    const graphs = await this.ensureGraphSet();
+    return [...graphs];
+  }
+
+  async listGraphsByPrefix(prefix: string): Promise<string[]> {
+    const graphs = await this.ensureGraphSet();
+    return [...graphs].filter((graph) => graph.startsWith(prefix));
+  }
+
+  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs([graphUri], 'deleteBySubjectPrefix'));
+    return removed;
+  }
+
+  async countQuads(graphUri?: string): Promise<number> {
+    return this.inner.countQuads(graphUri);
+  }
+
+  async flush(): Promise<void> {
+    await this.inner.flush?.();
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+
+  private async ensureGraphSet(): Promise<Set<string>> {
+    if (
+      this.graphs &&
+      this.revalidateMs > 0 &&
+      this.now() - this.validatedAt < this.revalidateMs
+    ) {
+      return this.graphs;
+    }
+    return this.refreshIndex(this.graphs ? 'revalidate' : 'seed');
+  }
+
+  private async refreshIndex(source: GraphSetRefreshSource): Promise<Set<string>> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    const task = this.refreshIndexLoop(source);
+    this.refreshInFlight = task;
+    try {
+      return await task;
+    } finally {
+      if (this.refreshInFlight === task) this.refreshInFlight = null;
+    }
+  }
+
+  private async refreshIndexLoop(source: GraphSetRefreshSource): Promise<Set<string>> {
+    for (;;) {
+      const generation = this.mutationGeneration;
+      const next = new Set((await this.inner.listGraphs()).filter(Boolean));
+      if (generation !== this.mutationGeneration) continue;
+      this.replaceGraphSet(next, source);
+      return this.graphs!;
+    }
+  }
+
+  private bumpMutation(): void {
+    this.mutationGeneration++;
+  }
+
+  private async maintainIndex(task: () => Promise<unknown>): Promise<void> {
+    try {
+      await task();
+    } catch {
+      this.clearIndex();
+    }
+  }
+
+  private clearIndex(): void {
+    this.graphs = null;
+    this.validatedAt = 0;
+  }
+
+  private replaceGraphSet(next: Set<string>, source: GraphSetRefreshSource): void {
+    const previous = this.graphs ?? new Set<string>();
+    const added = [...next].filter((graph) => !previous.has(graph)).sort();
+    const removed = [...previous].filter((graph) => !next.has(graph)).sort();
+    this.graphs = next;
+    this.validatedAt = this.now();
+    if (added.length > 0 || removed.length > 0 || source !== 'seed') {
+      this.emit({ type: 'graph-set-revalidated', added, removed, source });
+    }
+  }
+
+  private addGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || this.graphs.has(graph)) continue;
+      this.graphs.add(graph);
+      this.emit({ type: 'graph-added', graph, source });
+    }
+  }
+
+  private removeGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || !this.graphs.delete(graph)) continue;
+      this.emit({ type: 'graph-removed', graph, source });
+    }
+  }
+
+  private async refreshTouchedGraphs(graphs: string[], source: GraphSetMutationSource): Promise<void> {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph) continue;
+      if (await this.inner.hasGraph(graph)) {
+        this.addGraphs([graph], source);
+      } else {
+        this.removeGraphs([graph], source);
+      }
+    }
+  }
+
+  private emit(event: GraphSetMutationEvent): void {
+    try {
+      this.onMutation?.(event);
+    } catch {
+      // Observability hooks must not make already-committed store writes fail.
+    }
+  }
+}
+
+function namedGraphsFromQuads(quads: Quad[]): string[] {
+  return [...new Set(quads.map((quad) => quad.graph).filter(Boolean))];
+}
+
+function isSparqlUpdate(sparql: string): boolean {
+  const withoutPrologue = sparql
+    .trimStart()
+    .replace(/^(?:(?:#[^\r\n]*(?:\r?\n|$))|(?:PREFIX\s+(?:[A-Za-z][\w-]*)?:\s*<[^>]*>|BASE\s*<[^>]*>)\s*)+/i, '')
+    .trimStart();
+  return /^(?:INSERT|DELETE|WITH|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -21,6 +21,13 @@ export {
   SharedMemoryLiteralBlobStore,
   type SharedMemoryLiteralBlobStoreOptions,
 } from './shared-memory-literal-blob-store.js';
+export {
+  DEFAULT_GRAPH_SET_REVALIDATE_MS,
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+  type GraphSetMutationEvent,
+  type GraphSetMutationSource,
+} from './graph-set-index-store.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -101,6 +101,12 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.listGraphs();
   }
 
+  async listGraphsByPrefix(prefix: string): Promise<string[]> {
+    return this.inner.listGraphsByPrefix
+      ? this.inner.listGraphsByPrefix(prefix)
+      : (await this.inner.listGraphs()).filter((graph) => graph.startsWith(prefix));
+  }
+
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
     return this.inner.deleteBySubjectPrefix(graphUri, prefix);
   }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,
   SharedMemoryLiteralBlobStore,
 } from './shared-memory-literal-blob-store.js';
+import {
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+} from './graph-set-index-store.js';
 
 export interface Quad {
   subject: string;
@@ -44,6 +48,7 @@ export interface TripleStore {
   createGraph(graphUri: string): Promise<void>;
   dropGraph(graphUri: string): Promise<void>;
   listGraphs(): Promise<string[]>;
+  listGraphsByPrefix?(prefix: string): Promise<string[]>;
 
   deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number>;
 
@@ -142,6 +147,7 @@ export interface TripleStoreConfig {
   backend: TripleStoreBackend;
   options?: Record<string, unknown>;
   largeLiteralStorage?: LargeLiteralStorageConfig;
+  graphSetIndex?: boolean | GraphSetIndexStoreOptions;
 }
 
 type AdapterFactory = (
@@ -169,8 +175,34 @@ export async function createTripleStore(
   }
   const store = await factory(config.options);
   const largeLiteralStorage = resolveLargeLiteralStorageOptions(config);
-  if (!largeLiteralStorage) return store;
-  return new SharedMemoryLiteralBlobStore(store, largeLiteralStorage);
+  const withLargeLiteralStorage = largeLiteralStorage
+    ? new SharedMemoryLiteralBlobStore(store, largeLiteralStorage)
+    : store;
+  return wrapGraphSetIndex(withLargeLiteralStorage, config);
+}
+
+function wrapGraphSetIndex(
+  store: TripleStore,
+  config: TripleStoreConfig,
+): TripleStore {
+  const graphSetIndex = config.graphSetIndex;
+  if (graphSetIndex === false) return store;
+  if (typeof graphSetIndex === 'object' && graphSetIndex.enabled === false) return store;
+  if (!shouldEnableGraphSetIndex(config)) return store;
+  const options = typeof graphSetIndex === 'object' ? graphSetIndex : undefined;
+  return new GraphSetIndexStore(store, options);
+}
+
+function shouldEnableGraphSetIndex(config: TripleStoreConfig): boolean {
+  if (config.graphSetIndex === true || typeof config.graphSetIndex === 'object') return true;
+  if (isDefaultLocalGraphSetIndexBackend(config.backend)) return true;
+  return config.options?.managedByDkg === true;
+}
+
+function isDefaultLocalGraphSetIndexBackend(backend: TripleStoreBackend): boolean {
+  return backend === 'oxigraph'
+    || backend === 'oxigraph-persistent'
+    || backend === 'oxigraph-worker';
 }
 
 function resolveLargeLiteralStorageOptions(

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -1,0 +1,312 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  GraphSetIndexStore,
+  OxigraphStore,
+  createTripleStore,
+  registerTripleStoreAdapter,
+  type Quad,
+  type QueryResult,
+  type TripleStore,
+} from '../src/index.js';
+
+function q(graph: string, subject = 'urn:s'): Quad {
+  return {
+    subject,
+    predicate: 'urn:p',
+    object: '"v"',
+    graph,
+  };
+}
+
+class CountingStore implements TripleStore {
+  listGraphsCalls = 0;
+  listGraphsGate: Promise<void> | null = null;
+  failListGraphs = false;
+
+  constructor(protected readonly inner: TripleStore) {}
+
+  insert(quads: Quad[]): Promise<void> { return this.inner.insert(quads); }
+  delete(quads: Quad[]): Promise<void> { return this.inner.delete(quads); }
+  deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.inner.deleteByPattern(pattern); }
+  query(sparql: string): Promise<QueryResult> { return this.inner.query(sparql); }
+  hasGraph(graphUri: string): Promise<boolean> { return this.inner.hasGraph(graphUri); }
+  createGraph(graphUri: string): Promise<void> { return this.inner.createGraph(graphUri); }
+  dropGraph(graphUri: string): Promise<void> { return this.inner.dropGraph(graphUri); }
+  deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    return this.inner.deleteBySubjectPrefix(graphUri, prefix);
+  }
+  countQuads(graphUri?: string): Promise<number> { return this.inner.countQuads(graphUri); }
+  flush(): Promise<void> { return this.inner.flush?.() ?? Promise.resolve(); }
+  close(): Promise<void> { return this.inner.close(); }
+
+  async listGraphs(): Promise<string[]> {
+    this.listGraphsCalls++;
+    if (this.listGraphsGate) await this.listGraphsGate;
+    if (this.failListGraphs) throw new Error('listGraphs failed');
+    return this.inner.listGraphs();
+  }
+}
+
+class FailingMaintenanceStore extends CountingStore {
+  failHasGraph = false;
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    if (this.failHasGraph) throw new Error('hasGraph failed');
+    return super.hasGraph(graphUri);
+  }
+}
+
+class MutatingQueryStore extends CountingStore {
+  async query(sparql: string): Promise<QueryResult> {
+    if (/^\s*(?:#[^\r\n]*(?:\r?\n|$)\s*)*INSERT\s+DATA\b/i.test(sparql)) {
+      await this.inner.insert([q('did:dkg:context-graph:query-created')]);
+      return { type: 'bindings', bindings: [] };
+    }
+    return this.inner.query(sparql);
+  }
+}
+
+describe('GraphSetIndexStore', () => {
+  it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([
+      q('did:dkg:context-graph:alpha'),
+      q('did:dkg:context-graph:beta'),
+    ]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting);
+
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:a')).resolves.toEqual([
+      'did:dkg:context-graph:alpha',
+    ]);
+    await expect(store.listGraphs()).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:alpha', 'did:dkg:context-graph:beta']),
+    );
+    expect(counting.listGraphsCalls).toBe(1);
+  });
+
+  it('maintains the graph set through local insert/delete/drop/deleteBySubjectPrefix mutators', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    const graph = 'did:dkg:context-graph:mutators';
+    const root = 'urn:root';
+    const child = `${root}/.well-known/genid/1`;
+    await store.insert([q(graph, root), q(graph, child)]);
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:mut')).resolves.toEqual([graph]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.delete([q(graph, child)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    await store.deleteBySubjectPrefix(graph, root);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.insert([q(graph)]);
+    await store.dropGraph(graph);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('refreshes the full index after graph-wide deleteByPattern without a graph constraint', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await store.insert([q('did:dkg:context-graph:one'), q('did:dkg:context-graph:two')]);
+    await expect(store.listGraphs()).resolves.toHaveLength(2);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.deleteByPattern({ predicate: 'urn:p' });
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('revalidates after the configured interval to discover out-of-contract writers', async () => {
+    let now = 1_000;
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 100, now: () => now });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:external')]);
+
+    now += 99;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:external']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('treats revalidateMs 0 as always expired', async () => {
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 0 });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:zero-revalidate')]);
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:zero-revalidate']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('coalesces concurrent refresh callers onto one listGraphs scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:coalesced')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const calls = Promise.all([
+      store.listGraphs(),
+      store.listGraphsByPrefix('did:dkg:context-graph:'),
+      store.listGraphs(),
+    ]);
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+    counting.listGraphsGate = null;
+    release();
+
+    const [a, b, c] = await calls;
+    expect(a).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(b).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(c).toEqual(['did:dkg:context-graph:coalesced']);
+  });
+
+  it('restarts an in-flight refresh when a local write lands during the scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:before')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const listed = store.listGraphs();
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.insert([q('did:dkg:context-graph:after')]);
+    counting.listGraphsGate = null;
+    release();
+
+    await expect(listed).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:before', 'did:dkg:context-graph:after']),
+    );
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('refreshes after successful mutating SPARQL passed through query()', async () => {
+    const counting = new MutatingQueryStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.query('# cleanup\nINSERT DATA { GRAPH <ignored> { <urn:s> <urn:p> "v" } }');
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:query-created']);
+  });
+
+  it('does not let observer failures reject committed writes', async () => {
+    const store = new GraphSetIndexStore(new CountingStore(new OxigraphStore()), {
+      onMutation: () => {
+        throw new Error('observer failed');
+      },
+    });
+    await store.listGraphs();
+
+    await expect(store.insert([q('did:dkg:context-graph:observer')])).resolves.toBeUndefined();
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:observer']);
+  });
+
+  it('clears the index instead of rejecting after post-commit maintenance failures', async () => {
+    const graph = 'did:dkg:context-graph:maintenance-failure';
+    const failing = new FailingMaintenanceStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failHasGraph = true;
+    await expect(store.delete([q(graph)])).resolves.toBeUndefined();
+
+    failing.failHasGraph = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('clears the index instead of rejecting after post-commit full refresh failures', async () => {
+    const graph = 'did:dkg:context-graph:refresh-failure';
+    const failing = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failListGraphs = true;
+    await expect(store.deleteByPattern({ predicate: 'urn:p' })).resolves.toBe(1);
+
+    failing.failListGraphs = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('createTripleStore wraps local and managed stores by default, composes outside large-literal storage, and can be disabled', async () => {
+    const defaultStore = await createTripleStore({ backend: 'oxigraph' });
+    expect(typeof defaultStore.listGraphsByPrefix).toBe('function');
+    await defaultStore.close();
+
+    const disabledStore = await createTripleStore({ backend: 'oxigraph', graphSetIndex: false });
+    expect(disabledStore.listGraphsByPrefix).toBeUndefined();
+    await disabledStore.close();
+
+    const blobDir = await mkdtemp(join(tmpdir(), 'dkg-graph-set-index-'));
+    try {
+      const composedStore = await createTripleStore({
+        backend: 'oxigraph',
+        largeLiteralStorage: { directory: blobDir, thresholdBytes: 1 },
+      });
+      expect(typeof composedStore.listGraphsByPrefix).toBe('function');
+      await composedStore.insert([q('did:dkg:context-graph:composed')]);
+      await expect(composedStore.listGraphsByPrefix!('did:dkg:context-graph:comp')).resolves.toEqual([
+        'did:dkg:context-graph:composed',
+      ]);
+      await composedStore.close();
+    } finally {
+      await rm(blobDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves operator-managed external stores uncached unless explicitly enabled', async () => {
+    const operatorStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+    });
+    expect(operatorStore.listGraphsByPrefix).toBeUndefined();
+    await operatorStore.close();
+
+    const managedStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query', managedByDkg: true },
+    });
+    expect(typeof managedStore.listGraphsByPrefix).toBe('function');
+    await managedStore.close();
+
+    const optedInStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+      graphSetIndex: { revalidateMs: 0 },
+    });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+
+  it('leaves custom backends uncached unless explicitly enabled', async () => {
+    const backend = 'custom-remote-graph-set-index-test';
+    registerTripleStoreAdapter(backend, async () => new OxigraphStore());
+
+    const defaultStore = await createTripleStore({ backend });
+    expect(defaultStore.listGraphsByPrefix).toBeUndefined();
+    await defaultStore.close();
+
+    const optedInStore = await createTripleStore({ backend, graphSetIndex: true });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+});

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1,7 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { SparqlHttpStore, createTripleStore, type Quad } from '../src/index.js';
-import { LIST_GRAPHS_CACHE_TTL_MS } from '../src/adapters/sparql-http.js';
 
 let server: Server;
 let queryUrl: string;
@@ -9,8 +8,6 @@ let updateUrl: string;
 const insertedQuads: string[] = [];
 /** How many times the server received the `SELECT DISTINCT ?g` listGraphs scan. */
 let listGraphsHits = 0;
-/** When set, the server holds every listGraphs response until this resolves. */
-let listGraphsGate: Promise<void> | null = null;
 
 function startTestServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -48,9 +45,7 @@ function startTestServer(): Promise<void> {
                 results: { bindings: [{ g: { type: 'uri', value: 'http://ex.org/g1' } }] },
               }));
             };
-            // Optionally hold the response so a test can keep a scan in flight.
-            if (listGraphsGate) void listGraphsGate.then(respond);
-            else respond();
+            respond();
             return;
           }
           res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
@@ -210,124 +205,19 @@ describe('SparqlHttpStore (test server)', () => {
     expect(result.type).toBe('bindings');
   });
 
-  // R6-A: on a daemon-owned (managed) endpoint, listGraphs() is served from an
-  // in-memory cache invalidated on writes — eliminating the data-proportional
-  // `SELECT DISTINCT ?g` full scan that the 30s host-mode reconcile (and
-  // on-demand CG enumeration) would otherwise re-run every cycle on an idle,
-  // data-rich node. External (non-managed) endpoints must NOT cache, since an
-  // outside writer could add a graph we never see.
-  describe('listGraphs() cache (R6-A)', () => {
-    const managedStore = () =>
-      new SparqlHttpStore({ queryEndpoint: queryUrl, updateEndpoint: updateUrl, managedByDkg: true });
-    const g = (graph: string) =>
-      [{ subject: 'http://ex.org/s', predicate: 'http://ex.org/p', object: '"v"', graph }];
-
-    it('managed endpoint serves repeated listGraphs() from cache (one scan)', async () => {
+  describe('listGraphs()', () => {
+    it('scans directly even when managedByDkg is set; GraphSetIndexStore owns caching', async () => {
       listGraphsHits = 0;
-      const store = managedStore();
-      const a = await store.listGraphs();
-      const b = await store.listGraphs();
-      expect(a).toContain('http://ex.org/g1');
-      expect(b).toContain('http://ex.org/g1');
-      expect(listGraphsHits).toBe(1); // second call hit the cache, not the server
-    });
-
-    it.each(['insert', 'delete', 'deleteByPattern', 'dropGraph', 'deleteBySubjectPrefix'] as const)(
-      'invalidates the cache on %s so the next listGraphs() re-scans',
-      async (method) => {
-        listGraphsHits = 0;
-        const store = managedStore();
-        await store.listGraphs();
-        await store.listGraphs();
-        expect(listGraphsHits).toBe(1); // warm
-
-        switch (method) {
-          case 'insert': await store.insert(g('http://ex.org/g2')); break;
-          case 'delete': await store.delete(g('http://ex.org/g')); break;
-          case 'deleteByPattern': await store.deleteByPattern({ graph: 'http://ex.org/g' }); break;
-          case 'dropGraph': await store.dropGraph('http://ex.org/g'); break;
-          case 'deleteBySubjectPrefix': await store.deleteBySubjectPrefix('http://ex.org/g', 'http://ex.org/'); break;
-        }
-
-        await store.listGraphs();
-        expect(listGraphsHits).toBe(2); // write invalidated the cache
-      },
-    );
-
-    it('does NOT cache for a non-managed (external) endpoint', async () => {
-      listGraphsHits = 0;
-      const store = new SparqlHttpStore({ queryEndpoint: queryUrl, updateEndpoint: updateUrl });
-      await store.listGraphs();
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(2); // every call queries the server
-    });
-
-    it('re-scans after the cache TTL expires, so a store outage cannot be masked forever', async () => {
-      listGraphsHits = 0;
-      let clock = 1_000_000;
       const store = new SparqlHttpStore({
         queryEndpoint: queryUrl,
         updateEndpoint: updateUrl,
         managedByDkg: true,
-        now: () => clock,
       });
-      await store.listGraphs();
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(1); // within TTL: served from cache
-
-      clock += LIST_GRAPHS_CACHE_TTL_MS + 1; // advance past the TTL
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(2); // expired: re-validated against the store
-    });
-
-    it('coalesces concurrent cold-cache callers onto a single scan', async () => {
-      // Without in-flight coalescing, simultaneous callers (reconcile + metrics
-      // CG-count + status) on a cold/expired cache each issue their own
-      // `SELECT DISTINCT ?g` — duplicate full scans, the load this fix removes.
-      listGraphsHits = 0;
-      const store = managedStore();
-      const [a, b, c] = await Promise.all([
-        store.listGraphs(),
-        store.listGraphs(),
-        store.listGraphs(),
-      ]);
+      const a = await store.listGraphs();
+      const b = await store.listGraphs();
       expect(a).toContain('http://ex.org/g1');
       expect(b).toContain('http://ex.org/g1');
-      expect(c).toContain('http://ex.org/g1');
-      expect(listGraphsHits).toBe(1); // all three shared one in-flight scan
-    });
-
-    it('a write during an in-flight scan forces the next caller to re-scan, not join stale work', async () => {
-      // Read-your-writes: if a scan is in flight and a write invalidates the
-      // cache before it resolves, a caller arriving after the write must start
-      // a fresh scan rather than join the pre-write in-flight one.
-      listGraphsHits = 0;
-      let release!: () => void;
-      listGraphsGate = new Promise<void>((r) => { release = r; });
-      const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-      const store = managedStore();
-      try {
-        const p1 = store.listGraphs();             // caller 1: scan in flight (held by gate)
-        await delay(30);                           // request reaches the server (hits=1)
-        await store.insert(g('http://ex.org/g2')); // write invalidates the cache (gen bump)
-        const p2 = store.listGraphs();             // caller 2: must NOT join the pre-write scan
-        await delay(30);                           // caller 2 issues its own request (hits=2)
-        release();
-        await Promise.all([p1, p2]);
-        expect(listGraphsHits).toBe(2);            // post-write caller ran a fresh scan
-      } finally {
-        listGraphsGate = null;
-      }
-    });
-
-    it('returns a defensive copy that cannot mutate the cached set', async () => {
-      listGraphsHits = 0;
-      const store = managedStore();
-      const first = await store.listGraphs();
-      first.push('http://ex.org/injected');
-      const second = await store.listGraphs();
-      expect(second).not.toContain('http://ex.org/injected');
-      expect(listGraphsHits).toBe(1); // second served from cache, copy was independent
+      expect(listGraphsHits).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `GraphSetIndexStore`, a storage decorator that keeps an exact write-through in-memory set of named graphs (seeded once, maintained by the five mutators), replacing the TTL/invalidation `listGraphs` cache — with a periodic revalidation backstop for out-of-contract writers (standalone publisher, operator GSP surgery).
- A1's graph enumeration can later upgrade to `listGraphsByPrefix` from this index.

## Related

- Part of #1138 (Track C, PR C1). Independent of the C2/C3/C4 stack.
- **Merge order:** Wave 2, after the checkpoint.

## Files changed

| File | What |
|------|------|
| `storage/src/graph-set-index-store.ts` | New decorator + `listGraphsByPrefix` |
| `storage/src/{graph-manager,triple-store,index}.ts`, `adapters/sparql-http.ts` | Wiring + revalidation backstop |
| `agent/src/dkg-agent-cg-registry.ts`, `dkg-agent-lifecycle.ts`, `cli/src/daemon/{oxigraph-managed,lifecycle}.ts`, `cli/src/config.ts` | Decorator install + config |
| `publisher/src/*`, `query/src/dkg-query-engine.ts` | Consume `listGraphsByPrefix` |

Plus 4 test files.

## Test plan

- [ ] `pnpm -F dkg-storage -F dkg-agent test`
- [ ] Index stays exact across insert/delete/drop; revalidation backstop catches an out-of-band write within the window
- [ ] `pnpm build` + lint

---
**Wave 2 (Track C) — draft, post-checkpoint.** Structural growth-proofing; do not merge before the Wave-1 live-node checkpoint passes (#1138, Verification). Targets `integration/issue-1138`.