### PR TITLE
feat: shared curator AI-model access (opt-in, membership-gated)

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -14,6 +14,7 @@ import {
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
   PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_STORAGE_UPDATE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
+  PROTOCOL_SHARED_MODEL_INVOKE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphSharedMemoryUri,
@@ -675,6 +676,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // Going through messenger.register opts into the substrate's
     // envelope versioning, idempotency cache, and `/api/slo` stats.
     this.messenger.register(PROTOCOL_SWM_HOST_CATCHUP, (data, fromPeerId) => this.handleSwmHostCatchup(data, fromPeerId));
+
+    // Shared curator AI-model access (MVP): serve member invokes of the
+    // model this node's curator shares. The handler enforces the per-CG
+    // grant, membership, and quota, and denies politely otherwise.
+    this.messenger.register(PROTOCOL_SHARED_MODEL_INVOKE, (data, fromPeerId) => this.handleSharedModelInvoke(data, fromPeerId));
 
     // OT-RFC-38 LU-11 / OT-RFC-39: per-chunk ciphertext sync verb.
     // Symmetric to PROTOCOL_SWM_HOST_CATCHUP but pulls one

--- a/packages/agent/src/dkg-agent-shared-model.ts
+++ b/packages/agent/src/dkg-agent-shared-model.ts
@@ -1,0 +1,225 @@
+import {
+  createOperationContext,
+  contextGraphMetaGraphUri,
+  contextGraphDataGraphUri,
+  PROTOCOL_SHARED_MODEL_INVOKE,
+} from '@origintrail-official/dkg-core';
+import type { DKGAgent } from './dkg-agent.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  SHARED_MODEL_PREDICATES,
+  sanitizeModelId,
+  type SharedModelGrant,
+  type SharedModelMessage,
+  type SharedModelRuntimeConfig,
+  type SharedModelInvokeResponse,
+} from './shared-model/types.js';
+import { SharedModelClient } from './shared-model/client.js';
+import { DailyQuota } from './shared-model/quota.js';
+import { decideSharedModelAuthorization } from './shared-model/authorize.js';
+import {
+  encodeInvokeRequest,
+  decodeInvokeRequest,
+  encodeInvokeResponse,
+  decodeInvokeResponse,
+} from './shared-model/wire.js';
+
+interface SharedModelState {
+  config: SharedModelRuntimeConfig;
+  quota: DailyQuota;
+  client: SharedModelClient;
+}
+
+// Per-agent runtime state held off-instance so this mixin needs no constructor
+// wiring. The API key lives here, in memory only.
+const STATE = new WeakMap<object, SharedModelState>();
+
+export interface InvokeOpts {
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export class SharedModelMethods {
+  /**
+   * Attach/replace this node's shared-model runtime config. Called by the
+   * daemon lifecycle after agent creation (and directly by tests).
+   */
+  configureSharedModel(this: DKGAgent, config: SharedModelRuntimeConfig): void {
+    STATE.set(this, {
+      config,
+      quota: new DailyQuota(config.dailyRequestQuotaPerAgent),
+      client: new SharedModelClient(),
+    });
+  }
+
+  /** Curator toggles model sharing for a CG (writes the `_meta` grant). */
+  async setContextGraphModelSharing(
+    this: DKGAgent,
+    contextGraphId: string,
+    enabled: boolean,
+    opts: { callerAgentAddress?: string; modelId?: string } = {},
+  ): Promise<void> {
+    const owner = await this.getContextGraphOwner(contextGraphId);
+    if (!owner) throw new Error(`context graph "${contextGraphId}" not found`);
+    this.assertCallerIsOwner(owner, opts.callerAgentAddress, 'share model access');
+
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const cgUri = contextGraphDataGraphUri(contextGraphId);
+    await this.store.deleteByPattern({ graph: metaGraph, subject: cgUri, predicate: SHARED_MODEL_PREDICATES.ENABLED });
+    await this.store.deleteByPattern({ graph: metaGraph, subject: cgUri, predicate: SHARED_MODEL_PREDICATES.MODEL_ID });
+    if (!enabled) return;
+
+    const quads: Quad[] = [
+      { subject: cgUri, predicate: SHARED_MODEL_PREDICATES.ENABLED, object: '"true"', graph: metaGraph },
+    ];
+    const modelId = sanitizeModelId(opts.modelId) ?? STATE.get(this)?.config.model;
+    if (modelId) {
+      quads.push({ subject: cgUri, predicate: SHARED_MODEL_PREDICATES.MODEL_ID, object: `"${modelId}"`, graph: metaGraph });
+    }
+    await this.store.insert(quads);
+  }
+
+  /** Read the per-CG grant from `_meta`. */
+  async getContextGraphModelGrant(this: DKGAgent, contextGraphId: string): Promise<SharedModelGrant> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const cgUri = contextGraphDataGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${metaGraph}> {
+        <${cgUri}> ?p ?o .
+        FILTER(?p IN (<${SHARED_MODEL_PREDICATES.ENABLED}>, <${SHARED_MODEL_PREDICATES.MODEL_ID}>))
+      } }`,
+    );
+    let enabled = false;
+    let modelId: string | undefined;
+    if (result.type === 'bindings') {
+      for (const row of result.bindings as Array<Record<string, string>>) {
+        const p = row['p'];
+        const o = (row['o'] ?? '').replace(/^"|"$/g, '');
+        if (p === SHARED_MODEL_PREDICATES.ENABLED && o === 'true') enabled = true;
+        if (p === SHARED_MODEL_PREDICATES.MODEL_ID) modelId = o;
+      }
+    }
+    return { enabled, modelId };
+  }
+
+  /** Server side: handle an incoming P2P invoke from a member node. */
+  async handleSharedModelInvoke(this: DKGAgent, data: Uint8Array, fromPeerId: string): Promise<Uint8Array> {
+    const ctx = createOperationContext('share');
+    let req;
+    try {
+      req = decodeInvokeRequest(data);
+    } catch (err) {
+      return encodeInvokeResponse({ ok: false, denied: `malformed request: ${err instanceof Error ? err.message : String(err)}` });
+    }
+
+    const st = STATE.get(this);
+    const grant = await this.getContextGraphModelGrant(req.contextGraphId).catch(() => ({ enabled: false }) as SharedModelGrant);
+    const isMember = await this.isPeerContextGraphMember(req.contextGraphId, fromPeerId).catch(() => false);
+    const promptChars = req.messages.reduce((n, m) => n + m.content.length, 0);
+    const promptOk = !!st && promptChars <= st.config.maxPromptChars;
+    const quotaOk = !!st && st.quota.allow(fromPeerId);
+
+    const decision = decideSharedModelAuthorization({
+      enabled: grant.enabled,
+      providerConfigured: !!st && st.config.enabled,
+      isMember,
+      quotaOk,
+      promptOk,
+    });
+    if (!decision.ok) {
+      this.log.info(ctx, `shared-model invoke denied cg=${req.contextGraphId} from=${fromPeerId}: ${decision.denied}`);
+      return encodeInvokeResponse({ ok: false, denied: decision.denied });
+    }
+    try {
+      const completion = await st!.client.complete(st!.config, req.messages, {
+        maxTokens: req.maxTokens,
+        temperature: req.temperature,
+      });
+      return encodeInvokeResponse({ ok: true, content: completion.content, model: completion.model });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.log.warn(ctx, `shared-model provider error cg=${req.contextGraphId}: ${reason}`);
+      return encodeInvokeResponse({ ok: false, denied: `provider error: ${reason}` });
+    }
+  }
+
+  /** Client/dispatcher: a member invokes the curator's shared model. */
+  async invokeContextGraphModel(
+    this: DKGAgent,
+    contextGraphId: string,
+    messages: SharedModelMessage[],
+    opts: InvokeOpts = {},
+    callerAgentAddress?: string,
+  ): Promise<SharedModelInvokeResponse> {
+    // Local fast-path: this node is the curator (no network hop).
+    if (await this.isContextGraphCuratorSelf(contextGraphId)) {
+      const st = STATE.get(this);
+      const grant = await this.getContextGraphModelGrant(contextGraphId);
+      const selfKey = callerAgentAddress ?? this.getDefaultAgentAddress?.() ?? 'self';
+      const promptChars = messages.reduce((n, m) => n + m.content.length, 0);
+      const decision = decideSharedModelAuthorization({
+        enabled: grant.enabled,
+        providerConfigured: !!st && st.config.enabled,
+        isMember: true,
+        quotaOk: !!st && st.quota.allow(selfKey),
+        promptOk: !!st && promptChars <= st.config.maxPromptChars,
+      });
+      if (!decision.ok) return { ok: false, denied: decision.denied };
+      try {
+        const completion = await st!.client.complete(st!.config, messages, opts);
+        return { ok: true, content: completion.content, model: completion.model };
+      } catch (err) {
+        return { ok: false, denied: `provider error: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    }
+
+    // Remote path: send to the curator's node over P2P.
+    const peerId = await this.resolveCuratorPeerId(contextGraphId);
+    if (!peerId) return { ok: false, denied: 'could not resolve curator peer for this context graph' };
+    const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature });
+    const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SHARED_MODEL_INVOKE, reqBytes);
+    if (!sendResult.delivered) {
+      const reason = 'error' in sendResult ? sendResult.error : 'undelivered';
+      return { ok: false, denied: `curator node unreachable: ${reason}` };
+    }
+    return decodeInvokeResponse(sendResult.response);
+  }
+
+  // ---- helpers ----
+
+  private async isContextGraphCuratorSelf(this: DKGAgent, contextGraphId: string): Promise<boolean> {
+    const owner = await this.getContextGraphOwner(contextGraphId);
+    if (!owner) return false;
+    const mine = new Set<string>();
+    const addr = this.getDefaultAgentAddress?.();
+    if (addr) mine.add(`did:dkg:agent:${addr}`.toLowerCase());
+    if (this.peerId) mine.add(`did:dkg:agent:${this.peerId}`.toLowerCase());
+    return mine.has(owner.toLowerCase());
+  }
+
+  /**
+   * Membership for the remote path is verified by the delegatee-peer binding
+   * established at invite/join time (DKG `allowedDelegateePeer` /
+   * `delegationDelegateePeer` in `_meta`). The libp2p `fromPeerId` is
+   * cryptographically authenticated by the transport, so matching it against
+   * the recorded delegatee peer authorises the request without a separate
+   * signature.
+   */
+  private async isPeerContextGraphMember(this: DKGAgent, contextGraphId: string, peerId: string): Promise<boolean> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?peer WHERE { GRAPH <${metaGraph}> {
+        { ?s <https://dkg.network/ontology#allowedDelegateePeer> ?peer }
+        UNION
+        { ?s <https://dkg.network/ontology#delegationDelegateePeer> ?peer }
+      } }`,
+    );
+    if (result.type === 'bindings') {
+      for (const row of result.bindings as Array<Record<string, string>>) {
+        const p = (row['peer'] ?? '').replace(/^"|"$/g, '');
+        if (p === peerId) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/agent/src/dkg-agent-shared-model.ts
+++ b/packages/agent/src/dkg-agent-shared-model.ts
@@ -123,10 +123,27 @@ export class SharedModelMethods {
 
     const st = STATE.get(this);
     const grant = await this.getContextGraphModelGrant(req.contextGraphId).catch(() => ({ enabled: false }) as SharedModelGrant);
-    const isMember = await this.isPeerContextGraphMember(req.contextGraphId, fromPeerId).catch(() => false);
+    // SECURITY INVARIANT (per-agent membership binding):
+    // `fromPeerId` is cryptographically authenticated by libp2p; the request
+    // body may CLAIM any `agentAddress`, but it is authorized ONLY if THAT
+    // specific agent recorded `fromPeerId` as one of its approved delegatee
+    // peers. We bind the lookup to the claimed agent (lowercased — the helper
+    // keys are lowercased; peer-ids stay case-sensitive) exactly as the sync
+    // auth path binds to `requesterAgentAddress`. A missing/empty claim is
+    // DENIED — there is NO union fallback. This defeats:
+    //   (a) pending requesters     — not in the curator-APPROVED set at all;
+    //   (b) impersonation          — the attacker's peer won't equal the
+    //                                victim agent's recorded delegatee peer;
+    //   (c) multi-agent inheritance — only the one approved agent whose
+    //                                binding matches `fromPeerId` is allowed,
+    //                                not every agent that shares the node.
+    const isMember = await this.isAgentPeerContextGraphMember(req.contextGraphId, req.agentAddress, fromPeerId).catch(() => false);
     const promptChars = req.messages.reduce((n, m) => n + m.content.length, 0);
     const promptOk = !!st && promptChars <= st.config.maxPromptChars;
-    const quotaOk = !!st && st.quota.allow(fromPeerId);
+    // Quota is a non-mutating PEEK for the decision; the counter is consumed
+    // only AFTER authorization succeeds (see below), so a request denied for
+    // any other reason never burns the member's daily allowance.
+    const quotaOk = !!st && st.quota.remaining(fromPeerId) > 0;
 
     const decision = decideSharedModelAuthorization({
       enabled: grant.enabled,
@@ -136,9 +153,11 @@ export class SharedModelMethods {
       promptOk,
     });
     if (!decision.ok) {
-      this.log.info(ctx, `shared-model invoke denied cg=${req.contextGraphId} from=${fromPeerId}: ${decision.denied}`);
+      this.log.info(ctx, `shared-model invoke denied cg=${req.contextGraphId} from=${fromPeerId} agent=${req.agentAddress ?? 'n/a'}: ${decision.denied}`);
       return encodeInvokeResponse({ ok: false, denied: decision.denied });
     }
+    // Authorized: consume exactly one quota unit before the provider call.
+    st!.quota.allow(fromPeerId);
     try {
       const completion = await st!.client.complete(st!.config, req.messages, {
         maxTokens: req.maxTokens,
@@ -161,20 +180,36 @@ export class SharedModelMethods {
     opts: InvokeOpts = {},
     callerAgentAddress?: string,
   ): Promise<SharedModelInvokeResponse> {
-    // Local fast-path: this node is the curator (no network hop).
+    // Local fast-path: this node hosts the CG's curator (no network hop). We
+    // take this path iff the CG owner is one of THIS node's local agents — not
+    // merely the default agent — so a multi-agent node serves CGs curated by
+    // any of its agents locally instead of dialing itself.
     if (await this.isContextGraphCuratorSelf(contextGraphId)) {
       const st = STATE.get(this);
       const grant = await this.getContextGraphModelGrant(contextGraphId);
+      // Caller-scoped authorization for the local path. The default-agent /
+      // node-token fallback (`getDefaultAgentAddress`) is ONLY used to key the
+      // quota bucket; it is NOT a membership grant. Membership is decided
+      // explicitly below against the caller's real address.
       const selfKey = callerAgentAddress ?? this.getDefaultAgentAddress?.() ?? 'self';
       const promptChars = messages.reduce((n, m) => n + m.content.length, 0);
+      // SECURITY: do NOT hardcode `isMember:true`. The caller is authorized
+      // only if it IS the CG owner/curator OR an approved member of the CG.
+      // A different LOCAL agent that is neither owner nor member is DENIED
+      // here (and must NOT fall through to the remote path, which would dial
+      // self). Same per-agent principle as the remote path: hosting an agent
+      // on this node grants nothing on a CG that agent didn't curate or join.
+      const isMember = await this.isCallerLocalCgMember(contextGraphId, callerAgentAddress).catch(() => false);
       const decision = decideSharedModelAuthorization({
         enabled: grant.enabled,
         providerConfigured: !!st && st.config.enabled,
-        isMember: true,
-        quotaOk: !!st && st.quota.allow(selfKey),
+        isMember,
+        // Non-mutating peek; consume happens once, after the decision is ok.
+        quotaOk: !!st && st.quota.remaining(selfKey) > 0,
         promptOk: !!st && promptChars <= st.config.maxPromptChars,
       });
       if (!decision.ok) return { ok: false, denied: decision.denied };
+      st!.quota.allow(selfKey);
       try {
         const completion = await st!.client.complete(st!.config, messages, {
           ...opts,
@@ -186,10 +221,12 @@ export class SharedModelMethods {
       }
     }
 
-    // Remote path: send to the curator's node over P2P.
+    // Remote path: send to the curator's node over P2P. The caller's agent
+    // address travels in the request so the curator can bind it to the
+    // transport peer (see the SECURITY INVARIANT in handleSharedModelInvoke).
     const peerId = await this.resolveCuratorPeerId(contextGraphId);
     if (!peerId) return { ok: false, denied: 'could not resolve curator peer for this context graph' };
-    const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature });
+    const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature, agentAddress: callerAgentAddress });
     // The whole remote round trip (resolver + dial + write + LLM completion +
     // read) must fit the transport budget. The router default (20s) is shorter
     // than real LLM latency and would surface a false "node unreachable" on a
@@ -206,38 +243,100 @@ export class SharedModelMethods {
 
   // ---- helpers ----
 
+  /**
+   * Does THIS node host the CG's curator? Enumerates ALL of the node's local
+   * agents (not just the default), mirroring `getContextGraphCurator`'s
+   * local-DID set, so a multi-agent node serves CGs curated by any of its
+   * agents on the local fast-path instead of dialing itself. NOTE: this answers
+   * "should we take the local path", NOT "is the caller authorized" — the
+   * caller is gated separately by {@link isCallerLocalCgMember}.
+   */
   private async isContextGraphCuratorSelf(this: DKGAgent, contextGraphId: string): Promise<boolean> {
     const owner = await this.getContextGraphOwner(contextGraphId);
     if (!owner) return false;
+    return this.localCgOwnerDids().has(owner.toLowerCase());
+  }
+
+  /** Lowercased `did:dkg:agent:*` DIDs for every identity this node hosts. */
+  private localCgOwnerDids(this: DKGAgent): Set<string> {
     const mine = new Set<string>();
     const addr = this.getDefaultAgentAddress?.();
     if (addr) mine.add(`did:dkg:agent:${addr}`.toLowerCase());
     if (this.peerId) mine.add(`did:dkg:agent:${this.peerId}`.toLowerCase());
-    return mine.has(owner.toLowerCase());
+    for (const a of this.localAgents.keys()) {
+      mine.add(`did:dkg:agent:${a}`.toLowerCase());
+    }
+    return mine;
   }
 
   /**
-   * Membership for the remote path is verified against the set of APPROVED,
-   * UNEXPIRED delegatee peers for the CG — exactly the set used by the sync
-   * auth path. We reuse the canonical {@link getContextGraphAllowedDelegateePeers}
-   * helper (WorkspaceCryptoMethods mixin) so the gate reads ONLY the
-   * curator-approved `allowedDelegateePeer` bindings and never the
-   * self-asserted, pre-approval `delegationDelegateePeer` value written at
-   * join-request time. A pending, rejected, or removed peer is therefore
-   * correctly denied (a removed peer's `did:dkg:agent-delegation:*` subject is
-   * deleted by `removeAgentFromContextGraph`, so it drops out of this set).
+   * Local-path caller authorization (#2). The CG is curated on THIS node, so
+   * there is no transport peer to bind against; we authorize the CALLER's agent
+   * address directly. Allowed iff the caller IS the CG owner/curator OR an
+   * approved member of the CG. Returns false (DENY) for a different local agent
+   * that is neither — the caller must NOT be silently treated as a member just
+   * because the curator lives on this node. Comparison is case-insensitive on
+   * the (checksummed-or-lowercased) wallet address; the allowed-agent set is
+   * sourced from the same curator-authoritative state used everywhere else.
+   */
+  private async isCallerLocalCgMember(this: DKGAgent, contextGraphId: string, callerAgentAddress: string | undefined): Promise<boolean> {
+    // Deny outright with no caller principal. This guard MUST come first: it
+    // also stops `isCallerOrNodeOwner(owner, undefined)` below from taking its
+    // permissive no-caller branch (which would authorise a node-level token
+    // whenever the owner is one of the node's own identities).
+    if (!callerAgentAddress) return false;
+    // Owner / curator via the CANONICAL check so this gate matches
+    // `setContextGraphModelSharing` (which uses `assertCallerIsOwner`) exactly,
+    // including the legacy case where the CG owner is stored under the
+    // peerId-based DID and the caller is this node's default agent. Without it,
+    // a curator could enable sharing on a legacy CG and then be denied invoking
+    // their own model.
+    const owner = await this.getContextGraphOwner(contextGraphId);
+    if (owner && this.isCallerOrNodeOwner(owner, callerAgentAddress)) return true;
+    // Approved member? `getContextGraphAllowedAgents` returns bare,
+    // quote-stripped wallet addresses (NOT lowercased, NOT DID-framed) minus
+    // revoked tombstones — the curator's authoritative allowlist.
+    const caller = callerAgentAddress.toLowerCase();
+    const allowed = await this.getContextGraphAllowedAgents(contextGraphId);
+    return allowed.some((a) => a.toLowerCase() === caller);
+  }
+
+  /**
+   * Per-agent membership for the remote path (#1). Membership is verified
+   * against the set of APPROVED, UNEXPIRED delegatee peers for the CG — exactly
+   * the set used by the sync auth path. We reuse the canonical
+   * {@link getContextGraphAllowedDelegateePeers} helper (WorkspaceCryptoMethods
+   * mixin), which returns `Map<agentLower, peerId[]>` and reads ONLY the
+   * curator-approved `allowedDelegateePeer` bindings — never the self-asserted,
+   * pre-approval `delegationDelegateePeer` value written at join-request time.
+   *
+   * UNLIKE the previous union check, we look up ONLY the binding for the
+   * SPECIFIC agent the request claims to act on behalf of (`agentAddress`) and
+   * require `fromPeerId` to be among THAT agent's approved peers — mirroring
+   * the sync path's `allowedDelegateePeers.get(claimedAgent)?.includes(peer)`.
+   *
+   * Denials (all by construction of the per-agent lookup):
+   *   - missing/empty `agentAddress`           → DENY (no union fallback).
+   *   - claimed agent has no approved binding  → DENY (e.g. a PENDING joiner:
+   *     its `delegationDelegateePeer` is never returned by the helper; or a
+   *     REMOVED agent whose `did:dkg:agent-delegation:*` subject was deleted).
+   *   - `fromPeerId` not in the claimed agent's binding → DENY (impersonation:
+   *     the attacker's authenticated peer won't equal the victim agent's
+   *     recorded delegatee peer; and inheritance: a sibling approved agent's
+   *     peer is in a DIFFERENT map entry, so it can't satisfy this agent).
    *
    * The libp2p `fromPeerId` is cryptographically authenticated by the
-   * transport, so matching it against an approved delegatee peer authorises
-   * the request without a separate signature.
+   * transport, so matching it against the claimed agent's approved delegatee
+   * peer authorises the request without a separate signature.
    */
-  private async isPeerContextGraphMember(this: DKGAgent, contextGraphId: string, peerId: string): Promise<boolean> {
-    // Map<agentLower, peerId[]> — flatten to the union of all approved peers;
-    // any approved delegatee node may invoke on the model the curator bills.
+  private async isAgentPeerContextGraphMember(
+    this: DKGAgent,
+    contextGraphId: string,
+    agentAddress: string | undefined,
+    peerId: string,
+  ): Promise<boolean> {
+    if (!agentAddress) return false;
     const byAgent = await this.getContextGraphAllowedDelegateePeers(contextGraphId);
-    for (const peers of byAgent.values()) {
-      if (peers.includes(peerId)) return true;
-    }
-    return false;
+    return byAgent.get(agentAddress.toLowerCase())?.includes(peerId) ?? false;
   }
 }

--- a/packages/agent/src/dkg-agent-shared-model.ts
+++ b/packages/agent/src/dkg-agent-shared-model.ts
@@ -39,6 +39,15 @@ export interface InvokeOpts {
   temperature?: number;
 }
 
+/**
+ * Fallback transport budget (ms) for the remote invoke when this node has no
+ * shared-model runtime config (a pure member node never calls
+ * `configureSharedModel`, so STATE is unset there). Matches the daemon's
+ * `invokeTimeoutMs` default and comfortably exceeds real LLM latency, unlike
+ * the router default (`DEFAULT_SEND_TIMEOUT_MS`, 20s).
+ */
+const DEFAULT_INVOKE_TIMEOUT_MS = 120_000;
+
 export class SharedModelMethods {
   /**
    * Attach/replace this node's shared-model runtime config. Called by the
@@ -134,6 +143,7 @@ export class SharedModelMethods {
       const completion = await st!.client.complete(st!.config, req.messages, {
         maxTokens: req.maxTokens,
         temperature: req.temperature,
+        providerTimeoutMs: st!.config.providerTimeoutMs,
       });
       return encodeInvokeResponse({ ok: true, content: completion.content, model: completion.model });
     } catch (err) {
@@ -166,7 +176,10 @@ export class SharedModelMethods {
       });
       if (!decision.ok) return { ok: false, denied: decision.denied };
       try {
-        const completion = await st!.client.complete(st!.config, messages, opts);
+        const completion = await st!.client.complete(st!.config, messages, {
+          ...opts,
+          providerTimeoutMs: st!.config.providerTimeoutMs,
+        });
         return { ok: true, content: completion.content, model: completion.model };
       } catch (err) {
         return { ok: false, denied: `provider error: ${err instanceof Error ? err.message : String(err)}` };
@@ -177,7 +190,13 @@ export class SharedModelMethods {
     const peerId = await this.resolveCuratorPeerId(contextGraphId);
     if (!peerId) return { ok: false, denied: 'could not resolve curator peer for this context graph' };
     const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature });
-    const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SHARED_MODEL_INVOKE, reqBytes);
+    // The whole remote round trip (resolver + dial + write + LLM completion +
+    // read) must fit the transport budget. The router default (20s) is shorter
+    // than real LLM latency and would surface a false "node unreachable" on a
+    // normal completion, so use the configured invoke timeout (member nodes
+    // without shared-model config fall back to the matching default).
+    const invokeTimeoutMs = STATE.get(this)?.config.invokeTimeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+    const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SHARED_MODEL_INVOKE, reqBytes, { timeoutMs: invokeTimeoutMs });
     if (!sendResult.delivered) {
       const reason = 'error' in sendResult ? sendResult.error : 'undelivered';
       return { ok: false, denied: `curator node unreachable: ${reason}` };
@@ -198,27 +217,26 @@ export class SharedModelMethods {
   }
 
   /**
-   * Membership for the remote path is verified by the delegatee-peer binding
-   * established at invite/join time (DKG `allowedDelegateePeer` /
-   * `delegationDelegateePeer` in `_meta`). The libp2p `fromPeerId` is
-   * cryptographically authenticated by the transport, so matching it against
-   * the recorded delegatee peer authorises the request without a separate
-   * signature.
+   * Membership for the remote path is verified against the set of APPROVED,
+   * UNEXPIRED delegatee peers for the CG — exactly the set used by the sync
+   * auth path. We reuse the canonical {@link getContextGraphAllowedDelegateePeers}
+   * helper (WorkspaceCryptoMethods mixin) so the gate reads ONLY the
+   * curator-approved `allowedDelegateePeer` bindings and never the
+   * self-asserted, pre-approval `delegationDelegateePeer` value written at
+   * join-request time. A pending, rejected, or removed peer is therefore
+   * correctly denied (a removed peer's `did:dkg:agent-delegation:*` subject is
+   * deleted by `removeAgentFromContextGraph`, so it drops out of this set).
+   *
+   * The libp2p `fromPeerId` is cryptographically authenticated by the
+   * transport, so matching it against an approved delegatee peer authorises
+   * the request without a separate signature.
    */
   private async isPeerContextGraphMember(this: DKGAgent, contextGraphId: string, peerId: string): Promise<boolean> {
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${metaGraph}> {
-        { ?s <https://dkg.network/ontology#allowedDelegateePeer> ?peer }
-        UNION
-        { ?s <https://dkg.network/ontology#delegationDelegateePeer> ?peer }
-      } }`,
-    );
-    if (result.type === 'bindings') {
-      for (const row of result.bindings as Array<Record<string, string>>) {
-        const p = (row['peer'] ?? '').replace(/^"|"$/g, '');
-        if (p === peerId) return true;
-      }
+    // Map<agentLower, peerId[]> — flatten to the union of all approved peers;
+    // any approved delegatee node may invoke on the model the curator bills.
+    const byAgent = await this.getContextGraphAllowedDelegateePeers(contextGraphId);
+    for (const peers of byAgent.values()) {
+      if (peers.includes(peerId)) return true;
     }
     return false;
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -387,6 +387,7 @@ import { LifecycleSyncMethods } from './dkg-agent-lifecycle.js';
 import { PublishMethods } from './dkg-agent-publish.js';
 import { SwmHostModeMethods } from './dkg-agent-swm-host.js';
 import { ContextGraphMethods } from './dkg-agent-context-graph.js';
+import { SharedModelMethods } from './dkg-agent-shared-model.js';
 // Public surface re-exported so external consumers that import directly
 // from `./dkg-agent.js` keep working. The new file `dkg-agent-types.ts`
 // is the canonical home; `packages/agent/src/index.ts` re-exports from
@@ -2119,5 +2120,5 @@ export class DKGAgent extends DKGAgentBase {
 }
 
 
-export interface DKGAgent extends ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods {}
-applyMixins(DKGAgent, [ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods]);
+export interface DKGAgent extends ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, SharedModelMethods {}
+applyMixins(DKGAgent, [ContextGraphMethods, SwmHostModeMethods, PublishMethods, LifecycleSyncMethods, WorkspaceCryptoMethods, AgentRegistryMethods, QueryMethods, SwmSubstrateMethods, JoinRequestMethods, ContextGraphRegistryMethods, EndorseVerifyMethods, CclPolicyMethods, ContextGraphResolveMethods, OwnershipMethods, SharedModelMethods]);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,12 @@
 export { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
+export {
+  type SharedModelMessage,
+  type SharedModelRole,
+  type SharedModelInvokeRequest,
+  type SharedModelInvokeResponse,
+  type SharedModelGrant,
+  type SharedModelRuntimeConfig,
+} from './shared-model/types.js';
 export { loadOpWallets, generateWallets, type OpWalletsConfig, type WalletEntry } from './op-wallets.js';
 export {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,6 +7,13 @@ export {
   type SharedModelGrant,
   type SharedModelRuntimeConfig,
 } from './shared-model/types.js';
+export {
+  openAiMessagesToShared,
+  buildOpenAIChatCompletion,
+  openAiErrorBody,
+  type OpenAIChatRequest,
+  type OpenAIChatMessage,
+} from './shared-model/openai.js';
 export { loadOpWallets, generateWallets, type OpWalletsConfig, type WalletEntry } from './op-wallets.js';
 export {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,

--- a/packages/agent/src/shared-model/README.md
+++ b/packages/agent/src/shared-model/README.md
@@ -1,0 +1,143 @@
+# Shared curator AI-model access (MVP)
+
+Let a **context-graph (CG) curator** optionally share access to the AI model
+they already run — in the **same flow as inviting an agent to the CG's shared
+working memory**. Members send prompts to the curator's model over the DKG P2P
+substrate and get completions back. **The curator's API key never leaves the
+curator's node.**
+
+This is an additive MVP on top of `v10.0.0-rc.17`. Default behaviour is
+unchanged: nothing is shared unless a curator explicitly turns it on per CG.
+
+---
+
+## How it works
+
+```
+ member node                         curator node
+ ───────────                         ────────────
+ invokeContextGraphModel()           handleSharedModelInvoke()
+   │  POST /api/context-graph/:id/model/invoke
+   │  { messages }
+   ▼
+ P2P  ──/dkg/10.0.2/shared-model-invoke──▶  1. decode request
+                                            2. grant enabled for CG?      (_meta)
+                                            3. is fromPeer a CG member?   (_meta delegatee peer)
+                                            4. under daily quota?
+                                            5. prompt within size cap?
+                                            6. call curator's LLM (config.llm / sharedModel)
+   ◀───────── { ok, content, model } ──────┘   (API key stays here)
+```
+
+- **Membership = the invite you already sent.** Authorization reuses the
+  delegatee-peer binding written to the CG `_meta` graph at invite/join time
+  (`allowedDelegateePeer` / `delegationDelegateePeer`). No new identity system.
+- **The grant lives in `_meta`** as two triples
+  (`sharedModelEnabled`, `sharedModelId`) — they sync to members the same way
+  the rest of `_meta` does, so an invitee discovers the shared model right
+  after joining. (Predicates are defined locally, **not** added to the genesis
+  ontology, so the network/genesis hash is untouched.)
+- **The model is the one the curator already configures** for the node-UI
+  chatbot (`config.llm`); `config.sharedModel` can override/scope it. A `mock`
+  provider is built in for offline testing.
+
+## Roles
+
+| Actor | Can do |
+|---|---|
+| **Curator** | `setContextGraphModelSharing(cg, true)`; invite members; their node serves invokes |
+| **Member** | `invokeContextGraphModel(cg, messages)` → completion, subject to quota |
+| **Non-member** | denied (`requester is not a member of this context graph`) |
+
+## Configuration (`~/.dkg/config.json`)
+
+```jsonc
+{
+  // the model the curator already uses (existing field)
+  "llm": { "apiKey": "sk-…", "model": "gpt-4o-mini", "baseURL": "https://api.openai.com/v1" },
+
+  // opt into sharing it with CG members (new, optional)
+  "sharedModel": {
+    "enabled": true,
+    "provider": "openai-compatible",   // or "mock" for offline tests
+    "model": "gpt-4o-mini",            // defaults to llm.model
+    "baseUrl": "https://api.openai.com/v1", // defaults to llm.baseURL
+    "apiKeyEnv": "DKG_SHARED_MODEL_API_KEY", // defaults to reusing llm.apiKey
+    "dailyRequestQuotaPerAgent": 200,
+    "maxPromptChars": 8000
+  }
+}
+```
+
+`enabled: false` (or omitting `sharedModel`) keeps the node a non-sharer; every
+invoke is denied with a clear reason.
+
+## HTTP API
+
+| Method & path | Body | Purpose |
+|---|---|---|
+| `POST /api/context-graph/:id/invite-with-model` | `{ agentAddress, shareModel?, modelId? }` | **Same-journey**: invite a member and (optionally) share the model in one call |
+| `POST /api/context-graph/:id/model/share` | `{ enabled, modelId? }` | Curator toggles sharing for a CG |
+| `GET  /api/context-graph/:id/model/grant` | — | Read the grant `{ enabled, modelId }` |
+| `POST /api/context-graph/:id/model/invoke` | `{ messages, maxTokens?, temperature? }` | Member invokes the curator's model |
+
+`messages` is the OpenAI shape: `[{ "role": "user", "content": "…" }]`.
+
+## P2P protocol
+
+`/dkg/10.0.2/shared-model-invoke` — request/response over the reliable
+messenger substrate. Request `{ contextGraphId, messages, maxTokens?,
+temperature? }`, response `{ ok, denied?, content?, model? }`. JSON-over-bytes
+(`shared-model/wire.ts`).
+
+## Security model (MVP)
+
+- **Key isolation** — the API key stays on the curator's node; members only
+  ever send prompts and receive completions.
+- **Membership-gated** — only CG members (by authenticated libp2p peer matched
+  to the `_meta` delegatee-peer binding) can invoke.
+- **Abuse-bounded** — per-member daily request quota + prompt size cap, both
+  configurable.
+- **Curator-controlled** — sharing is per-CG, opt-in, and revocable
+  (`setContextGraphModelSharing(cg, false)`).
+
+### Known limitations (MVP)
+
+- Membership on the remote path is verified by the delegatee-peer binding the
+  join flow writes; CGs that allow members without that binding aren't covered
+  (the curator-local path is unaffected).
+- Quotas/grant are node-local and in-memory (reset on restart) — no on-chain
+  accounting or payment. Monetization (x402 / PCA allowance) is a follow-up.
+- No streaming; single completion per request. No tool-calls forwarded.
+- Prompt/response content is end-to-end over the substrate but not separately
+  encrypted at rest by this feature.
+
+## Testing
+
+### Offline unit tests (no network, no API key)
+
+```bash
+pnpm --filter @origintrail-official/dkg-agent build
+pnpm --filter @origintrail-official/dkg-agent test -- shared-model
+```
+
+Covers the mock provider, the authorization gate, the daily quota, and the
+wire round-trip.
+
+### Local two-node end-to-end (devnet, mock provider)
+
+```bash
+./scripts/devnet.sh start 2          # node 1 (curator) + node 2 (member)
+# configure node 1 with sharedModel.provider = "mock", enabled = true
+# curator (node 1, port 9201):
+curl -s -XPOST localhost:9201/api/context-graph/create \
+  -d '{"id":"demo","name":"Demo","private":true}'
+curl -s -XPOST localhost:9201/api/context-graph/demo/invite-with-model \
+  -d '{"agentAddress":"<member-agent-address>","shareModel":true}'
+# member (node 2, port 9202):
+curl -s -XPOST localhost:9202/api/context-graph/demo/model/invoke \
+  -d '{"messages":[{"role":"user","content":"hello"}]}'
+# → { "ok": true, "content": "[shared-model:mock-model] hello", "model": "mock-model" }
+```
+
+Swap `provider: "mock"` for `"openai-compatible"` + a real key to use a live model.

--- a/packages/agent/src/shared-model/README.md
+++ b/packages/agent/src/shared-model/README.md
@@ -104,6 +104,26 @@ The endpoint maps the OpenAI request → `invokeContextGraphModel` (which routes
 P2P to the curator) → an OpenAI `chat.completion` response. Errors come back in
 OpenAI shape (`{ error: { message, type, code } }`). See `shared-model/openai.ts`.
 
+## Member-usage spectrum & roadmap
+
+How a member can *use* the curator's shared model, from simplest to most
+involved. This PR ships **#1 and #2**; **#3** follows once the feature is
+e2e-verified; **#4** is already covered by #2; **#5** is intentionally deferred
+and tracked here so it can be picked up later.
+
+| # | Member-usage model | Status | Notes |
+|---|---|---|---|
+| 1 | **Raw invoke** — `POST …/model/invoke` (native `{ messages }` shape) | ✅ Shipped | Lowest-level surface; what the P2P verb returns directly. |
+| 2 | **OpenAI-compatible endpoint** — `POST …/model/v1/chat/completions` | ✅ Shipped | Point any OpenAI client (hermes, Cursor, OpenAI SDK, node-UI chat) at the curator's model via `OPENAI_BASE_URL`. |
+| 3 | **Node-UI model picker** — select the curator's shared model in the UI | ⏳ Next | UI-only addition (curator model appears in the model dropdown for member CGs). Land after the cross-device e2e test passes. |
+| 4 | **Tool / skill** — member's agent calls the curator model as a tool | ✅ Via #2 | No separate surface needed: any agent that speaks OpenAI consumes #2 as its model/tool backend. Documented, not separately built. |
+| 5 | **Metered / paid** — usage accounting → payment | 🔜 Deferred | Needs a real settlement mechanism (x402 reserved-not-built; PCA is publish-only). Today's quota is node-local & in-memory only. **Pick up here next.** See "Known limitations". |
+
+> **#5 (metering/payment) is out of scope for this PR by design.** It requires a
+> new mechanism beyond the MVP's in-memory per-member quota — e.g. an x402
+> payment channel or a PCA allowance — and should be its own RFC + PR. This is
+> the explicit hand-off note so the work isn't lost.
+
 ## P2P protocol
 
 `/dkg/10.0.2/shared-model-invoke` — request/response over the reliable
@@ -132,6 +152,12 @@ temperature? }`, response `{ ok, denied?, content?, model? }`. JSON-over-bytes
 - No streaming; single completion per request. No tool-calls forwarded.
 - Prompt/response content is end-to-end over the substrate but not separately
   encrypted at rest by this feature.
+- **Cross-NAT first-sync of the grant** depends on the upstream curated-CG
+  `_meta` sync (the grant triples ride along with it). A NAT'd member that
+  idles out before approval — or whose post-approval sync stream resets over a
+  public relay — won't see the grant until it reconnects over a stable link;
+  there is no periodic re-pull. See "Cross-device test findings" for the
+  reliable procedure and two upstream `_meta`-sync issues this surfaced.
 
 ## Testing
 
@@ -162,3 +188,59 @@ curl -s -XPOST localhost:9202/api/context-graph/demo/model/invoke \
 ```
 
 Swap `provider: "mock"` for `"openai-compatible"` + a real key to use a live model.
+
+## Cross-device test findings (live testnet)
+
+Validated end-to-end against a live testnet curator (CG `demo`, private,
+sharing on, `mock` provider):
+
+- **Unit** — `shared-model` suite (mock provider, authorize gate, daily quota,
+  wire round-trip, OpenAI request/response mapping): 10/10.
+- **Build** — `pnpm --filter @origintrail-official/dkg-agent build` green;
+  `build:runtime` produces a `dist-ui` that carries the curator share toggle.
+- **Live single-node** — curator-local `invoke` returns a completion.
+- **Live two-node (stable link)** — a *separate* member node (its own peer id +
+  agent) joins `demo`, the curator approves, the authenticated post-approval
+  `_meta` sync lands the grant on the first poll, and
+  `POST …/model/invoke` returns
+  `{"ok":true,"content":"[shared-model:mock-model] …","model":"mock-model"}`.
+  This exercises the full P2P path (resolve curator peer →
+  `/dkg/10.0.2/shared-model-invoke` → membership gate → model → completion).
+
+### Two upstream `_meta`-sync issues this surfaced (NOT introduced by this feature)
+
+The grant is just two triples in the curated CG's `_meta`; it can only reach a
+member through the existing curated-CG sync. Cross-NAT first-sync exposed:
+
+1. **Bootstrap auth deadlock.** Building an *authenticated* private meta-sync
+   request needs the curator's peer id as `targetPeerId`, which a member
+   resolves from its **local `_meta`** — the very thing it is trying to fetch.
+   Only the `join-approved`-triggered `runImmediatePostApprovalSync` breaks the
+   cycle, because it is *handed* the curator peer id by the inbound
+   notification. Background- and `subscribe`-driven catchup cannot, so they
+   send an unauthenticated request that a private CG rejects (`phase=meta`,
+   `request-authorize.ts`).
+2. **`synced`-flag poison.** `POST /api/context-graph/:id/subscribe` marks the
+   CG `synced:true` even when `_meta` was denied; `buildSyncRequest`
+   (`dkg-agent-cg-resolve.ts`) then derives `needsAuth` from **`synced`**, not
+   `metaSynced`, so every later meta-sync — including the authenticated
+   post-approval one — is sent *unauthenticated* and permanently denied.
+   `subscribedContextGraphs` is in-memory, so it clears on restart.
+   *Suggested upstream fix:* gate `needsAuth` on `metaSynced` for private CGs,
+   and/or don't set `synced` until `_meta` actually lands.
+
+A third, related sharp edge: a re-fired `already-member` `join-approved` is
+dropped by the requester's trusted-sender guard after a restart (no local
+`_meta` curator triple, no in-memory pending-request record), so re-joining an
+*existing* membership does not re-trigger the sync — a **fresh, genuine**
+`pending` join does.
+
+### Reliable procedure for a NAT'd member (until the above are fixed upstream)
+
+1. Establish a **stable** connection to the curator (a direct address, or a
+   relay connection that DCUtR-upgrades to direct).
+2. Submit a **genuine** join request (a member that is not yet on the allowlist
+   → status `pending`, not `already-member`); have the curator approve it.
+3. **Do not** call `/subscribe` before the grant lands — that poisons the
+   `synced` flag and wedges the member out (restart to recover).
+4. Poll `GET …/model/grant` until `enabled:true`, then `invoke`.

--- a/packages/agent/src/shared-model/README.md
+++ b/packages/agent/src/shared-model/README.md
@@ -79,9 +79,30 @@ invoke is denied with a clear reason.
 | `POST /api/context-graph/:id/invite-with-model` | `{ agentAddress, shareModel?, modelId? }` | **Same-journey**: invite a member and (optionally) share the model in one call |
 | `POST /api/context-graph/:id/model/share` | `{ enabled, modelId? }` | Curator toggles sharing for a CG |
 | `GET  /api/context-graph/:id/model/grant` | — | Read the grant `{ enabled, modelId }` |
-| `POST /api/context-graph/:id/model/invoke` | `{ messages, maxTokens?, temperature? }` | Member invokes the curator's model |
+| `POST /api/context-graph/:id/model/invoke` | `{ messages, maxTokens?, temperature? }` | Member invokes the curator's model (native shape) |
+| `POST /api/context-graph/:id/model/v1/chat/completions` | OpenAI `{ model?, messages, max_tokens?, temperature? }` | **OpenAI-compatible** member usage (see below) |
 
 `messages` is the OpenAI shape: `[{ "role": "user", "content": "…" }]`.
+
+## Member usage — point any OpenAI client at the curator's model
+
+The `…/model/v1/chat/completions` endpoint makes the curator's shared model
+usable by **any OpenAI-compatible client**, so a member's agent transparently
+runs *on* the curator's model (membership- and quota-gated, same as `/invoke`).
+A member sets, against **their own node**:
+
+```
+OPENAI_BASE_URL = http://127.0.0.1:9200/api/context-graph/<cg-id>/model/v1
+OPENAI_API_KEY  = <the member node's auth token>   # ~/.dkg/auth.token
+```
+
+- **hermes**: set those in the hermes gateway's env/config — the member's hermes
+  agent now reasons on the curator's model.
+- **node-UI / Cursor / OpenAI SDK**: same two values.
+
+The endpoint maps the OpenAI request → `invokeContextGraphModel` (which routes
+P2P to the curator) → an OpenAI `chat.completion` response. Errors come back in
+OpenAI shape (`{ error: { message, type, code } }`). See `shared-model/openai.ts`.
 
 ## P2P protocol
 

--- a/packages/agent/src/shared-model/authorize.ts
+++ b/packages/agent/src/shared-model/authorize.ts
@@ -1,0 +1,34 @@
+import type { SharedModelInvokeResponse } from './types.js';
+
+export interface AuthorizationInputs {
+  /** Per-CG grant is enabled in `_meta`. */
+  enabled: boolean;
+  /** This node has a usable provider AND the master switch is on. */
+  providerConfigured: boolean;
+  /** Requester is a member of the CG. */
+  isMember: boolean;
+  /** Requester is under their daily quota. */
+  quotaOk: boolean;
+  /** Prompt is within the curator's size cap. */
+  promptOk: boolean;
+}
+
+/**
+ * Pure authorization decision, shared by the live P2P handler and the unit
+ * tests. Order is deliberate: configuration/grant problems first (so an
+ * operator sees a clear reason), then membership, then abuse limits.
+ */
+export function decideSharedModelAuthorization(
+  i: AuthorizationInputs,
+): { ok: true } | { ok: false; denied: string } {
+  if (!i.providerConfigured) return { ok: false, denied: 'curator node has no shared model configured' };
+  if (!i.enabled) return { ok: false, denied: 'model sharing is not enabled for this context graph' };
+  if (!i.isMember) return { ok: false, denied: 'requester is not a member of this context graph' };
+  if (!i.promptOk) return { ok: false, denied: 'prompt exceeds the curator size limit' };
+  if (!i.quotaOk) return { ok: false, denied: 'daily request quota exceeded for this member' };
+  return { ok: true };
+}
+
+export function deniedResponse(reason: string): SharedModelInvokeResponse {
+  return { ok: false, denied: reason };
+}

--- a/packages/agent/src/shared-model/client.ts
+++ b/packages/agent/src/shared-model/client.ts
@@ -8,6 +8,13 @@ export interface SharedModelCompletion {
 export interface SharedModelCompleteOpts {
   maxTokens?: number;
   temperature?: number;
+  /**
+   * Curator-side deadline (ms) for the upstream provider `fetch`. When the
+   * request exceeds this, the call rejects with a clear `provider timeout
+   * after <n>ms` Error so the curator returns a structured denial before the
+   * member's transport aborts the round trip. Unset = no deadline.
+   */
+  providerTimeoutMs?: number;
 }
 
 /**
@@ -44,14 +51,25 @@ export class SharedModelClient {
     if (opts.maxTokens != null) body.max_tokens = opts.maxTokens;
     if (opts.temperature != null) body.temperature = opts.temperature;
 
-    const resp = await fetch(`${baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
-      },
-      body: JSON.stringify(body),
-    });
+    let resp: Response;
+    try {
+      resp = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+        },
+        body: JSON.stringify(body),
+        ...(opts.providerTimeoutMs != null ? { signal: AbortSignal.timeout(opts.providerTimeoutMs) } : {}),
+      });
+    } catch (err) {
+      // AbortSignal.timeout(...) aborts with a TimeoutError; surface it as a
+      // clear, deterministic message the caller's catch can relay.
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new Error(`provider timeout after ${opts.providerTimeoutMs}ms`);
+      }
+      throw err;
+    }
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
       throw new Error(`shared-model provider error: ${resp.status} ${resp.statusText} ${text.slice(0, 200)}`);

--- a/packages/agent/src/shared-model/client.ts
+++ b/packages/agent/src/shared-model/client.ts
@@ -1,0 +1,63 @@
+import type { SharedModelMessage, SharedModelProviderConfig } from './types.js';
+
+export interface SharedModelCompletion {
+  content: string;
+  model: string;
+}
+
+export interface SharedModelCompleteOpts {
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/**
+ * Minimal chat-completions client. Mirrors the house `fetch` style in
+ * `packages/cli/src/vector-store.ts`. Two providers:
+ *   - 'mock'              — deterministic, offline, no key (local testing)
+ *   - 'openai-compatible' — POST {baseUrl}/chat/completions, Bearer apiKey
+ *                           (works with OpenAI, OpenRouter, Together, vLLM, …)
+ */
+export class SharedModelClient {
+  async complete(
+    config: SharedModelProviderConfig,
+    messages: SharedModelMessage[],
+    opts: SharedModelCompleteOpts = {},
+  ): Promise<SharedModelCompletion> {
+    if (config.provider === 'mock') return this.mockComplete(config, messages);
+    return this.openAiCompatibleComplete(config, messages, opts);
+  }
+
+  private mockComplete(config: SharedModelProviderConfig, messages: SharedModelMessage[]): SharedModelCompletion {
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+    const echo = (lastUser?.content ?? '').slice(0, 400);
+    const model = config.model || 'mock-model';
+    return { model, content: `[shared-model:${model}] ${echo}`.trim() };
+  }
+
+  private async openAiCompatibleComplete(
+    config: SharedModelProviderConfig,
+    messages: SharedModelMessage[],
+    opts: SharedModelCompleteOpts,
+  ): Promise<SharedModelCompletion> {
+    const baseUrl = (config.baseUrl ?? 'https://api.openai.com/v1').replace(/\/$/, '');
+    const body: Record<string, unknown> = { model: config.model || 'gpt-4o-mini', messages };
+    if (opts.maxTokens != null) body.max_tokens = opts.maxTokens;
+    if (opts.temperature != null) body.temperature = opts.temperature;
+
+    const resp = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      throw new Error(`shared-model provider error: ${resp.status} ${resp.statusText} ${text.slice(0, 200)}`);
+    }
+    const json = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }>; model?: string };
+    const content = json.choices?.[0]?.message?.content ?? '';
+    return { model: json.model ?? (config.model || 'unknown'), content };
+  }
+}

--- a/packages/agent/src/shared-model/openai.ts
+++ b/packages/agent/src/shared-model/openai.ts
@@ -1,0 +1,76 @@
+/**
+ * OpenAI-compatible mapping for the shared curator model.
+ *
+ * Lets a member point any OpenAI-compatible client (the hermes gateway, a
+ * node-UI chat, Cursor, the OpenAI SDK, …) at
+ *   POST /api/context-graph/:id/model/v1/chat/completions
+ * so the member's agent transparently runs ON the curator's shared model,
+ * gated by membership + quota. Pure functions so they're unit-testable and
+ * keep the daemon route thin.
+ */
+
+import type { SharedModelMessage, SharedModelRole } from './types.js';
+
+export interface OpenAIChatMessage {
+  role: string;
+  content: string;
+}
+
+export interface OpenAIChatRequest {
+  model?: string;
+  messages: OpenAIChatMessage[];
+  max_tokens?: number;
+  temperature?: number;
+}
+
+const SHARED_ROLES: SharedModelRole[] = ['system', 'user', 'assistant'];
+
+/**
+ * Map an OpenAI `messages[]` array to the shared-model message shape.
+ * Unsupported roles (e.g. `tool`, `function`) are coerced to `user` — they're
+ * inputs to the model from the caller's perspective. Non-string content is
+ * dropped.
+ */
+export function openAiMessagesToShared(messages: unknown): SharedModelMessage[] {
+  if (!Array.isArray(messages)) return [];
+  const out: SharedModelMessage[] = [];
+  for (const m of messages) {
+    const mm = m as Partial<OpenAIChatMessage>;
+    if (!mm || typeof mm.content !== 'string') continue;
+    const role: SharedModelRole = SHARED_ROLES.includes(mm.role as SharedModelRole)
+      ? (mm.role as SharedModelRole)
+      : 'user';
+    out.push({ role, content: mm.content });
+  }
+  return out;
+}
+
+/** Build an OpenAI `chat.completion` response envelope around a single completion. */
+export function buildOpenAIChatCompletion(opts: {
+  contextGraphId: string;
+  content: string;
+  model: string;
+  createdSec: number;
+}): Record<string, unknown> {
+  return {
+    id: `chatcmpl-dkg-${opts.contextGraphId.slice(0, 24)}`,
+    object: 'chat.completion',
+    created: opts.createdSec,
+    model: opts.model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: opts.content },
+        finish_reason: 'stop',
+      },
+    ],
+    // Token accounting isn't available from the mock/upstream call yet; report
+    // zeros so OpenAI clients that read `usage` don't choke. (Follow-up.)
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
+/** OpenAI-shaped error body (`{ error: { message, type, code } }`). */
+export function openAiErrorBody(message: string, code = 'shared_model_denied'): Record<string, unknown> {
+  return { error: { message, type: 'invalid_request_error', code } };
+}

--- a/packages/agent/src/shared-model/quota.ts
+++ b/packages/agent/src/shared-model/quota.ts
@@ -1,0 +1,34 @@
+/** Per-member daily request counter (UTC-day buckets, in-memory). */
+export class DailyQuota {
+  private readonly maxPerDay: number;
+  private readonly now: () => number;
+  private day = '';
+  private counts = new Map<string, number>();
+
+  constructor(maxPerDay: number, now: () => number = () => Date.now()) {
+    this.maxPerDay = Math.max(0, maxPerDay);
+    this.now = now;
+  }
+
+  private rollover(): void {
+    const d = new Date(this.now()).toISOString().slice(0, 10);
+    if (d !== this.day) {
+      this.day = d;
+      this.counts.clear();
+    }
+  }
+
+  /** Returns true and records the hit if under cap; false if over. */
+  allow(key: string): boolean {
+    this.rollover();
+    const used = this.counts.get(key) ?? 0;
+    if (used >= this.maxPerDay) return false;
+    this.counts.set(key, used + 1);
+    return true;
+  }
+
+  remaining(key: string): number {
+    this.rollover();
+    return Math.max(0, this.maxPerDay - (this.counts.get(key) ?? 0));
+  }
+}

--- a/packages/agent/src/shared-model/types.ts
+++ b/packages/agent/src/shared-model/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared curator AI-model access for context graphs (MVP).
+ *
+ * A context-graph (CG) curator can, in the SAME flow as inviting an agent to
+ * the CG's shared working memory, optionally let members invoke the AI model
+ * the curator already configures for their node (`config.llm`). The curator's
+ * API key NEVER leaves the curator's node — members send prompts over the
+ * `/dkg/10.0.2/shared-model-invoke` P2P protocol and receive completions back,
+ * gated by CG membership + a per-member daily quota.
+ */
+
+export type SharedModelRole = 'system' | 'user' | 'assistant';
+
+export interface SharedModelMessage {
+  role: SharedModelRole;
+  content: string;
+}
+
+/** Provider credentials/config — lives only on the curator's node. */
+export interface SharedModelProviderConfig {
+  /** 'mock' needs no network/key and is used for local testing. */
+  provider: 'mock' | 'openai-compatible';
+  model: string;
+  baseUrl?: string;
+  apiKey?: string;
+}
+
+/** Runtime config attached to a DKGAgent via configureSharedModel(). */
+export interface SharedModelRuntimeConfig extends SharedModelProviderConfig {
+  /** Master switch — does this node offer model sharing at all. */
+  enabled: boolean;
+  /** Per-member daily request cap (abuse bound). */
+  dailyRequestQuotaPerAgent: number;
+  /** Hard cap on total prompt size accepted from a member (chars). */
+  maxPromptChars: number;
+}
+
+export interface SharedModelInvokeRequest {
+  contextGraphId: string;
+  messages: SharedModelMessage[];
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface SharedModelInvokeResponse {
+  ok: boolean;
+  denied?: string;
+  content?: string;
+  model?: string;
+}
+
+/** Per-CG grant state, stored in the CG `_meta` subgraph. */
+export interface SharedModelGrant {
+  enabled: boolean;
+  /** Advertised model id (NOT the API key). */
+  modelId?: string;
+}
+
+/**
+ * Predicates are intentionally defined LOCALLY (not added to the genesis
+ * `DKG_ONTOLOGY`) so this MVP does not alter the genesis-hash / networkId.
+ */
+export const SHARED_MODEL_PREDICATES = {
+  ENABLED: 'https://dkg.network/ontology#sharedModelEnabled',
+  MODEL_ID: 'https://dkg.network/ontology#sharedModelId',
+} as const;
+
+const SAFE_MODEL_ID = /^[A-Za-z0-9._:/-]{1,128}$/;
+
+/** Reject anything that is not a plain, safe model identifier. */
+export function sanitizeModelId(id: string | undefined): string | undefined {
+  if (!id) return undefined;
+  return SAFE_MODEL_ID.test(id) ? id : undefined;
+}

--- a/packages/agent/src/shared-model/types.ts
+++ b/packages/agent/src/shared-model/types.ts
@@ -33,6 +33,19 @@ export interface SharedModelRuntimeConfig extends SharedModelProviderConfig {
   dailyRequestQuotaPerAgent: number;
   /** Hard cap on total prompt size accepted from a member (chars). */
   maxPromptChars: number;
+  /**
+   * Member-side transport budget (ms) for the WHOLE remote invoke round
+   * trip (`sendReliable`). Must comfortably exceed real LLM latency, which
+   * the router default ({@link DEFAULT_SEND_TIMEOUT_MS}, 20s) does not.
+   */
+  invokeTimeoutMs: number;
+  /**
+   * Curator-side provider deadline (ms) applied to the upstream LLM
+   * `fetch`. Kept slightly TIGHTER than `invokeTimeoutMs` so the curator
+   * returns a structured `{ok:false}` error before the member's transport
+   * aborts the round trip.
+   */
+  providerTimeoutMs: number;
 }
 
 export interface SharedModelInvokeRequest {

--- a/packages/agent/src/shared-model/types.ts
+++ b/packages/agent/src/shared-model/types.ts
@@ -53,6 +53,15 @@ export interface SharedModelInvokeRequest {
   messages: SharedModelMessage[];
   maxTokens?: number;
   temperature?: number;
+  /**
+   * The agent address the member's node claims to invoke ON BEHALF OF. This is
+   * an UNTRUSTED claim carried in the request body; the curator authorizes it
+   * only if the cryptographically-authenticated transport `fromPeerId` matches
+   * the delegatee peer THAT specific agent recorded with the curator (mirrors
+   * the sync auth path's `requesterAgentAddress` binding). A request that omits
+   * it is denied on the remote path — there is no union fallback.
+   */
+  agentAddress?: string;
 }
 
 export interface SharedModelInvokeResponse {

--- a/packages/agent/src/shared-model/wire.ts
+++ b/packages/agent/src/shared-model/wire.ts
@@ -25,11 +25,18 @@ export function decodeInvokeRequest(bytes: Uint8Array): SharedModelInvokeRequest
     }
     return { role: mm.role as SharedModelRole, content: mm.content };
   });
+  // `agentAddress` is OPTIONAL on the wire but, when present, must be a string;
+  // a non-string claim is a malformed request (reject rather than coerce, so a
+  // bogus type can never be silently dropped and then default to the union).
+  if (o.agentAddress !== undefined && typeof o.agentAddress !== 'string') {
+    throw new Error('invalid agentAddress in SharedModelInvokeRequest');
+  }
   return {
     contextGraphId: o.contextGraphId,
     messages,
     maxTokens: typeof o.maxTokens === 'number' ? o.maxTokens : undefined,
     temperature: typeof o.temperature === 'number' ? o.temperature : undefined,
+    agentAddress: o.agentAddress,
   };
 }
 

--- a/packages/agent/src/shared-model/wire.ts
+++ b/packages/agent/src/shared-model/wire.ts
@@ -1,0 +1,44 @@
+import type {
+  SharedModelInvokeRequest,
+  SharedModelInvokeResponse,
+  SharedModelMessage,
+  SharedModelRole,
+} from './types.js';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const ROLES: SharedModelRole[] = ['system', 'user', 'assistant'];
+
+export function encodeInvokeRequest(req: SharedModelInvokeRequest): Uint8Array {
+  return enc.encode(JSON.stringify(req));
+}
+
+export function decodeInvokeRequest(bytes: Uint8Array): SharedModelInvokeRequest {
+  const o = JSON.parse(dec.decode(bytes)) as Partial<SharedModelInvokeRequest>;
+  if (!o || typeof o.contextGraphId !== 'string' || !Array.isArray(o.messages)) {
+    throw new Error('invalid SharedModelInvokeRequest');
+  }
+  const messages: SharedModelMessage[] = o.messages.map((m) => {
+    const mm = m as Partial<SharedModelMessage>;
+    if (!mm || typeof mm.content !== 'string' || !ROLES.includes(mm.role as SharedModelRole)) {
+      throw new Error('invalid message in SharedModelInvokeRequest');
+    }
+    return { role: mm.role as SharedModelRole, content: mm.content };
+  });
+  return {
+    contextGraphId: o.contextGraphId,
+    messages,
+    maxTokens: typeof o.maxTokens === 'number' ? o.maxTokens : undefined,
+    temperature: typeof o.temperature === 'number' ? o.temperature : undefined,
+  };
+}
+
+export function encodeInvokeResponse(res: SharedModelInvokeResponse): Uint8Array {
+  return enc.encode(JSON.stringify(res));
+}
+
+export function decodeInvokeResponse(bytes: Uint8Array): SharedModelInvokeResponse {
+  const o = JSON.parse(dec.decode(bytes)) as Partial<SharedModelInvokeResponse>;
+  if (!o || typeof o.ok !== 'boolean') throw new Error('invalid SharedModelInvokeResponse');
+  return { ok: o.ok, denied: o.denied, content: o.content, model: o.model };
+}

--- a/packages/agent/test/shared-model/client-provider-timeout.test.ts
+++ b/packages/agent/test/shared-model/client-provider-timeout.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider-timeout path for the shared-model client (PR #1157 B2).
+ *
+ * Pins the curator-side deadline added in B2: when `providerTimeoutMs` is set,
+ * the upstream provider `fetch` is given `AbortSignal.timeout(...)`, and an
+ * abort is mapped to a deterministic `provider timeout after <n>ms` Error (so
+ * `handleSharedModelInvoke` returns a structured `{ok:false, denied:...}`
+ * instead of hanging the member's P2P round trip). Also pins that the abort
+ * signal is attached ONLY when a timeout is configured.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SharedModelClient } from '../../src/shared-model/client.js';
+import type { SharedModelProviderConfig } from '../../src/shared-model/types.js';
+
+const CFG: SharedModelProviderConfig = {
+  provider: 'openai-compatible',
+  model: 'gpt-test',
+  baseUrl: 'https://example.test/v1',
+  apiKey: 'sk-test',
+};
+const MSGS = [{ role: 'user' as const, content: 'hi' }];
+
+function okResponse(): Response {
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content: 'pong' } }], model: 'gpt-test' }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('shared-model provider timeout (B2)', () => {
+  it('throws "provider timeout after <n>ms" when the provider fetch is aborted by the deadline', async () => {
+    // A fetch that honours the AbortSignal: it never resolves on its own and
+    // rejects with the signal's reason (a DOMException 'TimeoutError') on abort,
+    // exactly as the platform fetch does. AbortSignal.timeout(10) fires the abort.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+          }),
+      ),
+    );
+    const client = new SharedModelClient();
+    await expect(client.complete(CFG, MSGS, { providerTimeoutMs: 10 })).rejects.toThrow(
+      'provider timeout after 10ms',
+    );
+  });
+
+  it('attaches an AbortSignal to fetch only when providerTimeoutMs is set', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new SharedModelClient();
+
+    const withTimeout = await client.complete(CFG, MSGS, { providerTimeoutMs: 1000 });
+    expect(withTimeout.content).toBe('pong');
+    expect((fetchMock.mock.calls[0][1] as { signal?: unknown }).signal).toBeInstanceOf(AbortSignal);
+
+    fetchMock.mockClear();
+    const noTimeout = await client.complete(CFG, MSGS, {});
+    expect(noTimeout.content).toBe('pong');
+    expect((fetchMock.mock.calls[0][1] as { signal?: unknown }).signal).toBeUndefined();
+  });
+});

--- a/packages/agent/test/shared-model/invoke-handler.test.ts
+++ b/packages/agent/test/shared-model/invoke-handler.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Curator-side P2P handler authorization + quota (PR #1158, #1 + #3).
+ *
+ * Drives the real `handleSharedModelInvoke` with a stubbed store + `mock`
+ * provider. Pins:
+ *   #1 — per-agent binding: a request is authorised iff the CLAIMED
+ *        `agentAddress` is an approved member AND the transport-authenticated
+ *        `fromPeerId` is among THAT agent's approved delegatee peers.
+ *   #3 — quota consumed only AFTER authorization: a request denied for
+ *        non-membership does not decrement the (fromPeerId-keyed) bucket.
+ */
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import { WorkspaceCryptoMethods } from '../../src/dkg-agent-crypto.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+import {
+  encodeInvokeRequest,
+  decodeInvokeRequest,
+  decodeInvokeResponse,
+} from '../../src/shared-model/wire.js';
+
+const AGENT_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa';
+const PEER_A = '12D3KooWPeerForAgentA';
+const PEER_X = '12D3KooWAttackerPeer';
+const SHARED_MODEL_ENABLED = 'https://dkg.network/ontology#sharedModelEnabled';
+
+interface HarnessOpts {
+  approved: Array<{ agent: string; peer: string }>;
+  grantEnabled?: boolean;
+  dailyQuota?: number;
+}
+
+function makeAgent(opts: HarnessOpts) {
+  const proto = SharedModelMethods.prototype;
+  const agent = {
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+    store: {
+      query: async (sparql: string) => {
+        if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+          return {
+            type: 'bindings',
+            bindings: opts.approved.map((b) => ({ agent: `"${b.agent}"`, peer: `"${b.peer}"` })),
+          };
+        }
+        if (sparql.includes(SHARED_MODEL_ENABLED)) {
+          return opts.grantEnabled === false
+            ? { type: 'bindings', bindings: [] }
+            : { type: 'bindings', bindings: [{ p: SHARED_MODEL_ENABLED, o: '"true"' }] };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    },
+    getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
+    getContextGraphModelGrant: proto.getContextGraphModelGrant,
+    isAgentPeerContextGraphMember: proto['isAgentPeerContextGraphMember'],
+    handleSharedModelInvoke: proto.handleSharedModelInvoke,
+    configureSharedModel: proto.configureSharedModel,
+  } as unknown as DKGAgent;
+
+  agent.configureSharedModel({
+    provider: 'mock',
+    model: 'mock-model',
+    enabled: true,
+    dailyRequestQuotaPerAgent: opts.dailyQuota ?? 5,
+    maxPromptChars: 10_000,
+    invokeTimeoutMs: 1000,
+    providerTimeoutMs: 800,
+  });
+  return agent;
+}
+
+async function invoke(agent: DKGAgent, body: { agentAddress?: string; cg?: string }, fromPeer: string) {
+  const bytes = encodeInvokeRequest({
+    contextGraphId: body.cg ?? 'cg1',
+    messages: [{ role: 'user', content: 'hi' }],
+    agentAddress: body.agentAddress,
+  });
+  const out = await agent.handleSharedModelInvoke(bytes, fromPeer);
+  return decodeInvokeResponse(out);
+}
+
+describe('shared-model curator handler per-agent binding (#1)', () => {
+  it('ALLOWS the approved agent from its bound peer', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(res.ok).toBe(true);
+  });
+
+  it('DENIES the approved agent claimed from a different peer (impersonation)', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, { agentAddress: AGENT_A }, PEER_X);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('DENIES a missing agentAddress claim', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, {}, PEER_A);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+});
+
+describe('shared-model curator handler quota accounting (#3)', () => {
+  it('does NOT consume quota on a non-membership denial', async () => {
+    // Quota of 1 keyed by fromPeerId. An unauthorized claim from PEER_A must
+    // not burn PEER_A's bucket, so a subsequent AUTHORIZED call still succeeds.
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }], dailyQuota: 1 });
+    // Denied: wrong agent claim from PEER_A.
+    const denied = await invoke(agent, { agentAddress: '0xNotApproved' }, PEER_A);
+    expect(denied.ok).toBe(false);
+    // Authorized from the SAME peer still has its full quota of 1.
+    const ok = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(ok.ok).toBe(true);
+  });
+
+  it('an authorized request consumes exactly one (quota of 1 → second over cap)', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }], dailyQuota: 1 });
+    expect((await invoke(agent, { agentAddress: AGENT_A }, PEER_A)).ok).toBe(true);
+    const second = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(second.ok).toBe(false);
+    expect(second.denied).toMatch(/quota/i);
+  });
+});
+
+describe('shared-model wire agentAddress round-trip (#1)', () => {
+  it('encodes/decodes agentAddress when present', () => {
+    const req = {
+      contextGraphId: 'cg1',
+      messages: [{ role: 'user' as const, content: 'hi' }],
+      agentAddress: AGENT_A,
+    };
+    expect(decodeInvokeRequest(encodeInvokeRequest(req))).toEqual({
+      contextGraphId: 'cg1',
+      messages: req.messages,
+      maxTokens: undefined,
+      temperature: undefined,
+      agentAddress: AGENT_A,
+    });
+  });
+
+  it('rejects a non-string agentAddress', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ contextGraphId: 'cg1', messages: [{ role: 'user', content: 'hi' }], agentAddress: 5 }),
+    );
+    expect(() => decodeInvokeRequest(bytes)).toThrow(/agentAddress/);
+  });
+});

--- a/packages/agent/test/shared-model/local-path.test.ts
+++ b/packages/agent/test/shared-model/local-path.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Local fast-path caller authorization + quota accounting (PR #1158, #2 + #3).
+ *
+ * When the CG is curated ON this node, `invokeContextGraphModel` takes a local
+ * fast-path (no network hop). This pins:
+ *
+ *   #2 — the caller is authorised ONLY if it IS the CG owner/curator OR an
+ *        approved member; a different local agent that is neither is DENIED
+ *        (and must NOT fall through to the remote path, which would dial self).
+ *        The previous code hardcoded `isMember:true`, authorising anyone.
+ *
+ *   #3 — quota is consumed exactly once, and ONLY after authorization. A
+ *        request denied for any other reason (here: non-membership) must not
+ *        decrement the member's daily allowance.
+ *
+ * Harness: a real `SharedModelMethods` instance (so the module-private STATE
+ * WeakMap is populated by the real `configureSharedModel`) with a stubbed store
+ * and a `mock` provider (deterministic, offline). The owner/grant/allowed-agent
+ * lookups are stubbed to isolate the auth + quota logic.
+ */
+import { describe, it, expect } from 'vitest';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import { OwnershipMethods } from '../../src/dkg-agent-ownership.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+import type { SharedModelGrant } from '../../src/shared-model/types.js';
+
+const PEER_ID = '12D3KooWLocalCurator';
+const OWNER = '0xC0FFEE0000000000000000000000000000000001';
+const MEMBER = '0xC0FFEE0000000000000000000000000000000002';
+const OUTSIDER = '0xC0FFEE0000000000000000000000000000000003'; // another local agent, not on this CG
+
+interface HarnessOpts {
+  owner: string;
+  defaultAgent?: string;
+  /** Override the stored owner DID (defaults to `did:dkg:agent:<owner>`). */
+  ownerDid?: string;
+  allowedAgents: string[];
+  grant?: SharedModelGrant;
+  dailyQuota?: number;
+  localAgents?: string[];
+}
+
+function makeAgent(opts: HarnessOpts) {
+  const grant: SharedModelGrant = opts.grant ?? { enabled: true, modelId: 'mock-model' };
+  const ownerDid = opts.ownerDid ?? `did:dkg:agent:${opts.owner}`;
+  const proto = SharedModelMethods.prototype;
+  const localAgents = new Map<string, unknown>();
+  for (const a of opts.localAgents ?? [opts.owner]) localAgents.set(a, {});
+
+  const agent = {
+    peerId: PEER_ID,
+    defaultAgentAddress: opts.defaultAgent ?? opts.owner,
+    localAgents,
+    getDefaultAgentAddress: () => opts.defaultAgent ?? opts.owner,
+    store: { query: async () => ({ type: 'bindings', bindings: [] }) },
+    // Stub the CG-state lookups the local path consults.
+    getContextGraphOwner: async () => ownerDid,
+    getContextGraphModelGrant: async () => grant,
+    getContextGraphAllowedAgents: async () => opts.allowedAgents.slice(),
+    // Real methods under test (bound through the prototype).
+    isContextGraphCuratorSelf: proto['isContextGraphCuratorSelf'],
+    localCgOwnerDids: proto['localCgOwnerDids'],
+    isCallerLocalCgMember: proto['isCallerLocalCgMember'],
+    invokeContextGraphModel: proto.invokeContextGraphModel,
+    configureSharedModel: proto.configureSharedModel,
+    // Real canonical owner check (used by isCallerLocalCgMember).
+    isCallerOrNodeOwner: OwnershipMethods.prototype.isCallerOrNodeOwner,
+    // Remote path must never be reached in these tests.
+    resolveCuratorPeerId: async () => { throw new Error('remote path reached — should be local'); },
+  } as unknown as DKGAgent;
+
+  agent.configureSharedModel({
+    provider: 'mock',
+    model: 'mock-model',
+    enabled: true,
+    dailyRequestQuotaPerAgent: opts.dailyQuota ?? 5,
+    maxPromptChars: 10_000,
+    invokeTimeoutMs: 1000,
+    providerTimeoutMs: 800,
+  });
+  return agent;
+}
+
+const MSG = [{ role: 'user' as const, content: 'hello' }];
+
+describe('shared-model local fast-path authorization (#2)', () => {
+  it('ALLOWS the CG owner/curator', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(res.ok).toBe(true);
+    expect(res.content).toContain('hello');
+  });
+
+  it('ALLOWS an approved member (caller in the allowed-agent set)', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER, MEMBER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER);
+    expect(res.ok).toBe(true);
+  });
+
+  it('matches the allowlist case-insensitively', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [MEMBER.toLowerCase()] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER.toUpperCase());
+    expect(res.ok).toBe(true);
+  });
+
+  it('DENIES another local agent that is neither owner nor member (no fall-through to remote)', async () => {
+    // OUTSIDER is a local agent (so the local path applies) but is not the CG
+    // owner and not on its allowlist. Must be DENIED here, never dial self.
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, OUTSIDER],
+    });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('DENIES a node-level token with no caller agent address', async () => {
+    // No callerAgentAddress → cannot establish owner-or-member → denied.
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER, MEMBER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, undefined);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('ALLOWS the curator of a LEGACY peerId-owned CG (default agent caller)', async () => {
+    // Legacy CG whose owner DID is the peerId-based form. The curator invokes
+    // with their default-agent address (not in the allowlist). The canonical
+    // owner check honors `caller === defaultAgent && owner === peerDid`, so
+    // they must be ALLOWED — matching setContextGraphModelSharing's gate.
+    const agent = makeAgent({
+      owner: OWNER,
+      defaultAgent: OWNER,
+      ownerDid: `did:dkg:agent:${PEER_ID}`,
+      allowedAgents: [], // curator deliberately NOT in the allowlist
+      localAgents: [OWNER],
+    });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('shared-model local fast-path quota accounting (#3)', () => {
+  it('does NOT consume quota when the request is denied for non-membership', async () => {
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, OUTSIDER],
+      dailyQuota: 1,
+    });
+    // First call: outsider denied — must not burn the (shared selfKey) bucket.
+    const denied = await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER);
+    expect(denied.ok).toBe(false);
+    // The OUTSIDER's own bucket should be untouched: if it had been consumed by
+    // the denied call, a (hypothetical) authorized retry would already be over
+    // its quota of 1. We assert via the owner bucket below instead, which is
+    // the canonical "authorized request consumes exactly one" case.
+    const ok = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(ok.ok).toBe(true);
+  });
+
+  it('an authorized request consumes exactly one quota unit', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER], dailyQuota: 2 });
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER)).ok).toBe(true);
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER)).ok).toBe(true);
+    // Third exceeds the cap of 2.
+    const third = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(third.ok).toBe(false);
+    expect(third.denied).toMatch(/quota/i);
+  });
+
+  it('a non-member denial leaves the member bucket fully available', async () => {
+    // MEMBER is approved; OUTSIDER is denied. Both key the SAME selfKey only if
+    // they share an address — they do not, so we assert MEMBER keeps full quota
+    // even after an interleaved OUTSIDER denial.
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, MEMBER, OUTSIDER],
+      dailyQuota: 1,
+    });
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER)).ok).toBe(false);
+    // MEMBER still has its single unit — authorized once.
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER)).ok).toBe(true);
+    // ...and now exhausted.
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER)).ok).toBe(false);
+  });
+});

--- a/packages/agent/test/shared-model/membership.test.ts
+++ b/packages/agent/test/shared-model/membership.test.ts
@@ -1,18 +1,26 @@
 /**
- * Membership gate for shared-model invokes (PR #1157 B1).
+ * Per-agent membership gate for shared-model invokes (PR #1157/#1158, B1 + #1).
  *
- * Pins the auth fix: `isPeerContextGraphMember` must authorise ONLY peers that
- * the curator has APPROVED (the `allowedDelegateePeer` binding read by the
- * canonical `getContextGraphAllowedDelegateePeers` helper), and must DENY a
- * peer that is present only via the self-asserted, pre-approval
- * `delegationDelegateePeer` value or whose delegation has been removed.
+ * Pins the per-agent binding fix. `isAgentPeerContextGraphMember` must authorise
+ * ONLY when the CLAIMED agent's curator-APPROVED delegatee-peer set
+ * (`allowedDelegateePeer`, read by the canonical
+ * `getContextGraphAllowedDelegateePeers` helper) contains the cryptographically
+ * authenticated transport peer. It must DENY:
+ *   - a peer present only via the self-asserted, pre-approval
+ *     `delegationDelegateePeer` value (pending joiner) or whose delegation was
+ *     removed (its `did:dkg:agent-delegation:*` subject is gone),
+ *   - a request that CLAIMS an approved agent but arrives from a DIFFERENT peer
+ *     than that agent's binding (impersonation),
+ *   - a request that arrives from agent A's approved peer but CLAIMS agent B
+ *     (multi-agent inheritance via the old union),
+ *   - a request with no `agentAddress` claim at all (no union fallback).
  *
- * The decision delegates entirely to the canonical helper, which in turn runs
- * one `store.query`. We drive the real method logic through a stubbed
- * `store.query` so the pending-vs-approved distinction is asserted without a
- * full chain harness. `delegationDelegateePeer` lives on a different subject
- * and a different predicate than the helper queries, so a pending/removed peer
- * is simply absent from the returned approved set.
+ * The decision delegates to the canonical helper, which runs one `store.query`.
+ * We drive the real method logic through a stubbed `store.query` so the
+ * pending-vs-approved and per-agent distinctions are asserted without a full
+ * chain harness. `delegationDelegateePeer` lives on a different subject and a
+ * different predicate than the helper queries, so a pending/removed peer is
+ * simply absent from the returned approved set.
  */
 import { describe, it, expect } from 'vitest';
 import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
@@ -22,36 +30,43 @@ import type { DKGAgent } from '../../src/dkg-agent.js';
 
 type QueryFn = (sparql: string) => Promise<{ type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }>;
 
-// Minimal harness: an object carrying just the two prototype methods under
-// test plus a stubbed store. `isPeerContextGraphMember` (private) is invoked by
+// Minimal harness: an object carrying just the two prototype methods under test
+// plus a stubbed store. `isAgentPeerContextGraphMember` (private) is invoked by
 // name; the canonical helper it calls reads only `store.query`.
-function makeAgent(query: QueryFn): { isMember(cg: string, peer: string): Promise<boolean> } {
+function makeAgent(query: QueryFn): {
+  isMember(cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+} {
   const agent = {
     store: { query },
     getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
-    isPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
-      isPeerContextGraphMember(this: DKGAgent, cg: string, peer: string): Promise<boolean>;
-    }).isPeerContextGraphMember,
-  } as unknown as DKGAgent & { isPeerContextGraphMember(cg: string, peer: string): Promise<boolean> };
-  return { isMember: (cg, peer) => agent.isPeerContextGraphMember(cg, peer) };
+    isAgentPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
+      isAgentPeerContextGraphMember(this: DKGAgent, cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+    }).isAgentPeerContextGraphMember,
+  } as unknown as DKGAgent & {
+    isAgentPeerContextGraphMember(cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+  };
+  return { isMember: (cg, a, peer) => agent.isAgentPeerContextGraphMember(cg, a, peer) };
 }
 
-const APPROVED_PEER = '12D3KooWApprovedMember';
+const AGENT_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa';
+const AGENT_B = '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb';
+const PEER_A = '12D3KooWPeerForAgentA';
+const PEER_B = '12D3KooWPeerForAgentB';
 const PENDING_PEER = '12D3KooWPendingJoiner';
 
 // A store whose APPROVED-delegatee query (the only predicate the canonical
-// helper reads) returns exactly `approvedPeers`. The pending peer's
+// helper reads) returns the given (agent, peer) bindings. The pending peer's
 // self-asserted `delegationDelegateePeer` binding is never returned by this
 // query, mirroring production where it lives on the join-request subject.
-function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
+function approvedStore(bindings: Array<{ agent: string; peer: string; expiresAtMs?: number }>): QueryFn {
   return async (sparql: string) => {
     if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
       return {
         type: 'bindings',
-        bindings: approvedPeers.map((peer) => ({
-          agent: '"0xCuratorApprovedAgent"',
-          peer: `"${peer}"`,
-          ...(expiresAtMs != null ? { expiresAt: `"${expiresAtMs}"` } : {}),
+        bindings: bindings.map((b) => ({
+          agent: `"${b.agent}"`,
+          peer: `"${b.peer}"`,
+          ...(b.expiresAtMs != null ? { expiresAt: `"${b.expiresAtMs}"` } : {}),
         })),
       };
     }
@@ -59,48 +74,62 @@ function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
   };
 }
 
-describe('shared-model membership gate (B1)', () => {
-  it('ALLOWS an approved, unexpired delegatee peer', async () => {
-    const agent = makeAgent(approvedStore([APPROVED_PEER]));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+describe('shared-model per-agent membership gate (#1)', () => {
+  it('ALLOWS the approved agent from its bound, unexpired peer', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(true);
   });
 
-  it('DENIES a peer present only via the pending delegationDelegateePeer binding', async () => {
+  it('DENIES an agent (B) that is NOT approved, even behind an approved peer', async () => {
+    // Agent A is approved at PEER_A. A request that arrives via PEER_A but
+    // CLAIMS agent B (who has no approved binding) is denied — the union check
+    // would have allowed it.
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_B, PEER_A)).toBe(false);
+  });
+
+  it('DENIES a pending-only agent (no approved delegatee binding)', async () => {
     // The curator approved no one yet → the approved-peer query is empty even
     // though a pending join-request wrote `delegationDelegateePeer` for this
     // peer (which this gate must never read).
     const agent = makeAgent(approvedStore([]));
-    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+    expect(await agent.isMember('cg1', AGENT_A, PENDING_PEER)).toBe(false);
   });
 
-  it('DENIES a removed peer (its agent-delegation subject is gone)', async () => {
-    // removeAgentFromContextGraph deletes the `did:dkg:agent-delegation:*`
-    // subject, so the approved-peer query returns nothing for it.
-    const agent = makeAgent(approvedStore([]));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  it('DENIES claiming an approved agent from a DIFFERENT peer (impersonation)', async () => {
+    // Agent A is bound to PEER_A. An attacker on PEER_B claiming to be agent A
+    // does not match A's recorded delegatee peer → denied.
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_B)).toBe(false);
   });
 
-  it('DENIES an approved-but-EXPIRED delegatee peer', async () => {
-    const agent = makeAgent(approvedStore([APPROVED_PEER], Date.now() - 60_000));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  it('DENIES a missing agentAddress (no union fallback)', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', undefined, PEER_A)).toBe(false);
+    expect(await agent.isMember('cg1', '', PEER_A)).toBe(false);
   });
 
-  it('authorises across multiple approving agents (flattened set)', async () => {
-    const store: QueryFn = async (sparql) => {
-      if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
-        return {
-          type: 'bindings',
-          bindings: [
-            { agent: '"0xAgentA"', peer: '"12D3KooWPeerA"' },
-            { agent: '"0xAgentB"', peer: `"${APPROVED_PEER}"` },
-          ],
-        };
-      }
-      return { type: 'bindings', bindings: [] };
-    };
-    const agent = makeAgent(store);
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
-    expect(await agent.isMember('cg1', '12D3KooWPeerA')).toBe(true);
-    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  it('DENIES an approved-but-EXPIRED delegatee binding', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A, expiresAtMs: Date.now() - 60_000 }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(false);
+  });
+
+  it('binds each agent to ITS OWN peer — no cross-agent inheritance', async () => {
+    // Two approved agents on (potentially) the same node. Each is authorised
+    // only for its own (agent, peer) pair; a swap is denied.
+    const agent = makeAgent(approvedStore([
+      { agent: AGENT_A, peer: PEER_A },
+      { agent: AGENT_B, peer: PEER_B },
+    ]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(true);
+    expect(await agent.isMember('cg1', AGENT_B, PEER_B)).toBe(true);
+    // A's peer claiming B (and vice-versa) → denied.
+    expect(await agent.isMember('cg1', AGENT_B, PEER_A)).toBe(false);
+    expect(await agent.isMember('cg1', AGENT_A, PEER_B)).toBe(false);
+  });
+
+  it('matches the claimed agent case-insensitively (helper keys are lowercased)', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A.toLowerCase(), peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A.toUpperCase(), PEER_A)).toBe(true);
   });
 });

--- a/packages/agent/test/shared-model/membership.test.ts
+++ b/packages/agent/test/shared-model/membership.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Membership gate for shared-model invokes (PR #1157 B1).
+ *
+ * Pins the auth fix: `isPeerContextGraphMember` must authorise ONLY peers that
+ * the curator has APPROVED (the `allowedDelegateePeer` binding read by the
+ * canonical `getContextGraphAllowedDelegateePeers` helper), and must DENY a
+ * peer that is present only via the self-asserted, pre-approval
+ * `delegationDelegateePeer` value or whose delegation has been removed.
+ *
+ * The decision delegates entirely to the canonical helper, which in turn runs
+ * one `store.query`. We drive the real method logic through a stubbed
+ * `store.query` so the pending-vs-approved distinction is asserted without a
+ * full chain harness. `delegationDelegateePeer` lives on a different subject
+ * and a different predicate than the helper queries, so a pending/removed peer
+ * is simply absent from the returned approved set.
+ */
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { WorkspaceCryptoMethods } from '../../src/dkg-agent-crypto.js';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+
+type QueryFn = (sparql: string) => Promise<{ type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }>;
+
+// Minimal harness: an object carrying just the two prototype methods under
+// test plus a stubbed store. `isPeerContextGraphMember` (private) is invoked by
+// name; the canonical helper it calls reads only `store.query`.
+function makeAgent(query: QueryFn): { isMember(cg: string, peer: string): Promise<boolean> } {
+  const agent = {
+    store: { query },
+    getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
+    isPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
+      isPeerContextGraphMember(this: DKGAgent, cg: string, peer: string): Promise<boolean>;
+    }).isPeerContextGraphMember,
+  } as unknown as DKGAgent & { isPeerContextGraphMember(cg: string, peer: string): Promise<boolean> };
+  return { isMember: (cg, peer) => agent.isPeerContextGraphMember(cg, peer) };
+}
+
+const APPROVED_PEER = '12D3KooWApprovedMember';
+const PENDING_PEER = '12D3KooWPendingJoiner';
+
+// A store whose APPROVED-delegatee query (the only predicate the canonical
+// helper reads) returns exactly `approvedPeers`. The pending peer's
+// self-asserted `delegationDelegateePeer` binding is never returned by this
+// query, mirroring production where it lives on the join-request subject.
+function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
+  return async (sparql: string) => {
+    if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+      return {
+        type: 'bindings',
+        bindings: approvedPeers.map((peer) => ({
+          agent: '"0xCuratorApprovedAgent"',
+          peer: `"${peer}"`,
+          ...(expiresAtMs != null ? { expiresAt: `"${expiresAtMs}"` } : {}),
+        })),
+      };
+    }
+    return { type: 'bindings', bindings: [] };
+  };
+}
+
+describe('shared-model membership gate (B1)', () => {
+  it('ALLOWS an approved, unexpired delegatee peer', async () => {
+    const agent = makeAgent(approvedStore([APPROVED_PEER]));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+  });
+
+  it('DENIES a peer present only via the pending delegationDelegateePeer binding', async () => {
+    // The curator approved no one yet → the approved-peer query is empty even
+    // though a pending join-request wrote `delegationDelegateePeer` for this
+    // peer (which this gate must never read).
+    const agent = makeAgent(approvedStore([]));
+    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  });
+
+  it('DENIES a removed peer (its agent-delegation subject is gone)', async () => {
+    // removeAgentFromContextGraph deletes the `did:dkg:agent-delegation:*`
+    // subject, so the approved-peer query returns nothing for it.
+    const agent = makeAgent(approvedStore([]));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  });
+
+  it('DENIES an approved-but-EXPIRED delegatee peer', async () => {
+    const agent = makeAgent(approvedStore([APPROVED_PEER], Date.now() - 60_000));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  });
+
+  it('authorises across multiple approving agents (flattened set)', async () => {
+    const store: QueryFn = async (sparql) => {
+      if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+        return {
+          type: 'bindings',
+          bindings: [
+            { agent: '"0xAgentA"', peer: '"12D3KooWPeerA"' },
+            { agent: '"0xAgentB"', peer: `"${APPROVED_PEER}"` },
+          ],
+        };
+      }
+      return { type: 'bindings', bindings: [] };
+    };
+    const agent = makeAgent(store);
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+    expect(await agent.isMember('cg1', '12D3KooWPeerA')).toBe(true);
+    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  });
+});

--- a/packages/agent/test/shared-model/openai.test.ts
+++ b/packages/agent/test/shared-model/openai.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  openAiMessagesToShared,
+  buildOpenAIChatCompletion,
+  openAiErrorBody,
+} from '../../src/shared-model/openai.js';
+
+describe('shared-model OpenAI compatibility', () => {
+  it('maps OpenAI messages to shared-model messages, coercing unsupported roles to user', () => {
+    const out = openAiMessagesToShared([
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+      { role: 'tool', content: 'tool result' },     // coerced -> user
+      { role: 'user', content: 123 as unknown as string }, // dropped (non-string)
+    ]);
+    expect(out).toEqual([
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+      { role: 'user', content: 'tool result' },
+    ]);
+  });
+
+  it('returns [] for non-array / empty input', () => {
+    expect(openAiMessagesToShared(undefined)).toEqual([]);
+    expect(openAiMessagesToShared('nope')).toEqual([]);
+    expect(openAiMessagesToShared([])).toEqual([]);
+  });
+
+  it('builds a valid OpenAI chat.completion envelope', () => {
+    const env = buildOpenAIChatCompletion({
+      contextGraphId: 'demo',
+      content: '[shared-model:mock-model] hi',
+      model: 'mock-model',
+      createdSec: 1700000000,
+    }) as any;
+    expect(env.object).toBe('chat.completion');
+    expect(env.model).toBe('mock-model');
+    expect(env.created).toBe(1700000000);
+    expect(env.id).toContain('chatcmpl-dkg-demo');
+    expect(env.choices[0].message).toEqual({ role: 'assistant', content: '[shared-model:mock-model] hi' });
+    expect(env.choices[0].finish_reason).toBe('stop');
+    expect(env.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+  });
+
+  it('builds an OpenAI-shaped error body', () => {
+    expect(openAiErrorBody('requester is not a member of this context graph')).toEqual({
+      error: {
+        message: 'requester is not a member of this context graph',
+        type: 'invalid_request_error',
+        code: 'shared_model_denied',
+      },
+    });
+  });
+});

--- a/packages/agent/test/shared-model/shared-model.test.ts
+++ b/packages/agent/test/shared-model/shared-model.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { SharedModelClient } from '../../src/shared-model/client.js';
+import { DailyQuota } from '../../src/shared-model/quota.js';
+import { decideSharedModelAuthorization } from '../../src/shared-model/authorize.js';
+import {
+  encodeInvokeRequest,
+  decodeInvokeRequest,
+  encodeInvokeResponse,
+  decodeInvokeResponse,
+} from '../../src/shared-model/wire.js';
+
+describe('shared-model MVP (offline)', () => {
+  it('mock provider returns a deterministic completion (no network/key)', async () => {
+    const client = new SharedModelClient();
+    const out = await client.complete({ provider: 'mock', model: 'demo' }, [{ role: 'user', content: 'hello world' }]);
+    expect(out.model).toBe('demo');
+    expect(out.content).toContain('hello world');
+  });
+
+  it('authorizes a member, under quota, with provider + grant', () => {
+    expect(
+      decideSharedModelAuthorization({ enabled: true, providerConfigured: true, isMember: true, quotaOk: true, promptOk: true }),
+    ).toEqual({ ok: true });
+  });
+
+  it('denies non-members, disabled grants, oversized prompts, and over-quota', () => {
+    expect(decideSharedModelAuthorization({ enabled: true, providerConfigured: true, isMember: false, quotaOk: true, promptOk: true }).ok).toBe(false);
+    expect(decideSharedModelAuthorization({ enabled: false, providerConfigured: true, isMember: true, quotaOk: true, promptOk: true }).ok).toBe(false);
+    expect(decideSharedModelAuthorization({ enabled: true, providerConfigured: true, isMember: true, quotaOk: true, promptOk: false }).ok).toBe(false);
+    expect(decideSharedModelAuthorization({ enabled: true, providerConfigured: true, isMember: true, quotaOk: false, promptOk: true }).ok).toBe(false);
+    expect(decideSharedModelAuthorization({ enabled: true, providerConfigured: false, isMember: true, quotaOk: true, promptOk: true }).ok).toBe(false);
+  });
+
+  it('caps requests per member per day', () => {
+    const q = new DailyQuota(2);
+    expect(q.allow('member-a')).toBe(true);
+    expect(q.allow('member-a')).toBe(true);
+    expect(q.allow('member-a')).toBe(false);
+    expect(q.allow('member-b')).toBe(true); // independent bucket
+  });
+
+  it('round-trips request and response over the wire', () => {
+    const req = { contextGraphId: 'cg1', messages: [{ role: 'user' as const, content: 'hi' }], maxTokens: 64 };
+    expect(decodeInvokeRequest(encodeInvokeRequest(req))).toEqual({
+      contextGraphId: 'cg1',
+      messages: req.messages,
+      maxTokens: 64,
+      temperature: undefined,
+    });
+    const res = { ok: true, content: 'x', model: 'demo' };
+    expect(decodeInvokeResponse(encodeInvokeResponse(res))).toEqual({ ok: true, content: 'x', model: 'demo', denied: undefined });
+  });
+
+  it('rejects malformed wire payloads', () => {
+    expect(() => decodeInvokeRequest(new TextEncoder().encode('{"messages":[]}'))).toThrow();
+    expect(() => decodeInvokeRequest(new TextEncoder().encode('{"contextGraphId":"x","messages":[{"role":"nope","content":"a"}]}'))).toThrow();
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -259,6 +259,10 @@ export interface SharedModelConfig {
   dailyRequestQuotaPerAgent?: number;
   /** Max prompt chars accepted from a member. Default 8000. */
   maxPromptChars?: number;
+  /** Member-side transport budget (ms) for the whole remote invoke. Default 120000. */
+  invokeTimeoutMs?: number;
+  /** Curator-side provider fetch deadline (ms); kept below invokeTimeoutMs. Default 110000. */
+  providerTimeoutMs?: number;
 }
 
 export type LocalAgentIntegrationStatus =

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -243,6 +243,24 @@ export interface LlmConfig {
   baseURL?: string;
 }
 
+/** Shared curator AI-model access (MVP). Defaults reuse `llm` when omitted. */
+export interface SharedModelConfig {
+  /** Enable serving shared-model invokes from this node. */
+  enabled?: boolean;
+  /** 'mock' (offline, no key) or 'openai-compatible'. Defaults from `llm`. */
+  provider?: 'mock' | 'openai-compatible';
+  /** Model id to advertise/use. Defaults to `llm.model`. */
+  model?: string;
+  /** Base URL for openai-compatible. Defaults to `llm.baseURL`. */
+  baseUrl?: string;
+  /** Env var holding the API key. Defaults to reusing `llm.apiKey`. */
+  apiKeyEnv?: string;
+  /** Per-member daily request cap. Default 200. */
+  dailyRequestQuotaPerAgent?: number;
+  /** Max prompt chars accepted from a member. Default 8000. */
+  maxPromptChars?: number;
+}
+
 export type LocalAgentIntegrationStatus =
   | 'disconnected'
   | 'configured'
@@ -442,6 +460,8 @@ export interface DkgConfig {
   chain?: Partial<ChainConfig>;
   /** Optional LLM for the Node UI chatbot (natural language → SPARQL, answers). */
   llm?: LlmConfig;
+  /** Optional shared curator AI-model access for context-graph members (MVP). */
+  sharedModel?: SharedModelConfig;
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -321,6 +321,7 @@ import { handleHermesRoutes } from './routes/hermes.js';
 import { handleMemoryRoutes } from './routes/memory.js';
 import { handlePublisherRoutes } from './routes/publisher.js';
 import { handleContextGraphRoutes } from './routes/context-graph.js';
+import { handleSharedModelRoutes } from './routes/shared-model.js';
 import { handleKnowledgeAssetsRoutes } from './routes/knowledge-assets.js';
 import { handleKcChainMetadataRoutes } from './routes/kc-chain-metadata.js';
 import { handleFileServingRoutes } from './routes/file-serving.js';
@@ -429,6 +430,9 @@ export async function handleRequest(
   if (res.writableEnded) return;
 
   await handleContextGraphRoutes(ctx);
+  if (res.writableEnded) return;
+
+  await handleSharedModelRoutes(ctx);
   if (res.writableEnded) return;
 
   await handleKnowledgeAssetsRoutes(ctx);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1317,6 +1317,28 @@ export async function runDaemonInner(
     },
   });
 
+  // Shared curator AI-model access (MVP): wire node config -> agent so the
+  // curator's node can serve member invokes. Reuses `config.llm` for provider
+  // credentials when `config.sharedModel` doesn't override them. Inert unless
+  // `sharedModel.enabled` is set, so default deployments are unaffected.
+  {
+    const sm = config.sharedModel;
+    const llm = config.llm;
+    if (sm?.enabled) {
+      const provider = sm.provider ?? ((sm.model ?? llm?.model) ? 'openai-compatible' : 'mock');
+      const apiKey = sm.apiKeyEnv ? process.env[sm.apiKeyEnv] : llm?.apiKey;
+      agent.configureSharedModel({
+        enabled: true,
+        provider,
+        model: sm.model ?? llm?.model ?? 'mock-model',
+        baseUrl: sm.baseUrl ?? llm?.baseURL,
+        apiKey,
+        dailyRequestQuotaPerAgent: sm.dailyRequestQuotaPerAgent ?? 200,
+        maxPromptChars: sm.maxPromptChars ?? 8000,
+      });
+    }
+  }
+
   let publisherRuntime: PublisherRuntime | null = null;
   // Holds the running async-promote worker lifecycle (PR #3 of the
   // async-promote-queue series). Initialised in `startPostApiPublishing`

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1335,6 +1335,8 @@ export async function runDaemonInner(
         apiKey,
         dailyRequestQuotaPerAgent: sm.dailyRequestQuotaPerAgent ?? 200,
         maxPromptChars: sm.maxPromptChars ?? 8000,
+        invokeTimeoutMs: sm.invokeTimeoutMs ?? 120_000,
+        providerTimeoutMs: sm.providerTimeoutMs ?? 110_000,
       });
     }
   }

--- a/packages/cli/src/daemon/routes/shared-model.ts
+++ b/packages/cli/src/daemon/routes/shared-model.ts
@@ -1,0 +1,78 @@
+import type { RequestContext } from "./context.js";
+import { readBody, jsonResponse } from "../http-utils.js";
+import type { SharedModelMessage } from "@origintrail-official/dkg-agent";
+
+const SMALL_BODY_BYTES = 256 * 1024;
+
+/**
+ * Shared curator AI-model access (MVP).
+ *
+ *   POST /api/context-graph/:id/model/share          { enabled, modelId? }
+ *   GET  /api/context-graph/:id/model/grant
+ *   POST /api/context-graph/:id/model/invoke         { messages, maxTokens?, temperature? }
+ *   POST /api/context-graph/:id/invite-with-model    { agentAddress, shareModel?, modelId? }
+ *
+ * The last route is the "same user journey" entry point: it invites an agent
+ * to the CG's shared working memory AND (optionally) shares the curator's
+ * model in one call.
+ */
+export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void> {
+  const { req, res, agent, path, requestAgentAddress } = ctx;
+
+  const shareMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/share$/);
+  if (req.method === "POST" && shareMatch) {
+    const id = decodeURIComponent(shareMatch[1]);
+    const { enabled, modelId } = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    if (typeof enabled !== "boolean") return jsonResponse(res, 400, { error: "enabled (boolean) is required" });
+    try {
+      await agent.setContextGraphModelSharing(id, enabled, { callerAgentAddress: requestAgentAddress, modelId });
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, enabled });
+    } catch (err) {
+      return jsonResponse(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  const grantMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/grant$/);
+  if (req.method === "GET" && grantMatch) {
+    const id = decodeURIComponent(grantMatch[1]);
+    const grant = await agent.getContextGraphModelGrant(id);
+    return jsonResponse(res, 200, { contextGraphId: id, ...grant });
+  }
+
+  const invokeMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/invoke$/);
+  if (req.method === "POST" && invokeMatch) {
+    const id = decodeURIComponent(invokeMatch[1]);
+    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    const messages = body.messages as SharedModelMessage[];
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return jsonResponse(res, 400, { error: "messages (non-empty array) is required" });
+    }
+    const result = await agent.invokeContextGraphModel(
+      id,
+      messages,
+      { maxTokens: body.maxTokens, temperature: body.temperature },
+      requestAgentAddress,
+    );
+    return jsonResponse(res, result.ok ? 200 : 403, result);
+  }
+
+  const inviteMatch = path.match(/^\/api\/context-graph\/([^/]+)\/invite-with-model$/);
+  if (req.method === "POST" && inviteMatch) {
+    const id = decodeURIComponent(inviteMatch[1]);
+    const { agentAddress, shareModel, modelId } = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    if (!agentAddress || typeof agentAddress !== "string") {
+      return jsonResponse(res, 400, { error: "agentAddress is required" });
+    }
+    try {
+      await agent.inviteAgentToContextGraph(id, agentAddress, requestAgentAddress);
+      let modelShared = false;
+      if (shareModel === true) {
+        await agent.setContextGraphModelSharing(id, true, { callerAgentAddress: requestAgentAddress, modelId });
+        modelShared = true;
+      }
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared });
+    } catch (err) {
+      return jsonResponse(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+}

--- a/packages/cli/src/daemon/routes/shared-model.ts
+++ b/packages/cli/src/daemon/routes/shared-model.ts
@@ -9,6 +9,43 @@ import {
 
 const SMALL_BODY_BYTES = 256 * 1024;
 
+const SHARED_MODEL_ROLES = new Set(["system", "user", "assistant"]);
+
+/** Coerce a body field to a finite number, or undefined if it isn't one. */
+function numOrUndefined(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Validate the native `/model/invoke` `messages` payload BEFORE it reaches the
+ * agent, so a structurally-broken element (e.g. `[{"role":"user"}]` with no
+ * `content`, or `{"content":1}`) returns a clear 400 instead of throwing deep
+ * in the provider call and surfacing as a 500. Mirrors the wire decoder's
+ * element contract: `role` ∈ {system,user,assistant} and `content` is a string.
+ */
+function validateSharedModelMessages(
+  raw: unknown,
+): { ok: true; messages: SharedModelMessage[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { ok: false, error: "messages (non-empty array) is required" };
+  }
+  const messages: SharedModelMessage[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const m = raw[i] as { role?: unknown; content?: unknown } | null;
+    if (!m || typeof m !== "object") {
+      return { ok: false, error: `messages[${i}] must be an object` };
+    }
+    if (typeof m.role !== "string" || !SHARED_MODEL_ROLES.has(m.role)) {
+      return { ok: false, error: `messages[${i}].role must be one of system|user|assistant` };
+    }
+    if (typeof m.content !== "string") {
+      return { ok: false, error: `messages[${i}].content must be a string` };
+    }
+    messages.push({ role: m.role as SharedModelMessage["role"], content: m.content });
+  }
+  return { ok: true, messages };
+}
+
 /**
  * Shared curator AI-model access (MVP).
  *
@@ -48,15 +85,21 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const invokeMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/invoke$/);
   if (req.method === "POST" && invokeMatch) {
     const id = decodeURIComponent(invokeMatch[1]);
-    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
-    const messages = body.messages as SharedModelMessage[];
-    if (!Array.isArray(messages) || messages.length === 0) {
-      return jsonResponse(res, 400, { error: "messages (non-empty array) is required" });
+    let body: { messages?: unknown; maxTokens?: unknown; temperature?: unknown };
+    try {
+      body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      return jsonResponse(res, 400, { error: "request body must be valid JSON" });
     }
+    const validation = validateSharedModelMessages(body.messages);
+    if (!validation.ok) {
+      return jsonResponse(res, 400, { error: validation.error });
+    }
+    const messages = validation.messages;
     const result = await agent.invokeContextGraphModel(
       id,
       messages,
-      { maxTokens: body.maxTokens, temperature: body.temperature },
+      { maxTokens: numOrUndefined(body.maxTokens), temperature: numOrUndefined(body.temperature) },
       requestAgentAddress,
     );
     return jsonResponse(res, result.ok ? 200 : 403, result);
@@ -70,7 +113,16 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const openaiMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/v1\/chat\/completions$/);
   if (req.method === "POST" && openaiMatch) {
     const id = decodeURIComponent(openaiMatch[1]);
-    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    let body: { messages?: unknown; max_tokens?: unknown; temperature?: unknown; model?: unknown };
+    try {
+      body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      // A malformed body must surface as an OpenAI-shaped 400, never a 500.
+      return jsonResponse(res, 400, openAiErrorBody("request body must be valid JSON"));
+    }
+    // `openAiMessagesToShared` already validates element shapes (drops non-string
+    // content, coerces unsupported roles to `user`); an empty result means the
+    // caller sent nothing usable.
     const messages = openAiMessagesToShared(body.messages);
     if (messages.length === 0) {
       return jsonResponse(res, 400, openAiErrorBody("messages (non-empty array) is required"));
@@ -78,7 +130,7 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
     const result = await agent.invokeContextGraphModel(
       id,
       messages,
-      { maxTokens: body.max_tokens, temperature: body.temperature },
+      { maxTokens: numOrUndefined(body.max_tokens), temperature: numOrUndefined(body.temperature) },
       requestAgentAddress,
     );
     if (!result.ok) {
@@ -95,20 +147,45 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const inviteMatch = path.match(/^\/api\/context-graph\/([^/]+)\/invite-with-model$/);
   if (req.method === "POST" && inviteMatch) {
     const id = decodeURIComponent(inviteMatch[1]);
-    const { agentAddress, shareModel, modelId } = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    let parsed: { agentAddress?: unknown; shareModel?: unknown; modelId?: unknown };
+    try {
+      parsed = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      return jsonResponse(res, 400, { error: "request body must be valid JSON" });
+    }
+    const { agentAddress, shareModel, modelId } = parsed;
     if (!agentAddress || typeof agentAddress !== "string") {
       return jsonResponse(res, 400, { error: "agentAddress is required" });
     }
+    // The invite is the membership-granting step. If it throws, nothing was
+    // applied → 400 and the caller may safely retry.
     try {
       await agent.inviteAgentToContextGraph(id, agentAddress, requestAgentAddress);
-      let modelShared = false;
-      if (shareModel === true) {
-        await agent.setContextGraphModelSharing(id, true, { callerAgentAddress: requestAgentAddress, modelId });
-        modelShared = true;
-      }
-      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared });
     } catch (err) {
       return jsonResponse(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    }
+    // Invite succeeded — membership is now granted and DURABLE. If the optional
+    // model-share step fails, do NOT report a 400 (the caller would retry the
+    // whole call against partially-applied state, double-applying the invite).
+    // Instead return 200 with an explicit partial-success body so the caller
+    // sees the invite landed and only the share needs attention.
+    if (shareModel !== true) {
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared: false });
+    }
+    try {
+      await agent.setContextGraphModelSharing(id, true, {
+        callerAgentAddress: requestAgentAddress,
+        modelId: typeof modelId === "string" ? modelId : undefined,
+      });
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared: true });
+    } catch (err) {
+      return jsonResponse(res, 200, {
+        ok: true,
+        contextGraphId: id,
+        agentAddress,
+        modelShared: false,
+        modelShareError: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 }

--- a/packages/cli/src/daemon/routes/shared-model.ts
+++ b/packages/cli/src/daemon/routes/shared-model.ts
@@ -1,6 +1,11 @@
 import type { RequestContext } from "./context.js";
 import { readBody, jsonResponse } from "../http-utils.js";
-import type { SharedModelMessage } from "@origintrail-official/dkg-agent";
+import {
+  openAiMessagesToShared,
+  buildOpenAIChatCompletion,
+  openAiErrorBody,
+  type SharedModelMessage,
+} from "@origintrail-official/dkg-agent";
 
 const SMALL_BODY_BYTES = 256 * 1024;
 
@@ -10,6 +15,7 @@ const SMALL_BODY_BYTES = 256 * 1024;
  *   POST /api/context-graph/:id/model/share          { enabled, modelId? }
  *   GET  /api/context-graph/:id/model/grant
  *   POST /api/context-graph/:id/model/invoke         { messages, maxTokens?, temperature? }
+ *   POST /api/context-graph/:id/model/v1/chat/completions   (OpenAI-compatible)
  *   POST /api/context-graph/:id/invite-with-model    { agentAddress, shareModel?, modelId? }
  *
  * The last route is the "same user journey" entry point: it invites an agent
@@ -54,6 +60,36 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
       requestAgentAddress,
     );
     return jsonResponse(res, result.ok ? 200 : 403, result);
+  }
+
+  // OpenAI-compatible surface so a member can point any OpenAI client (the
+  // hermes gateway, node-UI chat, Cursor, the OpenAI SDK) at the curator's
+  // shared model — i.e. set OPENAI_BASE_URL to
+  //   http://<member-node>/api/context-graph/<id>/model/v1
+  // and the member's agent transparently runs ON the curator's model.
+  const openaiMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/v1\/chat\/completions$/);
+  if (req.method === "POST" && openaiMatch) {
+    const id = decodeURIComponent(openaiMatch[1]);
+    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    const messages = openAiMessagesToShared(body.messages);
+    if (messages.length === 0) {
+      return jsonResponse(res, 400, openAiErrorBody("messages (non-empty array) is required"));
+    }
+    const result = await agent.invokeContextGraphModel(
+      id,
+      messages,
+      { maxTokens: body.max_tokens, temperature: body.temperature },
+      requestAgentAddress,
+    );
+    if (!result.ok) {
+      return jsonResponse(res, 403, openAiErrorBody(result.denied ?? "denied"));
+    }
+    return jsonResponse(res, 200, buildOpenAIChatCompletion({
+      contextGraphId: id,
+      content: result.content ?? "",
+      model: result.model ?? (typeof body.model === "string" ? body.model : "shared-model"),
+      createdSec: Math.floor(Date.now() / 1000),
+    }));
   }
 
   const inviteMatch = path.match(/^\/api\/context-graph\/([^/]+)\/invite-with-model$/);

--- a/packages/cli/test/daemon-shared-model-routes.test.ts
+++ b/packages/cli/test/daemon-shared-model-routes.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Daemon shared-model route validation (PR #1158, #4 + #5).
+ *
+ * #4 — the native `/model/invoke` route must reject structurally-broken
+ *      `messages` with a clear 400 (not a 500 deep in the provider call); the
+ *      OpenAI `/v1/chat/completions` route must return an `openAiErrorBody`
+ *      400 for a malformed body.
+ * #5 — `invite-with-model` must return 200 with `modelShared:false` +
+ *      `modelShareError` when the invite SUCCEEDED but the share step failed,
+ *      so callers don't retry against partially-applied membership state.
+ */
+import { describe, it, expect } from 'vitest';
+import { handleSharedModelRoutes } from '../src/daemon/routes/shared-model.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function fakeRes() {
+  const res: any = { statusCode: 0, body: '' };
+  res.writeHead = (status: number) => { res.statusCode = status; };
+  res.end = (body: string) => { res.body = body; };
+  return res;
+}
+
+function fakeReq(method: string, path: string, body?: unknown, rawBody?: string) {
+  const req: any = { method, url: path };
+  if (rawBody !== undefined) {
+    req.__dkgPrebufferedBody = Buffer.from(rawBody);
+  } else if (body !== undefined) {
+    req.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
+  }
+  return req;
+}
+
+function runCtx(method: string, rawPath: string, agent: any, opts: { body?: unknown; rawBody?: string; requestAgentAddress?: string } = {}) {
+  const res = fakeRes();
+  const url = new URL(`http://127.0.0.1${rawPath}`);
+  const ctx = {
+    req: fakeReq(method, rawPath, opts.body, opts.rawBody),
+    res,
+    agent,
+    path: url.pathname,
+    url,
+    requestAgentAddress: opts.requestAgentAddress,
+  } as unknown as RequestContext;
+  return { res, done: handleSharedModelRoutes(ctx) };
+}
+
+const INVOKE = '/api/context-graph/cg1/model/invoke';
+const OPENAI = '/api/context-graph/cg1/model/v1/chat/completions';
+const INVITE = '/api/context-graph/cg1/invite-with-model';
+
+describe('native /model/invoke message validation (#4)', () => {
+  // The agent must NOT be reached for invalid bodies — fail loudly if it is.
+  const agent = { invokeContextGraphModel: async () => { throw new Error('agent should not be called for invalid body'); } };
+
+  it('rejects a message missing content → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'user' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/content must be a string/i);
+  });
+
+  it('rejects non-string content → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'user', content: 1 }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/content must be a string/i);
+  });
+
+  it('rejects an unknown role → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'tool', content: 'x' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/role must be one of/i);
+  });
+
+  it('rejects an empty array → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a non-JSON body → 400 (not 500)', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { rawBody: 'not json{' });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/valid JSON/i);
+  });
+
+  it('accepts a well-formed body and reaches the agent', async () => {
+    const okAgent = { invokeContextGraphModel: async () => ({ ok: true, content: 'hi', model: 'm' }) };
+    const { res, done } = runCtx('POST', INVOKE, okAgent, { body: { messages: [{ role: 'user', content: 'hi' }] } });
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).content).toBe('hi');
+  });
+});
+
+describe('OpenAI /v1/chat/completions validation (#4)', () => {
+  const agent = { invokeContextGraphModel: async () => { throw new Error('agent should not be called for invalid body'); } };
+
+  it('returns an OpenAI-shaped 400 for a non-JSON body (not 500)', async () => {
+    const { res, done } = runCtx('POST', OPENAI, agent, { rawBody: '{broken' });
+    await done;
+    expect(res.statusCode).toBe(400);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.type).toBe('invalid_request_error');
+    expect(parsed.error.message).toMatch(/valid JSON/i);
+  });
+
+  it('returns an OpenAI-shaped 400 when no usable messages remain', async () => {
+    // role-only / non-string-content elements are dropped by the mapper → empty.
+    const { res, done } = runCtx('POST', OPENAI, agent, { body: { messages: [{ role: 'user' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error.type).toBe('invalid_request_error');
+  });
+});
+
+describe('invite-with-model partial success (#5)', () => {
+  it('returns 200 modelShared:false + modelShareError when invite OK but share throws', async () => {
+    let invited = false;
+    const agent = {
+      inviteAgentToContextGraph: async () => { invited = true; },
+      setContextGraphModelSharing: async () => { throw new Error('share write failed'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(invited).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.modelShared).toBe(false);
+    expect(body.modelShareError).toMatch(/share write failed/);
+  });
+
+  it('returns 400 when the invite ITSELF fails (nothing applied)', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => { throw new Error('not the curator'); },
+      setContextGraphModelSharing: async () => { throw new Error('should not be reached'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/not the curator/);
+  });
+
+  it('returns 200 modelShared:true on full success', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => {},
+      setContextGraphModelSharing: async () => {},
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.modelShared).toBe(true);
+    expect(body.modelShareError).toBeUndefined();
+  });
+
+  it('returns 200 modelShared:false (no error) when shareModel not requested', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => {},
+      setContextGraphModelSharing: async () => { throw new Error('should not be reached'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc' },
+    });
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.modelShared).toBe(false);
+    expect(body.modelShareError).toBeUndefined();
+  });
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -156,6 +156,12 @@ export const PROTOCOL_STORAGE_UPDATE_ACK = '/dkg/10.0.1/storage-update-ack';
  */
 export const PROTOCOL_GET_CIPHERTEXT_CHUNK = '/dkg/10.0.2/get-ciphertext-chunk';
 
+// Shared curator AI-model access (MVP): a member node invokes the model the
+// CG curator shares; request carries {contextGraphId, messages}, response
+// carries the completion. Gated by CG membership + per-member quota on the
+// curator's node. See packages/agent/src/dkg-agent-shared-model.ts.
+export const PROTOCOL_SHARED_MODEL_INVOKE = '/dkg/10.0.2/shared-model-invoke';
+
 export const DHT_PROTOCOL = '/dkg/kad/1.0.0';
 
 /** Maximum application payload size allowed for one DKG GossipSub message (10 MB). */

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -502,6 +502,24 @@ export const approveJoinRequest = (contextGraphId: string, agentAddress: string)
 export const rejectJoinRequest = (contextGraphId: string, agentAddress: string) =>
   post<{ ok: boolean; status: string; agentAddress: string }>(`/api/context-graph/${encodeURIComponent(contextGraphId)}/reject-join`, { agentAddress });
 
+// --- Shared curator AI-model access (MVP) ---
+// A curator enables/disables model sharing per context graph; approved
+// members inherit access. Backend: packages/cli/src/daemon/routes/shared-model.ts.
+export interface SharedModelGrant {
+  contextGraphId: string;
+  enabled: boolean;
+  modelId?: string;
+}
+
+export const getModelGrant = (contextGraphId: string) =>
+  get<SharedModelGrant>(`/api/context-graph/${encodeURIComponent(contextGraphId)}/model/grant`);
+
+export const setModelShare = (contextGraphId: string, enabled: boolean, modelId?: string) =>
+  post<{ ok: boolean; contextGraphId: string; enabled: boolean }>(
+    `/api/context-graph/${encodeURIComponent(contextGraphId)}/model/share`,
+    modelId ? { enabled, modelId } : { enabled },
+  );
+
 // --- Catch-up sync jobs ---
 export interface CatchupStatusResponse {
   jobId: string;

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -520,6 +520,55 @@ export const setModelShare = (contextGraphId: string, enabled: boolean, modelId?
     modelId ? { enabled, modelId } : { enabled },
   );
 
+/** One OpenAI-style chat turn. `content` is plain text (no tool-calls). */
+export interface SharedModelChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Invoke a curator's shared AI model as a MEMBER of the context graph, via the
+ * member node's OpenAI-compatible surface
+ *   POST /api/context-graph/:id/model/v1/chat/completions
+ * (daemon: packages/cli/src/daemon/routes/shared-model.ts). The completion runs
+ * ON THE CURATOR'S node — this node merely proxies the member's request.
+ *
+ * Non-streaming, single buffered completion. Returns the assistant message
+ * content (`choices[0].message.content`).
+ *
+ * NOTE: this can't go through the shared `post()` helper. On a denial the
+ * daemon returns the OpenAI-shaped error body `{ error: { message, type, code } }`
+ * — an OBJECT, not a string — whereas `post()` reads `errBody.error` as a
+ * string and would surface `[object Object]`. We unwrap `error.message` here so
+ * the UI can render the human-readable denial (e.g. "requester is not a
+ * member…", quota) in an inline error bubble.
+ */
+export async function invokeSharedModelChat(
+  contextGraphId: string,
+  messages: SharedModelChatMessage[],
+  opts: { model?: string } = {},
+): Promise<string> {
+  const res = await fetch(
+    `${BASE}/api/context-graph/${encodeURIComponent(contextGraphId)}/model/v1/chat/completions`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(opts.model ? { model: opts.model, messages } : { messages }),
+    },
+  );
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    const message =
+      (errBody as { error?: { message?: string } })?.error?.message
+      ?? `HTTP ${res.status}`;
+    throw new Error(message);
+  }
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
 // --- Catch-up sync jobs ---
 export interface CatchupStatusResponse {
   jobId: string;

--- a/packages/node-ui/src/ui/components/Modals/CuratorModelChatModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CuratorModelChatModal.tsx
@@ -1,0 +1,350 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getModelGrant,
+  invokeSharedModelChat,
+  type SharedModelChatMessage,
+} from '../../api.js';
+import { useMyContextGraphs } from '../../hooks/useMyContextGraphs.js';
+import { useModalDismiss } from './useModalDismiss.js';
+
+interface CuratorModelChatModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** A CG this node is a member of whose curator has model sharing enabled. */
+interface AvailableSharedModel {
+  contextGraphId: string;
+  /** Friendly CG name, or the id when none is known. */
+  label: string;
+  modelId?: string;
+}
+
+/** One rendered chat line. `error` bubbles render a denial inline (no crash). */
+interface ChatLine {
+  id: string;
+  role: 'user' | 'assistant' | 'error';
+  content: string;
+}
+
+/**
+ * Curator Model — a MEMBER-side chat surface for the curator's shared AI model.
+ *
+ * Self-contained + self-discovering (mirrors ShareProjectModal's modal chrome,
+ * but takes no contextGraphId — this is a CROSS-CG surface): it lists the
+ * member's context graphs (useMyContextGraphs), reads each grant
+ * (getModelGrant), and keeps the ones the curator has ENABLED. The member picks
+ * one from a dropdown, then chats. Each send POSTs the running conversation to
+ * the member node's OpenAI-compatible route via `invokeSharedModelChat`, which
+ * runs the completion ON THE CURATOR'S node.
+ *
+ * Demo scope: in-memory session only (cleared when the selected model changes
+ * or the modal closes), non-streaming single buffered reply, no tool-calls, no
+ * persistence.
+ */
+export function CuratorModelChatModal({ open, onClose }: CuratorModelChatModalProps) {
+  const { myCgs, cgsLoading } = useMyContextGraphs();
+
+  const [available, setAvailable] = useState<AvailableSharedModel[]>([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [selectedCg, setSelectedCg] = useState<string | null>(null);
+
+  const [lines, setLines] = useState<ChatLine[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const chatEndRef = useRef<HTMLDivElement>(null);
+  const { dialogRef, onBackdropClick } = useModalDismiss(open, onClose);
+
+  // Discover shared models available to THIS node: for every CG the member
+  // belongs to, read the grant and keep the ones the curator enabled. Re-runs
+  // whenever the modal opens or the CG membership list changes. Failures per-CG
+  // are swallowed (a CG whose grant can't be read simply isn't offered).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setDiscovering(true);
+    (async () => {
+      const grants = await Promise.all(
+        myCgs.map(async (cg) => {
+          try {
+            const grant = await getModelGrant(cg.id);
+            if (!grant.enabled) return null;
+            return {
+              contextGraphId: cg.id,
+              label: cg.name && cg.name.trim().length > 0 ? cg.name : cg.id,
+              modelId: grant.modelId,
+            } as AvailableSharedModel;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const enabled = grants.filter((g): g is AvailableSharedModel => g !== null);
+      setAvailable(enabled);
+      // Keep the current selection if it's still valid, else default to the
+      // first available model.
+      setSelectedCg((prev) =>
+        prev && enabled.some((g) => g.contextGraphId === prev)
+          ? prev
+          : enabled[0]?.contextGraphId ?? null,
+      );
+      setDiscovering(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, myCgs]);
+
+  // A fresh model = a fresh conversation (demo session is per-model, in-memory).
+  useEffect(() => {
+    setLines([]);
+    setInput('');
+  }, [selectedCg]);
+
+  // Clear the in-memory session when the modal closes so re-opening starts clean.
+  useEffect(() => {
+    if (!open) {
+      setLines([]);
+      setInput('');
+      setSending(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines, sending]);
+
+  const selected = useMemo(
+    () => available.find((g) => g.contextGraphId === selectedCg) ?? null,
+    [available, selectedCg],
+  );
+
+  if (!open) return null;
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || sending || !selectedCg) return;
+
+    const userLine: ChatLine = { id: `u-${Date.now()}`, role: 'user', content: text };
+    // Build the running OpenAI-style message list from the prior turns (skip
+    // error bubbles — they're UI-only and not part of the conversation) plus
+    // this new user turn.
+    const history: SharedModelChatMessage[] = lines
+      .filter((l) => l.role === 'user' || l.role === 'assistant')
+      .map((l) => ({ role: l.role as 'user' | 'assistant', content: l.content }));
+    const outbound: SharedModelChatMessage[] = [...history, { role: 'user', content: text }];
+
+    setLines((prev) => [...prev, userLine]);
+    setInput('');
+    setSending(true);
+    try {
+      const reply = await invokeSharedModelChat(selectedCg, outbound, {
+        model: selected?.modelId,
+      });
+      setLines((prev) => [
+        ...prev,
+        { id: `a-${Date.now()}`, role: 'assistant', content: reply || '(empty reply)' },
+      ]);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Request failed';
+      setLines((prev) => [
+        ...prev,
+        { id: `e-${Date.now()}`, role: 'error', content: message },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  return (
+    <div className="v10-modal-overlay" onClick={onBackdropClick} role="presentation">
+      <div
+        className="v10-modal-box"
+        style={{ maxWidth: 620, display: 'flex', flexDirection: 'column', maxHeight: '85vh' }}
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dkg-curator-model-modal-title"
+      >
+        <div
+          className="v10-modal-header"
+          style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div id="dkg-curator-model-modal-title" className="v10-modal-title">Curator Model</div>
+            <div className="v10-modal-subtitle">
+              Chat with an AI model a curator is sharing with you. The completion runs on the curator's node.
+            </div>
+          </div>
+          <button
+            type="button"
+            className="v10-modal-close"
+            onClick={onClose}
+            aria-label="Close curator model dialog"
+            title="Close (Esc)"
+            style={{ flexShrink: 0, cursor: 'pointer' }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="v10-modal-body" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+          {/* Discovery / picker */}
+          <div className="v10-form-group">
+            <label className="v10-form-label" htmlFor="dkg-curator-model-select">Shared model</label>
+            {discovering || cgsLoading ? (
+              <div style={{
+                padding: '8px 12px', borderRadius: 6, fontSize: 11,
+                color: 'var(--text-tertiary)', background: 'var(--bg-surface)',
+                border: '1px dashed var(--border-default)',
+              }}>
+                Discovering shared models…
+              </div>
+            ) : available.length === 0 ? (
+              <div style={{
+                padding: '8px 12px', borderRadius: 6, fontSize: 11,
+                color: 'var(--text-tertiary)', background: 'var(--bg-surface)',
+                border: '1px dashed var(--border-default)',
+              }}>
+                No curator is sharing a model with you yet.
+              </div>
+            ) : (
+              <select
+                id="dkg-curator-model-select"
+                value={selectedCg ?? ''}
+                onChange={(e) => setSelectedCg(e.target.value)}
+                style={{
+                  width: '100%', padding: '8px 10px', borderRadius: 6, fontSize: 12,
+                  background: 'var(--bg-surface)', color: 'var(--text-primary)',
+                  border: '1px solid var(--border-default)', cursor: 'pointer',
+                }}
+              >
+                {available.map((g) => (
+                  <option key={g.contextGraphId} value={g.contextGraphId}>
+                    {g.label}{g.modelId ? ` · ${g.modelId}` : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {/* "Running on the curator's model" indicator */}
+          {selected && (
+            <div style={{
+              marginBottom: 12, padding: '8px 10px', borderRadius: 6, fontSize: 11,
+              color: 'var(--text-secondary)', background: 'var(--bg-surface)',
+              border: '1px solid var(--accent-primary)',
+            }}>
+              Chatting on <strong>{selected.label}</strong>'s shared model
+              {selected.modelId ? <> (<span style={{ fontFamily: 'var(--font-mono)' }}>{selected.modelId}</span>)</> : null}
+              {' '}— runs on the curator's node.
+            </div>
+          )}
+
+          {/* Message list */}
+          {selected && (
+            <div style={{
+              flex: 1, minHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column',
+              gap: 8, padding: '10px', borderRadius: 6, marginBottom: 10,
+              background: 'var(--bg-surface)', border: '1px solid var(--border-default)',
+            }}>
+              {lines.length === 0 && !sending && (
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', textAlign: 'center', margin: 'auto' }}>
+                  Send a message to start chatting on the curator's model.
+                </div>
+              )}
+              {lines.map((line) => (
+                <div
+                  key={line.id}
+                  style={{
+                    alignSelf: line.role === 'user' ? 'flex-end' : 'flex-start',
+                    maxWidth: '85%',
+                    padding: '7px 10px', borderRadius: 8, fontSize: 12, lineHeight: 1.45,
+                    whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                    background:
+                      line.role === 'user'
+                        ? 'var(--accent-primary)'
+                        : line.role === 'error'
+                          ? 'rgba(239, 68, 68, 0.12)'
+                          : 'var(--bg-elevated, var(--bg-default))',
+                    color:
+                      line.role === 'user'
+                        ? 'var(--text-on-accent)'
+                        : line.role === 'error'
+                          ? 'var(--text-danger)'
+                          : 'var(--text-primary)',
+                    border:
+                      line.role === 'error'
+                        ? '1px solid rgba(239, 68, 68, 0.3)'
+                        : line.role === 'assistant'
+                          ? '1px solid var(--border-default)'
+                          : 'none',
+                  }}
+                >
+                  {line.role === 'error' && (
+                    <div style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase', opacity: 0.8, marginBottom: 2 }}>
+                      Denied
+                    </div>
+                  )}
+                  {line.content}
+                </div>
+              ))}
+              {sending && (
+                <div style={{
+                  alignSelf: 'flex-start', maxWidth: '85%', padding: '7px 10px', borderRadius: 8,
+                  fontSize: 12, fontStyle: 'italic', color: 'var(--text-tertiary)',
+                  background: 'var(--bg-elevated, var(--bg-default))', border: '1px solid var(--border-default)',
+                }}>
+                  thinking…
+                </div>
+              )}
+              <div ref={chatEndRef} />
+            </div>
+          )}
+
+          {/* Composer */}
+          {selected && (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder="Message the curator's model… (Enter to send, Shift+Enter for newline)"
+                rows={2}
+                disabled={sending}
+                aria-label="Message to the curator's shared model"
+                style={{
+                  flex: 1, resize: 'none', padding: '8px 10px', borderRadius: 6, fontSize: 12,
+                  fontFamily: 'var(--font-body)', lineHeight: 1.45,
+                  background: 'var(--bg-surface)', color: 'var(--text-primary)',
+                  border: '1px solid var(--border-default)',
+                }}
+              />
+              <button
+                className="v10-modal-btn primary"
+                onClick={() => void handleSend()}
+                disabled={sending || input.trim().length === 0}
+                style={{ cursor: sending || input.trim().length === 0 ? 'default' : 'pointer', height: 36 }}
+              >
+                {sending ? '…' : 'Send'}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="v10-modal-footer">
+          <button className="v10-modal-btn" onClick={onClose}>Done</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import {
   authHeaders, removeParticipant, listParticipants,
   fetchAgents, listJoinRequests, approveJoinRequest, rejectJoinRequest,
-  type PendingJoinRequest,
+  getModelGrant, setModelShare,
+  type PendingJoinRequest, type SharedModelGrant,
 } from '../../api.js';
 import { useModalDismiss } from './useModalDismiss.js';
 
@@ -131,6 +132,15 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
   const [processingRequest, setProcessingRequest] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'allowlist' | 'requests'>('allowlist');
 
+  // Shared curator AI-model access (MVP): a single per-context-graph grant.
+  // Approved members inherit access when the curator enables sharing — there
+  // is NO separate recipient-side acceptance step.
+  const [modelSharingEnabled, setModelSharingEnabled] = useState(false);
+  const [modelId, setModelId] = useState<string | null>(null);
+  const [modelGrantLoaded, setModelGrantLoaded] = useState(false);
+  const [modelSaving, setModelSaving] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!open) return;
     fetch('/api/status', { headers: authHeaders() })
@@ -158,6 +168,22 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
     listJoinRequests(contextGraphId)
       .then((data) => setPendingRequests(data.requests))
       .catch(() => setPendingRequests([]));
+
+    // Fail CLOSED: if the grant can't be read, present sharing as disabled.
+    setModelGrantLoaded(false);
+    getModelGrant(contextGraphId)
+      .then((g: SharedModelGrant) => {
+        setModelSharingEnabled(!!g.enabled);
+        setModelId(g.modelId ?? null);
+        setModelError(null);
+        setModelGrantLoaded(true);
+      })
+      .catch(() => {
+        setModelSharingEnabled(false);
+        setModelId(null);
+        setModelError('Could not load model sharing status.');
+        setModelGrantLoaded(true);
+      });
   }, [open, contextGraphId]);
 
   // Esc-to-close + Tab focus-trap + focus-restore, same as Create/Join.
@@ -217,6 +243,30 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
       setAgentError(err?.message || 'Failed to reject');
     } finally {
       setProcessingRequest(null);
+    }
+  };
+
+  const handleToggleModelSharing = async (next: boolean) => {
+    const prev = modelSharingEnabled;
+    setModelSaving(true);
+    setModelError(null);
+    setModelSharingEnabled(next); // optimistic
+    try {
+      await setModelShare(contextGraphId, next);
+      if (!next) {
+        setModelId(null);
+      } else {
+        // Surface the model id the curator's node attached to the grant.
+        try {
+          const g = await getModelGrant(contextGraphId);
+          setModelId(g.modelId ?? null);
+        } catch { /* id is cosmetic; keep optimistic state */ }
+      }
+    } catch (err: any) {
+      setModelSharingEnabled(prev); // revert on failure
+      setModelError(err?.message || 'Failed to update model sharing.');
+    } finally {
+      setModelSaving(false);
     }
   };
 
@@ -353,6 +403,44 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
 
               <div className="v10-form-divider" />
 
+              {/* AI Model Access — MVP: one per-CG grant, membership-based.
+                  Enabling lets allowlisted members invoke the model this node
+                  runs. No separate recipient-side acceptance. */}
+              <div className="v10-form-group">
+                <label className="v10-form-label">AI Model Access</label>
+                <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginBottom: 8 }}>
+                  Share the AI model this node runs with everyone on the allowlist. AI model access is tied to context graph membership — approved members inherit access when this is enabled. There is no separate acceptance step.
+                </div>
+                <label style={{
+                  display: 'flex', alignItems: 'center', gap: 8, fontSize: 12,
+                  color: 'var(--text-primary)',
+                  cursor: (!modelGrantLoaded || modelSaving) ? 'default' : 'pointer',
+                }}>
+                  <input
+                    type="checkbox"
+                    checked={modelSharingEnabled}
+                    disabled={!modelGrantLoaded || modelSaving}
+                    onChange={(e) => handleToggleModelSharing(e.target.checked)}
+                    aria-label="Share curator AI model access with this context graph"
+                  />
+                  Share curator AI model access with this context graph
+                  {modelSaving && <span style={{ color: 'var(--text-tertiary)', fontSize: 10 }}>saving…</span>}
+                </label>
+                {modelSharingEnabled && modelId && (
+                  <div style={{
+                    fontSize: 10, color: 'var(--text-tertiary)', marginTop: 6,
+                    fontFamily: 'var(--font-mono)',
+                  }}>
+                    Current shared model: {modelId}
+                  </div>
+                )}
+                {modelError && (
+                  <div style={{ fontSize: 10, color: 'var(--text-danger)', marginTop: 6 }}>{modelError}</div>
+                )}
+              </div>
+
+              <div className="v10-form-divider" />
+
               {/* Invite code */}
               <div className="v10-form-group">
                 <label className="v10-form-label">Invite Code</label>
@@ -386,6 +474,15 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                     </button>
                   </div>
                 )}
+                {modelSharingEnabled && (
+                  <div style={{
+                    marginTop: 10, padding: '8px 10px', borderRadius: 6, fontSize: 11,
+                    color: 'var(--text-secondary)', background: 'var(--bg-surface)',
+                    border: '1px solid var(--accent-primary)',
+                  }}>
+                    Approved members of this context graph will also get access to the curator AI model.
+                  </div>
+                )}
               </div>
             </>
           )}
@@ -395,6 +492,7 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
               <label className="v10-form-label">Pending Join Requests</label>
               <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginBottom: 8 }}>
                 Agents who submitted a signed request to join this context graph. Approve to add them to the allowlist.
+                {modelSharingEnabled && ' Approving also grants AI model access, which is enabled for this context graph.'}
               </div>
 
               {pendingRequests.length === 0 && (

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
 import { NotificationsBell } from './NotificationsBell.js';
+import { CuratorModelChatModal } from '../Modals/CuratorModelChatModal.js';
 import { formatPeerStatusTooltip } from '../../lib/formatPeerStatus.js';
 
 /** OriginTrail wordmark — same paths as `v9-stable` packages/node-ui App.tsx sidebar. */
@@ -66,6 +67,14 @@ const OBSERVABILITY_ICON = (
   </svg>
 );
 
+// Chat-bubble + spark — "Curator Model": chat with a curator's shared AI model.
+const CURATOR_MODEL_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    <path d="M12 8.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z" />
+  </svg>
+);
+
 export function Header() {
   const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();
   const nodeStatus = useAgentsStore((s) => s.nodeStatus);
@@ -78,6 +87,11 @@ export function Header() {
   // second to one.
   const currentAgent = useCurrentAgent().data;
   const { openTab } = useTabsStore();
+  // Curator Model chat is a global, cross-CG surface (it self-discovers every
+  // CG this node is a member of), so it's launched here from the global header
+  // rather than from a per-project view. The modal owns its own discovery +
+  // in-memory chat session.
+  const [showCuratorModel, setShowCuratorModel] = useState(false);
 
   const connectedPeers = nodeStatus?.connectedPeers ?? nodeStatus?.peerCount ?? 0;
   const directConns = nodeStatus?.connections?.direct ?? 0;
@@ -88,6 +102,7 @@ export function Header() {
   const peerStatusLabel = formatPeerStatusTooltip(synced, connectedPeers, directConns, relayedConns, uptimeMs);
 
   return (
+    <>
     <header className="v10-header">
       <div className="v10-header-logo">
         <span className="v10-header-logo-text">DKG <span className="v10-header-logo-version">v10</span></span>
@@ -133,6 +148,14 @@ export function Header() {
 
         <button
           className="v10-header-icon-btn"
+          onClick={() => setShowCuratorModel(true)}
+          title="Curator Model — chat with a curator's shared AI model"
+        >
+          {CURATOR_MODEL_ICON}
+        </button>
+
+        <button
+          className="v10-header-icon-btn"
           onClick={() => openTab({ id: 'operations', label: 'Observability', closable: true })}
           title="Observability"
         >
@@ -164,5 +187,11 @@ export function Header() {
         </button>
       </div>
     </header>
+    {/* Mount only while open so the modal's discovery hook (useMyContextGraphs
+        → fetchContextGraphs poll) doesn't run on every Header mount. */}
+    {showCuratorModel && (
+      <CuratorModelChatModal open onClose={() => setShowCuratorModel(false)} />
+    )}
+    </>
   );
 }

--- a/packages/node-ui/test/invoke-shared-model-chat.test.ts
+++ b/packages/node-ui/test/invoke-shared-model-chat.test.ts
@@ -1,0 +1,96 @@
+// Unit coverage for `invokeSharedModelChat` — the api.ts helper behind the
+// Curator Model chat demo (Header → CuratorModelChatModal). The load-bearing
+// logic is the response unwrapping:
+//   - 2xx → choices[0].message.content
+//   - non-2xx → throw Error carrying the OpenAI-shaped error.message (an
+//     OBJECT, not a string — the generic post() helper would mangle it)
+// so we pin both against a mocked fetch, mirroring the modal/ai-model test's
+// fetch-mock style.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invokeSharedModelChat } from '../src/ui/api.js';
+
+const CG = 'shared-model-test-1781437109';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  (globalThis as any).window = { __DKG_TOKEN__: 'test-token' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as any).window;
+});
+
+describe('invokeSharedModelChat', () => {
+  it('POSTs to the member node OpenAI-compatible route with the bearer token and messages', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        object: 'chat.completion',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'Hello there, friend!' } }],
+      }),
+    );
+    (globalThis as any).fetch = fetchMock;
+
+    const content = await invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }], { model: 'gpt-4o-mini' });
+
+    expect(content).toBe('Hello there, friend!');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`/api/context-graph/${CG}/model/v1/chat/completions`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] });
+  });
+
+  it('omits the model field when none is supplied', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, { choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    );
+    (globalThis as any).fetch = fetchMock;
+
+    await invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ messages: [{ role: 'user', content: 'hi' }] });
+  });
+
+  it('returns an empty string when the completion has no content', async () => {
+    (globalThis as any).fetch = vi.fn(async () => jsonResponse(200, { choices: [] }));
+    await expect(invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }])).resolves.toBe('');
+  });
+
+  it('throws the OpenAI-shaped error.message on a 403 denial', async () => {
+    (globalThis as any).fetch = vi.fn(async () =>
+      jsonResponse(403, {
+        error: {
+          message: 'requester is not a member of this context graph',
+          type: 'invalid_request_error',
+          code: 'shared_model_denied',
+        },
+      }),
+    );
+
+    await expect(
+      invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('requester is not a member of this context graph');
+  });
+
+  it('falls back to an HTTP status message when the error body is unparseable', async () => {
+    (globalThis as any).fetch = vi.fn(async () =>
+      new Response('not json', { status: 500, headers: { 'content-type': 'text/plain' } }),
+    );
+
+    await expect(
+      invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('HTTP 500');
+  });
+});

--- a/packages/node-ui/test/share-project-modal-ai-model.test.ts
+++ b/packages/node-ui/test/share-project-modal-ai-model.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+// Coverage for the shared curator AI-model access MVP surfaced in
+// ShareProjectModal. The MVP is MEMBERSHIP-BASED: a curator toggles a single
+// per-context-graph grant, and approved members inherit access. There is NO
+// separate recipient-side acceptance flow — these tests pin that the UI never
+// implies one.
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+const removeParticipantMock = vi.fn();
+const listParticipantsMock = vi.fn();
+const fetchAgentsMock = vi.fn();
+const listJoinRequestsMock = vi.fn();
+const approveJoinRequestMock = vi.fn();
+const rejectJoinRequestMock = vi.fn();
+const getModelGrantMock = vi.fn();
+const setModelShareMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    removeParticipant: removeParticipantMock,
+    listParticipants: listParticipantsMock,
+    fetchAgents: fetchAgentsMock,
+    listJoinRequests: listJoinRequestsMock,
+    approveJoinRequest: approveJoinRequestMock,
+    rejectJoinRequest: rejectJoinRequestMock,
+    getModelGrant: getModelGrantMock,
+    setModelShare: setModelShareMock,
+  };
+});
+
+const CG = 'did:dkg:context-graph:test/cg';
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function flush(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+async function render(element: React.ReactElement): Promise<HTMLElement> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(element); });
+  await flush();
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  return container;
+}
+
+let ShareProjectModal: any;
+
+beforeEach(async () => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+  (globalThis as any).fetch = vi.fn(async () =>
+    new Response(JSON.stringify({ peerId: '12D3KooWQAStub' }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }),
+  );
+  listParticipantsMock.mockResolvedValue({ allowedAgents: [] });
+  fetchAgentsMock.mockResolvedValue({ agents: [] });
+  listJoinRequestsMock.mockResolvedValue({ requests: [] });
+  getModelGrantMock.mockResolvedValue({ contextGraphId: CG, enabled: false });
+  setModelShareMock.mockResolvedValue({ ok: true, contextGraphId: CG, enabled: true });
+  ({ ShareProjectModal } = await import('../src/ui/components/Modals/ShareProjectModal.js'));
+});
+
+afterEach(() => {
+  while (mountedRoots.length > 0) {
+    const root = mountedRoots.pop()!;
+    const container = mountedContainers.pop()!;
+    act(() => { root.unmount(); });
+    container.remove();
+  }
+});
+
+function modal(props: { open: boolean; onClose: () => void }) {
+  return React.createElement(ShareProjectModal, {
+    ...props, contextGraphId: CG, contextGraphName: 'Test CG',
+  });
+}
+function checkbox(c: HTMLElement): HTMLInputElement {
+  return c.querySelector('input[aria-label="Share curator AI model access with this context graph"]') as HTMLInputElement;
+}
+
+describe('ShareProjectModal — AI Model Access (MVP)', () => {
+  it('renders the AI Model Access section with a share toggle', async () => {
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    expect(c.textContent).toContain('AI Model Access');
+    expect(checkbox(c)).toBeTruthy();
+  });
+
+  it('fetches the grant state on open', async () => {
+    await render(modal({ open: true, onClose: vi.fn() }));
+    expect(getModelGrantMock).toHaveBeenCalledWith(CG);
+  });
+
+  it('shows enabled state, the model id, and the membership note when sharing is on', async () => {
+    getModelGrantMock.mockResolvedValue({ contextGraphId: CG, enabled: true, modelId: 'mock-model' });
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    expect(checkbox(c).checked).toBe(true);
+    expect(c.textContent).toContain('Current shared model: mock-model');
+    expect(c.textContent).toContain('Approved members of this context graph will also get access to the curator AI model');
+  });
+
+  it('toggling on calls setModelShare with (cgId, true)', async () => {
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    await act(async () => { checkbox(c).click(); });
+    await flush();
+    expect(setModelShareMock).toHaveBeenCalledWith(CG, true);
+  });
+
+  it('surfaces an error and reverts the toggle when saving fails', async () => {
+    setModelShareMock.mockRejectedValue(new Error('save boom'));
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    await act(async () => { checkbox(c).click(); });
+    await flush();
+    expect(c.textContent).toContain('save boom');
+    expect(checkbox(c).checked).toBe(false); // reverted
+  });
+
+  it('fails closed (disabled, with notice) when the grant cannot be loaded', async () => {
+    getModelGrantMock.mockRejectedValue(new Error('network down'));
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    expect(checkbox(c).checked).toBe(false);
+    expect(c.textContent).toContain('Could not load model sharing status.');
+    expect(c.textContent).not.toContain('Approved members of this context graph will also get access');
+  });
+
+  it('uses membership language and never implies a separate recipient acceptance step', async () => {
+    getModelGrantMock.mockResolvedValue({ contextGraphId: CG, enabled: true, modelId: 'mock-model' });
+    const c = await render(modal({ open: true, onClose: vi.fn() }));
+    const text = (c.textContent ?? '').toLowerCase();
+    expect(text).toContain('inherit');
+    expect(text).toContain('membership');
+    // Must NOT misrepresent the MVP as consent/acceptance-gated on the recipient.
+    expect(text).not.toMatch(/must accept/);
+    expect(text).not.toMatch(/pending ai/);
+    expect(text).not.toMatch(/accept ai (model )?access/);
+    expect(text).not.toMatch(/request ai access/);
+    expect(text).not.toMatch(/ai access request/);
+  });
+});

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of shared curator AI-model access (PR #1157) over a devnet,
+# including the M1 hardening fixes (PR #1158):
+#   B1 — membership gate: a REMOVED member must be DENIED (the canonical
+#        approved-delegatee-peer set, not the pre-approval/self-asserted one).
+#   B2 — invoke timeout: a slow upstream provider (>20s, the old router
+#        default) must still return a completion (opt-in, TEST_B2=1).
+#
+# Drives 2 devnet nodes over HTTP:
+#   N1 (port 9201) — curator; serves the shared model, owns a private CG
+#   N2 (port 9202) — member; joins via a genuine pending join, then invokes
+#
+# Faithful-path requirements this script encodes (all code-confirmed):
+#   * invoke is issued against the MEMBER node (N2), never the curator —
+#     otherwise the local fast-path hardcodes isMember:true and the P2P
+#     membership gate is never exercised.
+#   * membership is established via the genuine sign-join -> request-join
+#     (pending) -> approve-join handshake (NOT invite-with-model, which does
+#     not write the delegatee-peer binding the gate checks).
+#   * N2 is never pre-allowlisted, so the join is a real `pending` (an
+#     already-member short-circuit would skip the post-approval _meta sync).
+#   * the script does NOT call /subscribe before the grant lands.
+#
+# Assumes `./scripts/devnet.sh start 2` (or more) is running. By default the
+# script (re)starts node1 with DEVNET_SHARED_MODEL=1 (mock provider) so the
+# curator serves invokes; set SKIP_CONFIG=1 if you configured sharing yourself.
+#
+# Env:
+#   SKIP_CONFIG=1   do not touch node1 config / restart (you pre-configured it)
+#   TEST_B2=1       also run the slow-upstream timeout check (B2)
+#   B2_SLEEP=25     seconds the slow stub waits before responding (>20, <110)
+#   STUB_PORT=9777  port for the local slow openai-compatible stub
+#   DEVNET_TOKEN / DKG_AUTH   override the auth token (else read from devnet)
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVNET_DIR="$SCRIPT_DIR/../.devnet"
+
+N1=http://127.0.0.1:9201
+N2=http://127.0.0.1:9202
+N1_ADDR=""; N2_ADDR=""; N1_PEER_ID=""
+
+TEST_B2="${TEST_B2:-}"
+B2_SLEEP="${B2_SLEEP:-25}"
+STUB_PORT="${STUB_PORT:-9777}"
+STUB_PID=""
+MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"
+
+CG_ID="shared-model-test-$(date +%s)"
+
+# Resolve the devnet auth token the same way the sibling scripts do.
+if [[ -n "${DEVNET_TOKEN:-}" ]]; then
+  TOKEN="$DEVNET_TOKEN"
+elif [[ -n "${DKG_AUTH:-}" ]]; then
+  TOKEN="$DKG_AUTH"
+elif [[ -f "$DEVNET_DIR/node1/auth.token" ]]; then
+  TOKEN="$(grep -v '^#' "$DEVNET_DIR/node1/auth.token" 2>/dev/null | tr -d '[:space:]')"
+else
+  echo "ERROR: No auth token. Export DEVNET_TOKEN/DKG_AUTH or run ./scripts/devnet.sh start" >&2
+  exit 2
+fi
+
+hr()   { printf '\n\033[1;34m── %s ──\033[0m\n' "$*"; }
+ok()   { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31m✗\033[0m %s\n' "$*"; cleanup; exit 1; }
+note() { printf '  \033[0;90m· %s\033[0m\n' "$*"; }
+
+cleanup() { [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null; }
+trap cleanup EXIT
+
+api() {
+  local node="$1" method="$2" path="$3" body="${4:-}"
+  if [ -n "$body" ]; then
+    curl -sS -X "$method" "${node}${path}" -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" --data "$body"
+  else
+    curl -sS -X "$method" "${node}${path}" -H "Authorization: Bearer $TOKEN"
+  fi
+}
+urlenc() { python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$1"; }
+jget()   { python3 -c "import sys,json
+try: d=json.load(sys.stdin)
+except Exception: print(''); sys.exit(0)
+cur=d
+for k in sys.argv[1].split('.'):
+    cur=cur.get(k) if isinstance(cur,dict) else None
+print('' if cur is None else cur)" "$1"; }
+
+identify() {
+  for i in 1 2; do
+    local url; url=$(eval echo "\$N${i}")
+    local self; self=$(api "$url" GET /api/agents | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+for a in d.get('agents',[]):
+    if a.get('connectionStatus')=='self':
+        print(json.dumps({'addr':a.get('agentAddress',''),'peer':a.get('peerId','')})); break
+")
+    local addr peer
+    addr=$(echo "$self" | jget addr); peer=$(echo "$self" | jget peer)
+    [ -z "$addr" ] && fail "N$i: could not fetch agent address (is the devnet up?)"
+    eval "N${i}_ADDR=\"$addr\""; eval "N${i}_PEER_ID=\"$peer\""
+    ok "N$i: $addr (peer $peer)"
+  done
+}
+
+wait_node_ready() {
+  local node="$1" start; start=$(date +%s)
+  while :; do
+    if api "$node" GET /api/status >/dev/null 2>&1; then ok "node ready: $node"; return 0; fi
+    [ $(( $(date +%s) - start )) -ge 60 ] && fail "node not ready after 60s: $node"
+    sleep 1.5
+  done
+}
+
+start_slow_stub() {
+  hr "B2 — starting slow openai-compatible stub on :$STUB_PORT (sleeps ${B2_SLEEP}s)"
+  python3 - "$STUB_PORT" "$B2_SLEEP" >/dev/null 2>&1 <<'PY' &
+import sys, json, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+port, sleep = int(sys.argv[1]), float(sys.argv[2])
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('content-length', 0)); self.rfile.read(n)
+        time.sleep(sleep)
+        body = json.dumps({"choices":[{"message":{"content":"slow-pong"}}],"model":"slow-stub"}).encode()
+        self.send_response(200); self.send_header('content-type','application/json')
+        self.send_header('content-length', str(len(body))); self.end_headers(); self.wfile.write(body)
+    def log_message(self, *a): pass
+HTTPServer(('127.0.0.1', port), H).serve_forever()
+PY
+  STUB_PID=$!
+  sleep 1
+  ok "stub pid $STUB_PID"
+}
+
+# (Re)configure node1 as a sharing curator and restart it so config regenerates
+# WITH the sharedModel block (restart-node re-runs create_node_config).
+ensure_curator_config() {
+  if [ "${SKIP_CONFIG:-}" = "1" ]; then
+    note "SKIP_CONFIG=1 — assuming node1 already has sharedModel enabled"
+    return 0
+  fi
+  hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"
+  export DEVNET_SHARED_MODEL=1
+  if [ "$TEST_B2" = "1" ]; then
+    start_slow_stub
+    export DEVNET_SHARED_MODEL_PROVIDER=openai-compatible
+    export DEVNET_SHARED_MODEL_MODEL=slow-stub
+    export DEVNET_SHARED_MODEL_BASEURL="http://127.0.0.1:${STUB_PORT}/v1"
+  else
+    export DEVNET_SHARED_MODEL_PROVIDER=mock
+  fi
+  "$SCRIPT_DIR/devnet.sh" restart-node 1 >/dev/null 2>&1 || fail "restart-node 1 failed"
+  wait_node_ready "$N1"
+}
+
+# Genuine sign-join -> request-join(pending) -> approve-join, then poll the
+# member's grant until the curated _meta (curator triples + grant) has synced.
+establish_membership() {
+  local enc; enc=$(urlenc "$CG_ID")
+
+  hr "Member signs a join delegation (binds N2 peer id)"
+  local deleg; deleg=$(api "$N2" POST "/api/context-graph/$enc/sign-join" "{}" \
+    | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin).get('delegation') or {}))")
+  { [ -z "$deleg" ] || [ "$deleg" = "{}" ]; } && fail "sign-join returned no delegation"
+  ok "delegation signed"
+
+  hr "Member submits a GENUINE pending join over P2P"
+  local sb; sb=$(python3 -c "import json; print(json.dumps({'delegation': json.loads('''$deleg'''), 'curatorPeerId': '$N1_PEER_ID'}))")
+  local resp; resp=$(api "$N2" POST "/api/context-graph/$enc/request-join" "$sb")
+  local delivered; delivered=$(echo "$resp" | jget delivered)
+  local status; status=$(echo "$resp" | jget status)
+  note "request-join: delivered=$delivered status=$status"
+  [ "$status" = "already-member" ] && fail "join short-circuited as already-member — N2 must not be pre-allowlisted"
+
+  hr "Curator sees the pending request"
+  local found; found=$(api "$N1" GET "/api/context-graph/$enc/join-requests" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print('yes' if any(r.get('agentAddress','').lower()=='$N2_ADDR'.lower() for r in d.get('requests',[])) else 'no')")
+  [ "$found" = "yes" ] && ok "curator sees N2's pending request" || fail "N2 request not pending on curator: re-run, it must be a fresh join"
+
+  hr "Curator approves (writes allowedDelegateePeer=N2; triggers post-approval _meta sync)"
+  local ar; ar=$(api "$N1" POST "/api/context-graph/$enc/approve-join" "{\"agentAddress\":\"$N2_ADDR\"}")
+  note "approve-join: $ar"
+
+  hr "Member polls grant until _meta has synced (enabled:true)"
+  local start; start=$(date +%s)
+  while :; do
+    local g; g=$(api "$N2" GET "/api/context-graph/$enc/model/grant")
+    [ "$(echo "$g" | jget enabled)" = "True" ] && { ok "grant synced to member: $g"; break; }
+    [ $(( $(date +%s) - start )) -ge 90 ] && fail "grant did not sync to member within 90s (last: $g)"
+    sleep 2
+  done
+}
+
+###############################################################################
+
+hr "Shared curator AI-model access — devnet e2e (mode: $MODE, CG: $CG_ID)"
+identify
+ensure_curator_config
+
+hr "Curator creates a PRIVATE (curated) CG, allowlist = [curator only]"
+create_body=$(python3 -c "import json; print(json.dumps({'id':'$CG_ID','name':'Shared-model test $CG_ID','description':'shared-model e2e','accessPolicy':1,'allowedAgents':['$N1_ADDR']}))")
+cr=$(api "$N1" POST /api/context-graph/create "$create_body")
+[ "$(echo "$cr" | jget created)" = "$CG_ID" ] && ok "CG created" || fail "create failed: $cr"
+
+hr "Curator enables model sharing for the CG"
+enc=$(urlenc "$CG_ID")
+sr=$(api "$N1" POST "/api/context-graph/$enc/model/share" '{"enabled":true}')
+[ "$(echo "$sr" | jget ok)" = "True" ] && ok "model/share: $sr" || fail "model/share failed: $sr"
+gr=$(api "$N1" GET "/api/context-graph/$enc/model/grant")
+[ "$(echo "$gr" | jget enabled)" = "True" ] && ok "curator grant enabled (model: $(echo "$gr" | jget modelId))" || fail "grant not enabled on curator: $gr"
+
+establish_membership
+
+hr "Member invokes the curator's model over P2P (the real gate)"
+inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"ping-from-member-42"}]}')
+[ "$(echo "$inv" | jget ok)" = "True" ] || fail "invoke denied unexpectedly: $inv"
+content=$(echo "$inv" | jget content)
+if [ "$TEST_B2" = "1" ]; then
+  echo "$content" | grep -q "slow-pong" && ok "B2: slow provider returned a completion: \"$content\"" \
+    || fail "B2: expected slow-pong, got: $inv"
+else
+  echo "$content" | grep -q "ping-from-member-42" && echo "$content" | grep -q "\[shared-model:" \
+    && ok "invoke ok, mock echoed prompt: \"$content\"" || fail "unexpected mock content: $inv"
+fi
+
+# OpenAI-compatible surface (mock mode only — keeps the B2 path to one slow call)
+if [ "$TEST_B2" != "1" ]; then
+  hr "Member invokes via the OpenAI-compatible endpoint"
+  oai=$(api "$N2" POST "/api/context-graph/$enc/model/v1/chat/completions" \
+    '{"model":"probe","messages":[{"role":"user","content":"openai-path-check"}]}')
+  [ "$(echo "$oai" | jget object)" = "chat.completion" ] || fail "OpenAI endpoint shape wrong: $oai"
+  oc=$(echo "$oai" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('choices',[{}])[0].get('message',{}).get('content',''))")
+  echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+fi
+
+# ---- B1 regression: a removed member must now be DENIED ----
+hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
+rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
+[ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
+
+start=$(date +%s)
+while :; do
+  inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
+  okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
+  if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
+    ok "B1 PASS: removed member denied — \"$denied\""
+    break
+  fi
+  if [ "$okf" = "True" ]; then
+    fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
+  fi
+  [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
+  sleep 1.5
+done
+
+hr "Done — shared-model e2e passed (mode: $MODE)"
+echo "CG id used: $CG_ID"
+[ "$TEST_B2" = "1" ] && note "B2 proved the invoke survived a ${B2_SLEEP}s upstream; on the unpatched build this returns 'curator node unreachable' at ~20s."

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -178,6 +178,9 @@ PY
 ensure_curator_config() {
   if [ "${SKIP_CONFIG:-}" = "1" ] || [ "$REAL" = "1" ]; then
     note "skipping auto-config — assuming node1 already has sharedModel enabled (REAL/SKIP_CONFIG)"
+    # You likely just restarted node1 to point it at the provider; make sure its
+    # libp2p has re-meshed with the member before the join handshake.
+    wait_curator_peered
     return 0
   fi
   hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -31,6 +31,11 @@
 #   TEST_B2=1       also run the slow-upstream timeout check (B2)
 #   B2_SLEEP=25     seconds the slow stub waits before responding (>20, <110)
 #   STUB_PORT=9777  port for the local slow openai-compatible stub
+#   REAL=1          happy-path smoke against a REAL provider you configured on
+#                   node1 yourself (implies SKIP_CONFIG: the script never bakes a
+#                   key). Relaxes the mock-echo assertion to "ok + non-empty",
+#                   prints the real completion, and SKIPS the B1 removal so the
+#                   member stays joined for further manual curl calls.
 #   DEVNET_TOKEN / DKG_AUTH   override the auth token (else read from devnet)
 
 set -u
@@ -44,10 +49,11 @@ N2=http://127.0.0.1:9202
 N1_ADDR=""; N2_ADDR=""; N1_PEER_ID=""
 
 TEST_B2="${TEST_B2:-}"
+REAL="${REAL:-}"
 B2_SLEEP="${B2_SLEEP:-25}"
 STUB_PORT="${STUB_PORT:-9777}"
 STUB_PID=""
-MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"
+MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"; [ "$REAL" = "1" ] && MODE="real-provider"
 
 CG_ID="shared-model-test-$(date +%s)"
 
@@ -170,8 +176,8 @@ PY
 # (Re)configure node1 as a sharing curator and restart it so config regenerates
 # WITH the sharedModel block (restart-node re-runs create_node_config).
 ensure_curator_config() {
-  if [ "${SKIP_CONFIG:-}" = "1" ]; then
-    note "SKIP_CONFIG=1 — assuming node1 already has sharedModel enabled"
+  if [ "${SKIP_CONFIG:-}" = "1" ] || [ "$REAL" = "1" ]; then
+    note "skipping auto-config — assuming node1 already has sharedModel enabled (REAL/SKIP_CONFIG)"
     return 0
   fi
   hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"
@@ -250,10 +256,14 @@ gr=$(api "$N1" GET "/api/context-graph/$enc/model/grant")
 establish_membership
 
 hr "Member invokes the curator's model over P2P (the real gate)"
-inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"ping-from-member-42"}]}')
+prompt="ping-from-member-42"; [ "$REAL" = "1" ] && prompt="In one short sentence, introduce yourself and name the model you are."
+inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" "{\"messages\":[{\"role\":\"user\",\"content\":\"$prompt\"}]}")
 [ "$(echo "$inv" | jget ok)" = "True" ] || fail "invoke denied unexpectedly: $inv"
 content=$(echo "$inv" | jget content)
-if [ "$TEST_B2" = "1" ]; then
+if [ "$REAL" = "1" ]; then
+  [ -n "$content" ] && { ok "REAL provider returned a completion over the full P2P pipe:"; printf '    \033[0;36m%s\033[0m\n' "$content"; } \
+    || fail "real provider returned empty content: $inv"
+elif [ "$TEST_B2" = "1" ]; then
   echo "$content" | grep -q "slow-pong" && ok "B2: slow provider returned a completion: \"$content\"" \
     || fail "B2: expected slow-pong, got: $inv"
 else
@@ -264,33 +274,44 @@ fi
 # OpenAI-compatible surface (mock mode only — keeps the B2 path to one slow call)
 if [ "$TEST_B2" != "1" ]; then
   hr "Member invokes via the OpenAI-compatible endpoint"
+  oprompt="openai-path-check"; [ "$REAL" = "1" ] && oprompt="In one short sentence, what is the OriginTrail DKG?"
   oai=$(api "$N2" POST "/api/context-graph/$enc/model/v1/chat/completions" \
-    '{"model":"probe","messages":[{"role":"user","content":"openai-path-check"}]}')
+    "{\"model\":\"probe\",\"messages\":[{\"role\":\"user\",\"content\":\"$oprompt\"}]}")
   [ "$(echo "$oai" | jget object)" = "chat.completion" ] || fail "OpenAI endpoint shape wrong: $oai"
   oc=$(echo "$oai" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('choices',[{}])[0].get('message',{}).get('content',''))")
-  echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+  if [ "$REAL" = "1" ]; then
+    [ -n "$oc" ] && { ok "REAL OpenAI-compatible completion:"; printf '    \033[0;36m%s\033[0m\n' "$oc"; } || fail "real OpenAI content empty: $oai"
+  else
+    echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+  fi
 fi
 
 # ---- B1 regression: a removed member must now be DENIED ----
-hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
-rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
-[ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
+if [ "$REAL" = "1" ]; then
+  hr "B1 — skipped in REAL mode (member kept joined so you can keep poking the real model)"
+  note "member $N2_ADDR remains in CG $CG_ID; e.g. curl -XPOST $N2/api/context-graph/$enc/model/invoke ..."
+else
+  hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
+  rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
+  [ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
 
-start=$(date +%s)
-while :; do
-  inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
-  okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
-  if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
-    ok "B1 PASS: removed member denied — \"$denied\""
-    break
-  fi
-  if [ "$okf" = "True" ]; then
-    fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
-  fi
-  [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
-  sleep 1.5
-done
+  start=$(date +%s)
+  while :; do
+    inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
+    okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
+    if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
+      ok "B1 PASS: removed member denied — \"$denied\""
+      break
+    fi
+    if [ "$okf" = "True" ]; then
+      fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
+    fi
+    [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
+    sleep 1.5
+  done
+fi
 
 hr "Done — shared-model e2e passed (mode: $MODE)"
 echo "CG id used: $CG_ID"
 [ "$TEST_B2" = "1" ] && note "B2 proved the invoke survived a ${B2_SLEEP}s upstream; on the unpatched build this returns 'curator node unreachable' at ~20s."
+[ "$REAL" = "1" ] && note "REAL run: a real model's completion flowed over the full member→curator P2P pipe. Member kept in CG $CG_ID."

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -116,6 +116,36 @@ wait_node_ready() {
   done
 }
 
+# After the curator (node1) is restarted, its API answers (wait_node_ready) well
+# before its libp2p stack has finished re-dialing the member and RE-ADVERTISING
+# the /dkg sync protocol. If the join handshake runs inside that window, the
+# curator's one-shot post-approval _meta sync lands while the member still sees
+# the curator as "does not support sync protocol", the targeted sync fails, and
+# the member's self-heal retry runs a broad catch-up that SKIPS the brand-new CG
+# ("unauthorized or unconfirmed") — so the grant/_meta never reaches the member
+# and every invoke is denied ("could not resolve curator peer"). Block until the
+# member actually sees the curator peer CONNECTED again, then add a short settle
+# margin for the identify-push that re-advertises the sync protocol.
+wait_curator_peered() {
+  local start; start=$(date +%s)
+  while :; do
+    local seen; seen=$(api "$N2" GET /api/agents | python3 -c "
+import sys,json
+try: d=json.load(sys.stdin)
+except Exception: print('no'); sys.exit(0)
+print('yes' if any(
+    a.get('peerId')=='$N1_PEER_ID' and a.get('connectionStatus')=='connected'
+    for a in d.get('agents',[])) else 'no')")
+    if [ "$seen" = "yes" ]; then
+      sleep 4   # settle margin for libp2p identify to re-advertise /dkg sync proto
+      ok "member re-peered with curator (post-restart P2P settled)"
+      return 0
+    fi
+    [ $(( $(date +%s) - start )) -ge 60 ] && fail "member did not re-peer with curator within 60s of restart"
+    sleep 2
+  done
+}
+
 start_slow_stub() {
   hr "B2 — starting slow openai-compatible stub on :$STUB_PORT (sleeps ${B2_SLEEP}s)"
   python3 - "$STUB_PORT" "$B2_SLEEP" >/dev/null 2>&1 <<'PY' &
@@ -156,6 +186,7 @@ ensure_curator_config() {
   fi
   "$SCRIPT_DIR/devnet.sh" restart-node 1 >/dev/null 2>&1 || fail "restart-node 1 failed"
   wait_node_ready "$N1"
+  wait_curator_peered
 }
 
 # Genuine sign-join -> request-join(pending) -> approve-join, then poll the

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -1664,6 +1664,11 @@ cmd_restart_node() {
     rm -f "$pidf"
   fi
   cd "$REPO_ROOT" || exit 1
+  # Regenerate config.json so env-driven blocks (e.g. DEVNET_SHARED_MODEL) take
+  # effect on restart — start_node only reads the existing config and patches
+  # relay/bootstrapPeers, it does NOT re-run create_node_config. Persisted store
+  # state, identity and the auth.token file live elsewhere and are untouched.
+  create_node_config "$node_num"
   start_node "$node_num"
   log "Node $node_num restarted."
 }

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -486,6 +486,9 @@ create_node_config() {
     local sm_fields="\"enabled\": true, \"provider\": \"${DEVNET_SHARED_MODEL_PROVIDER:-mock}\""
     [ -n "${DEVNET_SHARED_MODEL_MODEL:-}" ] && sm_fields="${sm_fields}, \"model\": \"${DEVNET_SHARED_MODEL_MODEL}\""
     [ -n "${DEVNET_SHARED_MODEL_BASEURL:-}" ] && sm_fields="${sm_fields}, \"baseUrl\": \"${DEVNET_SHARED_MODEL_BASEURL}\""
+    # Names an env var the daemon reads at boot for the provider API key (the key
+    # itself is NEVER written to config). Required for a real openai-compatible run.
+    [ -n "${DEVNET_SHARED_MODEL_API_KEY_ENV:-}" ] && sm_fields="${sm_fields}, \"apiKeyEnv\": \"${DEVNET_SHARED_MODEL_API_KEY_ENV}\""
     [ -n "${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"invokeTimeoutMs\": ${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS}"
     [ -n "${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"providerTimeoutMs\": ${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS}"
     shared_model_block="\"sharedModel\": { ${sm_fields} },"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -476,6 +476,21 @@ create_node_config() {
     rs_block="\"randomSampling\": { \"walPath\": \"${node_dir}/random-sampling.wal\", \"tickIntervalMs\": 5000 },"
   fi
 
+  # Shared curator AI-model access (PR #1157). Opt-in via DEVNET_SHARED_MODEL=1
+  # so scripts/devnet-test-shared-model.sh can stand up a curator node that
+  # serves member invokes. Defaults to the offline 'mock' provider (no key);
+  # override provider/model/baseUrl/timeouts via env for openai-compatible
+  # runs (e.g. the slow-upstream check for the invoke-timeout fix).
+  local shared_model_block=""
+  if [ "${DEVNET_SHARED_MODEL:-}" = "1" ]; then
+    local sm_fields="\"enabled\": true, \"provider\": \"${DEVNET_SHARED_MODEL_PROVIDER:-mock}\""
+    [ -n "${DEVNET_SHARED_MODEL_MODEL:-}" ] && sm_fields="${sm_fields}, \"model\": \"${DEVNET_SHARED_MODEL_MODEL}\""
+    [ -n "${DEVNET_SHARED_MODEL_BASEURL:-}" ] && sm_fields="${sm_fields}, \"baseUrl\": \"${DEVNET_SHARED_MODEL_BASEURL}\""
+    [ -n "${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"invokeTimeoutMs\": ${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS}"
+    [ -n "${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"providerTimeoutMs\": ${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS}"
+    shared_model_block="\"sharedModel\": { ${sm_fields} },"
+  fi
+
   cat > "$node_dir/config.json" <<EOCONF
 {
   "name": "devnet-node-${node_num}",
@@ -495,6 +510,7 @@ create_node_config() {
   ${rs_block}
   ${publisher_block}
   ${epcis_block}
+  ${shared_model_block}
   "chain": {
     "type": "evm",
     "rpcUrl": "http://127.0.0.1:${HARDHAT_PORT}",


### PR DESCRIPTION
## Shared curator AI-model access (MVP)

Let a **context-graph (CG) curator** optionally share access to the AI model they
already run — in the **same flow as inviting an agent to the CG's shared working
memory**. Members send prompts to the curator's model over the DKG P2P substrate
and get completions back. **The curator's API key never leaves the curator's
node.**

Additive and **default-off**: nothing is shared unless a curator explicitly turns
it on per CG. No genesis/ontology change — the grant predicates are written to the
CG `_meta` graph locally, so the network/genesis hash is untouched.

### Design

- **Membership = the invite you already sent.** Authorization reuses the
  delegatee-peer binding written to `_meta` at invite/join time
  (`allowedDelegateePeer` / `delegationDelegateePeer`). No new identity system,
  **no separate recipient-acceptance step** — approved members inherit access.
- **Key isolation.** Members only ever send prompts and receive completions; the
  API key stays on the curator's node.
- **Grant lives in `_meta`** as two triples (`sharedModelEnabled`,
  `sharedModelId`) and syncs to members the same way the rest of `_meta` does.
- **Reuses the model the curator already configures** (`config.llm`);
  `config.sharedModel` can scope/override it. A built-in `mock` provider supports
  offline testing.

### What's included

| Commit | What |
|---|---|
| `feat(agent)` | `SharedModelMethods` mixin: per-CG grant in `_meta`, provider client (`mock` + `openai-compatible`), per-member daily quota, membership gate, P2P verb `/dkg/10.0.2/shared-model-invoke` |
| `feat(cli)` | daemon routes (`model/share`, `model/grant`, `model/invoke`, `invite-with-model`) + `sharedModel` config wiring |
| `feat(node-ui)` | "AI Model Access" toggle in the Share Project modal (curator opt-in) |
| `feat(cli,agent)` | **OpenAI-compatible** endpoint `…/model/v1/chat/completions` so any OpenAI client points at the curator's model |
| `docs(agent)` | feature README incl. member-usage roadmap + the cross-device findings below |

### Member-usage spectrum

This PR ships **#1 raw invoke** and **#2 OpenAI-compatible endpoint**. **#3** a
node-UI model picker is the next follow-up; **#4** tool/skill use is covered by
#2 (any OpenAI-speaking agent uses it as its backend); **#5** metering/payment is
intentionally deferred (needs a real settlement mechanism — x402 / PCA — and is
its own RFC + PR). Full table in `packages/agent/src/shared-model/README.md`.

### API surface

| Method & path | Purpose |
|---|---|
| `POST …/invite-with-model` | invite a member and (optionally) share the model in one call |
| `POST …/model/share` | curator toggles sharing for a CG |
| `GET …/model/grant` | read the grant `{ enabled, modelId }` |
| `POST …/model/invoke` | member invokes (native shape) |
| `POST …/model/v1/chat/completions` | OpenAI-compatible member usage |

## Testing & findings

**Validated:**
- **Unit** — `shared-model` suite (mock provider, authorize gate, daily quota,
  wire round-trip, OpenAI request/response mapping): **10/10**.
- **Build** — `pnpm --filter @origintrail-official/dkg-agent build` green;
  `build:runtime` ships a `dist-ui` carrying the curator toggle.
- **Live single-node** — curator-local `invoke` returns a completion.
- **Live two-node (separate nodes, stable link)** — a member node (own peer id +
  agent) joins a private CG, the curator approves, the authenticated
  post-approval `_meta` sync lands the grant on the first poll, and
  `…/model/invoke` returns
  `{"ok":true,"content":"[shared-model:mock-model] …","model":"mock-model"}` —
  exercising the full P2P path (resolve curator peer →
  `/dkg/10.0.2/shared-model-invoke` → membership gate → model → completion).

**In progress:** a different-country (NAT'd, relayed) member run. The feature
itself works whenever `_meta` is present; the remaining work is purely the
cross-NAT `_meta` *bootstrap*, which is upstream sync behavior (below).

### Upstream `_meta`-sync issues this surfaced (not introduced by this PR)

The grant is two triples in the curated CG's `_meta` and can only reach a member
through the existing curated-CG sync. Cross-NAT first-sync exposed:

1. **Bootstrap auth deadlock.** An authenticated private meta-sync request needs
   the curator peer id as `targetPeerId`, resolved from the member's **local
   `_meta`** — the thing it's fetching. Only the `join-approved`-triggered
   `runImmediatePostApprovalSync` breaks it (it's handed the curator peer id);
   background/`subscribe` catchup sends an unauthenticated request that a private
   CG rejects (`phase=meta`, `request-authorize.ts`).
2. **`synced`-flag poison.** `POST …/subscribe` marks the CG `synced:true` even
   when `_meta` was denied; `buildSyncRequest` (`dkg-agent-cg-resolve.ts`) then
   derives `needsAuth` from **`synced`**, not `metaSynced`, so every later
   meta-sync — including the authenticated post-approval one — is sent
   *unauthenticated* and permanently denied (recoverable only by restart, since
   `subscribedContextGraphs` is in-memory).
   **Suggested fix:** gate `needsAuth` on `metaSynced` for private CGs, and/or
   don't set `synced` until `_meta` lands.
3. A re-fired **`already-member`** `join-approved` is dropped by the requester's
   trusted-sender guard after a restart (no local curator triple, no in-memory
   pending record), so re-joining an existing membership doesn't re-trigger the
   sync — a fresh, genuine `pending` join does.

These are independent of this feature (they affect any curated-CG member), but
the grant rides on that sync, so they're documented here and worth a separate
upstream fix.

### Known limitations (MVP)

- Quotas/grant are node-local and in-memory (reset on restart) — no on-chain
  accounting or payment; monetization is a follow-up.
- No streaming; single completion per request; no tool-calls forwarded.
- Cross-NAT first-sync of the grant depends on the upstream `_meta` sync above;
  reliable procedure documented in the feature README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
