### PR TITLE
fix(agent): shared-model M1 — membership-gate auth fix + invoke timeouts (B1+B2)

### DIFF
--- a/packages/agent/src/dkg-agent-shared-model.ts
+++ b/packages/agent/src/dkg-agent-shared-model.ts
@@ -123,10 +123,27 @@ export class SharedModelMethods {
 
     const st = STATE.get(this);
     const grant = await this.getContextGraphModelGrant(req.contextGraphId).catch(() => ({ enabled: false }) as SharedModelGrant);
-    const isMember = await this.isPeerContextGraphMember(req.contextGraphId, fromPeerId).catch(() => false);
+    // SECURITY INVARIANT (per-agent membership binding):
+    // `fromPeerId` is cryptographically authenticated by libp2p; the request
+    // body may CLAIM any `agentAddress`, but it is authorized ONLY if THAT
+    // specific agent recorded `fromPeerId` as one of its approved delegatee
+    // peers. We bind the lookup to the claimed agent (lowercased — the helper
+    // keys are lowercased; peer-ids stay case-sensitive) exactly as the sync
+    // auth path binds to `requesterAgentAddress`. A missing/empty claim is
+    // DENIED — there is NO union fallback. This defeats:
+    //   (a) pending requesters     — not in the curator-APPROVED set at all;
+    //   (b) impersonation          — the attacker's peer won't equal the
+    //                                victim agent's recorded delegatee peer;
+    //   (c) multi-agent inheritance — only the one approved agent whose
+    //                                binding matches `fromPeerId` is allowed,
+    //                                not every agent that shares the node.
+    const isMember = await this.isAgentPeerContextGraphMember(req.contextGraphId, req.agentAddress, fromPeerId).catch(() => false);
     const promptChars = req.messages.reduce((n, m) => n + m.content.length, 0);
     const promptOk = !!st && promptChars <= st.config.maxPromptChars;
-    const quotaOk = !!st && st.quota.allow(fromPeerId);
+    // Quota is a non-mutating PEEK for the decision; the counter is consumed
+    // only AFTER authorization succeeds (see below), so a request denied for
+    // any other reason never burns the member's daily allowance.
+    const quotaOk = !!st && st.quota.remaining(fromPeerId) > 0;
 
     const decision = decideSharedModelAuthorization({
       enabled: grant.enabled,
@@ -136,9 +153,11 @@ export class SharedModelMethods {
       promptOk,
     });
     if (!decision.ok) {
-      this.log.info(ctx, `shared-model invoke denied cg=${req.contextGraphId} from=${fromPeerId}: ${decision.denied}`);
+      this.log.info(ctx, `shared-model invoke denied cg=${req.contextGraphId} from=${fromPeerId} agent=${req.agentAddress ?? 'n/a'}: ${decision.denied}`);
       return encodeInvokeResponse({ ok: false, denied: decision.denied });
     }
+    // Authorized: consume exactly one quota unit before the provider call.
+    st!.quota.allow(fromPeerId);
     try {
       const completion = await st!.client.complete(st!.config, req.messages, {
         maxTokens: req.maxTokens,
@@ -161,20 +180,36 @@ export class SharedModelMethods {
     opts: InvokeOpts = {},
     callerAgentAddress?: string,
   ): Promise<SharedModelInvokeResponse> {
-    // Local fast-path: this node is the curator (no network hop).
+    // Local fast-path: this node hosts the CG's curator (no network hop). We
+    // take this path iff the CG owner is one of THIS node's local agents — not
+    // merely the default agent — so a multi-agent node serves CGs curated by
+    // any of its agents locally instead of dialing itself.
     if (await this.isContextGraphCuratorSelf(contextGraphId)) {
       const st = STATE.get(this);
       const grant = await this.getContextGraphModelGrant(contextGraphId);
+      // Caller-scoped authorization for the local path. The default-agent /
+      // node-token fallback (`getDefaultAgentAddress`) is ONLY used to key the
+      // quota bucket; it is NOT a membership grant. Membership is decided
+      // explicitly below against the caller's real address.
       const selfKey = callerAgentAddress ?? this.getDefaultAgentAddress?.() ?? 'self';
       const promptChars = messages.reduce((n, m) => n + m.content.length, 0);
+      // SECURITY: do NOT hardcode `isMember:true`. The caller is authorized
+      // only if it IS the CG owner/curator OR an approved member of the CG.
+      // A different LOCAL agent that is neither owner nor member is DENIED
+      // here (and must NOT fall through to the remote path, which would dial
+      // self). Same per-agent principle as the remote path: hosting an agent
+      // on this node grants nothing on a CG that agent didn't curate or join.
+      const isMember = await this.isCallerLocalCgMember(contextGraphId, callerAgentAddress).catch(() => false);
       const decision = decideSharedModelAuthorization({
         enabled: grant.enabled,
         providerConfigured: !!st && st.config.enabled,
-        isMember: true,
-        quotaOk: !!st && st.quota.allow(selfKey),
+        isMember,
+        // Non-mutating peek; consume happens once, after the decision is ok.
+        quotaOk: !!st && st.quota.remaining(selfKey) > 0,
         promptOk: !!st && promptChars <= st.config.maxPromptChars,
       });
       if (!decision.ok) return { ok: false, denied: decision.denied };
+      st!.quota.allow(selfKey);
       try {
         const completion = await st!.client.complete(st!.config, messages, {
           ...opts,
@@ -186,10 +221,12 @@ export class SharedModelMethods {
       }
     }
 
-    // Remote path: send to the curator's node over P2P.
+    // Remote path: send to the curator's node over P2P. The caller's agent
+    // address travels in the request so the curator can bind it to the
+    // transport peer (see the SECURITY INVARIANT in handleSharedModelInvoke).
     const peerId = await this.resolveCuratorPeerId(contextGraphId);
     if (!peerId) return { ok: false, denied: 'could not resolve curator peer for this context graph' };
-    const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature });
+    const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature, agentAddress: callerAgentAddress });
     // The whole remote round trip (resolver + dial + write + LLM completion +
     // read) must fit the transport budget. The router default (20s) is shorter
     // than real LLM latency and would surface a false "node unreachable" on a
@@ -206,38 +243,100 @@ export class SharedModelMethods {
 
   // ---- helpers ----
 
+  /**
+   * Does THIS node host the CG's curator? Enumerates ALL of the node's local
+   * agents (not just the default), mirroring `getContextGraphCurator`'s
+   * local-DID set, so a multi-agent node serves CGs curated by any of its
+   * agents on the local fast-path instead of dialing itself. NOTE: this answers
+   * "should we take the local path", NOT "is the caller authorized" — the
+   * caller is gated separately by {@link isCallerLocalCgMember}.
+   */
   private async isContextGraphCuratorSelf(this: DKGAgent, contextGraphId: string): Promise<boolean> {
     const owner = await this.getContextGraphOwner(contextGraphId);
     if (!owner) return false;
+    return this.localCgOwnerDids().has(owner.toLowerCase());
+  }
+
+  /** Lowercased `did:dkg:agent:*` DIDs for every identity this node hosts. */
+  private localCgOwnerDids(this: DKGAgent): Set<string> {
     const mine = new Set<string>();
     const addr = this.getDefaultAgentAddress?.();
     if (addr) mine.add(`did:dkg:agent:${addr}`.toLowerCase());
     if (this.peerId) mine.add(`did:dkg:agent:${this.peerId}`.toLowerCase());
-    return mine.has(owner.toLowerCase());
+    for (const a of this.localAgents.keys()) {
+      mine.add(`did:dkg:agent:${a}`.toLowerCase());
+    }
+    return mine;
   }
 
   /**
-   * Membership for the remote path is verified against the set of APPROVED,
-   * UNEXPIRED delegatee peers for the CG — exactly the set used by the sync
-   * auth path. We reuse the canonical {@link getContextGraphAllowedDelegateePeers}
-   * helper (WorkspaceCryptoMethods mixin) so the gate reads ONLY the
-   * curator-approved `allowedDelegateePeer` bindings and never the
-   * self-asserted, pre-approval `delegationDelegateePeer` value written at
-   * join-request time. A pending, rejected, or removed peer is therefore
-   * correctly denied (a removed peer's `did:dkg:agent-delegation:*` subject is
-   * deleted by `removeAgentFromContextGraph`, so it drops out of this set).
+   * Local-path caller authorization (#2). The CG is curated on THIS node, so
+   * there is no transport peer to bind against; we authorize the CALLER's agent
+   * address directly. Allowed iff the caller IS the CG owner/curator OR an
+   * approved member of the CG. Returns false (DENY) for a different local agent
+   * that is neither — the caller must NOT be silently treated as a member just
+   * because the curator lives on this node. Comparison is case-insensitive on
+   * the (checksummed-or-lowercased) wallet address; the allowed-agent set is
+   * sourced from the same curator-authoritative state used everywhere else.
+   */
+  private async isCallerLocalCgMember(this: DKGAgent, contextGraphId: string, callerAgentAddress: string | undefined): Promise<boolean> {
+    // Deny outright with no caller principal. This guard MUST come first: it
+    // also stops `isCallerOrNodeOwner(owner, undefined)` below from taking its
+    // permissive no-caller branch (which would authorise a node-level token
+    // whenever the owner is one of the node's own identities).
+    if (!callerAgentAddress) return false;
+    // Owner / curator via the CANONICAL check so this gate matches
+    // `setContextGraphModelSharing` (which uses `assertCallerIsOwner`) exactly,
+    // including the legacy case where the CG owner is stored under the
+    // peerId-based DID and the caller is this node's default agent. Without it,
+    // a curator could enable sharing on a legacy CG and then be denied invoking
+    // their own model.
+    const owner = await this.getContextGraphOwner(contextGraphId);
+    if (owner && this.isCallerOrNodeOwner(owner, callerAgentAddress)) return true;
+    // Approved member? `getContextGraphAllowedAgents` returns bare,
+    // quote-stripped wallet addresses (NOT lowercased, NOT DID-framed) minus
+    // revoked tombstones — the curator's authoritative allowlist.
+    const caller = callerAgentAddress.toLowerCase();
+    const allowed = await this.getContextGraphAllowedAgents(contextGraphId);
+    return allowed.some((a) => a.toLowerCase() === caller);
+  }
+
+  /**
+   * Per-agent membership for the remote path (#1). Membership is verified
+   * against the set of APPROVED, UNEXPIRED delegatee peers for the CG — exactly
+   * the set used by the sync auth path. We reuse the canonical
+   * {@link getContextGraphAllowedDelegateePeers} helper (WorkspaceCryptoMethods
+   * mixin), which returns `Map<agentLower, peerId[]>` and reads ONLY the
+   * curator-approved `allowedDelegateePeer` bindings — never the self-asserted,
+   * pre-approval `delegationDelegateePeer` value written at join-request time.
+   *
+   * UNLIKE the previous union check, we look up ONLY the binding for the
+   * SPECIFIC agent the request claims to act on behalf of (`agentAddress`) and
+   * require `fromPeerId` to be among THAT agent's approved peers — mirroring
+   * the sync path's `allowedDelegateePeers.get(claimedAgent)?.includes(peer)`.
+   *
+   * Denials (all by construction of the per-agent lookup):
+   *   - missing/empty `agentAddress`           → DENY (no union fallback).
+   *   - claimed agent has no approved binding  → DENY (e.g. a PENDING joiner:
+   *     its `delegationDelegateePeer` is never returned by the helper; or a
+   *     REMOVED agent whose `did:dkg:agent-delegation:*` subject was deleted).
+   *   - `fromPeerId` not in the claimed agent's binding → DENY (impersonation:
+   *     the attacker's authenticated peer won't equal the victim agent's
+   *     recorded delegatee peer; and inheritance: a sibling approved agent's
+   *     peer is in a DIFFERENT map entry, so it can't satisfy this agent).
    *
    * The libp2p `fromPeerId` is cryptographically authenticated by the
-   * transport, so matching it against an approved delegatee peer authorises
-   * the request without a separate signature.
+   * transport, so matching it against the claimed agent's approved delegatee
+   * peer authorises the request without a separate signature.
    */
-  private async isPeerContextGraphMember(this: DKGAgent, contextGraphId: string, peerId: string): Promise<boolean> {
-    // Map<agentLower, peerId[]> — flatten to the union of all approved peers;
-    // any approved delegatee node may invoke on the model the curator bills.
+  private async isAgentPeerContextGraphMember(
+    this: DKGAgent,
+    contextGraphId: string,
+    agentAddress: string | undefined,
+    peerId: string,
+  ): Promise<boolean> {
+    if (!agentAddress) return false;
     const byAgent = await this.getContextGraphAllowedDelegateePeers(contextGraphId);
-    for (const peers of byAgent.values()) {
-      if (peers.includes(peerId)) return true;
-    }
-    return false;
+    return byAgent.get(agentAddress.toLowerCase())?.includes(peerId) ?? false;
   }
 }

--- a/packages/agent/src/dkg-agent-shared-model.ts
+++ b/packages/agent/src/dkg-agent-shared-model.ts
@@ -39,6 +39,15 @@ export interface InvokeOpts {
   temperature?: number;
 }
 
+/**
+ * Fallback transport budget (ms) for the remote invoke when this node has no
+ * shared-model runtime config (a pure member node never calls
+ * `configureSharedModel`, so STATE is unset there). Matches the daemon's
+ * `invokeTimeoutMs` default and comfortably exceeds real LLM latency, unlike
+ * the router default (`DEFAULT_SEND_TIMEOUT_MS`, 20s).
+ */
+const DEFAULT_INVOKE_TIMEOUT_MS = 120_000;
+
 export class SharedModelMethods {
   /**
    * Attach/replace this node's shared-model runtime config. Called by the
@@ -134,6 +143,7 @@ export class SharedModelMethods {
       const completion = await st!.client.complete(st!.config, req.messages, {
         maxTokens: req.maxTokens,
         temperature: req.temperature,
+        providerTimeoutMs: st!.config.providerTimeoutMs,
       });
       return encodeInvokeResponse({ ok: true, content: completion.content, model: completion.model });
     } catch (err) {
@@ -166,7 +176,10 @@ export class SharedModelMethods {
       });
       if (!decision.ok) return { ok: false, denied: decision.denied };
       try {
-        const completion = await st!.client.complete(st!.config, messages, opts);
+        const completion = await st!.client.complete(st!.config, messages, {
+          ...opts,
+          providerTimeoutMs: st!.config.providerTimeoutMs,
+        });
         return { ok: true, content: completion.content, model: completion.model };
       } catch (err) {
         return { ok: false, denied: `provider error: ${err instanceof Error ? err.message : String(err)}` };
@@ -177,7 +190,13 @@ export class SharedModelMethods {
     const peerId = await this.resolveCuratorPeerId(contextGraphId);
     if (!peerId) return { ok: false, denied: 'could not resolve curator peer for this context graph' };
     const reqBytes = encodeInvokeRequest({ contextGraphId, messages, maxTokens: opts.maxTokens, temperature: opts.temperature });
-    const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SHARED_MODEL_INVOKE, reqBytes);
+    // The whole remote round trip (resolver + dial + write + LLM completion +
+    // read) must fit the transport budget. The router default (20s) is shorter
+    // than real LLM latency and would surface a false "node unreachable" on a
+    // normal completion, so use the configured invoke timeout (member nodes
+    // without shared-model config fall back to the matching default).
+    const invokeTimeoutMs = STATE.get(this)?.config.invokeTimeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+    const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SHARED_MODEL_INVOKE, reqBytes, { timeoutMs: invokeTimeoutMs });
     if (!sendResult.delivered) {
       const reason = 'error' in sendResult ? sendResult.error : 'undelivered';
       return { ok: false, denied: `curator node unreachable: ${reason}` };
@@ -198,27 +217,26 @@ export class SharedModelMethods {
   }
 
   /**
-   * Membership for the remote path is verified by the delegatee-peer binding
-   * established at invite/join time (DKG `allowedDelegateePeer` /
-   * `delegationDelegateePeer` in `_meta`). The libp2p `fromPeerId` is
-   * cryptographically authenticated by the transport, so matching it against
-   * the recorded delegatee peer authorises the request without a separate
-   * signature.
+   * Membership for the remote path is verified against the set of APPROVED,
+   * UNEXPIRED delegatee peers for the CG — exactly the set used by the sync
+   * auth path. We reuse the canonical {@link getContextGraphAllowedDelegateePeers}
+   * helper (WorkspaceCryptoMethods mixin) so the gate reads ONLY the
+   * curator-approved `allowedDelegateePeer` bindings and never the
+   * self-asserted, pre-approval `delegationDelegateePeer` value written at
+   * join-request time. A pending, rejected, or removed peer is therefore
+   * correctly denied (a removed peer's `did:dkg:agent-delegation:*` subject is
+   * deleted by `removeAgentFromContextGraph`, so it drops out of this set).
+   *
+   * The libp2p `fromPeerId` is cryptographically authenticated by the
+   * transport, so matching it against an approved delegatee peer authorises
+   * the request without a separate signature.
    */
   private async isPeerContextGraphMember(this: DKGAgent, contextGraphId: string, peerId: string): Promise<boolean> {
-    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${metaGraph}> {
-        { ?s <https://dkg.network/ontology#allowedDelegateePeer> ?peer }
-        UNION
-        { ?s <https://dkg.network/ontology#delegationDelegateePeer> ?peer }
-      } }`,
-    );
-    if (result.type === 'bindings') {
-      for (const row of result.bindings as Array<Record<string, string>>) {
-        const p = (row['peer'] ?? '').replace(/^"|"$/g, '');
-        if (p === peerId) return true;
-      }
+    // Map<agentLower, peerId[]> — flatten to the union of all approved peers;
+    // any approved delegatee node may invoke on the model the curator bills.
+    const byAgent = await this.getContextGraphAllowedDelegateePeers(contextGraphId);
+    for (const peers of byAgent.values()) {
+      if (peers.includes(peerId)) return true;
     }
     return false;
   }

--- a/packages/agent/src/shared-model/client.ts
+++ b/packages/agent/src/shared-model/client.ts
@@ -8,6 +8,13 @@ export interface SharedModelCompletion {
 export interface SharedModelCompleteOpts {
   maxTokens?: number;
   temperature?: number;
+  /**
+   * Curator-side deadline (ms) for the upstream provider `fetch`. When the
+   * request exceeds this, the call rejects with a clear `provider timeout
+   * after <n>ms` Error so the curator returns a structured denial before the
+   * member's transport aborts the round trip. Unset = no deadline.
+   */
+  providerTimeoutMs?: number;
 }
 
 /**
@@ -44,14 +51,25 @@ export class SharedModelClient {
     if (opts.maxTokens != null) body.max_tokens = opts.maxTokens;
     if (opts.temperature != null) body.temperature = opts.temperature;
 
-    const resp = await fetch(`${baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
-      },
-      body: JSON.stringify(body),
-    });
+    let resp: Response;
+    try {
+      resp = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+        },
+        body: JSON.stringify(body),
+        ...(opts.providerTimeoutMs != null ? { signal: AbortSignal.timeout(opts.providerTimeoutMs) } : {}),
+      });
+    } catch (err) {
+      // AbortSignal.timeout(...) aborts with a TimeoutError; surface it as a
+      // clear, deterministic message the caller's catch can relay.
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new Error(`provider timeout after ${opts.providerTimeoutMs}ms`);
+      }
+      throw err;
+    }
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
       throw new Error(`shared-model provider error: ${resp.status} ${resp.statusText} ${text.slice(0, 200)}`);

--- a/packages/agent/src/shared-model/types.ts
+++ b/packages/agent/src/shared-model/types.ts
@@ -33,6 +33,19 @@ export interface SharedModelRuntimeConfig extends SharedModelProviderConfig {
   dailyRequestQuotaPerAgent: number;
   /** Hard cap on total prompt size accepted from a member (chars). */
   maxPromptChars: number;
+  /**
+   * Member-side transport budget (ms) for the WHOLE remote invoke round
+   * trip (`sendReliable`). Must comfortably exceed real LLM latency, which
+   * the router default ({@link DEFAULT_SEND_TIMEOUT_MS}, 20s) does not.
+   */
+  invokeTimeoutMs: number;
+  /**
+   * Curator-side provider deadline (ms) applied to the upstream LLM
+   * `fetch`. Kept slightly TIGHTER than `invokeTimeoutMs` so the curator
+   * returns a structured `{ok:false}` error before the member's transport
+   * aborts the round trip.
+   */
+  providerTimeoutMs: number;
 }
 
 export interface SharedModelInvokeRequest {

--- a/packages/agent/src/shared-model/types.ts
+++ b/packages/agent/src/shared-model/types.ts
@@ -53,6 +53,15 @@ export interface SharedModelInvokeRequest {
   messages: SharedModelMessage[];
   maxTokens?: number;
   temperature?: number;
+  /**
+   * The agent address the member's node claims to invoke ON BEHALF OF. This is
+   * an UNTRUSTED claim carried in the request body; the curator authorizes it
+   * only if the cryptographically-authenticated transport `fromPeerId` matches
+   * the delegatee peer THAT specific agent recorded with the curator (mirrors
+   * the sync auth path's `requesterAgentAddress` binding). A request that omits
+   * it is denied on the remote path — there is no union fallback.
+   */
+  agentAddress?: string;
 }
 
 export interface SharedModelInvokeResponse {

--- a/packages/agent/src/shared-model/wire.ts
+++ b/packages/agent/src/shared-model/wire.ts
@@ -25,11 +25,18 @@ export function decodeInvokeRequest(bytes: Uint8Array): SharedModelInvokeRequest
     }
     return { role: mm.role as SharedModelRole, content: mm.content };
   });
+  // `agentAddress` is OPTIONAL on the wire but, when present, must be a string;
+  // a non-string claim is a malformed request (reject rather than coerce, so a
+  // bogus type can never be silently dropped and then default to the union).
+  if (o.agentAddress !== undefined && typeof o.agentAddress !== 'string') {
+    throw new Error('invalid agentAddress in SharedModelInvokeRequest');
+  }
   return {
     contextGraphId: o.contextGraphId,
     messages,
     maxTokens: typeof o.maxTokens === 'number' ? o.maxTokens : undefined,
     temperature: typeof o.temperature === 'number' ? o.temperature : undefined,
+    agentAddress: o.agentAddress,
   };
 }
 

--- a/packages/agent/test/shared-model/client-provider-timeout.test.ts
+++ b/packages/agent/test/shared-model/client-provider-timeout.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider-timeout path for the shared-model client (PR #1157 B2).
+ *
+ * Pins the curator-side deadline added in B2: when `providerTimeoutMs` is set,
+ * the upstream provider `fetch` is given `AbortSignal.timeout(...)`, and an
+ * abort is mapped to a deterministic `provider timeout after <n>ms` Error (so
+ * `handleSharedModelInvoke` returns a structured `{ok:false, denied:...}`
+ * instead of hanging the member's P2P round trip). Also pins that the abort
+ * signal is attached ONLY when a timeout is configured.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SharedModelClient } from '../../src/shared-model/client.js';
+import type { SharedModelProviderConfig } from '../../src/shared-model/types.js';
+
+const CFG: SharedModelProviderConfig = {
+  provider: 'openai-compatible',
+  model: 'gpt-test',
+  baseUrl: 'https://example.test/v1',
+  apiKey: 'sk-test',
+};
+const MSGS = [{ role: 'user' as const, content: 'hi' }];
+
+function okResponse(): Response {
+  return new Response(
+    JSON.stringify({ choices: [{ message: { content: 'pong' } }], model: 'gpt-test' }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('shared-model provider timeout (B2)', () => {
+  it('throws "provider timeout after <n>ms" when the provider fetch is aborted by the deadline', async () => {
+    // A fetch that honours the AbortSignal: it never resolves on its own and
+    // rejects with the signal's reason (a DOMException 'TimeoutError') on abort,
+    // exactly as the platform fetch does. AbortSignal.timeout(10) fires the abort.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+          }),
+      ),
+    );
+    const client = new SharedModelClient();
+    await expect(client.complete(CFG, MSGS, { providerTimeoutMs: 10 })).rejects.toThrow(
+      'provider timeout after 10ms',
+    );
+  });
+
+  it('attaches an AbortSignal to fetch only when providerTimeoutMs is set', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new SharedModelClient();
+
+    const withTimeout = await client.complete(CFG, MSGS, { providerTimeoutMs: 1000 });
+    expect(withTimeout.content).toBe('pong');
+    expect((fetchMock.mock.calls[0][1] as { signal?: unknown }).signal).toBeInstanceOf(AbortSignal);
+
+    fetchMock.mockClear();
+    const noTimeout = await client.complete(CFG, MSGS, {});
+    expect(noTimeout.content).toBe('pong');
+    expect((fetchMock.mock.calls[0][1] as { signal?: unknown }).signal).toBeUndefined();
+  });
+});

--- a/packages/agent/test/shared-model/invoke-handler.test.ts
+++ b/packages/agent/test/shared-model/invoke-handler.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Curator-side P2P handler authorization + quota (PR #1158, #1 + #3).
+ *
+ * Drives the real `handleSharedModelInvoke` with a stubbed store + `mock`
+ * provider. Pins:
+ *   #1 — per-agent binding: a request is authorised iff the CLAIMED
+ *        `agentAddress` is an approved member AND the transport-authenticated
+ *        `fromPeerId` is among THAT agent's approved delegatee peers.
+ *   #3 — quota consumed only AFTER authorization: a request denied for
+ *        non-membership does not decrement the (fromPeerId-keyed) bucket.
+ */
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import { WorkspaceCryptoMethods } from '../../src/dkg-agent-crypto.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+import {
+  encodeInvokeRequest,
+  decodeInvokeRequest,
+  decodeInvokeResponse,
+} from '../../src/shared-model/wire.js';
+
+const AGENT_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa';
+const PEER_A = '12D3KooWPeerForAgentA';
+const PEER_X = '12D3KooWAttackerPeer';
+const SHARED_MODEL_ENABLED = 'https://dkg.network/ontology#sharedModelEnabled';
+
+interface HarnessOpts {
+  approved: Array<{ agent: string; peer: string }>;
+  grantEnabled?: boolean;
+  dailyQuota?: number;
+}
+
+function makeAgent(opts: HarnessOpts) {
+  const proto = SharedModelMethods.prototype;
+  const agent = {
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+    store: {
+      query: async (sparql: string) => {
+        if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+          return {
+            type: 'bindings',
+            bindings: opts.approved.map((b) => ({ agent: `"${b.agent}"`, peer: `"${b.peer}"` })),
+          };
+        }
+        if (sparql.includes(SHARED_MODEL_ENABLED)) {
+          return opts.grantEnabled === false
+            ? { type: 'bindings', bindings: [] }
+            : { type: 'bindings', bindings: [{ p: SHARED_MODEL_ENABLED, o: '"true"' }] };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    },
+    getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
+    getContextGraphModelGrant: proto.getContextGraphModelGrant,
+    isAgentPeerContextGraphMember: proto['isAgentPeerContextGraphMember'],
+    handleSharedModelInvoke: proto.handleSharedModelInvoke,
+    configureSharedModel: proto.configureSharedModel,
+  } as unknown as DKGAgent;
+
+  agent.configureSharedModel({
+    provider: 'mock',
+    model: 'mock-model',
+    enabled: true,
+    dailyRequestQuotaPerAgent: opts.dailyQuota ?? 5,
+    maxPromptChars: 10_000,
+    invokeTimeoutMs: 1000,
+    providerTimeoutMs: 800,
+  });
+  return agent;
+}
+
+async function invoke(agent: DKGAgent, body: { agentAddress?: string; cg?: string }, fromPeer: string) {
+  const bytes = encodeInvokeRequest({
+    contextGraphId: body.cg ?? 'cg1',
+    messages: [{ role: 'user', content: 'hi' }],
+    agentAddress: body.agentAddress,
+  });
+  const out = await agent.handleSharedModelInvoke(bytes, fromPeer);
+  return decodeInvokeResponse(out);
+}
+
+describe('shared-model curator handler per-agent binding (#1)', () => {
+  it('ALLOWS the approved agent from its bound peer', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(res.ok).toBe(true);
+  });
+
+  it('DENIES the approved agent claimed from a different peer (impersonation)', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, { agentAddress: AGENT_A }, PEER_X);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('DENIES a missing agentAddress claim', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }] });
+    const res = await invoke(agent, {}, PEER_A);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+});
+
+describe('shared-model curator handler quota accounting (#3)', () => {
+  it('does NOT consume quota on a non-membership denial', async () => {
+    // Quota of 1 keyed by fromPeerId. An unauthorized claim from PEER_A must
+    // not burn PEER_A's bucket, so a subsequent AUTHORIZED call still succeeds.
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }], dailyQuota: 1 });
+    // Denied: wrong agent claim from PEER_A.
+    const denied = await invoke(agent, { agentAddress: '0xNotApproved' }, PEER_A);
+    expect(denied.ok).toBe(false);
+    // Authorized from the SAME peer still has its full quota of 1.
+    const ok = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(ok.ok).toBe(true);
+  });
+
+  it('an authorized request consumes exactly one (quota of 1 → second over cap)', async () => {
+    const agent = makeAgent({ approved: [{ agent: AGENT_A, peer: PEER_A }], dailyQuota: 1 });
+    expect((await invoke(agent, { agentAddress: AGENT_A }, PEER_A)).ok).toBe(true);
+    const second = await invoke(agent, { agentAddress: AGENT_A }, PEER_A);
+    expect(second.ok).toBe(false);
+    expect(second.denied).toMatch(/quota/i);
+  });
+});
+
+describe('shared-model wire agentAddress round-trip (#1)', () => {
+  it('encodes/decodes agentAddress when present', () => {
+    const req = {
+      contextGraphId: 'cg1',
+      messages: [{ role: 'user' as const, content: 'hi' }],
+      agentAddress: AGENT_A,
+    };
+    expect(decodeInvokeRequest(encodeInvokeRequest(req))).toEqual({
+      contextGraphId: 'cg1',
+      messages: req.messages,
+      maxTokens: undefined,
+      temperature: undefined,
+      agentAddress: AGENT_A,
+    });
+  });
+
+  it('rejects a non-string agentAddress', () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ contextGraphId: 'cg1', messages: [{ role: 'user', content: 'hi' }], agentAddress: 5 }),
+    );
+    expect(() => decodeInvokeRequest(bytes)).toThrow(/agentAddress/);
+  });
+});

--- a/packages/agent/test/shared-model/local-path.test.ts
+++ b/packages/agent/test/shared-model/local-path.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Local fast-path caller authorization + quota accounting (PR #1158, #2 + #3).
+ *
+ * When the CG is curated ON this node, `invokeContextGraphModel` takes a local
+ * fast-path (no network hop). This pins:
+ *
+ *   #2 — the caller is authorised ONLY if it IS the CG owner/curator OR an
+ *        approved member; a different local agent that is neither is DENIED
+ *        (and must NOT fall through to the remote path, which would dial self).
+ *        The previous code hardcoded `isMember:true`, authorising anyone.
+ *
+ *   #3 — quota is consumed exactly once, and ONLY after authorization. A
+ *        request denied for any other reason (here: non-membership) must not
+ *        decrement the member's daily allowance.
+ *
+ * Harness: a real `SharedModelMethods` instance (so the module-private STATE
+ * WeakMap is populated by the real `configureSharedModel`) with a stubbed store
+ * and a `mock` provider (deterministic, offline). The owner/grant/allowed-agent
+ * lookups are stubbed to isolate the auth + quota logic.
+ */
+import { describe, it, expect } from 'vitest';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import { OwnershipMethods } from '../../src/dkg-agent-ownership.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+import type { SharedModelGrant } from '../../src/shared-model/types.js';
+
+const PEER_ID = '12D3KooWLocalCurator';
+const OWNER = '0xC0FFEE0000000000000000000000000000000001';
+const MEMBER = '0xC0FFEE0000000000000000000000000000000002';
+const OUTSIDER = '0xC0FFEE0000000000000000000000000000000003'; // another local agent, not on this CG
+
+interface HarnessOpts {
+  owner: string;
+  defaultAgent?: string;
+  /** Override the stored owner DID (defaults to `did:dkg:agent:<owner>`). */
+  ownerDid?: string;
+  allowedAgents: string[];
+  grant?: SharedModelGrant;
+  dailyQuota?: number;
+  localAgents?: string[];
+}
+
+function makeAgent(opts: HarnessOpts) {
+  const grant: SharedModelGrant = opts.grant ?? { enabled: true, modelId: 'mock-model' };
+  const ownerDid = opts.ownerDid ?? `did:dkg:agent:${opts.owner}`;
+  const proto = SharedModelMethods.prototype;
+  const localAgents = new Map<string, unknown>();
+  for (const a of opts.localAgents ?? [opts.owner]) localAgents.set(a, {});
+
+  const agent = {
+    peerId: PEER_ID,
+    defaultAgentAddress: opts.defaultAgent ?? opts.owner,
+    localAgents,
+    getDefaultAgentAddress: () => opts.defaultAgent ?? opts.owner,
+    store: { query: async () => ({ type: 'bindings', bindings: [] }) },
+    // Stub the CG-state lookups the local path consults.
+    getContextGraphOwner: async () => ownerDid,
+    getContextGraphModelGrant: async () => grant,
+    getContextGraphAllowedAgents: async () => opts.allowedAgents.slice(),
+    // Real methods under test (bound through the prototype).
+    isContextGraphCuratorSelf: proto['isContextGraphCuratorSelf'],
+    localCgOwnerDids: proto['localCgOwnerDids'],
+    isCallerLocalCgMember: proto['isCallerLocalCgMember'],
+    invokeContextGraphModel: proto.invokeContextGraphModel,
+    configureSharedModel: proto.configureSharedModel,
+    // Real canonical owner check (used by isCallerLocalCgMember).
+    isCallerOrNodeOwner: OwnershipMethods.prototype.isCallerOrNodeOwner,
+    // Remote path must never be reached in these tests.
+    resolveCuratorPeerId: async () => { throw new Error('remote path reached — should be local'); },
+  } as unknown as DKGAgent;
+
+  agent.configureSharedModel({
+    provider: 'mock',
+    model: 'mock-model',
+    enabled: true,
+    dailyRequestQuotaPerAgent: opts.dailyQuota ?? 5,
+    maxPromptChars: 10_000,
+    invokeTimeoutMs: 1000,
+    providerTimeoutMs: 800,
+  });
+  return agent;
+}
+
+const MSG = [{ role: 'user' as const, content: 'hello' }];
+
+describe('shared-model local fast-path authorization (#2)', () => {
+  it('ALLOWS the CG owner/curator', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(res.ok).toBe(true);
+    expect(res.content).toContain('hello');
+  });
+
+  it('ALLOWS an approved member (caller in the allowed-agent set)', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER, MEMBER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER);
+    expect(res.ok).toBe(true);
+  });
+
+  it('matches the allowlist case-insensitively', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [MEMBER.toLowerCase()] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER.toUpperCase());
+    expect(res.ok).toBe(true);
+  });
+
+  it('DENIES another local agent that is neither owner nor member (no fall-through to remote)', async () => {
+    // OUTSIDER is a local agent (so the local path applies) but is not the CG
+    // owner and not on its allowlist. Must be DENIED here, never dial self.
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, OUTSIDER],
+    });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('DENIES a node-level token with no caller agent address', async () => {
+    // No callerAgentAddress → cannot establish owner-or-member → denied.
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER, MEMBER] });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, undefined);
+    expect(res.ok).toBe(false);
+    expect(res.denied).toMatch(/not a member/i);
+  });
+
+  it('ALLOWS the curator of a LEGACY peerId-owned CG (default agent caller)', async () => {
+    // Legacy CG whose owner DID is the peerId-based form. The curator invokes
+    // with their default-agent address (not in the allowlist). The canonical
+    // owner check honors `caller === defaultAgent && owner === peerDid`, so
+    // they must be ALLOWED — matching setContextGraphModelSharing's gate.
+    const agent = makeAgent({
+      owner: OWNER,
+      defaultAgent: OWNER,
+      ownerDid: `did:dkg:agent:${PEER_ID}`,
+      allowedAgents: [], // curator deliberately NOT in the allowlist
+      localAgents: [OWNER],
+    });
+    const res = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('shared-model local fast-path quota accounting (#3)', () => {
+  it('does NOT consume quota when the request is denied for non-membership', async () => {
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, OUTSIDER],
+      dailyQuota: 1,
+    });
+    // First call: outsider denied — must not burn the (shared selfKey) bucket.
+    const denied = await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER);
+    expect(denied.ok).toBe(false);
+    // The OUTSIDER's own bucket should be untouched: if it had been consumed by
+    // the denied call, a (hypothetical) authorized retry would already be over
+    // its quota of 1. We assert via the owner bucket below instead, which is
+    // the canonical "authorized request consumes exactly one" case.
+    const ok = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(ok.ok).toBe(true);
+  });
+
+  it('an authorized request consumes exactly one quota unit', async () => {
+    const agent = makeAgent({ owner: OWNER, allowedAgents: [OWNER], dailyQuota: 2 });
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER)).ok).toBe(true);
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER)).ok).toBe(true);
+    // Third exceeds the cap of 2.
+    const third = await agent.invokeContextGraphModel('cg1', MSG, {}, OWNER);
+    expect(third.ok).toBe(false);
+    expect(third.denied).toMatch(/quota/i);
+  });
+
+  it('a non-member denial leaves the member bucket fully available', async () => {
+    // MEMBER is approved; OUTSIDER is denied. Both key the SAME selfKey only if
+    // they share an address — they do not, so we assert MEMBER keeps full quota
+    // even after an interleaved OUTSIDER denial.
+    const agent = makeAgent({
+      owner: OWNER,
+      allowedAgents: [OWNER, MEMBER],
+      localAgents: [OWNER, MEMBER, OUTSIDER],
+      dailyQuota: 1,
+    });
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, OUTSIDER)).ok).toBe(false);
+    // MEMBER still has its single unit — authorized once.
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER)).ok).toBe(true);
+    // ...and now exhausted.
+    expect((await agent.invokeContextGraphModel('cg1', MSG, {}, MEMBER)).ok).toBe(false);
+  });
+});

--- a/packages/agent/test/shared-model/membership.test.ts
+++ b/packages/agent/test/shared-model/membership.test.ts
@@ -1,18 +1,26 @@
 /**
- * Membership gate for shared-model invokes (PR #1157 B1).
+ * Per-agent membership gate for shared-model invokes (PR #1157/#1158, B1 + #1).
  *
- * Pins the auth fix: `isPeerContextGraphMember` must authorise ONLY peers that
- * the curator has APPROVED (the `allowedDelegateePeer` binding read by the
- * canonical `getContextGraphAllowedDelegateePeers` helper), and must DENY a
- * peer that is present only via the self-asserted, pre-approval
- * `delegationDelegateePeer` value or whose delegation has been removed.
+ * Pins the per-agent binding fix. `isAgentPeerContextGraphMember` must authorise
+ * ONLY when the CLAIMED agent's curator-APPROVED delegatee-peer set
+ * (`allowedDelegateePeer`, read by the canonical
+ * `getContextGraphAllowedDelegateePeers` helper) contains the cryptographically
+ * authenticated transport peer. It must DENY:
+ *   - a peer present only via the self-asserted, pre-approval
+ *     `delegationDelegateePeer` value (pending joiner) or whose delegation was
+ *     removed (its `did:dkg:agent-delegation:*` subject is gone),
+ *   - a request that CLAIMS an approved agent but arrives from a DIFFERENT peer
+ *     than that agent's binding (impersonation),
+ *   - a request that arrives from agent A's approved peer but CLAIMS agent B
+ *     (multi-agent inheritance via the old union),
+ *   - a request with no `agentAddress` claim at all (no union fallback).
  *
- * The decision delegates entirely to the canonical helper, which in turn runs
- * one `store.query`. We drive the real method logic through a stubbed
- * `store.query` so the pending-vs-approved distinction is asserted without a
- * full chain harness. `delegationDelegateePeer` lives on a different subject
- * and a different predicate than the helper queries, so a pending/removed peer
- * is simply absent from the returned approved set.
+ * The decision delegates to the canonical helper, which runs one `store.query`.
+ * We drive the real method logic through a stubbed `store.query` so the
+ * pending-vs-approved and per-agent distinctions are asserted without a full
+ * chain harness. `delegationDelegateePeer` lives on a different subject and a
+ * different predicate than the helper queries, so a pending/removed peer is
+ * simply absent from the returned approved set.
  */
 import { describe, it, expect } from 'vitest';
 import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
@@ -22,36 +30,43 @@ import type { DKGAgent } from '../../src/dkg-agent.js';
 
 type QueryFn = (sparql: string) => Promise<{ type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }>;
 
-// Minimal harness: an object carrying just the two prototype methods under
-// test plus a stubbed store. `isPeerContextGraphMember` (private) is invoked by
+// Minimal harness: an object carrying just the two prototype methods under test
+// plus a stubbed store. `isAgentPeerContextGraphMember` (private) is invoked by
 // name; the canonical helper it calls reads only `store.query`.
-function makeAgent(query: QueryFn): { isMember(cg: string, peer: string): Promise<boolean> } {
+function makeAgent(query: QueryFn): {
+  isMember(cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+} {
   const agent = {
     store: { query },
     getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
-    isPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
-      isPeerContextGraphMember(this: DKGAgent, cg: string, peer: string): Promise<boolean>;
-    }).isPeerContextGraphMember,
-  } as unknown as DKGAgent & { isPeerContextGraphMember(cg: string, peer: string): Promise<boolean> };
-  return { isMember: (cg, peer) => agent.isPeerContextGraphMember(cg, peer) };
+    isAgentPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
+      isAgentPeerContextGraphMember(this: DKGAgent, cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+    }).isAgentPeerContextGraphMember,
+  } as unknown as DKGAgent & {
+    isAgentPeerContextGraphMember(cg: string, agent: string | undefined, peer: string): Promise<boolean>;
+  };
+  return { isMember: (cg, a, peer) => agent.isAgentPeerContextGraphMember(cg, a, peer) };
 }
 
-const APPROVED_PEER = '12D3KooWApprovedMember';
+const AGENT_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa';
+const AGENT_B = '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb';
+const PEER_A = '12D3KooWPeerForAgentA';
+const PEER_B = '12D3KooWPeerForAgentB';
 const PENDING_PEER = '12D3KooWPendingJoiner';
 
 // A store whose APPROVED-delegatee query (the only predicate the canonical
-// helper reads) returns exactly `approvedPeers`. The pending peer's
+// helper reads) returns the given (agent, peer) bindings. The pending peer's
 // self-asserted `delegationDelegateePeer` binding is never returned by this
 // query, mirroring production where it lives on the join-request subject.
-function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
+function approvedStore(bindings: Array<{ agent: string; peer: string; expiresAtMs?: number }>): QueryFn {
   return async (sparql: string) => {
     if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
       return {
         type: 'bindings',
-        bindings: approvedPeers.map((peer) => ({
-          agent: '"0xCuratorApprovedAgent"',
-          peer: `"${peer}"`,
-          ...(expiresAtMs != null ? { expiresAt: `"${expiresAtMs}"` } : {}),
+        bindings: bindings.map((b) => ({
+          agent: `"${b.agent}"`,
+          peer: `"${b.peer}"`,
+          ...(b.expiresAtMs != null ? { expiresAt: `"${b.expiresAtMs}"` } : {}),
         })),
       };
     }
@@ -59,48 +74,62 @@ function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
   };
 }
 
-describe('shared-model membership gate (B1)', () => {
-  it('ALLOWS an approved, unexpired delegatee peer', async () => {
-    const agent = makeAgent(approvedStore([APPROVED_PEER]));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+describe('shared-model per-agent membership gate (#1)', () => {
+  it('ALLOWS the approved agent from its bound, unexpired peer', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(true);
   });
 
-  it('DENIES a peer present only via the pending delegationDelegateePeer binding', async () => {
+  it('DENIES an agent (B) that is NOT approved, even behind an approved peer', async () => {
+    // Agent A is approved at PEER_A. A request that arrives via PEER_A but
+    // CLAIMS agent B (who has no approved binding) is denied — the union check
+    // would have allowed it.
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_B, PEER_A)).toBe(false);
+  });
+
+  it('DENIES a pending-only agent (no approved delegatee binding)', async () => {
     // The curator approved no one yet → the approved-peer query is empty even
     // though a pending join-request wrote `delegationDelegateePeer` for this
     // peer (which this gate must never read).
     const agent = makeAgent(approvedStore([]));
-    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+    expect(await agent.isMember('cg1', AGENT_A, PENDING_PEER)).toBe(false);
   });
 
-  it('DENIES a removed peer (its agent-delegation subject is gone)', async () => {
-    // removeAgentFromContextGraph deletes the `did:dkg:agent-delegation:*`
-    // subject, so the approved-peer query returns nothing for it.
-    const agent = makeAgent(approvedStore([]));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  it('DENIES claiming an approved agent from a DIFFERENT peer (impersonation)', async () => {
+    // Agent A is bound to PEER_A. An attacker on PEER_B claiming to be agent A
+    // does not match A's recorded delegatee peer → denied.
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_B)).toBe(false);
   });
 
-  it('DENIES an approved-but-EXPIRED delegatee peer', async () => {
-    const agent = makeAgent(approvedStore([APPROVED_PEER], Date.now() - 60_000));
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  it('DENIES a missing agentAddress (no union fallback)', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A }]));
+    expect(await agent.isMember('cg1', undefined, PEER_A)).toBe(false);
+    expect(await agent.isMember('cg1', '', PEER_A)).toBe(false);
   });
 
-  it('authorises across multiple approving agents (flattened set)', async () => {
-    const store: QueryFn = async (sparql) => {
-      if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
-        return {
-          type: 'bindings',
-          bindings: [
-            { agent: '"0xAgentA"', peer: '"12D3KooWPeerA"' },
-            { agent: '"0xAgentB"', peer: `"${APPROVED_PEER}"` },
-          ],
-        };
-      }
-      return { type: 'bindings', bindings: [] };
-    };
-    const agent = makeAgent(store);
-    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
-    expect(await agent.isMember('cg1', '12D3KooWPeerA')).toBe(true);
-    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  it('DENIES an approved-but-EXPIRED delegatee binding', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A, peer: PEER_A, expiresAtMs: Date.now() - 60_000 }]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(false);
+  });
+
+  it('binds each agent to ITS OWN peer — no cross-agent inheritance', async () => {
+    // Two approved agents on (potentially) the same node. Each is authorised
+    // only for its own (agent, peer) pair; a swap is denied.
+    const agent = makeAgent(approvedStore([
+      { agent: AGENT_A, peer: PEER_A },
+      { agent: AGENT_B, peer: PEER_B },
+    ]));
+    expect(await agent.isMember('cg1', AGENT_A, PEER_A)).toBe(true);
+    expect(await agent.isMember('cg1', AGENT_B, PEER_B)).toBe(true);
+    // A's peer claiming B (and vice-versa) → denied.
+    expect(await agent.isMember('cg1', AGENT_B, PEER_A)).toBe(false);
+    expect(await agent.isMember('cg1', AGENT_A, PEER_B)).toBe(false);
+  });
+
+  it('matches the claimed agent case-insensitively (helper keys are lowercased)', async () => {
+    const agent = makeAgent(approvedStore([{ agent: AGENT_A.toLowerCase(), peer: PEER_A }]));
+    expect(await agent.isMember('cg1', AGENT_A.toUpperCase(), PEER_A)).toBe(true);
   });
 });

--- a/packages/agent/test/shared-model/membership.test.ts
+++ b/packages/agent/test/shared-model/membership.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Membership gate for shared-model invokes (PR #1157 B1).
+ *
+ * Pins the auth fix: `isPeerContextGraphMember` must authorise ONLY peers that
+ * the curator has APPROVED (the `allowedDelegateePeer` binding read by the
+ * canonical `getContextGraphAllowedDelegateePeers` helper), and must DENY a
+ * peer that is present only via the self-asserted, pre-approval
+ * `delegationDelegateePeer` value or whose delegation has been removed.
+ *
+ * The decision delegates entirely to the canonical helper, which in turn runs
+ * one `store.query`. We drive the real method logic through a stubbed
+ * `store.query` so the pending-vs-approved distinction is asserted without a
+ * full chain harness. `delegationDelegateePeer` lives on a different subject
+ * and a different predicate than the helper queries, so a pending/removed peer
+ * is simply absent from the returned approved set.
+ */
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { WorkspaceCryptoMethods } from '../../src/dkg-agent-crypto.js';
+import { SharedModelMethods } from '../../src/dkg-agent-shared-model.js';
+import type { DKGAgent } from '../../src/dkg-agent.js';
+
+type QueryFn = (sparql: string) => Promise<{ type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }>;
+
+// Minimal harness: an object carrying just the two prototype methods under
+// test plus a stubbed store. `isPeerContextGraphMember` (private) is invoked by
+// name; the canonical helper it calls reads only `store.query`.
+function makeAgent(query: QueryFn): { isMember(cg: string, peer: string): Promise<boolean> } {
+  const agent = {
+    store: { query },
+    getContextGraphAllowedDelegateePeers: WorkspaceCryptoMethods.prototype.getContextGraphAllowedDelegateePeers,
+    isPeerContextGraphMember: (SharedModelMethods.prototype as unknown as {
+      isPeerContextGraphMember(this: DKGAgent, cg: string, peer: string): Promise<boolean>;
+    }).isPeerContextGraphMember,
+  } as unknown as DKGAgent & { isPeerContextGraphMember(cg: string, peer: string): Promise<boolean> };
+  return { isMember: (cg, peer) => agent.isPeerContextGraphMember(cg, peer) };
+}
+
+const APPROVED_PEER = '12D3KooWApprovedMember';
+const PENDING_PEER = '12D3KooWPendingJoiner';
+
+// A store whose APPROVED-delegatee query (the only predicate the canonical
+// helper reads) returns exactly `approvedPeers`. The pending peer's
+// self-asserted `delegationDelegateePeer` binding is never returned by this
+// query, mirroring production where it lives on the join-request subject.
+function approvedStore(approvedPeers: string[], expiresAtMs?: number): QueryFn {
+  return async (sparql: string) => {
+    if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+      return {
+        type: 'bindings',
+        bindings: approvedPeers.map((peer) => ({
+          agent: '"0xCuratorApprovedAgent"',
+          peer: `"${peer}"`,
+          ...(expiresAtMs != null ? { expiresAt: `"${expiresAtMs}"` } : {}),
+        })),
+      };
+    }
+    return { type: 'bindings', bindings: [] };
+  };
+}
+
+describe('shared-model membership gate (B1)', () => {
+  it('ALLOWS an approved, unexpired delegatee peer', async () => {
+    const agent = makeAgent(approvedStore([APPROVED_PEER]));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+  });
+
+  it('DENIES a peer present only via the pending delegationDelegateePeer binding', async () => {
+    // The curator approved no one yet → the approved-peer query is empty even
+    // though a pending join-request wrote `delegationDelegateePeer` for this
+    // peer (which this gate must never read).
+    const agent = makeAgent(approvedStore([]));
+    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  });
+
+  it('DENIES a removed peer (its agent-delegation subject is gone)', async () => {
+    // removeAgentFromContextGraph deletes the `did:dkg:agent-delegation:*`
+    // subject, so the approved-peer query returns nothing for it.
+    const agent = makeAgent(approvedStore([]));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  });
+
+  it('DENIES an approved-but-EXPIRED delegatee peer', async () => {
+    const agent = makeAgent(approvedStore([APPROVED_PEER], Date.now() - 60_000));
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(false);
+  });
+
+  it('authorises across multiple approving agents (flattened set)', async () => {
+    const store: QueryFn = async (sparql) => {
+      if (sparql.includes(DKG_ONTOLOGY.DKG_ALLOWED_DELEGATEE_PEER)) {
+        return {
+          type: 'bindings',
+          bindings: [
+            { agent: '"0xAgentA"', peer: '"12D3KooWPeerA"' },
+            { agent: '"0xAgentB"', peer: `"${APPROVED_PEER}"` },
+          ],
+        };
+      }
+      return { type: 'bindings', bindings: [] };
+    };
+    const agent = makeAgent(store);
+    expect(await agent.isMember('cg1', APPROVED_PEER)).toBe(true);
+    expect(await agent.isMember('cg1', '12D3KooWPeerA')).toBe(true);
+    expect(await agent.isMember('cg1', PENDING_PEER)).toBe(false);
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -259,6 +259,10 @@ export interface SharedModelConfig {
   dailyRequestQuotaPerAgent?: number;
   /** Max prompt chars accepted from a member. Default 8000. */
   maxPromptChars?: number;
+  /** Member-side transport budget (ms) for the whole remote invoke. Default 120000. */
+  invokeTimeoutMs?: number;
+  /** Curator-side provider fetch deadline (ms); kept below invokeTimeoutMs. Default 110000. */
+  providerTimeoutMs?: number;
 }
 
 export type LocalAgentIntegrationStatus =

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1335,6 +1335,8 @@ export async function runDaemonInner(
         apiKey,
         dailyRequestQuotaPerAgent: sm.dailyRequestQuotaPerAgent ?? 200,
         maxPromptChars: sm.maxPromptChars ?? 8000,
+        invokeTimeoutMs: sm.invokeTimeoutMs ?? 120_000,
+        providerTimeoutMs: sm.providerTimeoutMs ?? 110_000,
       });
     }
   }

--- a/packages/cli/src/daemon/routes/shared-model.ts
+++ b/packages/cli/src/daemon/routes/shared-model.ts
@@ -9,6 +9,43 @@ import {
 
 const SMALL_BODY_BYTES = 256 * 1024;
 
+const SHARED_MODEL_ROLES = new Set(["system", "user", "assistant"]);
+
+/** Coerce a body field to a finite number, or undefined if it isn't one. */
+function numOrUndefined(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Validate the native `/model/invoke` `messages` payload BEFORE it reaches the
+ * agent, so a structurally-broken element (e.g. `[{"role":"user"}]` with no
+ * `content`, or `{"content":1}`) returns a clear 400 instead of throwing deep
+ * in the provider call and surfacing as a 500. Mirrors the wire decoder's
+ * element contract: `role` ∈ {system,user,assistant} and `content` is a string.
+ */
+function validateSharedModelMessages(
+  raw: unknown,
+): { ok: true; messages: SharedModelMessage[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { ok: false, error: "messages (non-empty array) is required" };
+  }
+  const messages: SharedModelMessage[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const m = raw[i] as { role?: unknown; content?: unknown } | null;
+    if (!m || typeof m !== "object") {
+      return { ok: false, error: `messages[${i}] must be an object` };
+    }
+    if (typeof m.role !== "string" || !SHARED_MODEL_ROLES.has(m.role)) {
+      return { ok: false, error: `messages[${i}].role must be one of system|user|assistant` };
+    }
+    if (typeof m.content !== "string") {
+      return { ok: false, error: `messages[${i}].content must be a string` };
+    }
+    messages.push({ role: m.role as SharedModelMessage["role"], content: m.content });
+  }
+  return { ok: true, messages };
+}
+
 /**
  * Shared curator AI-model access (MVP).
  *
@@ -48,15 +85,21 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const invokeMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/invoke$/);
   if (req.method === "POST" && invokeMatch) {
     const id = decodeURIComponent(invokeMatch[1]);
-    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
-    const messages = body.messages as SharedModelMessage[];
-    if (!Array.isArray(messages) || messages.length === 0) {
-      return jsonResponse(res, 400, { error: "messages (non-empty array) is required" });
+    let body: { messages?: unknown; maxTokens?: unknown; temperature?: unknown };
+    try {
+      body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      return jsonResponse(res, 400, { error: "request body must be valid JSON" });
     }
+    const validation = validateSharedModelMessages(body.messages);
+    if (!validation.ok) {
+      return jsonResponse(res, 400, { error: validation.error });
+    }
+    const messages = validation.messages;
     const result = await agent.invokeContextGraphModel(
       id,
       messages,
-      { maxTokens: body.maxTokens, temperature: body.temperature },
+      { maxTokens: numOrUndefined(body.maxTokens), temperature: numOrUndefined(body.temperature) },
       requestAgentAddress,
     );
     return jsonResponse(res, result.ok ? 200 : 403, result);
@@ -70,7 +113,16 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const openaiMatch = path.match(/^\/api\/context-graph\/([^/]+)\/model\/v1\/chat\/completions$/);
   if (req.method === "POST" && openaiMatch) {
     const id = decodeURIComponent(openaiMatch[1]);
-    const body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    let body: { messages?: unknown; max_tokens?: unknown; temperature?: unknown; model?: unknown };
+    try {
+      body = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      // A malformed body must surface as an OpenAI-shaped 400, never a 500.
+      return jsonResponse(res, 400, openAiErrorBody("request body must be valid JSON"));
+    }
+    // `openAiMessagesToShared` already validates element shapes (drops non-string
+    // content, coerces unsupported roles to `user`); an empty result means the
+    // caller sent nothing usable.
     const messages = openAiMessagesToShared(body.messages);
     if (messages.length === 0) {
       return jsonResponse(res, 400, openAiErrorBody("messages (non-empty array) is required"));
@@ -78,7 +130,7 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
     const result = await agent.invokeContextGraphModel(
       id,
       messages,
-      { maxTokens: body.max_tokens, temperature: body.temperature },
+      { maxTokens: numOrUndefined(body.max_tokens), temperature: numOrUndefined(body.temperature) },
       requestAgentAddress,
     );
     if (!result.ok) {
@@ -95,20 +147,45 @@ export async function handleSharedModelRoutes(ctx: RequestContext): Promise<void
   const inviteMatch = path.match(/^\/api\/context-graph\/([^/]+)\/invite-with-model$/);
   if (req.method === "POST" && inviteMatch) {
     const id = decodeURIComponent(inviteMatch[1]);
-    const { agentAddress, shareModel, modelId } = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    let parsed: { agentAddress?: unknown; shareModel?: unknown; modelId?: unknown };
+    try {
+      parsed = JSON.parse(await readBody(req, SMALL_BODY_BYTES));
+    } catch {
+      return jsonResponse(res, 400, { error: "request body must be valid JSON" });
+    }
+    const { agentAddress, shareModel, modelId } = parsed;
     if (!agentAddress || typeof agentAddress !== "string") {
       return jsonResponse(res, 400, { error: "agentAddress is required" });
     }
+    // The invite is the membership-granting step. If it throws, nothing was
+    // applied → 400 and the caller may safely retry.
     try {
       await agent.inviteAgentToContextGraph(id, agentAddress, requestAgentAddress);
-      let modelShared = false;
-      if (shareModel === true) {
-        await agent.setContextGraphModelSharing(id, true, { callerAgentAddress: requestAgentAddress, modelId });
-        modelShared = true;
-      }
-      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared });
     } catch (err) {
       return jsonResponse(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    }
+    // Invite succeeded — membership is now granted and DURABLE. If the optional
+    // model-share step fails, do NOT report a 400 (the caller would retry the
+    // whole call against partially-applied state, double-applying the invite).
+    // Instead return 200 with an explicit partial-success body so the caller
+    // sees the invite landed and only the share needs attention.
+    if (shareModel !== true) {
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared: false });
+    }
+    try {
+      await agent.setContextGraphModelSharing(id, true, {
+        callerAgentAddress: requestAgentAddress,
+        modelId: typeof modelId === "string" ? modelId : undefined,
+      });
+      return jsonResponse(res, 200, { ok: true, contextGraphId: id, agentAddress, modelShared: true });
+    } catch (err) {
+      return jsonResponse(res, 200, {
+        ok: true,
+        contextGraphId: id,
+        agentAddress,
+        modelShared: false,
+        modelShareError: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 }

--- a/packages/cli/test/daemon-shared-model-routes.test.ts
+++ b/packages/cli/test/daemon-shared-model-routes.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Daemon shared-model route validation (PR #1158, #4 + #5).
+ *
+ * #4 — the native `/model/invoke` route must reject structurally-broken
+ *      `messages` with a clear 400 (not a 500 deep in the provider call); the
+ *      OpenAI `/v1/chat/completions` route must return an `openAiErrorBody`
+ *      400 for a malformed body.
+ * #5 — `invite-with-model` must return 200 with `modelShared:false` +
+ *      `modelShareError` when the invite SUCCEEDED but the share step failed,
+ *      so callers don't retry against partially-applied membership state.
+ */
+import { describe, it, expect } from 'vitest';
+import { handleSharedModelRoutes } from '../src/daemon/routes/shared-model.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function fakeRes() {
+  const res: any = { statusCode: 0, body: '' };
+  res.writeHead = (status: number) => { res.statusCode = status; };
+  res.end = (body: string) => { res.body = body; };
+  return res;
+}
+
+function fakeReq(method: string, path: string, body?: unknown, rawBody?: string) {
+  const req: any = { method, url: path };
+  if (rawBody !== undefined) {
+    req.__dkgPrebufferedBody = Buffer.from(rawBody);
+  } else if (body !== undefined) {
+    req.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
+  }
+  return req;
+}
+
+function runCtx(method: string, rawPath: string, agent: any, opts: { body?: unknown; rawBody?: string; requestAgentAddress?: string } = {}) {
+  const res = fakeRes();
+  const url = new URL(`http://127.0.0.1${rawPath}`);
+  const ctx = {
+    req: fakeReq(method, rawPath, opts.body, opts.rawBody),
+    res,
+    agent,
+    path: url.pathname,
+    url,
+    requestAgentAddress: opts.requestAgentAddress,
+  } as unknown as RequestContext;
+  return { res, done: handleSharedModelRoutes(ctx) };
+}
+
+const INVOKE = '/api/context-graph/cg1/model/invoke';
+const OPENAI = '/api/context-graph/cg1/model/v1/chat/completions';
+const INVITE = '/api/context-graph/cg1/invite-with-model';
+
+describe('native /model/invoke message validation (#4)', () => {
+  // The agent must NOT be reached for invalid bodies — fail loudly if it is.
+  const agent = { invokeContextGraphModel: async () => { throw new Error('agent should not be called for invalid body'); } };
+
+  it('rejects a message missing content → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'user' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/content must be a string/i);
+  });
+
+  it('rejects non-string content → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'user', content: 1 }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/content must be a string/i);
+  });
+
+  it('rejects an unknown role → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [{ role: 'tool', content: 'x' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/role must be one of/i);
+  });
+
+  it('rejects an empty array → 400', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { body: { messages: [] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a non-JSON body → 400 (not 500)', async () => {
+    const { res, done } = runCtx('POST', INVOKE, agent, { rawBody: 'not json{' });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/valid JSON/i);
+  });
+
+  it('accepts a well-formed body and reaches the agent', async () => {
+    const okAgent = { invokeContextGraphModel: async () => ({ ok: true, content: 'hi', model: 'm' }) };
+    const { res, done } = runCtx('POST', INVOKE, okAgent, { body: { messages: [{ role: 'user', content: 'hi' }] } });
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).content).toBe('hi');
+  });
+});
+
+describe('OpenAI /v1/chat/completions validation (#4)', () => {
+  const agent = { invokeContextGraphModel: async () => { throw new Error('agent should not be called for invalid body'); } };
+
+  it('returns an OpenAI-shaped 400 for a non-JSON body (not 500)', async () => {
+    const { res, done } = runCtx('POST', OPENAI, agent, { rawBody: '{broken' });
+    await done;
+    expect(res.statusCode).toBe(400);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.type).toBe('invalid_request_error');
+    expect(parsed.error.message).toMatch(/valid JSON/i);
+  });
+
+  it('returns an OpenAI-shaped 400 when no usable messages remain', async () => {
+    // role-only / non-string-content elements are dropped by the mapper → empty.
+    const { res, done } = runCtx('POST', OPENAI, agent, { body: { messages: [{ role: 'user' }] } });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error.type).toBe('invalid_request_error');
+  });
+});
+
+describe('invite-with-model partial success (#5)', () => {
+  it('returns 200 modelShared:false + modelShareError when invite OK but share throws', async () => {
+    let invited = false;
+    const agent = {
+      inviteAgentToContextGraph: async () => { invited = true; },
+      setContextGraphModelSharing: async () => { throw new Error('share write failed'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(invited).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.modelShared).toBe(false);
+    expect(body.modelShareError).toMatch(/share write failed/);
+  });
+
+  it('returns 400 when the invite ITSELF fails (nothing applied)', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => { throw new Error('not the curator'); },
+      setContextGraphModelSharing: async () => { throw new Error('should not be reached'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/not the curator/);
+  });
+
+  it('returns 200 modelShared:true on full success', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => {},
+      setContextGraphModelSharing: async () => {},
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc', shareModel: true },
+    });
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.modelShared).toBe(true);
+    expect(body.modelShareError).toBeUndefined();
+  });
+
+  it('returns 200 modelShared:false (no error) when shareModel not requested', async () => {
+    const agent = {
+      inviteAgentToContextGraph: async () => {},
+      setContextGraphModelSharing: async () => { throw new Error('should not be reached'); },
+    };
+    const { res, done } = runCtx('POST', INVITE, agent, {
+      body: { agentAddress: '0xabc' },
+    });
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.modelShared).toBe(false);
+    expect(body.modelShareError).toBeUndefined();
+  });
+});

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# End-to-end test of shared curator AI-model access (PR #1157) over a devnet,
+# including the M1 hardening fixes (PR #1158):
+#   B1 — membership gate: a REMOVED member must be DENIED (the canonical
+#        approved-delegatee-peer set, not the pre-approval/self-asserted one).
+#   B2 — invoke timeout: a slow upstream provider (>20s, the old router
+#        default) must still return a completion (opt-in, TEST_B2=1).
+#
+# Drives 2 devnet nodes over HTTP:
+#   N1 (port 9201) — curator; serves the shared model, owns a private CG
+#   N2 (port 9202) — member; joins via a genuine pending join, then invokes
+#
+# Faithful-path requirements this script encodes (all code-confirmed):
+#   * invoke is issued against the MEMBER node (N2), never the curator —
+#     otherwise the local fast-path hardcodes isMember:true and the P2P
+#     membership gate is never exercised.
+#   * membership is established via the genuine sign-join -> request-join
+#     (pending) -> approve-join handshake (NOT invite-with-model, which does
+#     not write the delegatee-peer binding the gate checks).
+#   * N2 is never pre-allowlisted, so the join is a real `pending` (an
+#     already-member short-circuit would skip the post-approval _meta sync).
+#   * the script does NOT call /subscribe before the grant lands.
+#
+# Assumes `./scripts/devnet.sh start 2` (or more) is running. By default the
+# script (re)starts node1 with DEVNET_SHARED_MODEL=1 (mock provider) so the
+# curator serves invokes; set SKIP_CONFIG=1 if you configured sharing yourself.
+#
+# Env:
+#   SKIP_CONFIG=1   do not touch node1 config / restart (you pre-configured it)
+#   TEST_B2=1       also run the slow-upstream timeout check (B2)
+#   B2_SLEEP=25     seconds the slow stub waits before responding (>20, <110)
+#   STUB_PORT=9777  port for the local slow openai-compatible stub
+#   DEVNET_TOKEN / DKG_AUTH   override the auth token (else read from devnet)
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVNET_DIR="$SCRIPT_DIR/../.devnet"
+
+N1=http://127.0.0.1:9201
+N2=http://127.0.0.1:9202
+N1_ADDR=""; N2_ADDR=""; N1_PEER_ID=""
+
+TEST_B2="${TEST_B2:-}"
+B2_SLEEP="${B2_SLEEP:-25}"
+STUB_PORT="${STUB_PORT:-9777}"
+STUB_PID=""
+MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"
+
+CG_ID="shared-model-test-$(date +%s)"
+
+# Resolve the devnet auth token the same way the sibling scripts do.
+if [[ -n "${DEVNET_TOKEN:-}" ]]; then
+  TOKEN="$DEVNET_TOKEN"
+elif [[ -n "${DKG_AUTH:-}" ]]; then
+  TOKEN="$DKG_AUTH"
+elif [[ -f "$DEVNET_DIR/node1/auth.token" ]]; then
+  TOKEN="$(grep -v '^#' "$DEVNET_DIR/node1/auth.token" 2>/dev/null | tr -d '[:space:]')"
+else
+  echo "ERROR: No auth token. Export DEVNET_TOKEN/DKG_AUTH or run ./scripts/devnet.sh start" >&2
+  exit 2
+fi
+
+hr()   { printf '\n\033[1;34m── %s ──\033[0m\n' "$*"; }
+ok()   { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31m✗\033[0m %s\n' "$*"; cleanup; exit 1; }
+note() { printf '  \033[0;90m· %s\033[0m\n' "$*"; }
+
+cleanup() { [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null; }
+trap cleanup EXIT
+
+api() {
+  local node="$1" method="$2" path="$3" body="${4:-}"
+  if [ -n "$body" ]; then
+    curl -sS -X "$method" "${node}${path}" -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" --data "$body"
+  else
+    curl -sS -X "$method" "${node}${path}" -H "Authorization: Bearer $TOKEN"
+  fi
+}
+urlenc() { python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$1"; }
+jget()   { python3 -c "import sys,json
+try: d=json.load(sys.stdin)
+except Exception: print(''); sys.exit(0)
+cur=d
+for k in sys.argv[1].split('.'):
+    cur=cur.get(k) if isinstance(cur,dict) else None
+print('' if cur is None else cur)" "$1"; }
+
+identify() {
+  for i in 1 2; do
+    local url; url=$(eval echo "\$N${i}")
+    local self; self=$(api "$url" GET /api/agents | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+for a in d.get('agents',[]):
+    if a.get('connectionStatus')=='self':
+        print(json.dumps({'addr':a.get('agentAddress',''),'peer':a.get('peerId','')})); break
+")
+    local addr peer
+    addr=$(echo "$self" | jget addr); peer=$(echo "$self" | jget peer)
+    [ -z "$addr" ] && fail "N$i: could not fetch agent address (is the devnet up?)"
+    eval "N${i}_ADDR=\"$addr\""; eval "N${i}_PEER_ID=\"$peer\""
+    ok "N$i: $addr (peer $peer)"
+  done
+}
+
+wait_node_ready() {
+  local node="$1" start; start=$(date +%s)
+  while :; do
+    if api "$node" GET /api/status >/dev/null 2>&1; then ok "node ready: $node"; return 0; fi
+    [ $(( $(date +%s) - start )) -ge 60 ] && fail "node not ready after 60s: $node"
+    sleep 1.5
+  done
+}
+
+start_slow_stub() {
+  hr "B2 — starting slow openai-compatible stub on :$STUB_PORT (sleeps ${B2_SLEEP}s)"
+  python3 - "$STUB_PORT" "$B2_SLEEP" >/dev/null 2>&1 <<'PY' &
+import sys, json, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+port, sleep = int(sys.argv[1]), float(sys.argv[2])
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('content-length', 0)); self.rfile.read(n)
+        time.sleep(sleep)
+        body = json.dumps({"choices":[{"message":{"content":"slow-pong"}}],"model":"slow-stub"}).encode()
+        self.send_response(200); self.send_header('content-type','application/json')
+        self.send_header('content-length', str(len(body))); self.end_headers(); self.wfile.write(body)
+    def log_message(self, *a): pass
+HTTPServer(('127.0.0.1', port), H).serve_forever()
+PY
+  STUB_PID=$!
+  sleep 1
+  ok "stub pid $STUB_PID"
+}
+
+# (Re)configure node1 as a sharing curator and restart it so config regenerates
+# WITH the sharedModel block (restart-node re-runs create_node_config).
+ensure_curator_config() {
+  if [ "${SKIP_CONFIG:-}" = "1" ]; then
+    note "SKIP_CONFIG=1 — assuming node1 already has sharedModel enabled"
+    return 0
+  fi
+  hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"
+  export DEVNET_SHARED_MODEL=1
+  if [ "$TEST_B2" = "1" ]; then
+    start_slow_stub
+    export DEVNET_SHARED_MODEL_PROVIDER=openai-compatible
+    export DEVNET_SHARED_MODEL_MODEL=slow-stub
+    export DEVNET_SHARED_MODEL_BASEURL="http://127.0.0.1:${STUB_PORT}/v1"
+  else
+    export DEVNET_SHARED_MODEL_PROVIDER=mock
+  fi
+  "$SCRIPT_DIR/devnet.sh" restart-node 1 >/dev/null 2>&1 || fail "restart-node 1 failed"
+  wait_node_ready "$N1"
+}
+
+# Genuine sign-join -> request-join(pending) -> approve-join, then poll the
+# member's grant until the curated _meta (curator triples + grant) has synced.
+establish_membership() {
+  local enc; enc=$(urlenc "$CG_ID")
+
+  hr "Member signs a join delegation (binds N2 peer id)"
+  local deleg; deleg=$(api "$N2" POST "/api/context-graph/$enc/sign-join" "{}" \
+    | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin).get('delegation') or {}))")
+  { [ -z "$deleg" ] || [ "$deleg" = "{}" ]; } && fail "sign-join returned no delegation"
+  ok "delegation signed"
+
+  hr "Member submits a GENUINE pending join over P2P"
+  local sb; sb=$(python3 -c "import json; print(json.dumps({'delegation': json.loads('''$deleg'''), 'curatorPeerId': '$N1_PEER_ID'}))")
+  local resp; resp=$(api "$N2" POST "/api/context-graph/$enc/request-join" "$sb")
+  local delivered; delivered=$(echo "$resp" | jget delivered)
+  local status; status=$(echo "$resp" | jget status)
+  note "request-join: delivered=$delivered status=$status"
+  [ "$status" = "already-member" ] && fail "join short-circuited as already-member — N2 must not be pre-allowlisted"
+
+  hr "Curator sees the pending request"
+  local found; found=$(api "$N1" GET "/api/context-graph/$enc/join-requests" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print('yes' if any(r.get('agentAddress','').lower()=='$N2_ADDR'.lower() for r in d.get('requests',[])) else 'no')")
+  [ "$found" = "yes" ] && ok "curator sees N2's pending request" || fail "N2 request not pending on curator: re-run, it must be a fresh join"
+
+  hr "Curator approves (writes allowedDelegateePeer=N2; triggers post-approval _meta sync)"
+  local ar; ar=$(api "$N1" POST "/api/context-graph/$enc/approve-join" "{\"agentAddress\":\"$N2_ADDR\"}")
+  note "approve-join: $ar"
+
+  hr "Member polls grant until _meta has synced (enabled:true)"
+  local start; start=$(date +%s)
+  while :; do
+    local g; g=$(api "$N2" GET "/api/context-graph/$enc/model/grant")
+    [ "$(echo "$g" | jget enabled)" = "True" ] && { ok "grant synced to member: $g"; break; }
+    [ $(( $(date +%s) - start )) -ge 90 ] && fail "grant did not sync to member within 90s (last: $g)"
+    sleep 2
+  done
+}
+
+###############################################################################
+
+hr "Shared curator AI-model access — devnet e2e (mode: $MODE, CG: $CG_ID)"
+identify
+ensure_curator_config
+
+hr "Curator creates a PRIVATE (curated) CG, allowlist = [curator only]"
+create_body=$(python3 -c "import json; print(json.dumps({'id':'$CG_ID','name':'Shared-model test $CG_ID','description':'shared-model e2e','accessPolicy':1,'allowedAgents':['$N1_ADDR']}))")
+cr=$(api "$N1" POST /api/context-graph/create "$create_body")
+[ "$(echo "$cr" | jget created)" = "$CG_ID" ] && ok "CG created" || fail "create failed: $cr"
+
+hr "Curator enables model sharing for the CG"
+enc=$(urlenc "$CG_ID")
+sr=$(api "$N1" POST "/api/context-graph/$enc/model/share" '{"enabled":true}')
+[ "$(echo "$sr" | jget ok)" = "True" ] && ok "model/share: $sr" || fail "model/share failed: $sr"
+gr=$(api "$N1" GET "/api/context-graph/$enc/model/grant")
+[ "$(echo "$gr" | jget enabled)" = "True" ] && ok "curator grant enabled (model: $(echo "$gr" | jget modelId))" || fail "grant not enabled on curator: $gr"
+
+establish_membership
+
+hr "Member invokes the curator's model over P2P (the real gate)"
+inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"ping-from-member-42"}]}')
+[ "$(echo "$inv" | jget ok)" = "True" ] || fail "invoke denied unexpectedly: $inv"
+content=$(echo "$inv" | jget content)
+if [ "$TEST_B2" = "1" ]; then
+  echo "$content" | grep -q "slow-pong" && ok "B2: slow provider returned a completion: \"$content\"" \
+    || fail "B2: expected slow-pong, got: $inv"
+else
+  echo "$content" | grep -q "ping-from-member-42" && echo "$content" | grep -q "\[shared-model:" \
+    && ok "invoke ok, mock echoed prompt: \"$content\"" || fail "unexpected mock content: $inv"
+fi
+
+# OpenAI-compatible surface (mock mode only — keeps the B2 path to one slow call)
+if [ "$TEST_B2" != "1" ]; then
+  hr "Member invokes via the OpenAI-compatible endpoint"
+  oai=$(api "$N2" POST "/api/context-graph/$enc/model/v1/chat/completions" \
+    '{"model":"probe","messages":[{"role":"user","content":"openai-path-check"}]}')
+  [ "$(echo "$oai" | jget object)" = "chat.completion" ] || fail "OpenAI endpoint shape wrong: $oai"
+  oc=$(echo "$oai" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('choices',[{}])[0].get('message',{}).get('content',''))")
+  echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+fi
+
+# ---- B1 regression: a removed member must now be DENIED ----
+hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
+rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
+[ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
+
+start=$(date +%s)
+while :; do
+  inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
+  okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
+  if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
+    ok "B1 PASS: removed member denied — \"$denied\""
+    break
+  fi
+  if [ "$okf" = "True" ]; then
+    fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
+  fi
+  [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
+  sleep 1.5
+done
+
+hr "Done — shared-model e2e passed (mode: $MODE)"
+echo "CG id used: $CG_ID"
+[ "$TEST_B2" = "1" ] && note "B2 proved the invoke survived a ${B2_SLEEP}s upstream; on the unpatched build this returns 'curator node unreachable' at ~20s."

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -178,6 +178,9 @@ PY
 ensure_curator_config() {
   if [ "${SKIP_CONFIG:-}" = "1" ] || [ "$REAL" = "1" ]; then
     note "skipping auto-config — assuming node1 already has sharedModel enabled (REAL/SKIP_CONFIG)"
+    # You likely just restarted node1 to point it at the provider; make sure its
+    # libp2p has re-meshed with the member before the join handshake.
+    wait_curator_peered
     return 0
   fi
   hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -31,6 +31,11 @@
 #   TEST_B2=1       also run the slow-upstream timeout check (B2)
 #   B2_SLEEP=25     seconds the slow stub waits before responding (>20, <110)
 #   STUB_PORT=9777  port for the local slow openai-compatible stub
+#   REAL=1          happy-path smoke against a REAL provider you configured on
+#                   node1 yourself (implies SKIP_CONFIG: the script never bakes a
+#                   key). Relaxes the mock-echo assertion to "ok + non-empty",
+#                   prints the real completion, and SKIPS the B1 removal so the
+#                   member stays joined for further manual curl calls.
 #   DEVNET_TOKEN / DKG_AUTH   override the auth token (else read from devnet)
 
 set -u
@@ -44,10 +49,11 @@ N2=http://127.0.0.1:9202
 N1_ADDR=""; N2_ADDR=""; N1_PEER_ID=""
 
 TEST_B2="${TEST_B2:-}"
+REAL="${REAL:-}"
 B2_SLEEP="${B2_SLEEP:-25}"
 STUB_PORT="${STUB_PORT:-9777}"
 STUB_PID=""
-MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"
+MODE="mock"; [ "$TEST_B2" = "1" ] && MODE="b2-slow-provider"; [ "$REAL" = "1" ] && MODE="real-provider"
 
 CG_ID="shared-model-test-$(date +%s)"
 
@@ -170,8 +176,8 @@ PY
 # (Re)configure node1 as a sharing curator and restart it so config regenerates
 # WITH the sharedModel block (restart-node re-runs create_node_config).
 ensure_curator_config() {
-  if [ "${SKIP_CONFIG:-}" = "1" ]; then
-    note "SKIP_CONFIG=1 — assuming node1 already has sharedModel enabled"
+  if [ "${SKIP_CONFIG:-}" = "1" ] || [ "$REAL" = "1" ]; then
+    note "skipping auto-config — assuming node1 already has sharedModel enabled (REAL/SKIP_CONFIG)"
     return 0
   fi
   hr "Configure curator (node1) for sharing — provider=$([ "$TEST_B2" = "1" ] && echo openai-compatible || echo mock)"
@@ -250,10 +256,14 @@ gr=$(api "$N1" GET "/api/context-graph/$enc/model/grant")
 establish_membership
 
 hr "Member invokes the curator's model over P2P (the real gate)"
-inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"ping-from-member-42"}]}')
+prompt="ping-from-member-42"; [ "$REAL" = "1" ] && prompt="In one short sentence, introduce yourself and name the model you are."
+inv=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" "{\"messages\":[{\"role\":\"user\",\"content\":\"$prompt\"}]}")
 [ "$(echo "$inv" | jget ok)" = "True" ] || fail "invoke denied unexpectedly: $inv"
 content=$(echo "$inv" | jget content)
-if [ "$TEST_B2" = "1" ]; then
+if [ "$REAL" = "1" ]; then
+  [ -n "$content" ] && { ok "REAL provider returned a completion over the full P2P pipe:"; printf '    \033[0;36m%s\033[0m\n' "$content"; } \
+    || fail "real provider returned empty content: $inv"
+elif [ "$TEST_B2" = "1" ]; then
   echo "$content" | grep -q "slow-pong" && ok "B2: slow provider returned a completion: \"$content\"" \
     || fail "B2: expected slow-pong, got: $inv"
 else
@@ -264,33 +274,44 @@ fi
 # OpenAI-compatible surface (mock mode only — keeps the B2 path to one slow call)
 if [ "$TEST_B2" != "1" ]; then
   hr "Member invokes via the OpenAI-compatible endpoint"
+  oprompt="openai-path-check"; [ "$REAL" = "1" ] && oprompt="In one short sentence, what is the OriginTrail DKG?"
   oai=$(api "$N2" POST "/api/context-graph/$enc/model/v1/chat/completions" \
-    '{"model":"probe","messages":[{"role":"user","content":"openai-path-check"}]}')
+    "{\"model\":\"probe\",\"messages\":[{\"role\":\"user\",\"content\":\"$oprompt\"}]}")
   [ "$(echo "$oai" | jget object)" = "chat.completion" ] || fail "OpenAI endpoint shape wrong: $oai"
   oc=$(echo "$oai" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('choices',[{}])[0].get('message',{}).get('content',''))")
-  echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+  if [ "$REAL" = "1" ]; then
+    [ -n "$oc" ] && { ok "REAL OpenAI-compatible completion:"; printf '    \033[0;36m%s\033[0m\n' "$oc"; } || fail "real OpenAI content empty: $oai"
+  else
+    echo "$oc" | grep -q "openai-path-check" && ok "OpenAI-compatible completion: \"$oc\"" || fail "OpenAI content wrong: $oai"
+  fi
 fi
 
 # ---- B1 regression: a removed member must now be DENIED ----
-hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
-rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
-[ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
+if [ "$REAL" = "1" ]; then
+  hr "B1 — skipped in REAL mode (member kept joined so you can keep poking the real model)"
+  note "member $N2_ADDR remains in CG $CG_ID; e.g. curl -XPOST $N2/api/context-graph/$enc/model/invoke ..."
+else
+  hr "B1 — curator removes the member, then member re-invokes (must be DENIED)"
+  rm=$(api "$N1" POST "/api/context-graph/$enc/remove-participant" "{\"agentAddress\":\"$N2_ADDR\"}")
+  [ "$(echo "$rm" | jget ok)" = "True" ] && ok "remove-participant: $rm" || fail "remove-participant failed: $rm"
 
-start=$(date +%s)
-while :; do
-  inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
-  okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
-  if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
-    ok "B1 PASS: removed member denied — \"$denied\""
-    break
-  fi
-  if [ "$okf" = "True" ]; then
-    fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
-  fi
-  [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
-  sleep 1.5
-done
+  start=$(date +%s)
+  while :; do
+    inv2=$(api "$N2" POST "/api/context-graph/$enc/model/invoke" '{"messages":[{"role":"user","content":"after-removal"}]}')
+    okf=$(echo "$inv2" | jget ok); denied=$(echo "$inv2" | jget denied)
+    if [ "$okf" = "False" ] && echo "$denied" | grep -qi "not a member"; then
+      ok "B1 PASS: removed member denied — \"$denied\""
+      break
+    fi
+    if [ "$okf" = "True" ]; then
+      fail "B1 FAIL: removed member STILL got a completion (this is the pre-patch auth bypass): $inv2"
+    fi
+    [ $(( $(date +%s) - start )) -ge 15 ] && fail "B1: unexpected response after removal: $inv2"
+    sleep 1.5
+  done
+fi
 
 hr "Done — shared-model e2e passed (mode: $MODE)"
 echo "CG id used: $CG_ID"
 [ "$TEST_B2" = "1" ] && note "B2 proved the invoke survived a ${B2_SLEEP}s upstream; on the unpatched build this returns 'curator node unreachable' at ~20s."
+[ "$REAL" = "1" ] && note "REAL run: a real model's completion flowed over the full member→curator P2P pipe. Member kept in CG $CG_ID."

--- a/scripts/devnet-test-shared-model.sh
+++ b/scripts/devnet-test-shared-model.sh
@@ -116,6 +116,36 @@ wait_node_ready() {
   done
 }
 
+# After the curator (node1) is restarted, its API answers (wait_node_ready) well
+# before its libp2p stack has finished re-dialing the member and RE-ADVERTISING
+# the /dkg sync protocol. If the join handshake runs inside that window, the
+# curator's one-shot post-approval _meta sync lands while the member still sees
+# the curator as "does not support sync protocol", the targeted sync fails, and
+# the member's self-heal retry runs a broad catch-up that SKIPS the brand-new CG
+# ("unauthorized or unconfirmed") — so the grant/_meta never reaches the member
+# and every invoke is denied ("could not resolve curator peer"). Block until the
+# member actually sees the curator peer CONNECTED again, then add a short settle
+# margin for the identify-push that re-advertises the sync protocol.
+wait_curator_peered() {
+  local start; start=$(date +%s)
+  while :; do
+    local seen; seen=$(api "$N2" GET /api/agents | python3 -c "
+import sys,json
+try: d=json.load(sys.stdin)
+except Exception: print('no'); sys.exit(0)
+print('yes' if any(
+    a.get('peerId')=='$N1_PEER_ID' and a.get('connectionStatus')=='connected'
+    for a in d.get('agents',[])) else 'no')")
+    if [ "$seen" = "yes" ]; then
+      sleep 4   # settle margin for libp2p identify to re-advertise /dkg sync proto
+      ok "member re-peered with curator (post-restart P2P settled)"
+      return 0
+    fi
+    [ $(( $(date +%s) - start )) -ge 60 ] && fail "member did not re-peer with curator within 60s of restart"
+    sleep 2
+  done
+}
+
 start_slow_stub() {
   hr "B2 — starting slow openai-compatible stub on :$STUB_PORT (sleeps ${B2_SLEEP}s)"
   python3 - "$STUB_PORT" "$B2_SLEEP" >/dev/null 2>&1 <<'PY' &
@@ -156,6 +186,7 @@ ensure_curator_config() {
   fi
   "$SCRIPT_DIR/devnet.sh" restart-node 1 >/dev/null 2>&1 || fail "restart-node 1 failed"
   wait_node_ready "$N1"
+  wait_curator_peered
 }
 
 # Genuine sign-join -> request-join(pending) -> approve-join, then poll the

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -1664,6 +1664,11 @@ cmd_restart_node() {
     rm -f "$pidf"
   fi
   cd "$REPO_ROOT" || exit 1
+  # Regenerate config.json so env-driven blocks (e.g. DEVNET_SHARED_MODEL) take
+  # effect on restart — start_node only reads the existing config and patches
+  # relay/bootstrapPeers, it does NOT re-run create_node_config. Persisted store
+  # state, identity and the auth.token file live elsewhere and are untouched.
+  create_node_config "$node_num"
   start_node "$node_num"
   log "Node $node_num restarted."
 }

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -486,6 +486,9 @@ create_node_config() {
     local sm_fields="\"enabled\": true, \"provider\": \"${DEVNET_SHARED_MODEL_PROVIDER:-mock}\""
     [ -n "${DEVNET_SHARED_MODEL_MODEL:-}" ] && sm_fields="${sm_fields}, \"model\": \"${DEVNET_SHARED_MODEL_MODEL}\""
     [ -n "${DEVNET_SHARED_MODEL_BASEURL:-}" ] && sm_fields="${sm_fields}, \"baseUrl\": \"${DEVNET_SHARED_MODEL_BASEURL}\""
+    # Names an env var the daemon reads at boot for the provider API key (the key
+    # itself is NEVER written to config). Required for a real openai-compatible run.
+    [ -n "${DEVNET_SHARED_MODEL_API_KEY_ENV:-}" ] && sm_fields="${sm_fields}, \"apiKeyEnv\": \"${DEVNET_SHARED_MODEL_API_KEY_ENV}\""
     [ -n "${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"invokeTimeoutMs\": ${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS}"
     [ -n "${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"providerTimeoutMs\": ${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS}"
     shared_model_block="\"sharedModel\": { ${sm_fields} },"

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -476,6 +476,21 @@ create_node_config() {
     rs_block="\"randomSampling\": { \"walPath\": \"${node_dir}/random-sampling.wal\", \"tickIntervalMs\": 5000 },"
   fi
 
+  # Shared curator AI-model access (PR #1157). Opt-in via DEVNET_SHARED_MODEL=1
+  # so scripts/devnet-test-shared-model.sh can stand up a curator node that
+  # serves member invokes. Defaults to the offline 'mock' provider (no key);
+  # override provider/model/baseUrl/timeouts via env for openai-compatible
+  # runs (e.g. the slow-upstream check for the invoke-timeout fix).
+  local shared_model_block=""
+  if [ "${DEVNET_SHARED_MODEL:-}" = "1" ]; then
+    local sm_fields="\"enabled\": true, \"provider\": \"${DEVNET_SHARED_MODEL_PROVIDER:-mock}\""
+    [ -n "${DEVNET_SHARED_MODEL_MODEL:-}" ] && sm_fields="${sm_fields}, \"model\": \"${DEVNET_SHARED_MODEL_MODEL}\""
+    [ -n "${DEVNET_SHARED_MODEL_BASEURL:-}" ] && sm_fields="${sm_fields}, \"baseUrl\": \"${DEVNET_SHARED_MODEL_BASEURL}\""
+    [ -n "${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"invokeTimeoutMs\": ${DEVNET_SHARED_MODEL_INVOKE_TIMEOUT_MS}"
+    [ -n "${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS:-}" ] && sm_fields="${sm_fields}, \"providerTimeoutMs\": ${DEVNET_SHARED_MODEL_PROVIDER_TIMEOUT_MS}"
+    shared_model_block="\"sharedModel\": { ${sm_fields} },"
+  fi
+
   cat > "$node_dir/config.json" <<EOCONF
 {
   "name": "devnet-node-${node_num}",
@@ -495,6 +510,7 @@ create_node_config() {
   ${rs_block}
   ${publisher_block}
   ${epcis_block}
+  ${shared_model_block}
   "chain": {
     "type": "evm",
     "rpcUrl": "http://127.0.0.1:${HARDHAT_PORT}",


### PR DESCRIPTION
Follow-up hardening on top of #1157 (`feat/llm-sharing-module`). Scoped to the two highest-leverage, lowest-risk fixes from the MVP→v1 review; **partial M1** (cost-abuse items B3 still to come).

## B1 — membership-gate auth bypass (security)
`isPeerContextGraphMember` previously ran a bespoke SPARQL that UNIONed `allowedDelegateePeer` **and** the self-asserted, pre-approval `delegationDelegateePeer`, filtering on neither approval-status nor expiry. Net effect: a peer that merely **submitted a join request** (or was later **rejected/removed**) could invoke the curator's billed model.

Fix: delegate to the canonical `getContextGraphAllowedDelegateePeers` (the approved-only, expiry-filtered set already used by the sync-auth path) and match the transport-authenticated `fromPeerId` against it. A pending / rejected / removed peer is now correctly denied (a removed peer's `did:dkg:agent-delegation:*` subject is deleted by `removeAgentFromContextGraph`, so it drops out of the set).

## B2 — invoke timeouts (usability)
The remote invoke used `messenger.sendReliable(...)` with no timeout, inheriting the router default (`DEFAULT_SEND_TIMEOUT_MS`, 20s) for the **whole** round trip — shorter than real LLM latency, so normal completions returned a false `curator node unreachable`.

- Member side: pass `{ timeoutMs: invokeTimeoutMs }` to `sendReliable` (default **120s**, with a constant fallback for pure member nodes that have no shared-model config).
- Curator side: the provider `fetch` now gets `AbortSignal.timeout(providerTimeoutMs)` (default **110s**, deliberately tighter than the transport budget so the curator returns a structured error first). A `TimeoutError` maps to `provider timeout after <n>ms` → surfaced as `{ok:false, denied:'provider error: provider timeout...'}`.
- New optional config: `sharedModel.invokeTimeoutMs` / `sharedModel.providerTimeoutMs`.

## Tests
- New `test/shared-model/membership.test.ts` (5): approved→allow, pending-only→deny, removed→deny, expired→deny, multi-agent flatten.
- New `test/shared-model/client-provider-timeout.test.ts` (2): abort→`provider timeout after <n>ms`; abort signal attached only when configured.
- Full agent suite green (`pnpm --filter @origintrail-official/dkg-agent test` — 1240 passed / 0 failed); agent + CLI `tsc` clean.

## Not in scope (later milestones)
Token/temperature clamp + per-peer rate limit + quota-consume reordering + audit log (rest of M1); `_meta`-sync reliability (M2); streaming / tool-calls / model-select / error-code mapping (M3); metering (M5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)