### PR TITLE
C4 — host-sweep bound + SPARQL query-source tagging

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -496,6 +496,8 @@ export class DKGAgentBase {
   protected readonly swmHostModeHandlers = new Map<string, (topic: string, data: Uint8Array, from: string) => void>();
   /** Async lock for the host-mode reconciler so simultaneous calls don't double-subscribe. */
   protected hostModeReconcileInflight?: Promise<void>;
+  /** Rotating cursor for bounded host-mode reconcile sweeps over known context graphs. */
+  protected hostModeReconcileCursor = 0;
   /**
    * OT-RFC-43 A2 — the KA-number allocator, retained on the agent (also
    * forwarded to the publisher as `kaAllocator`). Held here so

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -550,7 +550,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       FILTER(!STRENDS(STR(?g), "/_meta"))
       FILTER(!STRENDS(STR(?g), "/_shared_memory_meta"))
     }`;
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.contextGraphHasLocalContent' });
     if (result.type === 'boolean') return result.value;
     return result.type === 'bindings' && result.bindings.length > 0;
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -395,6 +395,18 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
+
+function jitteredIntervalMs(intervalMs: number, ratio: number | undefined): number {
+  const normalizedRatio =
+    typeof ratio === 'number' && Number.isFinite(ratio)
+      ? Math.min(1, Math.max(0, ratio))
+      : DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO;
+  if (normalizedRatio === 0) return intervalMs;
+  const delta = intervalMs * normalizedRatio;
+  return Math.max(1, Math.round(intervalMs - delta + Math.random() * delta * 2));
+}
+
 export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
@@ -2044,6 +2056,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // store's TTL/cap prune.
     if (this.swmHostModeStore) {
       const reconcileEveryMs = this.config.swmHostMode?.reconcileIntervalMs ?? 30_000;
+      const reconcileTimerMs = jitteredIntervalMs(
+        reconcileEveryMs,
+        this.config.swmHostMode?.reconcileJitterRatio,
+      );
       const pruneEveryMs = this.config.swmHostMode?.pruneIntervalMs ?? 5 * 60_000;
       this.reconcileHostModeSubscriptions().catch(() => {});
       this.hostModeReconcilerTimer = setInterval(() => {
@@ -2051,7 +2067,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const msg = err instanceof Error ? err.message : String(err);
           this.log.warn(createOperationContext('system'), `Host-mode reconciler tick failed: ${msg}`);
         });
-      }, reconcileEveryMs);
+      }, reconcileTimerMs);
       if (this.hostModeReconcilerTimer.unref) this.hostModeReconcilerTimer.unref();
       this.hostModePruneTimer = setInterval(() => {
         this.swmHostModeStore?.prune().catch((err: unknown) => {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2801,7 +2801,7 @@ export class PublishMethods extends DKGAgentBase {
         ${sharedMemoryReadBothFilter(swmGraph)}
       }`;
     }
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.resolveLiftWorkspaceSlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1111,7 +1111,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     let markedDefaultAddr: string | undefined;
     const needsMigration: AgentKeyRecord[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.agentKeyMigration' });
       if (result.type !== 'bindings') return;
       const strip = (v?: string) => v?.replace(/^"|"$/g, '').replace(/"?\^\^.*$/, '') ?? '';
       for (const row of result.bindings) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -379,6 +379,13 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE = 32;
+
+function normalizeHostModeReconcileBatchSize(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE;
+  return Math.max(1, Math.floor(value));
+}
+
 export class SwmHostModeMethods extends DKGAgentBase {
   /**
    * OT-RFC-38 LU-6 — initialize the on-disk opaque ciphertext store
@@ -779,9 +786,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   /**
    * Periodic reconciler driven by `hostModeReconcilerTimer`. Sweeps
-   * every locally-known CG and ensures host-mode subscription is
-   * in sync. Cheap to call repeatedly because the per-CG
-   * reconciler is idempotent.
+   * a bounded slice of locally-known CGs and ensures host-mode
+   * subscription is in sync. The cursor rotates through the stable
+   * sorted set so large stores converge without each tick touching
+   * every known graph.
    *
    * Serialized via `hostModeReconcileInflight` so an overlap with
    * the cleanup timer (or a manual call from a test) doesn't
@@ -796,9 +804,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const inflight = (async () => {
       try {
         const graphManager = new GraphManager(this.store);
-        const knownCgs = await graphManager.listContextGraphs();
-        for (const cgId of knownCgs) {
-          await this.reconcileSwmHostModeSubscription(cgId);
+        const knownCgs = (await graphManager.listContextGraphs()).sort();
+        if (knownCgs.length === 0) {
+          this.hostModeReconcileCursor = 0;
+          return;
+        }
+        const batchSize = normalizeHostModeReconcileBatchSize(this.config.swmHostMode?.reconcileBatchSize);
+        const start = this.hostModeReconcileCursor % knownCgs.length;
+        const count = Math.min(batchSize, knownCgs.length);
+        for (let i = 0; i < count; i++) {
+          const index = (start + i) % knownCgs.length;
+          const cgId = knownCgs[index];
+          try {
+            await this.reconcileSwmHostModeSubscription(cgId);
+          } finally {
+            this.hostModeReconcileCursor = (index + 1) % knownCgs.length;
+          }
         }
       } finally {
         this.hostModeReconcileInflight = undefined;
@@ -1732,7 +1753,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const sparql = `SELECT ?o WHERE { ${graphClause} { <${subject}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`;
     let result;
     try {
-      result = await this.store.query(sparql);
+      result = await this.store.query(sparql, { source: 'agent.ciphertextChunkCatchup' });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `LU-11 chunk-catchup store query failed cg=${req.contextGraphId} chunkIndex=${req.chunkIndex}: ${reason}`);

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -933,6 +933,8 @@ export interface DKGAgentConfig {
    *  - `registered`: TTL/byte-cap for on-chain registered CGs (typically larger).
    *  - `pruneIntervalMs`: how often the TTL/cap sweep runs.
    *  - `reconcileIntervalMs`: how often the host-mode subscription reconciler ensures cores are subscribed to all known curated CGs.
+   *  - `reconcileBatchSize`: max known CGs reconciled per tick. Default 32.
+   *  - `reconcileJitterRatio`: startup interval jitter ratio in [0, 1]. Default 0.15.
    */
   swmHostMode?: {
     enabled?: boolean;
@@ -940,6 +942,8 @@ export interface DKGAgentConfig {
     registered?: SwmHostModeStoreLimits;
     pruneIntervalMs?: number;
     reconcileIntervalMs?: number;
+    reconcileBatchSize?: number;
+    reconcileJitterRatio?: number;
     /**
      * OT-RFC-38 / LU-6 Phase B — discovery-beacon rate limits for
      * pre-registration (freemium-tier) ciphertext writes. All three

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -300,7 +300,7 @@ export class FinalizationHandler {
       }
     }`;
 
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.finalization.sharedMemorySlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 
@@ -327,7 +327,7 @@ export class FinalizationHandler {
 
     const roots: Uint8Array[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.privateRoots' });
       if (result.type === 'bindings') {
         for (const row of result.bindings) {
           const hex = (row['root'] as string).replace(/^"(.*)".*$/, '$1').replace(/^0x/, '');
@@ -375,7 +375,7 @@ export class FinalizationHandler {
       }
     }`;
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.keepRootCopySignal' });
       if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
       let sawFalse = false;
       for (const row of result.bindings) {
@@ -421,7 +421,7 @@ export class FinalizationHandler {
     } LIMIT 1`;
 
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.publisherPeerId' });
       if (result.type === 'bindings' && result.bindings.length > 0) {
         const raw = result.bindings[0]['peerId'] as string;
         const peerId = raw.replace(/^"(.*)".*$/, '$1');

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -253,7 +253,7 @@ export class GossipPublishHandler {
           return;
         }
         const sparql = `SELECT DISTINCT ?s WHERE { GRAPH ?g { ?s ?p ?o } VALUES ?s { ${rootEntities.map(e => `<${e}>`).join(' ')} } FILTER(STRSTARTS(STR(?g), "${dataGraph}/_verifiable_memory/") || STR(?g) = "${dataGraph}") }`;
-        const result = await this.store.query(sparql);
+        const result = await this.store.query(sparql, { source: 'agent.gossipPublishValidation' });
         const existingEntities = new Set<string>(
           result.type === 'bindings' ? result.bindings.map(b => b['s']).filter(Boolean) : [],
         );

--- a/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
+++ b/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
@@ -28,6 +28,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DKGAgent } from '../../src/index.js';
 import { SwmHostModeStore } from '../../src/swm/host-mode-store.js';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 
 /**
  * Minimal in-memory gossip transport — mirrors the surface the agent
@@ -87,6 +88,9 @@ interface AgentInternals {
   swmHostModeSubscribed: Map<string, string>;
   swmHostModeHandlers: Map<string, unknown>;
   wireIdToLocalCgId: Map<string, string>;
+  config: { swmHostMode?: { reconcileBatchSize?: number } };
+  hostModeReconcileCursor: number;
+  reconcileSwmHostModeSubscription(contextGraphId: string): Promise<void>;
   enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void;
   awaitHostModePersistence(contextGraphId: string): Promise<void>;
   hostModePersistenceStoreKey(rawCgId: string): string;
@@ -129,6 +133,65 @@ describe('host-mode bookkeeping key canonicalisation', () => {
     await installHostModeStore(core, dataDir);
     return { core, bus };
   }
+
+  it('reconcileHostModeSubscriptions advances a bounded cursor instead of sweeping every CG per tick', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['cursor-cg-d', 'cursor-cg-b', 'cursor-cg-a', 'cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    expect(knownCgs.length).toBeGreaterThanOrEqual(4);
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+    };
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual(knownCgs.slice(0, 2));
+    expect(internals.hostModeReconcileCursor).toBe(2);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([...knownCgs.slice(0, 2), ...knownCgs.slice(2, 4)]);
+    expect(internals.hostModeReconcileCursor).toBe(4 % knownCgs.length);
+  });
+
+  it('reconcileHostModeSubscriptions advances past a failing CG so later CGs are not starved', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['failing-cursor-cg-a', 'failing-cursor-cg-b', 'failing-cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+      if (contextGraphId === knownCgs[0]) throw new Error('boom');
+    };
+
+    await expect(core.reconcileHostModeSubscriptions()).rejects.toThrow('boom');
+    expect(calls).toEqual([knownCgs[0]]);
+    expect(internals.hostModeReconcileCursor).toBe(1);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([knownCgs[0], knownCgs[1], knownCgs[2]]);
+  });
 
   it('cleartext subscribe followed by wire-hash subscribe for the same CG is idempotent', async () => {
     const { core } = await makeCore();

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -5,6 +5,7 @@ import type {
   SelectResult,
   ConstructResult,
   AskResult,
+  TripleStoreQueryOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { buildBlankNodeSafeDelete } from './sparql-http.js';
@@ -87,7 +88,7 @@ export class BlazegraphStore implements TripleStore {
   // Queries
   // -------------------------------------------------------------------
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, _options?: TripleStoreQueryOptions): Promise<QueryResult> {
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -2,7 +2,7 @@ import { Worker } from 'node:worker_threads';
 import { existsSync } from 'node:fs';
 import { sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { TripleStore, Quad, QueryResult } from '../triple-store.js';
+import type { TripleStore, Quad, QueryResult, TripleStoreQueryOptions } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 
 /**
@@ -214,7 +214,7 @@ export class OxigraphWorkerStore implements TripleStore {
   async insert(quads: Quad[]): Promise<void> { return this.call('insert', quads); }
   async delete(quads: Quad[]): Promise<void> { return this.call('delete', quads); }
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
-  async query(sparql: string): Promise<QueryResult> { return this.call('query', sparql); }
+  async query(sparql: string, _options?: TripleStoreQueryOptions): Promise<QueryResult> { return this.call('query', sparql); }
   async hasGraph(graphUri: string): Promise<boolean> { return this.call('hasGraph', graphUri); }
   async createGraph(graphUri: string): Promise<void> { return this.call('createGraph', graphUri); }
   async dropGraph(graphUri: string): Promise<void> { return this.call('dropGraph', graphUri); }

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -9,6 +9,7 @@ import type {
   SelectResult,
   ConstructResult,
   AskResult,
+  TripleStoreQueryOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 
@@ -212,7 +213,7 @@ export class OxigraphStore implements TripleStore {
     return matches.length;
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, _options?: TripleStoreQueryOptions): Promise<QueryResult> {
     const result = this.store.query(sparql);
 
     if (typeof result === 'boolean') {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -28,8 +28,10 @@ import type {
   SelectResult,
   ConstructResult,
   AskResult,
+  TripleStoreQueryOptions,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 
 /**
@@ -50,6 +52,24 @@ const monotonicNow = (): number => performance.now();
  * within the window instead of being masked indefinitely (review round 1).
  */
 export const LIST_GRAPHS_CACHE_TTL_MS = 30_000;
+
+const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
+const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
+
+export interface SparqlHttpQueryOptions extends TripleStoreQueryOptions {
+  /** Caller tag used in slow-query telemetry, e.g. `agent.listContextGraphs`. */
+  source?: string;
+}
+
+export interface SparqlHttpSlowQueryEvent {
+  source: string;
+  operation: 'select' | 'ask' | 'construct' | 'describe' | 'unknown';
+  elapsedMs: number;
+  thresholdMs: number;
+  endpoint: string;
+  queryHash: string;
+  queryBytes: number;
+}
 
 export interface SparqlHttpStoreOptions {
   /** SPARQL query endpoint URL (required). */
@@ -75,6 +95,12 @@ export interface SparqlHttpStoreOptions {
    * miss — so caching is unsafe there and `listGraphs()` always queries.
    */
   managedByDkg?: boolean;
+  /** Emit sampled slow-query events after this duration. Default 10_000 ms; set 0 to disable. */
+  slowQueryThresholdMs?: number;
+  /** Sampling rate for slow-query events, from 0 to 1. Default 1. */
+  slowQuerySampleRate?: number;
+  /** Optional sink for sampled slow-query events; defaults to a compact console warning. */
+  onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
   /**
    * Clock for the `listGraphs()` cache TTL. Test seam only; defaults to the
    * monotonic {@link monotonicNow} (`performance.now`), never `Date.now`, so a
@@ -93,6 +119,9 @@ export class SparqlHttpStore implements TripleStore {
   private readonly cacheGraphList: boolean;
   /** Monotonic clock for the cache TTL (defaults to performance.now). */
   private readonly now: () => number;
+  private readonly slowQueryThresholdMs: number;
+  private readonly slowQuerySampleRate: number;
+  private readonly onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
   /** Cached graph-name list; null = not built / invalidated by a write. */
   private graphListCache: string[] | null = null;
   /** Wall-clock (via {@link now}) when {@link graphListCache} was last built. */
@@ -130,6 +159,15 @@ export class SparqlHttpStore implements TripleStore {
     this.timeout = options.timeout ?? 30_000;
     this.cacheGraphList = options.managedByDkg === true;
     this.now = options.now ?? monotonicNow;
+    this.slowQueryThresholdMs = normalizeNonNegativeNumber(
+      options.slowQueryThresholdMs,
+      DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+    );
+    this.slowQuerySampleRate = normalizeSampleRate(
+      options.slowQuerySampleRate,
+      DEFAULT_SLOW_QUERY_SAMPLE_RATE,
+    );
+    this.onSlowQuery = options.onSlowQuery;
     // Content-Type is set per-request in postQuery/postUpdate (direct POST:
     // application/sparql-query | application/sparql-update). Only shared
     // headers (e.g. Authorization) belong here.
@@ -151,7 +189,7 @@ export class SparqlHttpStore implements TripleStore {
     this.graphListCacheGen++;
   }
 
-  private async postQuery(sparql: string, accept: string): Promise<Response> {
+  private async postQuery(sparql: string, accept: string, options?: SparqlHttpQueryOptions): Promise<Response> {
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
     // data. Form-encoded bodies (`query=...`) are parsed by the server's
@@ -163,7 +201,7 @@ export class SparqlHttpStore implements TripleStore {
       method: 'POST',
       headers: { ...this.headers, 'Content-Type': 'application/sparql-query', Accept: accept },
       body: sparql,
-      signal: AbortSignal.timeout(this.timeout),
+      signal: combineAbortSignals(AbortSignal.timeout(this.timeout), options?.signal),
     });
     return res;
   }
@@ -265,43 +303,54 @@ export class SparqlHttpStore implements TripleStore {
     return Math.max(0, before - after);
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {
+    const startedAt = this.now();
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');
     const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    const operation = inferQueryOperation(trimmed);
 
-    if (isConstruct) {
-      return this.queryConstruct(trimmed);
-    }
-
-    const res = await this.postQuery(trimmed, 'application/sparql-results+json');
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
-    }
-
-    const json = (await res.json()) as W3CSelectResponse | W3CAskResponse;
-
-    if (isAsk || 'boolean' in json) {
-      return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
-    }
-
-    const sr = json as W3CSelectResponse;
-    const vars = sr.head?.vars ?? [];
-    const bindings: Array<Record<string, string>> = (sr.results?.bindings ?? []).map((row) => {
-      const obj: Record<string, string> = {};
-      for (const v of vars) {
-        const cell = row[v];
-        if (cell) obj[v] = w3cTermToString(cell);
+    try {
+      if (isConstruct) {
+        return await this.queryConstruct(trimmed, options);
       }
-      return obj;
-    });
-    return { type: 'bindings', bindings } satisfies SelectResult;
+
+      const res = await this.postQuery(trimmed, 'application/sparql-results+json', options);
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
+      }
+
+      const json = (await res.json()) as W3CSelectResponse | W3CAskResponse;
+
+      if (isAsk || 'boolean' in json) {
+        return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
+      }
+
+      const sr = json as W3CSelectResponse;
+      const vars = sr.head?.vars ?? [];
+      const bindings: Array<Record<string, string>> = (sr.results?.bindings ?? []).map((row) => {
+        const obj: Record<string, string> = {};
+        for (const v of vars) {
+          const cell = row[v];
+          if (cell) obj[v] = w3cTermToString(cell);
+        }
+        return obj;
+      });
+      return { type: 'bindings', bindings } satisfies SelectResult;
+    } finally {
+      this.maybeEmitSlowQuery({
+        sparql: trimmed,
+        source: options?.source,
+        operation,
+        startedAt,
+      });
+    }
   }
 
-  private async queryConstruct(sparql: string): Promise<ConstructResult> {
-    const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads');
+  private async queryConstruct(sparql: string, options?: SparqlHttpQueryOptions): Promise<ConstructResult> {
+    const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads', options);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
@@ -312,7 +361,10 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   async hasGraph(graphUri: string): Promise<boolean> {
-    const r = await this.query(`ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`);
+    const r = await this.query(
+      `ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`,
+      { source: 'sparql-http.hasGraph' },
+    );
     return r.type === 'boolean' && r.value;
   }
 
@@ -384,7 +436,10 @@ export class SparqlHttpStore implements TripleStore {
    * that write so the next call rebuilds.
    */
   private async scanGraphs(startGen: number): Promise<string[]> {
-    const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
+    const r = await this.query(
+      'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
+      { source: 'sparql-http.listGraphs' },
+    );
     const graphs = r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
     if (this.cacheGraphList && startGen === this.graphListCacheGen) {
       this.graphListCache = graphs;
@@ -397,7 +452,7 @@ export class SparqlHttpStore implements TripleStore {
     const sparql = graphUri
       ? `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`
       : `SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }`;
-    const r = await this.query(sparql);
+    const r = await this.query(sparql, { source: 'sparql-http.countQuads' });
     if (r.type === 'bindings' && r.bindings.length > 0) {
       const c = String(r.bindings[0].c ?? '');
       const stripped = c.replace(/^"|"$/g, '');
@@ -406,9 +461,107 @@ export class SparqlHttpStore implements TripleStore {
     return 0;
   }
 
+  private maybeEmitSlowQuery(input: {
+    sparql: string;
+    source?: string;
+    operation: SparqlHttpSlowQueryEvent['operation'];
+    startedAt: number;
+  }): void {
+    if (this.slowQueryThresholdMs <= 0 || this.slowQuerySampleRate <= 0) return;
+    const elapsedMs = this.now() - input.startedAt;
+    if (elapsedMs < this.slowQueryThresholdMs) return;
+    if (this.slowQuerySampleRate < 1 && Math.random() >= this.slowQuerySampleRate) return;
+
+    const event: SparqlHttpSlowQueryEvent = {
+      source: normalizeQuerySource(input.source),
+      operation: input.operation,
+      elapsedMs,
+      thresholdMs: this.slowQueryThresholdMs,
+      endpoint: sanitizeEndpointForTelemetry(this.queryEndpoint),
+      queryHash: hashQuery(input.sparql),
+      queryBytes: Buffer.byteLength(input.sparql, 'utf8'),
+    };
+
+    if (this.onSlowQuery) {
+      try {
+        this.onSlowQuery(event);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`SPARQL HTTP slow query hook failed: ${reason}`);
+      }
+      return;
+    }
+    console.warn(
+      `SPARQL HTTP slow query source=${event.source} operation=${event.operation} ` +
+      `elapsedMs=${Math.round(event.elapsedMs)} thresholdMs=${event.thresholdMs} ` +
+      `queryHash=${event.queryHash} queryBytes=${event.queryBytes} endpoint=${event.endpoint}`,
+    );
+  }
+
   async close(): Promise<void> {
     // Remote service — nothing to close.
   }
+}
+
+function normalizeNonNegativeNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+}
+
+function normalizeSampleRate(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.min(1, Math.max(0, value));
+}
+
+function normalizeQuerySource(source: string | undefined): string {
+  const trimmed = source?.trim();
+  if (!trimmed) return 'unknown';
+  return trimmed.replace(/[^\w:./-]/g, '_').slice(0, 120) || 'unknown';
+}
+
+function inferQueryOperation(sparql: string): SparqlHttpSlowQueryEvent['operation'] {
+  const upper = sparql.trimStart().toUpperCase();
+  if (upper.startsWith('SELECT')) return 'select';
+  if (upper.startsWith('ASK')) return 'ask';
+  if (upper.startsWith('CONSTRUCT')) return 'construct';
+  if (upper.startsWith('DESCRIBE')) return 'describe';
+  return 'unknown';
+}
+
+function hashQuery(sparql: string): string {
+  return createHash('sha256').update(sparql).digest('hex').slice(0, 16);
+}
+
+function sanitizeEndpointForTelemetry(endpoint: string): string {
+  try {
+    const url = new URL(endpoint);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return endpoint.split(/[?#]/, 1)[0];
+  }
+}
+
+function combineAbortSignals(timeoutSignal: AbortSignal, callerSignal?: AbortSignal): AbortSignal {
+  if (!callerSignal) return timeoutSignal;
+  if (timeoutSignal.aborted) return timeoutSignal;
+  if (callerSignal.aborted) return callerSignal;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([timeoutSignal, callerSignal]);
+  }
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+  };
+  timeoutSignal.addEventListener('abort', () => abort(timeoutSignal), { once: true });
+  callerSignal.addEventListener('abort', () => abort(callerSignal), { once: true });
+  return controller.signal;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -7,6 +7,7 @@ export {
   type AskResult,
   type TripleStoreConfig,
   type TripleStoreBackend,
+  type TripleStoreQueryOptions,
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
@@ -25,7 +26,12 @@ export {
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
 export { BlazegraphStore } from './adapters/blazegraph.js';
-export { SparqlHttpStore, type SparqlHttpStoreOptions } from './adapters/sparql-http.js';
+export {
+  SparqlHttpStore,
+  type SparqlHttpStoreOptions,
+  type SparqlHttpQueryOptions,
+  type SparqlHttpSlowQueryEvent,
+} from './adapters/sparql-http.js';
 export { ContextGraphManager, GraphManager } from './graph-manager.js';
 export { PrivateContentStore } from './private-store.js';
 

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -7,6 +7,7 @@ import type {
   QueryResult,
   SelectResult,
   TripleStore,
+  TripleStoreQueryOptions,
 } from './triple-store.js';
 
 export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
@@ -71,16 +72,16 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return removed;
   }
 
-  async query(sparql: string): Promise<QueryResult> {
+  async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     const rewritten = this.rewriteLargeLiteralConstants(sparql);
     if (!rewritten) {
-      const result = await this.inner.query(sparql);
+      const result = await this.inner.query(sparql, options);
       return this.hydrateQueryResult(result);
     }
 
     const [original, placeholder] = await Promise.all([
-      this.inner.query(sparql),
-      this.inner.query(rewritten),
+      this.inner.query(sparql, options),
+      this.inner.query(rewritten, options),
     ]);
     return this.hydrateQueryResult(mergeQueryResults(original, placeholder));
   }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -34,11 +34,18 @@ export interface AskResult {
 
 export type QueryResult = SelectResult | ConstructResult | AskResult;
 
+export interface TripleStoreQueryOptions {
+  /** Human-readable caller tag used by adapters for diagnostics/telemetry. */
+  source?: string;
+  /** Optional caller cancellation signal. Adapters that cannot cancel may ignore it. */
+  signal?: AbortSignal;
+}
+
 export interface TripleStore {
   insert(quads: Quad[]): Promise<void>;
   delete(quads: Quad[]): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>): Promise<number>;
-  query(sparql: string): Promise<QueryResult>;
+  query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult>;
 
   hasGraph(graphUri: string): Promise<boolean>;
   createGraph(graphUri: string): Promise<void>;

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { SparqlHttpStore, createTripleStore, type Quad } from '../src/index.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { SparqlHttpStore, createTripleStore, type Quad, type SparqlHttpSlowQueryEvent } from '../src/index.js';
 import { LIST_GRAPHS_CACHE_TTL_MS } from '../src/adapters/sparql-http.js';
 
 let server: Server;
@@ -25,7 +25,7 @@ function startTestServer(): Promise<void> {
           res.end();
           return;
         }
-        if (req.url === '/query') {
+        if (req.url?.startsWith('/query')) {
           if (decoded.includes('ASK')) {
             res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
             res.end(JSON.stringify({ boolean: true }));
@@ -116,6 +116,105 @@ describe('SparqlHttpStore (test server)', () => {
       expect(result.bindings.length).toBe(1);
       expect(result.bindings[0]['name']).toBe('"Alice"');
     }
+  });
+
+  it('emits sampled slow-query events with source tags and query fingerprints', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const taggedStore = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 10,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = taggedStore.query(
+      'SELECT ?name WHERE { GRAPH <http://ex.org/g1> { <http://ex.org/alice> <http://schema.org/name> ?name } }',
+      { source: 'unit test/source' },
+    );
+    clock = 25;
+    await pending;
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      source: 'unit_test/source',
+      operation: 'select',
+      elapsedMs: 25,
+      thresholdMs: 10,
+      endpoint: queryUrl,
+    });
+    expect(events[0].queryHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].queryBytes).toBeGreaterThan(0);
+    expect(events[0]).not.toHaveProperty('sparql');
+  });
+
+  it('honors slow-query sample rate zero', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const sampledOutStore = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      slowQuerySampleRate: 0,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = sampledOutStore.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+      source: 'sampled-out',
+    });
+    clock = 50;
+    await pending;
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not let slow-query hook failures fail the query', async () => {
+    let clock = 0;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      onSlowQuery: () => { throw new Error('sink down'); },
+      now: () => clock,
+    });
+
+    try {
+      const pending = store.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+        source: 'throwing-hook',
+      });
+      clock = 50;
+      const result = await pending;
+      expect(result.type).toBe('boolean');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('slow query hook failed'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('redacts endpoint query strings from slow-query telemetry', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const store = new SparqlHttpStore({
+      queryEndpoint: `${queryUrl}?token=secret#fragment`,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = store.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+      source: 'secret-endpoint',
+    });
+    clock = 50;
+    await pending;
+
+    expect(events).toHaveLength(1);
+    expect(events[0].endpoint).toBe(queryUrl);
+    expect(events[0].endpoint).not.toContain('secret');
+    expect(events[0].endpoint).not.toContain('#fragment');
   });
 
   it('query ASK returns boolean', async () => {


### PR DESCRIPTION
## Summary

- Hygiene: bounds the core-node host-mode reconcile sweep (budget/cursor/jitter) and adds per-query-source tagging + slow-query sampling in `sparql-http` — the observability that would have attributed this whole class to its call site in hours.

## Related

- Part of #1138 (Track C, PR C4). **Stacked on C3** (base = `codex/issue-1138-c3-list-projection`) — review only the incremental commit. Last in the sequence.
- Also file the deferred follow-ups noted in #1138 C4 (numeric `publishContextGraphId` preflight bypass; 64-row rehydration-cap interplay with #997).

## Files changed

| File | What |
|------|------|
| `agent/src/dkg-agent-swm-host.ts` | Host-mode sweep budget/cursor/jitter |
| `storage/src/adapters/*`, `storage/src/index.ts`, `triple-store.ts` | Per-query-source tagging + slow-query sampling |
| (+ the C2/C3 file set) | Carried from the C3 base |

Incremental commit only: `fix(agent): bound host sweep and tag sparql queries`. Plus 9 test files.

## Test plan

- [ ] `pnpm -F dkg-agent -F dkg-storage test`
- [ ] Host sweep respects the per-tick budget and cursor wrap; slow-query sampling emits source-tagged warnings
- [ ] `pnpm build` + lint

---
**Wave 2 (Track C) — draft, post-checkpoint.** Structural growth-proofing; do not merge before the Wave-1 live-node checkpoint passes (#1138, Verification). Targets `integration/issue-1138`.