### PR TITLE
C2 — ContextGraphMetaProjection (one policy cache)

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  assertSafeIri,
+  contextGraphDataGraphUri,
+  contextGraphDataUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { strip, stripLiteral } from './dkg-agent-utils.js';
+
+export interface ContextGraphSubGraphMeta {
+  uri: string;
+  name: string;
+  createdBy: string;
+  createdAt?: string;
+  description?: string;
+}
+
+export interface ContextGraphMetaRecord {
+  id: string;
+  uri: string;
+  declared: boolean;
+  isSystem: boolean;
+  name?: string;
+  description?: string;
+  creator?: string;
+  creators: string[];
+  curator?: string;
+  curators: string[];
+  accessPolicy?: string;
+  createdAt?: string;
+  allowedPeers: string[];
+  allowedAgents: string[];
+  participantAgents: string[];
+  participantIdentityIds: string[];
+  revokedAgents: string[];
+  onChainId?: string;
+  subGraphs: ContextGraphSubGraphMeta[];
+  hasAgentGate: boolean;
+  hasPeerGate: boolean;
+  hasLegacyParticipantGate: boolean;
+}
+
+interface ProjectionEntry {
+  value?: ContextGraphMetaRecord;
+  inflight?: Promise<ContextGraphMetaRecord>;
+  dirty: boolean;
+  invalidationVersion: number;
+}
+
+const DKG_NS = 'https://dkg.network/ontology#';
+const LEGACY_DKG_NS = 'http://dkg.io/ontology/';
+const LEGACY_SCHEMA_NS = 'http://schema.org/';
+const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SUB_GRAPH_TYPE_URIS = new Set([
+  `${DKG_NS}SubGraph`,
+  `${LEGACY_DKG_NS}SubGraph`,
+]);
+
+const DIRECT_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  DKG_ONTOLOGY.DKG_CREATOR,
+  DKG_ONTOLOGY.DKG_CURATOR,
+  DKG_ONTOLOGY.DKG_CREATED_AT,
+  DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+  DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+  DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+  DKG_ONTOLOGY.DKG_REVOKED_AGENT,
+  DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+  DKG_ONTOLOGY.DKG_PUBLISH_POLICY,
+  DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`,
+]);
+
+const SUB_GRAPH_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  `${DKG_NS}parentContextGraph`,
+  `${LEGACY_DKG_NS}parentContextGraph`,
+  `${DKG_NS}createdBy`,
+  `${LEGACY_DKG_NS}createdBy`,
+  `${DKG_NS}createdAt`,
+  `${LEGACY_DKG_NS}createdAt`,
+  `${DKG_NS}authorizedWriter`,
+  `${LEGACY_DKG_NS}authorizedWriter`,
+]);
+
+export class ContextGraphMetaProjection {
+  private readonly entries = new Map<string, ProjectionEntry>();
+
+  constructor(private readonly store: TripleStore) {}
+
+  async get(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const existing = this.entries.get(contextGraphId);
+    if (existing?.value && !existing.dirty) return existing.value;
+    if (existing?.inflight) {
+      if (!existing.dirty) return existing.inflight;
+      await existing.inflight;
+      return this.get(contextGraphId);
+    }
+
+    const entry = existing ?? { dirty: true, invalidationVersion: 0 };
+    const rebuildVersion = entry.invalidationVersion;
+    entry.dirty = false;
+    const inflight = this.rebuild(contextGraphId)
+      .then((record) => {
+        entry.value = record;
+        entry.inflight = undefined;
+        entry.dirty = entry.invalidationVersion !== rebuildVersion;
+        this.entries.set(contextGraphId, entry);
+        return record;
+      })
+      .catch((err) => {
+        entry.inflight = undefined;
+        entry.dirty = true;
+        this.entries.set(contextGraphId, entry);
+        throw err;
+      });
+
+    entry.inflight = inflight;
+    this.entries.set(contextGraphId, entry);
+    return inflight;
+  }
+
+  markDirty(contextGraphId: string): void {
+    const existing = this.entries.get(contextGraphId);
+    if (existing) {
+      existing.dirty = true;
+      existing.invalidationVersion += 1;
+      return;
+    }
+    this.entries.set(contextGraphId, { dirty: true, invalidationVersion: 1 });
+  }
+
+  markAllDirty(): void {
+    for (const entry of this.entries.values()) {
+      entry.dirty = true;
+      entry.invalidationVersion += 1;
+    }
+  }
+
+  markDirtyFromQuads(quads: readonly Quad[]): string[] {
+    const touched = new Set<string>();
+    for (const quad of quads) {
+      const contextGraphId = this.contextGraphIdTouchedByQuad(quad);
+      if (!contextGraphId) continue;
+      touched.add(contextGraphId);
+      this.markDirty(contextGraphId);
+    }
+    return [...touched];
+  }
+
+  private async rebuild(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const uri = contextGraphDataUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+
+    assertSafeIri(uri);
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+    assertSafeIri(metaGraph);
+
+    const record: ContextGraphMetaRecord = {
+      id: contextGraphId,
+      uri,
+      declared: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      isSystem: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      creators: [],
+      curators: [],
+      allowedPeers: [],
+      allowedAgents: [],
+      participantAgents: [],
+      participantIdentityIds: [],
+      revokedAgents: [],
+      subGraphs: [],
+      hasAgentGate: false,
+      hasPeerGate: false,
+      hasLegacyParticipantGate: false,
+    };
+
+    const graphUris = [ontologyGraph, agentsGraph, metaGraph];
+    for (const graphUri of graphUris) {
+      await this.loadContextGraphFacts(graphUri, uri, record);
+    }
+    record.subGraphs = await this.loadSubGraphs(contextGraphId);
+
+    record.hasAgentGate = record.allowedAgents.length > 0 || record.participantAgents.length > 0;
+    record.hasPeerGate = record.allowedPeers.length > 0;
+    record.hasLegacyParticipantGate = record.participantIdentityIds.length > 0;
+    return record;
+  }
+
+  private async loadContextGraphFacts(graphUri: string, contextGraphUri: string, record: ContextGraphMetaRecord): Promise<void> {
+    const result = await this.store.query(
+      `SELECT ?p ?o WHERE {
+        GRAPH <${graphUri}> {
+          <${contextGraphUri}> ?p ?o .
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return;
+
+    for (const row of result.bindings) {
+      const predicate = typeof row['p'] === 'string' ? strip(row['p']) : undefined;
+      const object = typeof row['o'] === 'string' ? stripTerm(row['o']) : undefined;
+      if (!predicate || object === undefined) continue;
+      this.applyFact(record, predicate, object);
+    }
+  }
+
+  private applyFact(record: ContextGraphMetaRecord, predicate: string, object: string): void {
+    switch (predicate) {
+      case DKG_ONTOLOGY.RDF_TYPE:
+        if (object === DKG_ONTOLOGY.DKG_CONTEXT_GRAPH) record.declared = true;
+        if (object === DKG_ONTOLOGY.DKG_SYSTEM_CONTEXT_GRAPH) record.isSystem = true;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_NAME:
+      case `${LEGACY_SCHEMA_NS}name`:
+        record.name ??= object;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_DESCRIPTION:
+      case `${LEGACY_SCHEMA_NS}description`:
+        record.description ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CREATOR:
+        pushUnique(record.creators, object);
+        record.creator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CURATOR:
+        pushUnique(record.curators, object);
+        record.curator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ACCESS_POLICY:
+        applyAccessPolicy(record, object);
+        break;
+      case DKG_ONTOLOGY.DKG_CREATED_AT:
+        record.createdAt ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_PEER:
+        pushUnique(record.allowedPeers, object);
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_AGENT:
+        pushUnique(record.allowedAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT:
+        pushUnique(record.participantAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID:
+        pushUnique(record.participantIdentityIds, object);
+        break;
+      case DKG_ONTOLOGY.DKG_REVOKED_AGENT:
+        pushUnique(record.revokedAgents, object);
+        break;
+      case `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`:
+        record.onChainId ??= object;
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async loadSubGraphs(contextGraphId: string): Promise<ContextGraphSubGraphMeta[]> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?subGraph ?name ?createdBy ?createdAt ?description WHERE {
+        GRAPH <${metaGraph}> {
+          ?subGraph ?typePred ?subGraphType ;
+                    ?namePred ?name ;
+                    ?createdByPred ?createdBy .
+          VALUES ?typePred { <${DKG_ONTOLOGY.RDF_TYPE}> }
+          VALUES ?subGraphType { <${DKG_NS}SubGraph> <${LEGACY_DKG_NS}SubGraph> }
+          VALUES ?namePred { <${DKG_ONTOLOGY.SCHEMA_NAME}> <${LEGACY_SCHEMA_NS}name> }
+          VALUES ?createdByPred { <${DKG_NS}createdBy> <${LEGACY_DKG_NS}createdBy> }
+          OPTIONAL {
+            ?subGraph ?createdAtPred ?createdAt .
+            VALUES ?createdAtPred { <${DKG_NS}createdAt> <${LEGACY_DKG_NS}createdAt> }
+          }
+          OPTIONAL {
+            ?subGraph ?descriptionPred ?description .
+            VALUES ?descriptionPred { <${DKG_ONTOLOGY.SCHEMA_DESCRIPTION}> <${LEGACY_SCHEMA_NS}description> }
+          }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return [];
+
+    const byUri = new Map<string, ContextGraphSubGraphMeta>();
+    for (const row of result.bindings) {
+      const uri = typeof row['subGraph'] === 'string' ? stripTerm(row['subGraph']) : '';
+      if (!uri) continue;
+      const current = byUri.get(uri) ?? {
+        uri,
+        name: row['name'] ? stripTerm(String(row['name'])) : '',
+        createdBy: row['createdBy'] ? stripTerm(String(row['createdBy'])) : '',
+      };
+      if (!current.name && row['name']) current.name = stripTerm(String(row['name']));
+      if (!current.createdBy && row['createdBy']) current.createdBy = stripTerm(String(row['createdBy']));
+      if (!current.createdAt && row['createdAt']) current.createdAt = stripTerm(String(row['createdAt']));
+      if (!current.description && row['description']) current.description = stripTerm(String(row['description']));
+      byUri.set(uri, current);
+    }
+    return [...byUri.values()];
+  }
+
+  private contextGraphIdTouchedByQuad(quad: Quad): string | null {
+    const subject = stripTerm(quad.subject);
+    const predicate = strip(quad.predicate);
+    const object = stripTerm(quad.object);
+    const graph = stripTerm(quad.graph);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaContextGraphId = contextGraphIdFromMetaGraphUri(graph);
+
+    if (metaContextGraphId) {
+      const contextGraphUri = contextGraphDataUri(metaContextGraphId);
+      if (subject === contextGraphUri && DIRECT_META_PREDICATES.has(predicate)) {
+        return metaContextGraphId;
+      }
+
+      if (!subject.startsWith(`${contextGraphUri}/`)) return null;
+      if (!SUB_GRAPH_META_PREDICATES.has(predicate)) return null;
+      if (predicate === DKG_ONTOLOGY.RDF_TYPE && !SUB_GRAPH_TYPE_URIS.has(object)) return null;
+      return metaContextGraphId;
+    }
+
+    if ((graph === ontologyGraph || graph === agentsGraph) && DIRECT_META_PREDICATES.has(predicate)) {
+      return contextGraphIdFromContextGraphUri(subject);
+    }
+
+    return null;
+  }
+}
+
+function pushUnique(target: string[], value: string): void {
+  const key = value.toLowerCase();
+  if (target.some((existing) => existing.toLowerCase() === key)) return;
+  target.push(value);
+}
+
+function stripTerm(value: string): string {
+  return stripLiteral(strip(value));
+}
+
+function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'private') {
+    record.accessPolicy = 'private';
+    return;
+  }
+  if (normalized === 'public') {
+    if (record.accessPolicy !== 'private') record.accessPolicy = 'public';
+    return;
+  }
+  record.accessPolicy ??= value;
+}
+
+function contextGraphIdFromContextGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX)) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length);
+  if (!tail) return null;
+  return tail;
+}
+
+function contextGraphIdFromMetaGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_meta')) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_meta'.length);
+  if (!tail) return null;
+  return tail;
+}

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -378,6 +378,7 @@ import {
   deserializeSwmSenderReceiveState,
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
+import { ContextGraphMetaProjection } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 export class DKGAgentBase {
@@ -415,6 +416,7 @@ export class DKGAgentBase {
   protected readonly chain: ChainAdapter;
   /** Shared memory-owned root entities per context graph: entity → creatorPeerId. Used by publisher and shared memory handler. */
   protected readonly workspaceOwnedEntities: Map<string, Map<string, string>>;
+  protected readonly contextGraphMetaProjection: ContextGraphMetaProjection;
   /**
    * OT-RFC-38 / LU-6 Phase B (Codex PR #610 round-2 #2) — highest
    * `nextSeqno` already consumed per (contextGraphId, hostPeerId)
@@ -1128,6 +1130,7 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
+    this.contextGraphMetaProjection = new ContextGraphMetaProjection(store);
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -701,20 +701,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return undefined;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-        UNION
-        { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-      } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
-    const raw = result.bindings[0]?.['policy'];
-    if (typeof raw !== 'string') return undefined;
-    const stripped = raw.replace(/^"|"$/g, '');
+    const stripped = (await this.getCgMeta(contextGraphId)).accessPolicy;
     if (stripped === 'public') return 0;
     if (stripped === 'private') return 1;
     return undefined;
@@ -769,18 +756,8 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
    * Returns null if no allowlist is set (open CG).
    */
   async getContextGraphAllowedPeers(this: DKGAgent, contextGraphId: string): Promise<string[] | null> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) {
-      return null;
-    }
-    return result.bindings
-      .map(row => row['peer'])
-      .filter((v): v is string => typeof v === 'string')
-      .map(v => v.replace(/^"|"$/g, ''));
+    const peers = (await this.getCgMeta(contextGraphId)).allowedPeers;
+    return peers.length > 0 ? peers : null;
   }
 
   // ── Sub-Graph Management ───────────────────────────────────────────────
@@ -837,6 +814,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     await gm.ensureSubGraph(contextGraphId, subGraphName);
     await this.store.insert(registrationQuads);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -856,17 +834,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     createdAt?: string;
     description?: string;
   }>> {
-    const { subGraphDiscoverySparql } = await import('@origintrail-official/dkg-publisher');
-    const sparql = subGraphDiscoverySparql(contextGraphId);
-    const result = await this.store.query(sparql);
-    if (result.type !== 'bindings') return [];
-    return result.bindings.map(row => ({
-      uri: row['subGraph'] ?? '',
-      name: stripLiteral(row['name'] ?? ''),
-      createdBy: row['createdBy'] ?? '',
-      createdAt: row['createdAt'] ? stripLiteral(row['createdAt']) : undefined,
-      description: row['description'] ? stripLiteral(row['description']) : undefined,
-    }));
+    return (await this.getCgMeta(contextGraphId)).subGraphs;
   }
 
   /**
@@ -911,6 +879,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     // Clear SWM ownership cache for this sub-graph
     const ownershipKey = `${contextGraphId}\0${subGraphName}`;
     this.publisher.clearSubGraphOwnership(ownershipKey);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -1001,6 +970,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     }
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     this.subscribeToContextGraph(opts.id);

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -378,9 +378,14 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
+  async getCgMeta(this: DKGAgent, contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    return this.contextGraphMetaProjection.get(contextGraphId);
+  }
+
   /**
    * Check whether a context graph exists in local storage. Definition triples in
    * ONTOLOGY/_meta count, and storage-backed graph presence also counts so local
@@ -445,20 +450,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * optimistic denial inference, not access control decisions).
    */
   async contextGraphIsCurated(this: DKGAgent, contextGraphId: string): Promise<boolean> {
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     try {
-      const res = await this.store.query(
-        `SELECT ?ap WHERE {
-          { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?ap } }
-          UNION
-          { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?ap } }
-        } LIMIT 1`,
-      );
-      if (res.type !== 'bindings' || res.bindings.length === 0) return false;
-      const ap = res.bindings[0]?.['ap']?.replace(/^"|"$/g, '');
-      return ap === 'private';
+      return (await this.getExplicitAccessPolicy(contextGraphId)) === 'private';
     } catch {
       return false;
     }
@@ -1038,26 +1031,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return null;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        }
-      } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    const policyValue = result.bindings[0]?.['policy'];
-    if (policyValue === '"public"') return 'public';
-    if (policyValue === '"private"') return 'private';
+    const policyValue = (await this.getCgMeta(contextGraphId)).accessPolicy?.trim().toLowerCase();
+    if (policyValue === 'public') return 'public';
+    if (policyValue === 'private') return 'private';
     // Defensive: any unknown literal (e.g. a future policy value the
     // older agent code doesn't recognize) is reported as `null` so
     // callers fall through to the legacy heuristic instead of
@@ -1123,9 +1099,6 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       return false;
     }
 
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-
     // Issue #865 — explicit `accessPolicy` ALWAYS wins over the allowlist
     // heuristic below. The previous behavior fell through to the ASK
     // check whenever `policy` was anything other than `"private"`, which
@@ -1159,22 +1132,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // the legacy peer-ID model need to be recognized here so the
     // store-discovery path doesn't misclassify a freshly-invited CG
     // as "open / discoverable only" and skip the same-connect catchup.
-    const allowlistResult = await this.store.query(
-      `ASK WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?participantAgent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer }
-        }
-      }`,
-    );
-    if (allowlistResult.type === 'boolean' && allowlistResult.value === true) {
-      return true;
-    }
-
-    return false;
+    const meta = await this.getCgMeta(contextGraphId);
+    return meta.hasAgentGate || meta.hasPeerGate;
   }
 
   async getPrivateContextGraphParticipants(this: DKGAgent, contextGraphId: string): Promise<string[] | null> {
@@ -1187,47 +1146,21 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       seen.add(key);
       merged.push(value);
     };
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    const addAgent = (value: string | undefined) => {
+      if (!value || revoked.has(value.toLowerCase())) return;
+      add(value);
+    };
 
     const localAgentParticipants = this.subscribedContextGraphs.get(contextGraphId)?.participantAgents;
     if (localAgentParticipants) {
-      for (const p of localAgentParticipants) add(p);
+      for (const p of localAgentParticipants) addAgent(p);
     }
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-
-    // V10 agent model: local allowedAgent entries plus explicit on-chain
-    // participantAgent entries both grant local curated access.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
-
-    // Legacy identity model: participantIdentityIds (numeric IDs as strings)
-    const metaResult = await this.store.query(
-      `SELECT ?identityId WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
-        }
-      }`,
-    );
-    if (metaResult.type === 'bindings') {
-      for (const row of metaResult.bindings) {
-        const raw = row['identityId'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
+    for (const agent of meta.allowedAgents) addAgent(agent);
+    for (const agent of meta.participantAgents) addAgent(agent);
+    for (const identityId of meta.participantIdentityIds) add(identityId);
 
     if (merged.length > 0) return merged;
 
@@ -1380,6 +1313,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       const metaResult = await this.fetchSyncPages(ctx, curatorPeerId, contextGraphId, false, 'meta', cgMetaGraph, deadline);
       if (metaResult.quads.length > 0) {
         await this.store.insert(metaResult.quads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(metaResult.quads);
         this.syncCheckpoints.delete(metaResult.checkpointKey);
         this.log.info(ctx, `Meta refresh for "${contextGraphId}": ${metaResult.quads.length} triples from curator ${curatorPeerId.slice(-8)}`);
         return true;
@@ -1621,14 +1555,23 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let rows = Array.from(seen.values());
 
     /**
-     * Open CGs replicate `DKG_CREATOR`/name/policy on ONTOLOGY but keep `DKG_CURATOR` in `_meta` only,
-     * so list rows lack `curator` and the sidebar cannot classify "mine" without a Bearer-scoped pass.
-     * Backfill once (parallelised) — also removes duplicate SPARQL in the involvement pass below.
+     * Normalize metadata through the keyed projection before privacy filtering.
+     * Raw discovery can see stale ONTOLOGY and authoritative AGENTS/_meta rows
+     * for the same CG; projection gives private policy precedence.
      */
     rows = await Promise.all(rows.map(async (r) => {
-      if (r.curator?.trim()) return r;
-      const c = await this.getContextGraphCurator(r.id);
-      return c ? { ...r, curator: c } : r;
+      const meta = await this.getCgMeta(r.id);
+      return {
+        ...r,
+        name: meta.name ?? r.name,
+        description: meta.description ?? r.description,
+        creator: meta.creator ?? r.creator,
+        curator: meta.curator ?? r.curator,
+        accessPolicy: meta.accessPolicy ?? r.accessPolicy,
+        createdAt: meta.createdAt ?? r.createdAt,
+        isSystem: meta.isSystem || r.isSystem,
+        onChainId: meta.onChainId ?? r.onChainId,
+      };
     }));
 
     let checksum: string | null = null;

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -652,6 +652,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     );
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
@@ -911,6 +912,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
       ]);
+      this.contextGraphMetaProjection.markDirty(id);
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);
       return curatorDid;
     };
@@ -1120,6 +1122,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         await this.store.insert([
           { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         return { onChainId: existingOnChainId, txHash: undefined };
       }
       this.log.warn(
@@ -1291,6 +1294,7 @@ export class ContextGraphMethods extends DKGAgentBase {
             graph: cgMetaGraph,
           },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         // Re-fetch participantAgents so the on-chain
         // registration also lists the calling agent (matches
         // what the local agent gate now enforces).
@@ -1391,6 +1395,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       // topic without re-reading the chain event.
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(id);
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
@@ -1517,6 +1522,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     });
 
     await this.store.insert(quadsToInsert);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
 
     // Issue #865 — log a clear warning AFTER the allowlist quad has
     // landed on a CG with an explicit `accessPolicy="public"` triple.
@@ -1680,6 +1686,8 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     await this.store.insert(quadsToInsert);
 
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
+
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
     // publishPolicy=curated + accessPolicy=public combination is a
@@ -1769,6 +1777,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT,
       object: `"${agentAddress}"`,
     }]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
     this.queueSharedMemoryGossipSubscription(contextGraphId);
     // Drop any cached sender-key send state for this CG so the next
@@ -1846,6 +1855,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: ontologyGraph },
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(ctx, `Renamed context graph "${contextGraphId}" to "${trimmed}"`);
   }
@@ -1854,8 +1864,6 @@ export class ContextGraphMethods extends DKGAgentBase {
    * List allowed agents for a context graph.
    */
   async getContextGraphAllowedAgents(this: DKGAgent, contextGraphId: string): Promise<string[]> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     // Subtract `dkg:revokedAgent` tombstones from the allowlist union
     // so a curator who has called `removeAgentFromContextGraph` sees
     // their authoritative view, not the union with peer-sync-replicated
@@ -1864,32 +1872,9 @@ export class ContextGraphMethods extends DKGAgentBase {
     // silently re-include a revoked agent the moment another node's
     // local CG metadata gossiped back (see C1 devnet harness for the
     // reproducer + `removeAgentFromContextGraph` for the write side).
-    const result = await this.store.query(
-      `SELECT ?agent ?revoked WHERE {
-        {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked
-          }
-        }
-      }`,
-    );
-    if (result.type !== 'bindings') return [];
-    const allowed: string[] = [];
-    const revoked = new Set<string>();
-    for (const row of result.bindings) {
-      const a = (row as Record<string, string>)['agent'];
-      const r = (row as Record<string, string>)['revoked'];
-      if (typeof a === 'string') {
-        allowed.push(a.replace(/^"|"$/g, ''));
-      }
-      if (typeof r === 'string') {
-        revoked.add(r.replace(/^"|"$/g, '').toLowerCase());
-      }
-    }
+    const meta = await this.getCgMeta(contextGraphId);
+    const allowed = meta.allowedAgents;
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     if (revoked.size === 0) return allowed;
     return allowed.filter((addr) => !revoked.has(addr.toLowerCase()));
   }

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -428,10 +428,13 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     const seen = new Set<string>();
     const agents: string[] = [];
     let sawAgentGate = false;
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     const add = (value: string | undefined) => {
       if (!value || !ethers.isAddress(value)) return;
       const checksum = ethers.getAddress(value);
       const key = checksum.toLowerCase();
+      if (revoked.has(key)) return;
       if (seen.has(key)) return;
       seen.add(key);
       agents.push(checksum);
@@ -443,26 +446,9 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
       add(agentAddress);
     }
 
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (result.type === 'bindings') {
-      if (result.bindings.length > 0) sawAgentGate = true;
-      for (const row of result.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') {
-          add(raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, ''));
-        }
-      }
-    }
+    if (meta.allowedAgents.length > 0 || meta.participantAgents.length > 0) sawAgentGate = true;
+    for (const agent of meta.allowedAgents) add(agent);
+    for (const agent of meta.participantAgents) add(agent);
 
     return sawAgentGate ? agents : null;
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2736,7 +2736,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       fetchSyncPages: this.fetchSyncPages.bind(this),
       sinceBatchIdFor,
       processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
-      storeInsert: (quads) => this.store.insert(quads),
+      storeInsert: async (quads) => {
+        await this.store.insert(quads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+      },
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
@@ -2867,7 +2870,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         const graphManager = new GraphManager(this.store);
         await graphManager.ensureContextGraph(contextGraphId);
       },
-      storeInsert: (quads) => this.store.insert(quads),
+      storeInsert: async (quads) => {
+        await this.store.insert(quads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+      },
       publicSnapshotStore: this.publicSnapshotStore,
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
       setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -700,8 +700,6 @@ export class OwnershipMethods extends DKGAgentBase {
   }
 
   async getContextGraphCurator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     // Multi-curator scenario: peer-to-peer sync of CG `_meta` triples
     // can replicate FOREIGN `dkg:curator` triples onto a node's local
     // store. The original behaviour (`LIMIT 1`) made ownership lookup
@@ -719,21 +717,7 @@ export class OwnershipMethods extends DKGAgentBase {
     // the first curator triple when no local match exists, preserving
     // the legacy "subscriber sees foreign owner" semantics for
     // membership/UI queries against CGs this node did not curate.
-    const curatorResult = await this.store.query(`
-      SELECT ?owner WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
-        }
-      }
-    `);
-    if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
-      return null;
-    }
-    const owners: string[] = [];
-    for (const b of curatorResult.bindings) {
-      const o = (b as Record<string, string>)['owner'];
-      if (o) owners.push(o);
-    }
+    const owners = (await this.getCgMeta(contextGraphId)).curators;
     if (owners.length === 0) return null;
     if (owners.length === 1) return owners[0];
     const selfDid = `did:dkg:agent:${this.peerId}`;
@@ -817,8 +801,6 @@ export class OwnershipMethods extends DKGAgentBase {
       merged.push(checksumAddress);
     };
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — the on-chain participant-agent list
     // is now the authoritative source for the host-mode envelope
     // authority check on cores (see `resolveOnChainParticipantAgents`
@@ -841,19 +823,13 @@ export class OwnershipMethods extends DKGAgentBase {
     // (those are persisted as PARTICIPANT triples). The merge below
     // is a UNION so any per-CG explicit list survives and just gets
     // augmented with whatever local allowlist exists.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        add(row['agent']);
-      }
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    for (const agent of meta.participantAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
+    }
+    for (const agent of meta.allowedAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
     }
     return merged;
   }
@@ -866,25 +842,7 @@ export class OwnershipMethods extends DKGAgentBase {
    * peers validating via `gossip-publish-handler` see a matching owner.
    */
   async getContextGraphCreator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(`
-      SELECT ?owner WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        }
-      }
-      LIMIT 1
-    `);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
+    return (await this.getCgMeta(contextGraphId)).creator ?? null;
   }
 
   public async listCclPolicyBindings(this: DKGAgent, opts: {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1517,6 +1517,7 @@ export class PublishMethods extends DKGAgentBase {
     ];
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(contextGraphId);
     await this.store.flush?.();
     this.subscribeToContextGraph(contextGraphId);

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -543,6 +543,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
   }
 
   async reconcileSharedMemoryGossipSubscription(this: DKGAgent, contextGraphId: string): Promise<void> {
+    // Reconcile is the membership boundary; rebuild this CG's policy view
+    // before deciding whether to keep or drop the SWM subscription.
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — subscribe on the wire-form (hash) topic.
     // Members compute the hash from their local cleartext id via
     // {@link gossipWireIdFor}; cores hosting CGs they never joined
@@ -812,6 +815,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
+          getCgMeta: (id) => this.getCgMeta(id),
+          markCgMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
       );
@@ -825,6 +830,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         sharedMemoryOwnedEntities: this.workspaceOwnedEntities,
         writeLocks: this.writeLocks,
         localAgentAddresses: () => [...this.localAgents.keys()],
+        contextGraphMetaOracle: (cgId: string) => this.getCgMeta(cgId),
+        markContextGraphMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
         // OT-RFC-38 / LU-6 Phase B: chain-backed agent-allowlist
         // fallback. Cores hosting curated CGs they are NOT members
         // of have no local meta for the allowlist — without this,
@@ -1508,6 +1515,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         // resolve the on-chain id locally so per-cgId promotion still
         // fires and the RS prover sees the KC.
         (cgName: string) => this.getContextGraphOnChainId(cgName),
+        (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1082,6 +1082,7 @@ export class DKGAgent extends DKGAgentBase {
         graph: ontoGraph,
       }]);
 
+      this.contextGraphMetaProjection.markDirty(p.name);
       this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
       discovered++;
     }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -43,11 +43,14 @@ export type ResolveContextGraphOnChainId = (
   contextGraphId: string,
 ) => Promise<string | null | undefined>;
 
+export type MarkContextGraphMetaDirtyFromQuads = (quads: readonly Quad[]) => void;
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly eventBus: EventBus | undefined;
   private readonly resolveContextGraphOnChainId: ResolveContextGraphOnChainId | undefined;
+  private readonly markContextGraphMetaDirtyFromQuads: MarkContextGraphMetaDirtyFromQuads | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
@@ -56,11 +59,13 @@ export class FinalizationHandler {
     chain: ChainAdapter | undefined,
     eventBus?: EventBus,
     resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
+    markContextGraphMetaDirtyFromQuads?: MarkContextGraphMetaDirtyFromQuads,
   ) {
     this.store = store;
     this.chain = chain;
     this.eventBus = eventBus;
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
+    this.markContextGraphMetaDirtyFromQuads = markContextGraphMetaDirtyFromQuads;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -928,12 +933,14 @@ export class FinalizationHandler {
         } }`,
       );
       if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
-        await this.store.insert(generateSubGraphRegistration({
+        const regQuads = generateSubGraphRegistration({
           contextGraphId,
           subGraphName,
           createdBy: publisherAddress || 'finalization-discovery',
           timestamp: new Date(),
-        }));
+        });
+        await this.store.insert(regQuads);
+        this.markContextGraphMetaDirtyFromQuads?.(regQuads);
         this.log.info(ctx, `Finalization: auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}"`);
       }
     }

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -15,6 +15,7 @@ import {
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
 
@@ -35,6 +36,8 @@ export interface GossipPublishHandlerCallbacks {
    * callback returned `false`).
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
+  getCgMeta?: (id: string) => Promise<ContextGraphMetaRecord>;
+  markCgMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
 }
@@ -291,6 +294,7 @@ export class GossipPublishHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.callbacks.markCgMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.contextGraphId}" from gossip`);
         }
       }
@@ -298,6 +302,7 @@ export class GossipPublishHandler {
       phase?.('store', 'start');
       if (normalized.length > 0 && !isReplay) {
         await this.store.insert(normalized);
+        this.callbacks.markCgMetaDirtyFromQuads?.(normalized);
       }
 
       if (request.ual) {
@@ -347,6 +352,7 @@ export class GossipPublishHandler {
         // never trust self-reported on-chain status from gossip messages.
         const metaQuads = generateTentativeMetadata(kcMeta, kaMetadata);
         await this.store.insert(metaQuads);
+        this.callbacks.markCgMetaDirtyFromQuads?.(metaQuads);
         phase?.('store', 'end');
 
         // If the gossip message includes on-chain proof (txHash + blockNumber),
@@ -553,6 +559,11 @@ export class GossipPublishHandler {
   }
 
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    if (this.callbacks.getCgMeta) {
+      const peers = (await this.callbacks.getCgMeta(contextGraphId)).allowedPeers;
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaGraphUri(contextGraphId);
     const cgData = contextGraphDataGraphUri(contextGraphId);
     const result = await this.store.query(

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -507,6 +507,35 @@ describe('listContextGraphs merge', () => {
     const unauthenticated = await agent.listContextGraphs();
     expect(unauthenticated.find(p => p.id === 'my-curated')).toBeUndefined();
   }, 15000);
+
+  it('listContextGraphs applies the same privacy rules to AGENTS-declared private CGs', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'agents-declared-private';
+    const myWallet = agent.getDefaultAgentAddress()!;
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await result.store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Declared Private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: metaGraph },
+    ]);
+
+    const otherWallet = ethers.Wallet.createRandom().address;
+    expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeUndefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === id)).toBeUndefined();
+    const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === id);
+    expect(visible).toBeDefined();
+    expect(visible?.accessPolicy).toBe('private');
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import { generateSubGraphRegistration } from '@origintrail-official/dkg-publisher';
+import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection.js';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('ContextGraphMetaProjection', () => {
+  it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = '0x0000000000000000000000000000000000000abc/projection-agents-private';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000111', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: '"0x0000000000000000000000000000000000000333"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: '"0x0000000000000000000000000000000000000111"', graph: metaGraph },
+    ]);
+
+    const first = await projection.get(id);
+    expect(first.accessPolicy).toBe('private');
+    expect(first.curator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000111');
+    expect(first.allowedAgents).toEqual(['0x0000000000000000000000000000000000000111']);
+    expect(first.revokedAgents).toEqual(['0x0000000000000000000000000000000000000333']);
+
+    const addedAgent: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: '"0x0000000000000000000000000000000000000222"',
+      graph: metaGraph,
+    };
+    await store.insert([addedAgent]);
+    expect(projection.markDirtyFromQuads([addedAgent])).toEqual([id]);
+
+    const second = await projection.get(id);
+    expect(second.allowedAgents).toHaveLength(2);
+    expect(second.allowedAgents).toEqual(expect.arrayContaining([
+      '0x0000000000000000000000000000000000000111',
+      '0x0000000000000000000000000000000000000222',
+    ]));
+  });
+
+  it('does not dirty policy entries for unrelated tentative KC metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-tentative-no-thrash';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+    ]);
+
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+    ]);
+
+    const tentativeQuad: Quad = {
+      subject: `did:dkg:assertion:${id}:tentative`,
+      predicate: 'https://dkg.network/ontology#assertionStatus',
+      object: '"TENTATIVE"',
+      graph: metaGraph,
+    };
+    const rootLikeDataQuad: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+      object: '"Not authoritative metadata"',
+      graph: contextGraphDataGraphUri('projection-user-data'),
+    };
+    expect(projection.markDirtyFromQuads([tentativeQuad, rootLikeDataQuad])).toEqual([]);
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    projection.markDirty(id);
+    expect((await projection.get(id)).accessPolicy).toBe('private');
+  });
+
+  it('rebuilds for callers that arrive after invalidation during an in-flight rebuild', async () => {
+    let releaseFirstQuery!: () => void;
+    const firstQuery = new Promise<void>((resolve) => { releaseFirstQuery = resolve; });
+    let queryCalls = 0;
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const store = {
+      async query(sparql: string) {
+        queryCalls += 1;
+        const callNumber = queryCalls;
+        if (callNumber === 1) await firstQuery;
+        if (callNumber <= 4) return { type: 'bindings', bindings: [] };
+        if (sparql.includes(`<${agentsGraph}>`)) {
+          return {
+            type: 'bindings',
+            bindings: [{ p: DKG_ONTOLOGY.DKG_ACCESS_POLICY, o: '"private"' }],
+          };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+
+    const first = projection.get('projection-inflight-dirty');
+    projection.markDirty('projection-inflight-dirty');
+    const afterDirty = projection.get('projection-inflight-dirty');
+    releaseFirstQuery();
+
+    expect((await first).accessPolicy).toBeUndefined();
+    expect((await afterDirty).accessPolicy).toBe('private');
+    expect(queryCalls).toBeGreaterThan(4);
+  });
+
+  it('projects sub-graph registrations from the context graph meta graph', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-subgraphs';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const registration = generateSubGraphRegistration({
+      contextGraphId: id,
+      subGraphName: 'tasks',
+      createdBy: 'projection-test',
+      description: 'Task memory',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      ...registration,
+    ]);
+    projection.markDirtyFromQuads(registration);
+
+    expect((await projection.get(id)).subGraphs).toEqual([
+      {
+        uri: `${uri}/tasks`,
+        name: 'tasks',
+        createdBy: 'did:dkg:agent:projection-test',
+        createdAt: '2026-01-01T00:00:00Z',
+        description: 'Task memory',
+      },
+    ]);
+  });
+
+  it('filters projected revoked agents from private participant authorization lists', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      subscribedContextGraphs: new Map<string, { participantAgents?: string[] }>([
+        ['projection-agents-private', { participantAgents: [revoked] }],
+      ]),
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        participantIdentityIds: ['identity:legacy'],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getPrivateContextGraphParticipants(this: unknown, contextGraphId: string): Promise<string[] | null>;
+    }).getPrivateContextGraphParticipants.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active, 'identity:legacy']);
+  });
+
+  it('filters projected revoked agents from registration participant agents', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getContextGraphParticipantAgentAddresses(this: unknown, contextGraphId: string): Promise<string[]>;
+    }).getContextGraphParticipantAgentAddresses.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active]);
+  });
+});

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, GraphManager } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
 import {
   encodeFinalizationMessage, type FinalizationMessageMsg, encodePublishRequest, createOperationContext,
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -247,8 +247,16 @@ describe('FinalizationHandler', () => {
     const publisherAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const dirtyQuads: Quad[] = [];
+    const localHandler = new FinalizationHandler(
+      store,
+      undefined,
+      undefined,
+      undefined,
+      (quads) => { dirtyQuads.push(...quads); },
+    );
 
-    await (handler as any).promoteSharedMemoryToCanonical(
+    await (localHandler as any).promoteSharedMemoryToCanonical(
       CONTEXT_GRAPH,
       [{ subject: entity, predicate: 'http://schema.org/name', object: '"Alice"', graph: '' }],
       'did:dkg:evm:31337/0xABC/1',
@@ -276,6 +284,16 @@ describe('FinalizationHandler', () => {
     );
     expect(registration.type).toBe('boolean');
     if (registration.type === 'boolean') expect(registration.value).toBe(true);
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphUri,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: metaGraph,
+        }),
+      ]),
+    );
 
     const canonical = await store.query(
       `ASK { GRAPH <${subGraphUri}> { <${entity}> <http://schema.org/name> ?o } }`,

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -302,4 +302,25 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
       await agent.stop().catch(() => {});
     }
   });
+
+  it('AGENTS graph private declarations are treated as explicit private policy', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const id = 'issue-1138-agents-private';
+      const uri = `did:dkg:context-graph:${id}`;
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      await store.insert([
+        { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${await ownerAddress(agent)}`, graph: agentsGraph },
+      ]);
+
+      expect(await agent.getExplicitAccessPolicy(id)).toBe('private');
+      expect(await agent.isPrivateContextGraph(id)).toBe(true);
+      expect(await agent.readLocalAccessPolicyEnum(id)).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });

--- a/packages/publisher/src/workspace-agent-recipients.ts
+++ b/packages/publisher/src/workspace-agent-recipients.ts
@@ -74,6 +74,7 @@ async function getWorkspaceAccessMetadata(
   const cgData = contextGraphDataUri(contextGraphId);
   const cgMeta = contextGraphMetaUri(contextGraphId);
   const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  const agentsGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
   const swmGraph = contextGraphSharedMemoryUri(contextGraphId);
   // Flattened UNION: Blazegraph rejects nested UnionNode inside a
   // GRAPH block that is itself a UNION branch. Semantically identical
@@ -90,6 +91,14 @@ async function getWorkspaceAccessMetadata(
         GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${ontologyGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${swmGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       }

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -47,6 +47,14 @@ export type WorkspaceSenderKeyDecryptor = (
   ctx: OperationContext,
 ) => Promise<Uint8Array>;
 
+export interface ContextGraphMetaOracleRecord {
+  allowedPeers?: readonly string[];
+  allowedAgents?: readonly string[];
+  participantAgents?: readonly string[];
+  revokedAgents?: readonly string[];
+  accessPolicy?: string;
+}
+
 /**
  * Outcome of one `SharedMemoryHandler.handle()` invocation. Added
  * in rc.9 PR-C (codex R3) so the new substrate fan-out receiver
@@ -170,6 +178,10 @@ export class SharedMemoryHandler {
   private readonly sharedMemoryOwnedEntities: Map<string, Map<string, string>> = new Map();
   private readonly writeLocks: Map<string, Promise<void>>;
   private readonly localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+  private readonly contextGraphMetaOracle?: (
+    contextGraphId: string,
+  ) => Promise<ContextGraphMetaOracleRecord | null>;
+  private readonly markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed fallback for the agent
    * allowlist read. Returns the participant-agent EOA set for a
@@ -285,6 +297,10 @@ export class SharedMemoryHandler {
       sharedMemoryOwnedEntities?: Map<string, Map<string, string>>;
       writeLocks?: Map<string, Promise<void>>;
       localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+      contextGraphMetaOracle?: (
+        contextGraphId: string,
+      ) => Promise<ContextGraphMetaOracleRecord | null>;
+      markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
       /**
        * OT-RFC-38 / LU-6 Phase B chain-backed agent-allowlist
        * fallback. See {@link SharedMemoryHandler#chainAgentGateOracle}.
@@ -340,6 +356,8 @@ export class SharedMemoryHandler {
     }
     this.writeLocks = options?.writeLocks ?? new Map();
     this.localAgentAddresses = options?.localAgentAddresses;
+    this.contextGraphMetaOracle = options?.contextGraphMetaOracle;
+    this.markContextGraphMetaDirtyFromQuads = options?.markContextGraphMetaDirtyFromQuads;
     this.chainAgentGateOracle = options?.chainAgentGateOracle;
     this.beaconCuratorOracle = options?.beaconCuratorOracle;
     this.workspaceRecipientPrivateKeys = options?.workspaceRecipientPrivateKeys;
@@ -966,6 +984,7 @@ export class SharedMemoryHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.markContextGraphMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}" from SWM`);
         }
       }
@@ -1452,6 +1471,12 @@ export class SharedMemoryHandler {
    * is set (open CG — all peers allowed).
    */
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected) {
+      const peers = [...new Set((projected.allowedPeers ?? []).filter((v): v is string => typeof v === 'string'))];
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
@@ -1472,6 +1497,18 @@ export class SharedMemoryHandler {
    * DKG_PARTICIPANT_AGENT metadata.
    */
   private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected) {
+      const revoked = new Set((projected.revokedAgents ?? []).map((v) => v.toLowerCase()));
+      const projectedAgents = [...(projected.allowedAgents ?? []), ...(projected.participantAgents ?? [])];
+      const agents = projectedAgents
+        .filter((v): v is string => typeof v === 'string' && ethers.isAddress(v) && !revoked.has(v.toLowerCase()))
+        .map((v) => ethers.getAddress(v));
+      const unique = [...new Set(agents)];
+      if (unique.length > 0) return unique;
+      if (projectedAgents.length > 0) return [];
+    }
+
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
@@ -1550,6 +1587,11 @@ export class SharedMemoryHandler {
   private async contextGraphHasPrivateAccessPolicy(contextGraphId: string): Promise<boolean> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return false;
+    }
+
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected?.accessPolicy) {
+      return projected.accessPolicy.trim().toLowerCase() === 'private';
     }
 
     const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/publisher/test/workspace-agent-recipients.test.ts
+++ b/packages/publisher/test/workspace-agent-recipients.test.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   computeWorkspaceAgentEncryptionKeyProofPayload,
   computeWorkspaceAgentEncryptionKeyRevocationPayload,
@@ -17,6 +18,7 @@ import { resolveWorkspaceAgentRecipients } from '../src/index.js';
 const CONTEXT_GRAPH_ID = 'workspace-agent-recipient-resolution';
 const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
 const META_GRAPH = contextGraphMetaUri(CONTEXT_GRAPH_ID);
+const AGENTS_GRAPH = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
 const DKG = 'https://dkg.network/ontology#';
 const DKG_PUBLIC_ENCRYPTION_KEY = `${DKG}publicEncryptionKey`;
 const DKG_ENCRYPTION_KEY_ALGORITHM = `${DKG}encryptionKeyAlgorithm`;
@@ -181,6 +183,32 @@ describe('resolveWorkspaceAgentRecipients', () => {
     expect(resolution.recipients).toHaveLength(1);
     expect(resolution.recipients[0]?.recipientId).toBe(agentUri(wallet.address));
     expect(resolution.recipients[0]?.encryptionKeyAlgorithm).toBe(WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519);
+  });
+
+  it('resolves AGENTS-graph private declarations through the sender-key recipient path', async () => {
+    const store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    await store.insert([
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: AGENTS_GRAPH,
+      },
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${wallet.address}"`,
+        graph: AGENTS_GRAPH,
+      },
+    ]);
+    await insertAgentEncryptionKey(store, wallet);
+
+    const resolution = await resolveWorkspaceAgentRecipients(store, { contextGraphId: CONTEXT_GRAPH_ID });
+
+    expect(resolution.requiresEncryption).toBe(true);
+    expect(resolution.recipients).toHaveLength(1);
+    expect(resolution.recipients[0]?.agentAddress).toBe(ethers.getAddress(wallet.address));
   });
 
   it('preserves peer-only non-private graphs as legacy plaintext-compatible SWM', async () => {

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -205,6 +205,33 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     await expectStoredName('Private Agent Signed');
   });
 
+  it('rejects signed SWM gossip when the projection oracle tombstones the agent', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    const recipientKey = recipientKeyFor(allowed.address);
+    let recipientLookups = 0;
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+      workspaceRecipientPrivateKeys: () => {
+        recipientLookups += 1;
+        return [recipientKey];
+      },
+      contextGraphMetaOracle: async () => ({
+        accessPolicy: 'private',
+        allowedAgents: [allowed.address],
+        revokedAgents: [allowed.address],
+      }),
+    });
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+
+    const raw = workspaceMessage('Projection Revoked', 'ws-agent-gate-projection-revoked');
+    const encrypted = await encryptWorkspaceMessage(allowed.address, raw, recipientKey);
+    await handler.handle(await signWorkspaceMessage(allowed, encrypted), PEER_ID);
+
+    await expectWorkspaceEmpty();
+    expect(recipientLookups).toBe(0);
+  });
+
   it.each([
     ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
     ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -659,6 +659,39 @@ describe('SharedMemoryHandler', () => {
     expect(workspaceOwned.get(CONTEXT_GRAPH)?.has(ENTITY)).toBe(true);
   });
 
+  it('notifies context-graph meta invalidation after SWM sub-graph auto-registration', async () => {
+    const dirtyQuads: Quad[] = [];
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      markContextGraphMetaDirtyFromQuads: (quads) => { dirtyQuads.push(...quads); },
+    });
+    const subGraphName = 'tasks';
+    const subGraphGraph = `${DATA_GRAPH}/${subGraphName}`;
+    const nquads = `<${ENTITY}> <http://schema.org/name> "SubGraph Handler Test" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      subGraphName,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'ws-handler-subgraph-dirty',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphGraph,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: `${DATA_GRAPH}/_meta`,
+        }),
+      ]),
+    );
+  });
+
   it('rejects raw workspace gossip when the context graph is agent-gated', async () => {
     const wallet = ethers.Wallet.createRandom();
     await store.insert([{


### PR DESCRIPTION
## Summary

- Adds `ContextGraphMetaProjection`: a per-CG record (policy / allowlists / curator / sub-graph registrations / onChainId) maintained as a dirty to single-flight keyed rebuild on mutation events, consulted behind existing signatures (`getExplicitAccessPolicy`, `isPrivateContextGraph`, gossip handler, workspace-handler oracle) instead of re-querying oxigraph.
- Loader includes the **AGENTS-graph declaration arm** (not just ontology + `_meta`), so agents-declared-private CGs aren't dropped. Predicate-filtered invalidation + security-ordering tests. Closes the swm-host negative-result re-probe and #1066 R6-C.

## Related

- Part of #1138 (Track C, PR C2). **Base of the C2 to C3 to C4 stack.** Security review required.
- **Merge order:** Wave 2, after C1; C3 and C4 stack on this.

## Files changed

| File | What |
|------|------|
| `agent/src/context-graph-meta-projection.ts` | New projection |
| `agent/src/dkg-agent-cg-resolve.ts`, `dkg-agent-context-graph.ts`, `dkg-agent-ownership.ts`, `gossip-publish-handler.ts`, `finalization-handler.ts` | Consult sites re-pointed; invalidation hooks |
| `publisher/src/workspace-handler.ts`, `workspace-agent-recipients.ts` | Oracle (chain-gate fallback preserved) |
| `agent/src/dkg-agent-{base,lifecycle,publish,swm-substrate,cg-registry,crypto}.ts`, `dkg-agent.ts` | Wiring |

Plus 7 test files (incl. agents-declared-private fixture, security-ordering).

## Test plan

- [ ] `pnpm -F dkg-agent -F dkg-publisher test`
- [ ] Security-ordering: allowlist add/revoke enforced on the very next message; tentative-KC inserts don't thrash policy entries
- [ ] Agents-declared-private CG not leaked (parity fixture)
- [ ] `pnpm build` + lint

---
**Wave 2 (Track C) — draft, post-checkpoint.** Structural growth-proofing; do not merge before the Wave-1 live-node checkpoint passes (#1138, Verification). Targets `integration/issue-1138`.