### PR TITLE
feat(node-ui): Curator Model chat — member-side shared AI model surface (demo MVP)

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -520,6 +520,55 @@ export const setModelShare = (contextGraphId: string, enabled: boolean, modelId?
     modelId ? { enabled, modelId } : { enabled },
   );
 
+/** One OpenAI-style chat turn. `content` is plain text (no tool-calls). */
+export interface SharedModelChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Invoke a curator's shared AI model as a MEMBER of the context graph, via the
+ * member node's OpenAI-compatible surface
+ *   POST /api/context-graph/:id/model/v1/chat/completions
+ * (daemon: packages/cli/src/daemon/routes/shared-model.ts). The completion runs
+ * ON THE CURATOR'S node — this node merely proxies the member's request.
+ *
+ * Non-streaming, single buffered completion. Returns the assistant message
+ * content (`choices[0].message.content`).
+ *
+ * NOTE: this can't go through the shared `post()` helper. On a denial the
+ * daemon returns the OpenAI-shaped error body `{ error: { message, type, code } }`
+ * — an OBJECT, not a string — whereas `post()` reads `errBody.error` as a
+ * string and would surface `[object Object]`. We unwrap `error.message` here so
+ * the UI can render the human-readable denial (e.g. "requester is not a
+ * member…", quota) in an inline error bubble.
+ */
+export async function invokeSharedModelChat(
+  contextGraphId: string,
+  messages: SharedModelChatMessage[],
+  opts: { model?: string } = {},
+): Promise<string> {
+  const res = await fetch(
+    `${BASE}/api/context-graph/${encodeURIComponent(contextGraphId)}/model/v1/chat/completions`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(opts.model ? { model: opts.model, messages } : { messages }),
+    },
+  );
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    const message =
+      (errBody as { error?: { message?: string } })?.error?.message
+      ?? `HTTP ${res.status}`;
+    throw new Error(message);
+  }
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
 // --- Catch-up sync jobs ---
 export interface CatchupStatusResponse {
   jobId: string;

--- a/packages/node-ui/src/ui/components/Modals/CuratorModelChatModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CuratorModelChatModal.tsx
@@ -1,0 +1,350 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getModelGrant,
+  invokeSharedModelChat,
+  type SharedModelChatMessage,
+} from '../../api.js';
+import { useMyContextGraphs } from '../../hooks/useMyContextGraphs.js';
+import { useModalDismiss } from './useModalDismiss.js';
+
+interface CuratorModelChatModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** A CG this node is a member of whose curator has model sharing enabled. */
+interface AvailableSharedModel {
+  contextGraphId: string;
+  /** Friendly CG name, or the id when none is known. */
+  label: string;
+  modelId?: string;
+}
+
+/** One rendered chat line. `error` bubbles render a denial inline (no crash). */
+interface ChatLine {
+  id: string;
+  role: 'user' | 'assistant' | 'error';
+  content: string;
+}
+
+/**
+ * Curator Model — a MEMBER-side chat surface for the curator's shared AI model.
+ *
+ * Self-contained + self-discovering (mirrors ShareProjectModal's modal chrome,
+ * but takes no contextGraphId — this is a CROSS-CG surface): it lists the
+ * member's context graphs (useMyContextGraphs), reads each grant
+ * (getModelGrant), and keeps the ones the curator has ENABLED. The member picks
+ * one from a dropdown, then chats. Each send POSTs the running conversation to
+ * the member node's OpenAI-compatible route via `invokeSharedModelChat`, which
+ * runs the completion ON THE CURATOR'S node.
+ *
+ * Demo scope: in-memory session only (cleared when the selected model changes
+ * or the modal closes), non-streaming single buffered reply, no tool-calls, no
+ * persistence.
+ */
+export function CuratorModelChatModal({ open, onClose }: CuratorModelChatModalProps) {
+  const { myCgs, cgsLoading } = useMyContextGraphs();
+
+  const [available, setAvailable] = useState<AvailableSharedModel[]>([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [selectedCg, setSelectedCg] = useState<string | null>(null);
+
+  const [lines, setLines] = useState<ChatLine[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const chatEndRef = useRef<HTMLDivElement>(null);
+  const { dialogRef, onBackdropClick } = useModalDismiss(open, onClose);
+
+  // Discover shared models available to THIS node: for every CG the member
+  // belongs to, read the grant and keep the ones the curator enabled. Re-runs
+  // whenever the modal opens or the CG membership list changes. Failures per-CG
+  // are swallowed (a CG whose grant can't be read simply isn't offered).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setDiscovering(true);
+    (async () => {
+      const grants = await Promise.all(
+        myCgs.map(async (cg) => {
+          try {
+            const grant = await getModelGrant(cg.id);
+            if (!grant.enabled) return null;
+            return {
+              contextGraphId: cg.id,
+              label: cg.name && cg.name.trim().length > 0 ? cg.name : cg.id,
+              modelId: grant.modelId,
+            } as AvailableSharedModel;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      const enabled = grants.filter((g): g is AvailableSharedModel => g !== null);
+      setAvailable(enabled);
+      // Keep the current selection if it's still valid, else default to the
+      // first available model.
+      setSelectedCg((prev) =>
+        prev && enabled.some((g) => g.contextGraphId === prev)
+          ? prev
+          : enabled[0]?.contextGraphId ?? null,
+      );
+      setDiscovering(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, myCgs]);
+
+  // A fresh model = a fresh conversation (demo session is per-model, in-memory).
+  useEffect(() => {
+    setLines([]);
+    setInput('');
+  }, [selectedCg]);
+
+  // Clear the in-memory session when the modal closes so re-opening starts clean.
+  useEffect(() => {
+    if (!open) {
+      setLines([]);
+      setInput('');
+      setSending(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines, sending]);
+
+  const selected = useMemo(
+    () => available.find((g) => g.contextGraphId === selectedCg) ?? null,
+    [available, selectedCg],
+  );
+
+  if (!open) return null;
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || sending || !selectedCg) return;
+
+    const userLine: ChatLine = { id: `u-${Date.now()}`, role: 'user', content: text };
+    // Build the running OpenAI-style message list from the prior turns (skip
+    // error bubbles — they're UI-only and not part of the conversation) plus
+    // this new user turn.
+    const history: SharedModelChatMessage[] = lines
+      .filter((l) => l.role === 'user' || l.role === 'assistant')
+      .map((l) => ({ role: l.role as 'user' | 'assistant', content: l.content }));
+    const outbound: SharedModelChatMessage[] = [...history, { role: 'user', content: text }];
+
+    setLines((prev) => [...prev, userLine]);
+    setInput('');
+    setSending(true);
+    try {
+      const reply = await invokeSharedModelChat(selectedCg, outbound, {
+        model: selected?.modelId,
+      });
+      setLines((prev) => [
+        ...prev,
+        { id: `a-${Date.now()}`, role: 'assistant', content: reply || '(empty reply)' },
+      ]);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Request failed';
+      setLines((prev) => [
+        ...prev,
+        { id: `e-${Date.now()}`, role: 'error', content: message },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  return (
+    <div className="v10-modal-overlay" onClick={onBackdropClick} role="presentation">
+      <div
+        className="v10-modal-box"
+        style={{ maxWidth: 620, display: 'flex', flexDirection: 'column', maxHeight: '85vh' }}
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dkg-curator-model-modal-title"
+      >
+        <div
+          className="v10-modal-header"
+          style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div id="dkg-curator-model-modal-title" className="v10-modal-title">Curator Model</div>
+            <div className="v10-modal-subtitle">
+              Chat with an AI model a curator is sharing with you. The completion runs on the curator's node.
+            </div>
+          </div>
+          <button
+            type="button"
+            className="v10-modal-close"
+            onClick={onClose}
+            aria-label="Close curator model dialog"
+            title="Close (Esc)"
+            style={{ flexShrink: 0, cursor: 'pointer' }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="v10-modal-body" style={{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1 }}>
+          {/* Discovery / picker */}
+          <div className="v10-form-group">
+            <label className="v10-form-label" htmlFor="dkg-curator-model-select">Shared model</label>
+            {discovering || cgsLoading ? (
+              <div style={{
+                padding: '8px 12px', borderRadius: 6, fontSize: 11,
+                color: 'var(--text-tertiary)', background: 'var(--bg-surface)',
+                border: '1px dashed var(--border-default)',
+              }}>
+                Discovering shared models…
+              </div>
+            ) : available.length === 0 ? (
+              <div style={{
+                padding: '8px 12px', borderRadius: 6, fontSize: 11,
+                color: 'var(--text-tertiary)', background: 'var(--bg-surface)',
+                border: '1px dashed var(--border-default)',
+              }}>
+                No curator is sharing a model with you yet.
+              </div>
+            ) : (
+              <select
+                id="dkg-curator-model-select"
+                value={selectedCg ?? ''}
+                onChange={(e) => setSelectedCg(e.target.value)}
+                style={{
+                  width: '100%', padding: '8px 10px', borderRadius: 6, fontSize: 12,
+                  background: 'var(--bg-surface)', color: 'var(--text-primary)',
+                  border: '1px solid var(--border-default)', cursor: 'pointer',
+                }}
+              >
+                {available.map((g) => (
+                  <option key={g.contextGraphId} value={g.contextGraphId}>
+                    {g.label}{g.modelId ? ` · ${g.modelId}` : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {/* "Running on the curator's model" indicator */}
+          {selected && (
+            <div style={{
+              marginBottom: 12, padding: '8px 10px', borderRadius: 6, fontSize: 11,
+              color: 'var(--text-secondary)', background: 'var(--bg-surface)',
+              border: '1px solid var(--accent-primary)',
+            }}>
+              Chatting on <strong>{selected.label}</strong>'s shared model
+              {selected.modelId ? <> (<span style={{ fontFamily: 'var(--font-mono)' }}>{selected.modelId}</span>)</> : null}
+              {' '}— runs on the curator's node.
+            </div>
+          )}
+
+          {/* Message list */}
+          {selected && (
+            <div style={{
+              flex: 1, minHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column',
+              gap: 8, padding: '10px', borderRadius: 6, marginBottom: 10,
+              background: 'var(--bg-surface)', border: '1px solid var(--border-default)',
+            }}>
+              {lines.length === 0 && !sending && (
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', textAlign: 'center', margin: 'auto' }}>
+                  Send a message to start chatting on the curator's model.
+                </div>
+              )}
+              {lines.map((line) => (
+                <div
+                  key={line.id}
+                  style={{
+                    alignSelf: line.role === 'user' ? 'flex-end' : 'flex-start',
+                    maxWidth: '85%',
+                    padding: '7px 10px', borderRadius: 8, fontSize: 12, lineHeight: 1.45,
+                    whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                    background:
+                      line.role === 'user'
+                        ? 'var(--accent-primary)'
+                        : line.role === 'error'
+                          ? 'rgba(239, 68, 68, 0.12)'
+                          : 'var(--bg-elevated, var(--bg-default))',
+                    color:
+                      line.role === 'user'
+                        ? 'var(--text-on-accent)'
+                        : line.role === 'error'
+                          ? 'var(--text-danger)'
+                          : 'var(--text-primary)',
+                    border:
+                      line.role === 'error'
+                        ? '1px solid rgba(239, 68, 68, 0.3)'
+                        : line.role === 'assistant'
+                          ? '1px solid var(--border-default)'
+                          : 'none',
+                  }}
+                >
+                  {line.role === 'error' && (
+                    <div style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase', opacity: 0.8, marginBottom: 2 }}>
+                      Denied
+                    </div>
+                  )}
+                  {line.content}
+                </div>
+              ))}
+              {sending && (
+                <div style={{
+                  alignSelf: 'flex-start', maxWidth: '85%', padding: '7px 10px', borderRadius: 8,
+                  fontSize: 12, fontStyle: 'italic', color: 'var(--text-tertiary)',
+                  background: 'var(--bg-elevated, var(--bg-default))', border: '1px solid var(--border-default)',
+                }}>
+                  thinking…
+                </div>
+              )}
+              <div ref={chatEndRef} />
+            </div>
+          )}
+
+          {/* Composer */}
+          {selected && (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder="Message the curator's model… (Enter to send, Shift+Enter for newline)"
+                rows={2}
+                disabled={sending}
+                aria-label="Message to the curator's shared model"
+                style={{
+                  flex: 1, resize: 'none', padding: '8px 10px', borderRadius: 6, fontSize: 12,
+                  fontFamily: 'var(--font-body)', lineHeight: 1.45,
+                  background: 'var(--bg-surface)', color: 'var(--text-primary)',
+                  border: '1px solid var(--border-default)',
+                }}
+              />
+              <button
+                className="v10-modal-btn primary"
+                onClick={() => void handleSend()}
+                disabled={sending || input.trim().length === 0}
+                style={{ cursor: sending || input.trim().length === 0 ? 'default' : 'pointer', height: 36 }}
+              >
+                {sending ? '…' : 'Send'}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="v10-modal-footer">
+          <button className="v10-modal-btn" onClick={onClose}>Done</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useLayoutStore } from '../../stores/layout.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { useCurrentAgent } from '../../hooks/useCurrentAgent.js';
 import { NotificationsBell } from './NotificationsBell.js';
+import { CuratorModelChatModal } from '../Modals/CuratorModelChatModal.js';
 import { formatPeerStatusTooltip } from '../../lib/formatPeerStatus.js';
 
 /** OriginTrail wordmark — same paths as `v9-stable` packages/node-ui App.tsx sidebar. */
@@ -66,6 +67,14 @@ const OBSERVABILITY_ICON = (
   </svg>
 );
 
+// Chat-bubble + spark — "Curator Model": chat with a curator's shared AI model.
+const CURATOR_MODEL_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    <path d="M12 8.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z" />
+  </svg>
+);
+
 export function Header() {
   const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();
   const nodeStatus = useAgentsStore((s) => s.nodeStatus);
@@ -78,6 +87,11 @@ export function Header() {
   // second to one.
   const currentAgent = useCurrentAgent().data;
   const { openTab } = useTabsStore();
+  // Curator Model chat is a global, cross-CG surface (it self-discovers every
+  // CG this node is a member of), so it's launched here from the global header
+  // rather than from a per-project view. The modal owns its own discovery +
+  // in-memory chat session.
+  const [showCuratorModel, setShowCuratorModel] = useState(false);
 
   const connectedPeers = nodeStatus?.connectedPeers ?? nodeStatus?.peerCount ?? 0;
   const directConns = nodeStatus?.connections?.direct ?? 0;
@@ -88,6 +102,7 @@ export function Header() {
   const peerStatusLabel = formatPeerStatusTooltip(synced, connectedPeers, directConns, relayedConns, uptimeMs);
 
   return (
+    <>
     <header className="v10-header">
       <div className="v10-header-logo">
         <span className="v10-header-logo-text">DKG <span className="v10-header-logo-version">v10</span></span>
@@ -133,6 +148,14 @@ export function Header() {
 
         <button
           className="v10-header-icon-btn"
+          onClick={() => setShowCuratorModel(true)}
+          title="Curator Model — chat with a curator's shared AI model"
+        >
+          {CURATOR_MODEL_ICON}
+        </button>
+
+        <button
+          className="v10-header-icon-btn"
           onClick={() => openTab({ id: 'operations', label: 'Observability', closable: true })}
           title="Observability"
         >
@@ -164,5 +187,11 @@ export function Header() {
         </button>
       </div>
     </header>
+    {/* Mount only while open so the modal's discovery hook (useMyContextGraphs
+        → fetchContextGraphs poll) doesn't run on every Header mount. */}
+    {showCuratorModel && (
+      <CuratorModelChatModal open onClose={() => setShowCuratorModel(false)} />
+    )}
+    </>
   );
 }

--- a/packages/node-ui/test/invoke-shared-model-chat.test.ts
+++ b/packages/node-ui/test/invoke-shared-model-chat.test.ts
@@ -1,0 +1,96 @@
+// Unit coverage for `invokeSharedModelChat` — the api.ts helper behind the
+// Curator Model chat demo (Header → CuratorModelChatModal). The load-bearing
+// logic is the response unwrapping:
+//   - 2xx → choices[0].message.content
+//   - non-2xx → throw Error carrying the OpenAI-shaped error.message (an
+//     OBJECT, not a string — the generic post() helper would mangle it)
+// so we pin both against a mocked fetch, mirroring the modal/ai-model test's
+// fetch-mock style.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invokeSharedModelChat } from '../src/ui/api.js';
+
+const CG = 'shared-model-test-1781437109';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  (globalThis as any).window = { __DKG_TOKEN__: 'test-token' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as any).window;
+});
+
+describe('invokeSharedModelChat', () => {
+  it('POSTs to the member node OpenAI-compatible route with the bearer token and messages', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        object: 'chat.completion',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'Hello there, friend!' } }],
+      }),
+    );
+    (globalThis as any).fetch = fetchMock;
+
+    const content = await invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }], { model: 'gpt-4o-mini' });
+
+    expect(content).toBe('Hello there, friend!');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`/api/context-graph/${CG}/model/v1/chat/completions`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] });
+  });
+
+  it('omits the model field when none is supplied', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, { choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    );
+    (globalThis as any).fetch = fetchMock;
+
+    await invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ messages: [{ role: 'user', content: 'hi' }] });
+  });
+
+  it('returns an empty string when the completion has no content', async () => {
+    (globalThis as any).fetch = vi.fn(async () => jsonResponse(200, { choices: [] }));
+    await expect(invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }])).resolves.toBe('');
+  });
+
+  it('throws the OpenAI-shaped error.message on a 403 denial', async () => {
+    (globalThis as any).fetch = vi.fn(async () =>
+      jsonResponse(403, {
+        error: {
+          message: 'requester is not a member of this context graph',
+          type: 'invalid_request_error',
+          code: 'shared_model_denied',
+        },
+      }),
+    );
+
+    await expect(
+      invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('requester is not a member of this context graph');
+  });
+
+  it('falls back to an HTTP status message when the error body is unparseable', async () => {
+    (globalThis as any).fetch = vi.fn(async () =>
+      new Response('not json', { status: 500, headers: { 'content-type': 'text/plain' } }),
+    );
+
+    await expect(
+      invokeSharedModelChat(CG, [{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('HTTP 500');
+  });
+});


### PR DESCRIPTION
## What

A demo-quality, UI-only surface that lets a context-graph **member** chat with a **curator's shared AI model**. The backend route already exists and is validated; this PR adds only the node-UI surface that consumes it.

The completion runs **on the curator's node** — the member node merely proxies via its existing OpenAI-compatible route `POST /api/context-graph/:id/model/v1/chat/completions`.

## Where it lives / how to reach it

A single **global launch point**: a chat-bubble icon button in the header action row (`v10-header-actions`, next to Observability/Settings), titled "Curator Model — chat with a curator's shared AI model". Clicking it opens a self-contained modal.

It's global (not per-project) because discovery is **cross-CG**: the modal lists every CG this node is a member of, so a per-project Share-style button would be the wrong scope.

## Behaviour

- **Discovers**: lists the member's CGs (`useMyContextGraphs`), reads each grant (`getModelGrant`), keeps the `enabled` ones in a `"<CG name> · <modelId>"` dropdown. Friendly empty state when none ("No curator is sharing a model with you yet").
- **Chats**: message list + textarea + Send (Enter to send, Shift+Enter for newline). Each send POSTs the running conversation via the new `invokeSharedModelChat` helper. Shows a "thinking…" state while awaiting the single buffered (non-streaming) reply.
- **Errors**: a 403/denial renders as an inline error bubble ("Denied" + message), not a crash.
- **Indicator**: a banner — "Chatting on <CG>'s shared model (<modelId>) — runs on the curator's node."
- In-memory session only (reset when the model changes or the modal closes). No streaming, no tool-calls, no persistence.

## Files

- `packages/node-ui/src/ui/api.ts` — new `invokeSharedModelChat(cg, messages, { model? })`. Reuses `authHeaders()`; returns `choices[0].message.content`; on non-2xx unwraps the OpenAI-shaped `{ error: { message } }` (an **object** — the generic `post()` helper would stringify it to `[object Object]`) and throws `Error(error.message)`.
- `packages/node-ui/src/ui/components/Modals/CuratorModelChatModal.tsx` — new self-discovering modal (mirrors `ShareProjectModal` chrome: `v10-*` classes, `useModalDismiss`).
- `packages/node-ui/src/ui/components/Shell/Header.tsx` — launch button + state; modal mounted only while open (so the discovery hook doesn't poll on every Header mount).
- `packages/node-ui/test/invoke-shared-model-chat.test.ts` — new unit test pinning the 200→content and 403→`error.message` contract against a mocked `fetch`.

## Validation

- `turbo build --filter @origintrail-official/dkg-node-ui`: clean.
- Production Vite UI build (`build:ui`): clean (bundles all new `.tsx`).
- `pnpm --filter @origintrail-official/dkg-node-ui test`: **97 files / 1429 passed**, 38 skipped (+5 new).
- Live curl smoke against member node2 (`shared-model-test-1781437109`, grant enabled, `gpt-4o-mini`):
  - `200 { object: "chat.completion", choices: [{ message: { role: "assistant", content: "Hello there, friend!" } }] }`
- Dev server (`UI_NODE_ID=2 ./scripts/devnet.sh ui start`) serves `http://localhost:5173/ui/` (200), Vite log clean, token injected for node2.

## Scope discipline

No backend/daemon changes, no streaming, no tool-calls, no persistence, no model-config editing. Demo quality.

## Notes for reviewers

- Per the spec's "optionally add a render test" clause, I unit-tested `invokeSharedModelChat` against a mocked `fetch` (directly pins the load-bearing response-unwrap logic) rather than a modal render test, which would mean mocking the full `useMyContextGraphs` discovery container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)