### PR TITLE
C3 — projection-backed listContextGraphs (retires B3 cache)

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -164,6 +164,43 @@ export class ContextGraphMetaProjection {
     return [...touched];
   }
 
+  async listDeclaredContextGraphIds(): Promise<string[]> {
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+
+    const result = await this.store.query(`
+      SELECT DISTINCT ?ctxGraph WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH ?g {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+          }
+        }
+      }
+    `);
+    if (result.type !== 'bindings') return [];
+
+    const ids = new Set<string>();
+    for (const row of result.bindings) {
+      const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+      const id = contextGraphIdFromContextGraphUri(uri);
+      if (id) ids.add(id);
+    }
+    return [...ids].sort();
+  }
+
   private async rebuild(contextGraphId: string): Promise<ContextGraphMetaRecord> {
     const uri = contextGraphDataUri(contextGraphId);
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -381,9 +381,123 @@ import { DKGAgentBase } from './dkg-agent-base.js';
 import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+interface ContextGraphListRow {
+  id: string;
+  uri: string;
+  name: string;
+  description?: string;
+  creator?: string;
+  curator?: string;
+  accessPolicy?: string;
+  createdAt?: string;
+  isSystem: boolean;
+  subscribed: boolean;
+  synced: boolean;
+  onChainId?: string;
+  callerInvolved?: boolean;
+}
+
+type InternalContextGraphListRow = ContextGraphListRow & {
+  policyKnown?: boolean;
+};
+
+function listContextGraphsProjectionEnabled(): boolean {
+  const raw = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
+  if (!accessPolicy?.trim()) return false;
+  const t = accessPolicy.trim().replace(/^["']|["']$/g, '').toLowerCase();
+  return t === 'private';
+}
+
+async function applyContextGraphListPrivacy(
+  agent: DKGAgent,
+  rows: InternalContextGraphListRow[],
+  opts?: { callerAgentAddress?: string | null },
+): Promise<ContextGraphListRow[]> {
+  const scopedList = opts !== undefined && Object.prototype.hasOwnProperty.call(opts, 'callerAgentAddress');
+  const visibleRows = scopedList ? rows.filter((r) => r.policyKnown !== false) : rows;
+  let checksum: string | null = null;
+  const rawCaller = opts?.callerAgentAddress?.trim();
+  if (rawCaller && ethers.isAddress(rawCaller)) {
+    try {
+      checksum = ethers.getAddress(rawCaller);
+    } catch {
+      checksum = null;
+    }
+  }
+
+  if (!checksum) {
+    return visibleRows
+      .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy))
+      .map(({ policyKnown: _policyKnown, ...row }) => row);
+  }
+
+  const annotated = await Promise.all(visibleRows.map(async (r) => {
+    const curatorMatch = agent.curatorDidMatchesChecksumAgent(r.curator, checksum);
+    const allowlisted = await agent.callerIsAllowlistedAgentParticipant(r.id, checksum);
+    return { ...r, callerInvolved: curatorMatch || allowlisted };
+  }));
+
+  return annotated
+    .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy) || r.callerInvolved === true)
+    .map(({ policyKnown: _policyKnown, ...row }) => row);
+}
+
 export class ContextGraphResolveMethods extends DKGAgentBase {
   async getCgMeta(this: DKGAgent, contextGraphId: string): Promise<ContextGraphMetaRecord> {
     return this.contextGraphMetaProjection.get(contextGraphId);
+  }
+
+  async listContextGraphsFromProjection(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    const candidateIds = new Set(await this.contextGraphMetaProjection.listDeclaredContextGraphIds());
+    for (const [id] of this.subscribedContextGraphs) {
+      candidateIds.add(id);
+    }
+
+    const graphManager = new GraphManager(this.store);
+    for (const id of await graphManager.listContextGraphs()) {
+      candidateIds.add(id);
+    }
+
+    const rows = await Promise.all([...candidateIds].sort().map(async (id): Promise<InternalContextGraphListRow | null> => {
+      if (!id) return null;
+      const sub = this.subscribedContextGraphs.get(id);
+      const meta = await this.getCgMeta(id);
+      const hasProjectionGate = meta.hasAgentGate || meta.hasPeerGate || meta.hasLegacyParticipantGate;
+      const projectedAccessPolicy = meta.accessPolicy ?? (hasProjectionGate ? 'private' : undefined);
+      const policyKnown = meta.declared || projectedAccessPolicy !== undefined;
+
+      if (!meta.declared && !sub?.onChainId && !sub?.pendingMeta) {
+        if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) return null;
+        const hasContent = await this.contextGraphHasLocalContent(id);
+        if (!hasContent) return null;
+      }
+
+      return {
+        id,
+        uri: meta.uri || contextGraphDataUri(id),
+        name: meta.name ?? sub?.name ?? id,
+        description: meta.description,
+        creator: meta.creator,
+        curator: meta.curator,
+        accessPolicy: projectedAccessPolicy,
+        createdAt: meta.createdAt,
+        isSystem: meta.isSystem,
+        subscribed: sub?.subscribed ?? false,
+        synced: sub?.synced ?? false,
+        onChainId: sub?.onChainId ?? meta.onChainId,
+        policyKnown,
+      };
+    }));
+
+    return applyContextGraphListPrivacy(
+      this,
+      rows.filter((row): row is ContextGraphListRow => row !== null),
+      opts,
+    );
   }
 
   /**
@@ -1339,28 +1453,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * With a valid `callerAgentAddress` option, each row includes `callerInvolved`.
    * With no usable caller wallet, omit that field entirely so callers can infer membership from `curator`.
    */
-  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<Array<{
-    id: string;
-    uri: string;
-    name: string;
-    description?: string;
-    creator?: string;
-    /** Wallet-scoped curator DID (from _meta / ontology), if present. */
-    curator?: string;
-    /** Declared access policy literal, e.g. public / private. */
-    accessPolicy?: string;
-    createdAt?: string;
-    isSystem: boolean;
-    subscribed: boolean;
-    synced: boolean;
-    onChainId?: string;
-    /**
-     * When `callerAgentAddress` is omitted or invalid: property is omitted —
-     * clients fall back to comparing `curator` to identity (listing was not scoped to a caller).
-     * When a valid caller is provided: explicit true/false.
-     */
-    callerInvolved?: boolean;
-  }>> {
+  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    if (listContextGraphsProjectionEnabled()) {
+      return this.listContextGraphsFromProjection(opts);
+    }
+
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const result = await this.store.query(`
@@ -1574,41 +1671,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       };
     }));
 
-    let checksum: string | null = null;
-    const rawCaller = opts?.callerAgentAddress?.trim();
-    if (rawCaller && ethers.isAddress(rawCaller)) {
-      try {
-        checksum = ethers.getAddress(rawCaller);
-      } catch {
-        checksum = null;
-      }
-    }
-
-    // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
-    // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
-    // keep private rows only when they are curator or allowlisted participant.
-    const isPrivateRow = (ap?: string): boolean => {
-      if (!ap?.trim()) return false;
-      const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
-      return t === 'private';
-    };
-
-    if (!checksum) {
-      // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
-      // curator-vs-identity fallback for OPEN graphs.
-      return rows.filter((r) => !isPrivateRow(r.accessPolicy));
-    }
-
-    const annotated = await Promise.all(rows.map(async (r) => {
-      const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
-      const allowlisted = await this.callerIsAllowlistedAgentParticipant(r.id, checksum);
-      // `callerInvolved` must reflect ONLY the provided caller wallet.
-      // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
-      const involved = curatorMatch || allowlisted;
-      return { ...r, callerInvolved: involved };
-    }));
-
-    return annotated.filter((r) => !isPrivateRow(r.accessPolicy) || r.callerInvolved === true);
+    return applyContextGraphListPrivacy(this, rows, opts);
   }
 
 }

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -536,6 +536,83 @@ describe('listContextGraphs merge', () => {
     expect(visible).toBeDefined();
     expect(visible?.accessPolicy).toBe('private');
   }, 15000);
+
+  it('listContextGraphs projection mode preserves AGENTS privacy and root _meta discovery', async () => {
+    const previous = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+    process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = '1';
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const privateId = 'projection-list-agents-private';
+      const gateOnlyId = 'projection-list-gate-only-private';
+      const metaOnlyId = 'projection-list-meta-only';
+      const policyUnknownId = 'projection-list-policy-unknown';
+      const implicitPublicId = 'projection-list-implicit-public';
+      const myWallet = agent.getDefaultAgentAddress()!;
+      const privateUri = contextGraphDataGraphUri(privateId);
+      const gateOnlyUri = contextGraphDataGraphUri(gateOnlyId);
+      const metaOnlyUri = contextGraphDataGraphUri(metaOnlyId);
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      const privateMetaGraph = contextGraphMetaGraphUri(privateId);
+      const gateOnlyMetaGraph = contextGraphMetaGraphUri(gateOnlyId);
+      await result.store.insert([
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Agents Private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: privateMetaGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Gate Only Private"', graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: gateOnlyMetaGraph },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Meta Only"', graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: 'urn:projection-list-policy-unknown:root', predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Policy Unknown"', graph: contextGraphSharedMemoryUri(policyUnknownId) },
+      ]);
+      await agent.share(implicitPublicId, [
+        {
+          subject: 'urn:projection-list-implicit-public:root',
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Projection Implicit Public"',
+          graph: '',
+        },
+      ], { callerAgentAddress: myWallet });
+
+      const unscoped = await agent.listContextGraphs();
+      expect(unscoped.find(p => p.id === privateId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === metaOnlyId)?.name).toBe('Projection Meta Only');
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const otherWallet = ethers.Wallet.createRandom().address;
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === privateId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === privateId);
+      expect(visible).toBeDefined();
+      expect(visible?.accessPolicy).toBe('private');
+      expect(visible?.callerInvolved).toBe(true);
+      const gateVisible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === gateOnlyId);
+      expect(gateVisible).toBeDefined();
+      expect(gateVisible?.accessPolicy).toBe('private');
+      expect(gateVisible?.callerInvolved).toBe(true);
+      const implicitPublic = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === implicitPublicId);
+      expect(implicitPublic).toBeDefined();
+      expect(implicitPublic?.accessPolicy).toBe('public');
+      expect(implicitPublic?.callerInvolved).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+      } else {
+        process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = previous;
+      }
+    }
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -6,6 +6,43 @@ import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection
 import { DKGAgent } from '../src/dkg-agent.js';
 
 describe('ContextGraphMetaProjection', () => {
+  it('enumerates declared context graph ids from ontology, agents, and root _meta graphs', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const ontologyId = 'projection-list-ontology';
+    const agentsId = 'projection-list-agents';
+    const metaId = '0x0000000000000000000000000000000000000abc/projection-list-meta';
+
+    await store.insert([
+      {
+        subject: contextGraphDataGraphUri(ontologyId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(agentsId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: agentsGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(metaId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: contextGraphMetaGraphUri(metaId),
+      },
+    ]);
+
+    expect(await projection.listDeclaredContextGraphIds()).toEqual([
+      agentsId,
+      metaId,
+      ontologyId,
+    ].sort());
+  });
+
   it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);


### PR DESCRIPTION
## Summary

- Routes `listContextGraphs()` through the C2 projection (flag-gated), retiring B3's interim caller-scoped cache. Oracle-parity suite extended with the agents-declared-private fixture and the non-member-bearer NOT_FOUND preflight check.

## Related

- Part of #1138 (Track C, PR C3). **Stacked on C2** (base = `codex/issue-1138-c2-meta-projection`) — review only the incremental commit here. Logically replaces B3's interim cache (verify the retire is clean).
- **Merge order:** Wave 2, after C2.

## Files changed

| File | What |
|------|------|
| `agent/src/dkg-agent-cg-resolve.ts` | Projection-backed `listContextGraphs` (flagged) |
| (+ the C2 file set) | Carried from the C2 base |

Incremental commit only: `feat(agent): flag projection-backed context graph list`. Plus 7 test files.

## Test plan

- [ ] `pnpm -F dkg-agent test`
- [ ] Projection-backed list matches the oracle row-for-row (incl. agents-declared-private + non-member-bearer NOT_FOUND)
- [ ] B3 interim cache cleanly removed (no dangling references)
- [ ] `pnpm build` + lint

---
**Wave 2 (Track C) — draft, post-checkpoint.** Structural growth-proofing; do not merge before the Wave-1 live-node checkpoint passes (#1138, Verification). Targets `integration/issue-1138`.