### PR TITLE
feat(storage): graph-set index + listGraphsByPrefix [2/5]

### DIFF
--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -564,7 +564,7 @@ export class DKGQueryEngine implements QueryEngine {
   }
 
   private async discoverGraphsByPrefix(prefix: string): Promise<string[]> {
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );
@@ -646,7 +646,7 @@ export class DKGQueryEngine implements QueryEngine {
       : await this.discoverRegisteredSubGraphNames(contextGraphId);
     const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(contextGraphId);
     const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(contextGraphId);
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphFamily(this.store, `did:dkg:context-graph:${contextGraphId}`);
 
     for (const graph of allGraphs) {
       if (
@@ -945,6 +945,20 @@ function assertNoCallerDatasetClauses(sparql: string): void {
       'FROM clauses are not allowed on scoped local queries',
     );
   }
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
 }
 
 function hasCallerDatasetClause(sparql: string): boolean {

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -15,6 +15,12 @@ import {
 
 const CG_PREFIX = 'did:dkg:context-graph:';
 
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
 export class ContextGraphManager {
   private readonly store: TripleStore;
   private readonly ensuredContextGraphs = new Set<string>();
@@ -87,7 +93,7 @@ export class ContextGraphManager {
   }
 
   async listContextGraphs(): Promise<string[]> {
-    const graphs = await this.store.listGraphs();
+    const graphs = await listGraphsByPrefix(this.store, CG_PREFIX);
     const contextGraphs = new Set<string>();
     for (const g of graphs) {
       if (g.startsWith(CG_PREFIX)) {
@@ -116,7 +122,7 @@ export class ContextGraphManager {
    */
   async listSubGraphs(contextGraphId: string): Promise<string[]> {
     const prefix = `${CG_PREFIX}${contextGraphId}/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     const subGraphNames = new Set<string>();
     const reservedPrefixes = ['_', 'assertion/', 'draft/', 'context/'];
     for (const g of allGraphs) {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,0 +1,267 @@
+import { performance } from 'node:perf_hooks';
+import type { Quad, QueryResult, TripleStore } from './triple-store.js';
+
+export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
+
+export type GraphSetMutationSource =
+  | 'seed'
+  | 'revalidate'
+  | 'insert'
+  | 'delete'
+  | 'deleteByPattern'
+  | 'deleteBySubjectPrefix'
+  | 'dropGraph'
+  | 'query';
+
+type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query';
+
+export type GraphSetMutationEvent =
+  | {
+      type: 'graph-added';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-removed';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-set-revalidated';
+      added: string[];
+      removed: string[];
+      source: GraphSetRefreshSource;
+    };
+
+export interface GraphSetIndexStoreOptions {
+  enabled?: boolean;
+  /** Revalidate after this interval. Use 0 to revalidate on every read. */
+  revalidateMs?: number;
+  now?: () => number;
+  onMutation?: (event: GraphSetMutationEvent) => void;
+}
+
+/**
+ * Write-through named-graph index for stores whose `listGraphs()` implementation
+ * is a full-store scan. The index follows the repo's existing graph semantics:
+ * only graphs containing at least one quad are listed; empty `createGraph()`
+ * calls are not visible until data is inserted.
+ */
+export class GraphSetIndexStore implements TripleStore {
+  private readonly inner: TripleStore;
+  private readonly revalidateMs: number;
+  private readonly now: () => number;
+  private readonly onMutation?: (event: GraphSetMutationEvent) => void;
+
+  private graphs: Set<string> | null = null;
+  private validatedAt = 0;
+  private mutationGeneration = 0;
+  private refreshInFlight: Promise<Set<string>> | null = null;
+
+  constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
+    this.inner = inner;
+    this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
+    this.now = options.now ?? (() => performance.now());
+    this.onMutation = options.onMutation;
+  }
+
+  async insert(quads: Quad[]): Promise<void> {
+    await this.inner.insert(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    this.addGraphs(touched, 'insert');
+  }
+
+  async delete(quads: Quad[]): Promise<void> {
+    await this.inner.delete(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'delete'));
+  }
+
+  async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    const removed = await this.inner.deleteByPattern(pattern);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    const graph = pattern.graph;
+    if (graph) {
+      await this.maintainIndex(() => this.refreshTouchedGraphs([graph], 'deleteByPattern'));
+    } else {
+      await this.maintainIndex(() => this.refreshIndex('deleteByPattern'));
+    }
+    return removed;
+  }
+
+  async query(sparql: string): Promise<QueryResult> {
+    const result = await this.inner.query(sparql);
+    if (isSparqlUpdate(sparql)) {
+      this.bumpMutation();
+      if (this.graphs || this.refreshInFlight) {
+        await this.maintainIndex(() => this.refreshIndex('query'));
+      }
+    }
+    return result;
+  }
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    const hasGraph = await this.inner.hasGraph(graphUri);
+    const indexed = this.graphs?.has(graphUri);
+    if (this.graphs && indexed !== hasGraph) {
+      this.bumpMutation();
+      if (hasGraph) this.addGraphs([graphUri], 'revalidate');
+      else this.removeGraphs([graphUri], 'revalidate');
+    }
+    return hasGraph;
+  }
+
+  async createGraph(graphUri: string): Promise<void> {
+    await this.inner.createGraph(graphUri);
+  }
+
+  async dropGraph(graphUri: string): Promise<void> {
+    await this.inner.dropGraph(graphUri);
+    this.bumpMutation();
+    this.removeGraphs([graphUri], 'dropGraph');
+  }
+
+  async listGraphs(): Promise<string[]> {
+    const graphs = await this.ensureGraphSet();
+    return [...graphs];
+  }
+
+  async listGraphsByPrefix(prefix: string): Promise<string[]> {
+    const graphs = await this.ensureGraphSet();
+    return [...graphs].filter((graph) => graph.startsWith(prefix));
+  }
+
+  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs([graphUri], 'deleteBySubjectPrefix'));
+    return removed;
+  }
+
+  async countQuads(graphUri?: string): Promise<number> {
+    return this.inner.countQuads(graphUri);
+  }
+
+  async flush(): Promise<void> {
+    await this.inner.flush?.();
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+
+  private async ensureGraphSet(): Promise<Set<string>> {
+    if (
+      this.graphs &&
+      this.revalidateMs > 0 &&
+      this.now() - this.validatedAt < this.revalidateMs
+    ) {
+      return this.graphs;
+    }
+    return this.refreshIndex(this.graphs ? 'revalidate' : 'seed');
+  }
+
+  private async refreshIndex(source: GraphSetRefreshSource): Promise<Set<string>> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    const task = this.refreshIndexLoop(source);
+    this.refreshInFlight = task;
+    try {
+      return await task;
+    } finally {
+      if (this.refreshInFlight === task) this.refreshInFlight = null;
+    }
+  }
+
+  private async refreshIndexLoop(source: GraphSetRefreshSource): Promise<Set<string>> {
+    for (;;) {
+      const generation = this.mutationGeneration;
+      const next = new Set((await this.inner.listGraphs()).filter(Boolean));
+      if (generation !== this.mutationGeneration) continue;
+      this.replaceGraphSet(next, source);
+      return this.graphs!;
+    }
+  }
+
+  private bumpMutation(): void {
+    this.mutationGeneration++;
+  }
+
+  private async maintainIndex(task: () => Promise<unknown>): Promise<void> {
+    try {
+      await task();
+    } catch {
+      this.clearIndex();
+    }
+  }
+
+  private clearIndex(): void {
+    this.graphs = null;
+    this.validatedAt = 0;
+  }
+
+  private replaceGraphSet(next: Set<string>, source: GraphSetRefreshSource): void {
+    const previous = this.graphs ?? new Set<string>();
+    const added = [...next].filter((graph) => !previous.has(graph)).sort();
+    const removed = [...previous].filter((graph) => !next.has(graph)).sort();
+    this.graphs = next;
+    this.validatedAt = this.now();
+    if (added.length > 0 || removed.length > 0 || source !== 'seed') {
+      this.emit({ type: 'graph-set-revalidated', added, removed, source });
+    }
+  }
+
+  private addGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || this.graphs.has(graph)) continue;
+      this.graphs.add(graph);
+      this.emit({ type: 'graph-added', graph, source });
+    }
+  }
+
+  private removeGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || !this.graphs.delete(graph)) continue;
+      this.emit({ type: 'graph-removed', graph, source });
+    }
+  }
+
+  private async refreshTouchedGraphs(graphs: string[], source: GraphSetMutationSource): Promise<void> {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph) continue;
+      if (await this.inner.hasGraph(graph)) {
+        this.addGraphs([graph], source);
+      } else {
+        this.removeGraphs([graph], source);
+      }
+    }
+  }
+
+  private emit(event: GraphSetMutationEvent): void {
+    try {
+      this.onMutation?.(event);
+    } catch {
+      // Observability hooks must not make already-committed store writes fail.
+    }
+  }
+}
+
+function namedGraphsFromQuads(quads: Quad[]): string[] {
+  return [...new Set(quads.map((quad) => quad.graph).filter(Boolean))];
+}
+
+function isSparqlUpdate(sparql: string): boolean {
+  const withoutPrologue = sparql
+    .trimStart()
+    .replace(/^(?:(?:#[^\r\n]*(?:\r?\n|$))|(?:PREFIX\s+(?:[A-Za-z][\w-]*)?:\s*<[^>]*>|BASE\s*<[^>]*>)\s*)+/i, '')
+    .trimStart();
+  return /^(?:INSERT|DELETE|WITH|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -8,6 +8,7 @@ export {
   type AskResult,
   type TripleStoreConfig,
   type TripleStoreBackend,
+  type TripleStoreQueryOptions,
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
@@ -22,6 +23,13 @@ export {
   SharedMemoryLiteralBlobStore,
   type SharedMemoryLiteralBlobStoreOptions,
 } from './shared-memory-literal-blob-store.js';
+export {
+  DEFAULT_GRAPH_SET_REVALIDATE_MS,
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+  type GraphSetMutationEvent,
+  type GraphSetMutationSource,
+} from './graph-set-index-store.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -106,6 +106,12 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.listGraphs(options);
   }
 
+  async listGraphsByPrefix(prefix: string): Promise<string[]> {
+    return this.inner.listGraphsByPrefix
+      ? this.inner.listGraphsByPrefix(prefix)
+      : (await this.inner.listGraphs()).filter((graph) => graph.startsWith(prefix));
+  }
+
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
     return this.inner.deleteBySubjectPrefix(graphUri, prefix);
   }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,
   SharedMemoryLiteralBlobStore,
 } from './shared-memory-literal-blob-store.js';
+import {
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+} from './graph-set-index-store.js';
 
 export interface Quad {
   subject: string;
@@ -44,6 +48,13 @@ export interface QueryOptions {
   signal?: AbortSignal;
 }
 
+export interface TripleStoreQueryOptions {
+  /** Human-readable caller tag used by adapters for diagnostics/telemetry. */
+  source?: string;
+  /** Optional caller cancellation signal. Adapters that cannot cancel may ignore it. */
+  signal?: AbortSignal;
+}
+
 export interface TripleStore {
   /**
    * Whether `query(..., { signal })` can reject while a query is already in
@@ -55,12 +66,13 @@ export interface TripleStore {
   insert(quads: Quad[]): Promise<void>;
   delete(quads: Quad[]): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>): Promise<number>;
-  query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
+  query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult>;
 
   hasGraph(graphUri: string): Promise<boolean>;
   createGraph(graphUri: string): Promise<void>;
   dropGraph(graphUri: string): Promise<void>;
   listGraphs(options?: QueryOptions): Promise<string[]>;
+  listGraphsByPrefix?(prefix: string): Promise<string[]>;
 
   deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number>;
 
@@ -159,6 +171,7 @@ export interface TripleStoreConfig {
   backend: TripleStoreBackend;
   options?: Record<string, unknown>;
   largeLiteralStorage?: LargeLiteralStorageConfig;
+  graphSetIndex?: boolean | GraphSetIndexStoreOptions;
 }
 
 type AdapterFactory = (
@@ -186,8 +199,34 @@ export async function createTripleStore(
   }
   const store = await factory(config.options);
   const largeLiteralStorage = resolveLargeLiteralStorageOptions(config);
-  if (!largeLiteralStorage) return store;
-  return new SharedMemoryLiteralBlobStore(store, largeLiteralStorage);
+  const withLargeLiteralStorage = largeLiteralStorage
+    ? new SharedMemoryLiteralBlobStore(store, largeLiteralStorage)
+    : store;
+  return wrapGraphSetIndex(withLargeLiteralStorage, config);
+}
+
+function wrapGraphSetIndex(
+  store: TripleStore,
+  config: TripleStoreConfig,
+): TripleStore {
+  const graphSetIndex = config.graphSetIndex;
+  if (graphSetIndex === false) return store;
+  if (typeof graphSetIndex === 'object' && graphSetIndex.enabled === false) return store;
+  if (!shouldEnableGraphSetIndex(config)) return store;
+  const options = typeof graphSetIndex === 'object' ? graphSetIndex : undefined;
+  return new GraphSetIndexStore(store, options);
+}
+
+function shouldEnableGraphSetIndex(config: TripleStoreConfig): boolean {
+  if (config.graphSetIndex === true || typeof config.graphSetIndex === 'object') return true;
+  if (isDefaultLocalGraphSetIndexBackend(config.backend)) return true;
+  return config.options?.managedByDkg === true;
+}
+
+function isDefaultLocalGraphSetIndexBackend(backend: TripleStoreBackend): boolean {
+  return backend === 'oxigraph'
+    || backend === 'oxigraph-persistent'
+    || backend === 'oxigraph-worker';
 }
 
 function resolveLargeLiteralStorageOptions(

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -1,0 +1,312 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  GraphSetIndexStore,
+  OxigraphStore,
+  createTripleStore,
+  registerTripleStoreAdapter,
+  type Quad,
+  type QueryResult,
+  type TripleStore,
+} from '../src/index.js';
+
+function q(graph: string, subject = 'urn:s'): Quad {
+  return {
+    subject,
+    predicate: 'urn:p',
+    object: '"v"',
+    graph,
+  };
+}
+
+class CountingStore implements TripleStore {
+  listGraphsCalls = 0;
+  listGraphsGate: Promise<void> | null = null;
+  failListGraphs = false;
+
+  constructor(protected readonly inner: TripleStore) {}
+
+  insert(quads: Quad[]): Promise<void> { return this.inner.insert(quads); }
+  delete(quads: Quad[]): Promise<void> { return this.inner.delete(quads); }
+  deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.inner.deleteByPattern(pattern); }
+  query(sparql: string): Promise<QueryResult> { return this.inner.query(sparql); }
+  hasGraph(graphUri: string): Promise<boolean> { return this.inner.hasGraph(graphUri); }
+  createGraph(graphUri: string): Promise<void> { return this.inner.createGraph(graphUri); }
+  dropGraph(graphUri: string): Promise<void> { return this.inner.dropGraph(graphUri); }
+  deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    return this.inner.deleteBySubjectPrefix(graphUri, prefix);
+  }
+  countQuads(graphUri?: string): Promise<number> { return this.inner.countQuads(graphUri); }
+  flush(): Promise<void> { return this.inner.flush?.() ?? Promise.resolve(); }
+  close(): Promise<void> { return this.inner.close(); }
+
+  async listGraphs(): Promise<string[]> {
+    this.listGraphsCalls++;
+    if (this.listGraphsGate) await this.listGraphsGate;
+    if (this.failListGraphs) throw new Error('listGraphs failed');
+    return this.inner.listGraphs();
+  }
+}
+
+class FailingMaintenanceStore extends CountingStore {
+  failHasGraph = false;
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    if (this.failHasGraph) throw new Error('hasGraph failed');
+    return super.hasGraph(graphUri);
+  }
+}
+
+class MutatingQueryStore extends CountingStore {
+  async query(sparql: string): Promise<QueryResult> {
+    if (/^\s*(?:#[^\r\n]*(?:\r?\n|$)\s*)*INSERT\s+DATA\b/i.test(sparql)) {
+      await this.inner.insert([q('did:dkg:context-graph:query-created')]);
+      return { type: 'bindings', bindings: [] };
+    }
+    return this.inner.query(sparql);
+  }
+}
+
+describe('GraphSetIndexStore', () => {
+  it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([
+      q('did:dkg:context-graph:alpha'),
+      q('did:dkg:context-graph:beta'),
+    ]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting);
+
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:a')).resolves.toEqual([
+      'did:dkg:context-graph:alpha',
+    ]);
+    await expect(store.listGraphs()).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:alpha', 'did:dkg:context-graph:beta']),
+    );
+    expect(counting.listGraphsCalls).toBe(1);
+  });
+
+  it('maintains the graph set through local insert/delete/drop/deleteBySubjectPrefix mutators', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    const graph = 'did:dkg:context-graph:mutators';
+    const root = 'urn:root';
+    const child = `${root}/.well-known/genid/1`;
+    await store.insert([q(graph, root), q(graph, child)]);
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:mut')).resolves.toEqual([graph]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.delete([q(graph, child)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    await store.deleteBySubjectPrefix(graph, root);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.insert([q(graph)]);
+    await store.dropGraph(graph);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('refreshes the full index after graph-wide deleteByPattern without a graph constraint', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await store.insert([q('did:dkg:context-graph:one'), q('did:dkg:context-graph:two')]);
+    await expect(store.listGraphs()).resolves.toHaveLength(2);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.deleteByPattern({ predicate: 'urn:p' });
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('revalidates after the configured interval to discover out-of-contract writers', async () => {
+    let now = 1_000;
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 100, now: () => now });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:external')]);
+
+    now += 99;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:external']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('treats revalidateMs 0 as always expired', async () => {
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 0 });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:zero-revalidate')]);
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:zero-revalidate']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('coalesces concurrent refresh callers onto one listGraphs scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:coalesced')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const calls = Promise.all([
+      store.listGraphs(),
+      store.listGraphsByPrefix('did:dkg:context-graph:'),
+      store.listGraphs(),
+    ]);
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+    counting.listGraphsGate = null;
+    release();
+
+    const [a, b, c] = await calls;
+    expect(a).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(b).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(c).toEqual(['did:dkg:context-graph:coalesced']);
+  });
+
+  it('restarts an in-flight refresh when a local write lands during the scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:before')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const listed = store.listGraphs();
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.insert([q('did:dkg:context-graph:after')]);
+    counting.listGraphsGate = null;
+    release();
+
+    await expect(listed).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:before', 'did:dkg:context-graph:after']),
+    );
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('refreshes after successful mutating SPARQL passed through query()', async () => {
+    const counting = new MutatingQueryStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.query('# cleanup\nINSERT DATA { GRAPH <ignored> { <urn:s> <urn:p> "v" } }');
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:query-created']);
+  });
+
+  it('does not let observer failures reject committed writes', async () => {
+    const store = new GraphSetIndexStore(new CountingStore(new OxigraphStore()), {
+      onMutation: () => {
+        throw new Error('observer failed');
+      },
+    });
+    await store.listGraphs();
+
+    await expect(store.insert([q('did:dkg:context-graph:observer')])).resolves.toBeUndefined();
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:observer']);
+  });
+
+  it('clears the index instead of rejecting after post-commit maintenance failures', async () => {
+    const graph = 'did:dkg:context-graph:maintenance-failure';
+    const failing = new FailingMaintenanceStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failHasGraph = true;
+    await expect(store.delete([q(graph)])).resolves.toBeUndefined();
+
+    failing.failHasGraph = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('clears the index instead of rejecting after post-commit full refresh failures', async () => {
+    const graph = 'did:dkg:context-graph:refresh-failure';
+    const failing = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failListGraphs = true;
+    await expect(store.deleteByPattern({ predicate: 'urn:p' })).resolves.toBe(1);
+
+    failing.failListGraphs = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('createTripleStore wraps local and managed stores by default, composes outside large-literal storage, and can be disabled', async () => {
+    const defaultStore = await createTripleStore({ backend: 'oxigraph' });
+    expect(typeof defaultStore.listGraphsByPrefix).toBe('function');
+    await defaultStore.close();
+
+    const disabledStore = await createTripleStore({ backend: 'oxigraph', graphSetIndex: false });
+    expect(disabledStore.listGraphsByPrefix).toBeUndefined();
+    await disabledStore.close();
+
+    const blobDir = await mkdtemp(join(tmpdir(), 'dkg-graph-set-index-'));
+    try {
+      const composedStore = await createTripleStore({
+        backend: 'oxigraph',
+        largeLiteralStorage: { directory: blobDir, thresholdBytes: 1 },
+      });
+      expect(typeof composedStore.listGraphsByPrefix).toBe('function');
+      await composedStore.insert([q('did:dkg:context-graph:composed')]);
+      await expect(composedStore.listGraphsByPrefix!('did:dkg:context-graph:comp')).resolves.toEqual([
+        'did:dkg:context-graph:composed',
+      ]);
+      await composedStore.close();
+    } finally {
+      await rm(blobDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves operator-managed external stores uncached unless explicitly enabled', async () => {
+    const operatorStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+    });
+    expect(operatorStore.listGraphsByPrefix).toBeUndefined();
+    await operatorStore.close();
+
+    const managedStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query', managedByDkg: true },
+    });
+    expect(typeof managedStore.listGraphsByPrefix).toBe('function');
+    await managedStore.close();
+
+    const optedInStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+      graphSetIndex: { revalidateMs: 0 },
+    });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+
+  it('leaves custom backends uncached unless explicitly enabled', async () => {
+    const backend = 'custom-remote-graph-set-index-test';
+    registerTripleStoreAdapter(backend, async () => new OxigraphStore());
+
+    const defaultStore = await createTripleStore({ backend });
+    expect(defaultStore.listGraphsByPrefix).toBeUndefined();
+    await defaultStore.close();
+
+    const optedInStore = await createTripleStore({ backend, graphSetIndex: true });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+});


### PR DESCRIPTION
Part **2/5** of the OT-RFC-49 stack · base: `rfc49/01-docs`.

The storage primitive backing the catalog/projection reads: a per-prefix graph-set index.

- **`GraphSetIndexStore`** — a decorator over the triple store that keeps an index of named graphs by prefix, so enumerating a context graph's KA-graphs / `_catalog` subgraph is O(prefix) instead of a full `SELECT DISTINCT ?g` scan.
- **`listGraphsByPrefix`** on the store interface (optional; callers fall back to a filtered `listGraphs`).
- query-engine wiring.

Additive. Storage package tests green. Please do not merge before review / out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Depends on #1165** — please merge that first.
