### PR TITLE
feat(agent): public/meta projection + facet open-serve [4/5]

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  assertSafeIri,
+  contextGraphDataGraphUri,
+  contextGraphDataUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { strip, stripLiteral } from './dkg-agent-utils.js';
+
+export interface ContextGraphSubGraphMeta {
+  uri: string;
+  name: string;
+  createdBy: string;
+  createdAt?: string;
+  description?: string;
+}
+
+export interface ContextGraphMetaRecord {
+  id: string;
+  uri: string;
+  declared: boolean;
+  isSystem: boolean;
+  name?: string;
+  description?: string;
+  creator?: string;
+  creators: string[];
+  curator?: string;
+  curators: string[];
+  accessPolicy?: string;
+  createdAt?: string;
+  allowedPeers: string[];
+  allowedAgents: string[];
+  participantAgents: string[];
+  participantIdentityIds: string[];
+  revokedAgents: string[];
+  onChainId?: string;
+  subGraphs: ContextGraphSubGraphMeta[];
+  hasAgentGate: boolean;
+  hasPeerGate: boolean;
+  hasLegacyParticipantGate: boolean;
+}
+
+interface ProjectionEntry {
+  value?: ContextGraphMetaRecord;
+  inflight?: Promise<ContextGraphMetaRecord>;
+  dirty: boolean;
+  invalidationVersion: number;
+}
+
+const DKG_NS = 'https://dkg.network/ontology#';
+const LEGACY_DKG_NS = 'http://dkg.io/ontology/';
+const LEGACY_SCHEMA_NS = 'http://schema.org/';
+const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SUB_GRAPH_TYPE_URIS = new Set([
+  `${DKG_NS}SubGraph`,
+  `${LEGACY_DKG_NS}SubGraph`,
+]);
+
+const DIRECT_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  DKG_ONTOLOGY.DKG_CREATOR,
+  DKG_ONTOLOGY.DKG_CURATOR,
+  DKG_ONTOLOGY.DKG_CREATED_AT,
+  DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+  DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+  DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+  DKG_ONTOLOGY.DKG_REVOKED_AGENT,
+  DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+  DKG_ONTOLOGY.DKG_PUBLISH_POLICY,
+  DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`,
+]);
+
+const SUB_GRAPH_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  `${DKG_NS}parentContextGraph`,
+  `${LEGACY_DKG_NS}parentContextGraph`,
+  `${DKG_NS}createdBy`,
+  `${LEGACY_DKG_NS}createdBy`,
+  `${DKG_NS}createdAt`,
+  `${LEGACY_DKG_NS}createdAt`,
+  `${DKG_NS}authorizedWriter`,
+  `${LEGACY_DKG_NS}authorizedWriter`,
+]);
+
+export class ContextGraphMetaProjection {
+  private readonly entries = new Map<string, ProjectionEntry>();
+
+  constructor(private readonly store: TripleStore) {}
+
+  async get(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const existing = this.entries.get(contextGraphId);
+    if (existing?.value && !existing.dirty) return existing.value;
+    if (existing?.inflight) {
+      if (!existing.dirty) return existing.inflight;
+      await existing.inflight;
+      return this.get(contextGraphId);
+    }
+
+    const entry = existing ?? { dirty: true, invalidationVersion: 0 };
+    const rebuildVersion = entry.invalidationVersion;
+    entry.dirty = false;
+    const inflight = this.rebuild(contextGraphId)
+      .then((record) => {
+        entry.value = record;
+        entry.inflight = undefined;
+        entry.dirty = entry.invalidationVersion !== rebuildVersion;
+        this.entries.set(contextGraphId, entry);
+        return record;
+      })
+      .catch((err) => {
+        entry.inflight = undefined;
+        entry.dirty = true;
+        this.entries.set(contextGraphId, entry);
+        throw err;
+      });
+
+    entry.inflight = inflight;
+    this.entries.set(contextGraphId, entry);
+    return inflight;
+  }
+
+  markDirty(contextGraphId: string): void {
+    const existing = this.entries.get(contextGraphId);
+    if (existing) {
+      existing.dirty = true;
+      existing.invalidationVersion += 1;
+      return;
+    }
+    this.entries.set(contextGraphId, { dirty: true, invalidationVersion: 1 });
+  }
+
+  markAllDirty(): void {
+    for (const entry of this.entries.values()) {
+      entry.dirty = true;
+      entry.invalidationVersion += 1;
+    }
+  }
+
+  markDirtyFromQuads(quads: readonly Quad[]): string[] {
+    const touched = new Set<string>();
+    for (const quad of quads) {
+      const contextGraphId = this.contextGraphIdTouchedByQuad(quad);
+      if (!contextGraphId) continue;
+      touched.add(contextGraphId);
+      this.markDirty(contextGraphId);
+    }
+    return [...touched];
+  }
+
+  async listDeclaredContextGraphIds(): Promise<string[]> {
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+
+    const result = await this.store.query(`
+      SELECT DISTINCT ?ctxGraph WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH ?g {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+          }
+        }
+      }
+    `);
+    if (result.type !== 'bindings') return [];
+
+    const ids = new Set<string>();
+    for (const row of result.bindings) {
+      const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+      const id = contextGraphIdFromContextGraphUri(uri);
+      if (id) ids.add(id);
+    }
+    return [...ids].sort();
+  }
+
+  private async rebuild(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const uri = contextGraphDataUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+
+    assertSafeIri(uri);
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+    assertSafeIri(metaGraph);
+
+    const record: ContextGraphMetaRecord = {
+      id: contextGraphId,
+      uri,
+      declared: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      isSystem: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      creators: [],
+      curators: [],
+      allowedPeers: [],
+      allowedAgents: [],
+      participantAgents: [],
+      participantIdentityIds: [],
+      revokedAgents: [],
+      subGraphs: [],
+      hasAgentGate: false,
+      hasPeerGate: false,
+      hasLegacyParticipantGate: false,
+    };
+
+    const graphUris = [ontologyGraph, agentsGraph, metaGraph];
+    for (const graphUri of graphUris) {
+      await this.loadContextGraphFacts(graphUri, uri, record);
+    }
+    record.subGraphs = await this.loadSubGraphs(contextGraphId);
+
+    record.hasAgentGate = record.allowedAgents.length > 0 || record.participantAgents.length > 0;
+    record.hasPeerGate = record.allowedPeers.length > 0;
+    record.hasLegacyParticipantGate = record.participantIdentityIds.length > 0;
+    return record;
+  }
+
+  private async loadContextGraphFacts(graphUri: string, contextGraphUri: string, record: ContextGraphMetaRecord): Promise<void> {
+    const result = await this.store.query(
+      `SELECT ?p ?o WHERE {
+        GRAPH <${graphUri}> {
+          <${contextGraphUri}> ?p ?o .
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return;
+
+    for (const row of result.bindings) {
+      const predicate = typeof row['p'] === 'string' ? strip(row['p']) : undefined;
+      const object = typeof row['o'] === 'string' ? stripTerm(row['o']) : undefined;
+      if (!predicate || object === undefined) continue;
+      this.applyFact(record, predicate, object);
+    }
+  }
+
+  private applyFact(record: ContextGraphMetaRecord, predicate: string, object: string): void {
+    switch (predicate) {
+      case DKG_ONTOLOGY.RDF_TYPE:
+        if (object === DKG_ONTOLOGY.DKG_CONTEXT_GRAPH) record.declared = true;
+        if (object === DKG_ONTOLOGY.DKG_SYSTEM_CONTEXT_GRAPH) record.isSystem = true;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_NAME:
+      case `${LEGACY_SCHEMA_NS}name`:
+        record.name ??= object;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_DESCRIPTION:
+      case `${LEGACY_SCHEMA_NS}description`:
+        record.description ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CREATOR:
+        pushUnique(record.creators, object);
+        record.creator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CURATOR:
+        pushUnique(record.curators, object);
+        record.curator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ACCESS_POLICY:
+        applyAccessPolicy(record, object);
+        break;
+      case DKG_ONTOLOGY.DKG_CREATED_AT:
+        record.createdAt ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_PEER:
+        pushUnique(record.allowedPeers, object);
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_AGENT:
+        pushUnique(record.allowedAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT:
+        pushUnique(record.participantAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID:
+        pushUnique(record.participantIdentityIds, object);
+        break;
+      case DKG_ONTOLOGY.DKG_REVOKED_AGENT:
+        pushUnique(record.revokedAgents, object);
+        break;
+      case `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`:
+        record.onChainId ??= object;
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async loadSubGraphs(contextGraphId: string): Promise<ContextGraphSubGraphMeta[]> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?subGraph ?name ?createdBy ?createdAt ?description WHERE {
+        GRAPH <${metaGraph}> {
+          ?subGraph ?typePred ?subGraphType ;
+                    ?namePred ?name ;
+                    ?createdByPred ?createdBy .
+          VALUES ?typePred { <${DKG_ONTOLOGY.RDF_TYPE}> }
+          VALUES ?subGraphType { <${DKG_NS}SubGraph> <${LEGACY_DKG_NS}SubGraph> }
+          VALUES ?namePred { <${DKG_ONTOLOGY.SCHEMA_NAME}> <${LEGACY_SCHEMA_NS}name> }
+          VALUES ?createdByPred { <${DKG_NS}createdBy> <${LEGACY_DKG_NS}createdBy> }
+          OPTIONAL {
+            ?subGraph ?createdAtPred ?createdAt .
+            VALUES ?createdAtPred { <${DKG_NS}createdAt> <${LEGACY_DKG_NS}createdAt> }
+          }
+          OPTIONAL {
+            ?subGraph ?descriptionPred ?description .
+            VALUES ?descriptionPred { <${DKG_ONTOLOGY.SCHEMA_DESCRIPTION}> <${LEGACY_SCHEMA_NS}description> }
+          }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return [];
+
+    const byUri = new Map<string, ContextGraphSubGraphMeta>();
+    for (const row of result.bindings) {
+      const uri = typeof row['subGraph'] === 'string' ? stripTerm(row['subGraph']) : '';
+      if (!uri) continue;
+      const current = byUri.get(uri) ?? {
+        uri,
+        name: row['name'] ? stripTerm(String(row['name'])) : '',
+        createdBy: row['createdBy'] ? stripTerm(String(row['createdBy'])) : '',
+      };
+      if (!current.name && row['name']) current.name = stripTerm(String(row['name']));
+      if (!current.createdBy && row['createdBy']) current.createdBy = stripTerm(String(row['createdBy']));
+      if (!current.createdAt && row['createdAt']) current.createdAt = stripTerm(String(row['createdAt']));
+      if (!current.description && row['description']) current.description = stripTerm(String(row['description']));
+      byUri.set(uri, current);
+    }
+    return [...byUri.values()];
+  }
+
+  private contextGraphIdTouchedByQuad(quad: Quad): string | null {
+    const subject = stripTerm(quad.subject);
+    const predicate = strip(quad.predicate);
+    const object = stripTerm(quad.object);
+    const graph = stripTerm(quad.graph);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaContextGraphId = contextGraphIdFromMetaGraphUri(graph);
+
+    if (metaContextGraphId) {
+      const contextGraphUri = contextGraphDataUri(metaContextGraphId);
+      if (subject === contextGraphUri && DIRECT_META_PREDICATES.has(predicate)) {
+        return metaContextGraphId;
+      }
+
+      if (!subject.startsWith(`${contextGraphUri}/`)) return null;
+      if (!SUB_GRAPH_META_PREDICATES.has(predicate)) return null;
+      if (predicate === DKG_ONTOLOGY.RDF_TYPE && !SUB_GRAPH_TYPE_URIS.has(object)) return null;
+      return metaContextGraphId;
+    }
+
+    if ((graph === ontologyGraph || graph === agentsGraph) && DIRECT_META_PREDICATES.has(predicate)) {
+      return contextGraphIdFromContextGraphUri(subject);
+    }
+
+    return null;
+  }
+}
+
+function pushUnique(target: string[], value: string): void {
+  const key = value.toLowerCase();
+  if (target.some((existing) => existing.toLowerCase() === key)) return;
+  target.push(value);
+}
+
+function stripTerm(value: string): string {
+  return stripLiteral(strip(value));
+}
+
+function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'private') {
+    record.accessPolicy = 'private';
+    return;
+  }
+  if (normalized === 'public') {
+    if (record.accessPolicy !== 'private') record.accessPolicy = 'public';
+    return;
+  }
+  record.accessPolicy ??= value;
+}
+
+function contextGraphIdFromContextGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX)) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length);
+  if (!tail) return null;
+  return tail;
+}
+
+function contextGraphIdFromMetaGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_meta')) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_meta'.length);
+  if (!tail) return null;
+  return tail;
+}

--- a/packages/agent/src/context-graph-public-projection.ts
+++ b/packages/agent/src/context-graph-public-projection.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// OT-RFC-49 §5.9 — the verifiable public projection of a private CG.
+//
+// A private CG holds its data off the network, but it is not invisible to
+// it. Every private CG maintains a small, public, signed RDF *projection*
+// that binds it into the public graph as a verifiable, addressable node —
+// enough for an outsider to discover that it exists, verify claims bound to
+// it, and learn how to ask for access — while disclosing nothing beyond what
+// the chain already exposes.
+//
+// This module is the *write* direction (CG state -> floor quads). It is pure
+// and side-effect-free: the caller publishes the returned quads as an
+// ordinary PUBLIC knowledge asset (signed + anchored, hence tamper-evident).
+// The *read* direction (triples -> ContextGraphMetaRecord) lives in
+// context-graph-meta-projection.ts.
+//
+// The disclosure invariant (§5.9.1): the floor MUST contain only facts
+// already derivable from the on-chain record. This builder enforces it
+// structurally — it accepts only typed floor/recommended/opt-in fields, so
+// it cannot emit a triple the caller did not explicitly supply.
+
+import { createHmac } from 'node:crypto';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+/** A 32-byte hex string, `0x`-prefixed (an on-chain merkle root). */
+const ROOT_RE = /^0x[0-9a-fA-F]{64}$/;
+
+export interface PublicProjectionInput {
+  /** The CG's UAL / DID — the subject of every projection triple (floor). */
+  ual: string;
+  /**
+   * The CG's access class. A catalog entry is a *private*-CG concept; this
+   * builder refuses any other value (a public CG IS its own public face).
+   */
+  accessPolicy: string;
+  /**
+   * Optional. The on-chain VM merkleRoot, `0x`+64 hex. Used only by the
+   * separate-KA model, where the catalog entry has its own root and needs an
+   * explicit `dkg:committedRoot` back-reference. The combined model commits
+   * the entry inside the CG's own root, so verifiability is intrinsic and this
+   * is omitted.
+   */
+  committedRoot?: string;
+  /** Target graph URI: the public `_catalog` subgraph this entry is written into (floor). */
+  graph: string;
+
+  // ---- Recommended (§5.9.2). Omit for the bare floor. ----
+  /** Controlling identity IRI for `dct:publisher`. MAY be a per-CG pseudonymous key (§9 Q5). */
+  publisher?: string;
+  /** Grant endpoint IRI for `dcat:accessService` — how a consumer requests scoped access. */
+  accessService?: string;
+
+  // ---- Opt-in, disclosure-priced (§5.9.4). Each is a deliberate curator choice. ----
+  /** T1: ontology / domain IRIs the CG conforms to. Discloses the field. */
+  conformsTo?: string[];
+  /**
+   * T2: blinded join keys, each `HMAC-SHA256(cgSecret, canonicalEntityId)`
+   * (see {@link blindedAnchor}). Discloses *how many* shared entities, never
+   * *which*. Matchable only by holders of the CG secret.
+   */
+  blindedAnchors?: string[];
+}
+
+function literal(value: string): string {
+  // Mirror dkg-agent-context-graph.ts's literal convention: quoted object.
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function quad(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
+}
+
+/**
+ * Build the public catalog-entry quads for a private CG — a DCAT dataset
+ * record (§5.9), the CG's standards-compliant public face.
+ *
+ * Returns the mandatory floor — `a dcat:Dataset, dkg:PrivateContextGraph`
+ * (dual-typed: DCAT for interop, dkg: for native consumers), `dct:identifier`
+ * (UAL), `dct:accessRights …/RESTRICTED` — plus any recommended/opt-in fields
+ * the caller explicitly supplied (including `dkg:committedRoot` iff a
+ * `committedRoot` is passed, for the separate-KA model), and nothing else.
+ *
+ * @throws if `accessPolicy` is not `'private'`, the UAL / graph are missing,
+ *         or a supplied `committedRoot` is malformed. The throw is the
+ *         disclosure-invariant guard: a malformed entry must never be
+ *         published as if authoritative.
+ */
+export function buildPublicProjection(input: PublicProjectionInput): Quad[] {
+  if (input.accessPolicy !== 'private') {
+    throw new Error(
+      `public catalog entry is a private-CG concept; refusing accessPolicy='${input.accessPolicy}'`,
+    );
+  }
+  const ual = input.ual?.trim();
+  if (!ual) throw new Error('public catalog entry requires a non-empty UAL');
+  const graph = input.graph?.trim();
+  if (!graph) throw new Error('public catalog entry requires a target graph URI');
+
+  // --- Mandatory floor (§5.9.3) — a DCAT dataset record ---
+  const quads: Quad[] = [
+    quad(ual, DKG_ONTOLOGY.RDF_TYPE, DKG_ONTOLOGY.DCAT_DATASET, graph),            // interop
+    quad(ual, DKG_ONTOLOGY.RDF_TYPE, DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph), // dkg-native
+    quad(ual, DKG_ONTOLOGY.DCT_IDENTIFIER, literal(ual), graph),
+    quad(ual, DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph),
+  ];
+
+  // --- Separate-KA back-reference (combined model omits it) ---
+  if (input.committedRoot !== undefined) {
+    if (!ROOT_RE.test(input.committedRoot)) {
+      throw new Error(`committedRoot, when given, must be 0x + 64 hex; got '${input.committedRoot}'`);
+    }
+    quads.push(quad(ual, DKG_ONTOLOGY.DKG_COMMITTED_ROOT, literal(input.committedRoot), graph));
+  }
+
+  // --- Recommended (§5.9.2) ---
+  if (input.publisher?.trim()) {
+    quads.push(quad(ual, DKG_ONTOLOGY.DCT_PUBLISHER, input.publisher.trim(), graph));
+  }
+  if (input.accessService?.trim()) {
+    quads.push(quad(ual, DKG_ONTOLOGY.DCAT_ACCESS_SERVICE, input.accessService.trim(), graph));
+  }
+
+  // --- Opt-in, disclosure-priced (§5.9.4) ---
+  for (const onto of input.conformsTo ?? []) {
+    if (onto?.trim()) quads.push(quad(ual, DKG_ONTOLOGY.DCT_CONFORMS_TO, onto.trim(), graph));
+  }
+  for (const anchor of input.blindedAnchors ?? []) {
+    if (anchor?.trim()) quads.push(quad(ual, DKG_ONTOLOGY.DKG_BLINDED_ANCHOR, literal(anchor.trim()), graph));
+  }
+
+  return quads;
+}
+
+/**
+ * Compute a blinded entity anchor (§5.9.4 T2): `HMAC-SHA256(cgSecret, id)`,
+ * hex, prefixed `hmac:`. Partners holding `cgSecret` recompute this over the
+ * same canonical entity id to discover overlap; the public sees only opaque
+ * hashes. `canonicalEntityId` MUST already be normalized by the caller (the
+ * normalization scheme is §9 Q10).
+ */
+export function blindedAnchor(cgSecret: Buffer | string, canonicalEntityId: string): string {
+  const key = typeof cgSecret === 'string' ? Buffer.from(cgSecret, 'utf8') : cgSecret;
+  const mac = createHmac('sha256', key).update(canonicalEntityId, 'utf8').digest('hex');
+  return `hmac:${mac}`;
+}
+
+/** Floor predicates, exported so tests / auditors can assert the disclosure invariant. */
+export const PUBLIC_PROJECTION_FLOOR_PREDICATES: readonly string[] = [
+  DKG_ONTOLOGY.RDF_TYPE,        // dcat:Dataset + dkg:PrivateContextGraph (two quads, one predicate)
+  DKG_ONTOLOGY.DCT_IDENTIFIER,
+  DKG_ONTOLOGY.DCT_ACCESS_RIGHTS,
+];
+
+// Combined-model partition (§5.9 / §4): separate the public catalog entry from
+// everything else at publish time. The catalog quads ride in the CG's own
+// merkle root (verifiability) but are routed PLAINTEXT to the public sink and
+// EXCLUDED from the ciphertext fed to the curated encryption emitter. Lives in
+// core so the publisher (encryption side) can use it too; re-exported here for
+// agent-side callers and tests.
+export { CATALOG_PREDICATES, partitionCatalogQuads, type CatalogPartition } from '@origintrail-official/dkg-core';
+
+// ---------------------------------------------------------------------------
+// Orchestration: emit a private CG's projection on VM publish (§5.9.3).
+//
+// The capabilities the agent supplies are injected, so the orchestration —
+// the private-CG short-circuit, resolution order, build, publish, and (load-
+// bearing) error isolation — is unit-testable without a running node.
+// ---------------------------------------------------------------------------
+
+export interface ProjectionEmitDeps {
+  /** True iff the CG is private. Only private CGs get a projection (§5.9). */
+  isPrivateContextGraph(contextGraphId: string): Promise<boolean>;
+  /** Resolve the CG's UAL — the subject of the projection. */
+  resolveUal(contextGraphId: string): Promise<string>;
+  /** The public graph URI the projection KA is published into. */
+  projectionGraph(contextGraphId: string): string;
+  /** Publish the projection quads as a PUBLIC knowledge asset. */
+  publishProjection(contextGraphId: string, quads: Quad[], graph: string): Promise<void>;
+  /** Optional controlling identity for `dct:publisher` (MAY be a per-CG pseudonym). */
+  publisherIdentity?(contextGraphId: string): string | undefined;
+  /** Optional grant endpoint for `dkg:accessService`. */
+  accessService?(contextGraphId: string): string | undefined;
+  log?(level: 'info' | 'warn', message: string): void;
+}
+
+export interface ProjectionEmitResult {
+  emitted: boolean;
+  quads: Quad[];
+  /** Set when emission was attempted but failed; never thrown (see below). */
+  error?: string;
+}
+
+/**
+ * Emit (or refresh) the public projection for a CG after a VM publish commits
+ * `committedRoot` on chain. Public CGs are a no-op (they are their own public
+ * face). For a private CG, builds the floor (plus any recommended fields the
+ * deps surface) and publishes it.
+ *
+ * Error isolation is deliberate and load-bearing: a projection failure MUST
+ * NOT break the VM publish that triggered it, so this never throws — it logs
+ * and returns `{ emitted: false, error }`. The caller treats the projection as
+ * best-effort and the next publish refreshes it.
+ */
+export async function emitPublicProjection(
+  deps: ProjectionEmitDeps,
+  contextGraphId: string,
+  committedRoot: string,
+): Promise<ProjectionEmitResult> {
+  try {
+    if (!(await deps.isPrivateContextGraph(contextGraphId))) {
+      return { emitted: false, quads: [] };
+    }
+    const ual = await deps.resolveUal(contextGraphId);
+    const graph = deps.projectionGraph(contextGraphId);
+    const quads = buildPublicProjection({
+      ual,
+      accessPolicy: 'private',
+      committedRoot,
+      graph,
+      publisher: deps.publisherIdentity?.(contextGraphId),
+      accessService: deps.accessService?.(contextGraphId),
+    });
+    await deps.publishProjection(contextGraphId, quads, graph);
+    deps.log?.('info', `public projection refreshed for ${contextGraphId} @ root ${committedRoot}`);
+    return { emitted: true, quads };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.log?.('warn', `public projection emit failed for ${contextGraphId}: ${message} (publish unaffected)`);
+    return { emitted: false, quads: [], error: message };
+  }
+}

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -379,6 +379,7 @@ import {
   deserializeSwmSenderReceiveState,
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
+import { ContextGraphMetaProjection } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 export class DKGAgentBase {
@@ -416,6 +417,7 @@ export class DKGAgentBase {
   protected readonly chain: ChainAdapter;
   /** Shared memory-owned root entities per context graph: entity → creatorPeerId. Used by publisher and shared memory handler. */
   protected readonly workspaceOwnedEntities: Map<string, Map<string, string>>;
+  protected readonly contextGraphMetaProjection: ContextGraphMetaProjection;
   /**
    * OT-RFC-38 / LU-6 Phase B (Codex PR #610 round-2 #2) — highest
    * `nextSeqno` already consumed per (contextGraphId, hostPeerId)
@@ -495,6 +497,8 @@ export class DKGAgentBase {
   protected readonly swmHostModeHandlers = new Map<string, (topic: string, data: Uint8Array, from: string) => void>();
   /** Async lock for the host-mode reconciler so simultaneous calls don't double-subscribe. */
   protected hostModeReconcileInflight?: Promise<void>;
+  /** Rotating cursor for bounded host-mode reconcile sweeps over known context graphs. */
+  protected hostModeReconcileCursor = 0;
   /**
    * OT-RFC-43 A2 — the KA-number allocator, retained on the agent (also
    * forwarded to the publisher as `kaAllocator`). Held here so
@@ -1186,6 +1190,7 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
+    this.contextGraphMetaProjection = new ContextGraphMetaProjection(store);
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -701,20 +701,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return undefined;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-        UNION
-        { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-      } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
-    const raw = result.bindings[0]?.['policy'];
-    if (typeof raw !== 'string') return undefined;
-    const stripped = raw.replace(/^"|"$/g, '');
+    const stripped = (await this.getCgMeta(contextGraphId)).accessPolicy;
     if (stripped === 'public') return 0;
     if (stripped === 'private') return 1;
     return undefined;
@@ -773,19 +760,9 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string[] | null> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
-      { signal: options.signal },
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) {
-      return null;
-    }
-    return result.bindings
-      .map(row => row['peer'])
-      .filter((v): v is string => typeof v === 'string')
-      .map(v => v.replace(/^"|"$/g, ''));
+    void options;
+    const peers = (await this.getCgMeta(contextGraphId)).allowedPeers;
+    return peers.length > 0 ? peers : null;
   }
 
   // ── Sub-Graph Management ───────────────────────────────────────────────
@@ -842,6 +819,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     await gm.ensureSubGraph(contextGraphId, subGraphName);
     await this.store.insert(registrationQuads);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -861,17 +839,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     createdAt?: string;
     description?: string;
   }>> {
-    const { subGraphDiscoverySparql } = await import('@origintrail-official/dkg-publisher');
-    const sparql = subGraphDiscoverySparql(contextGraphId);
-    const result = await this.store.query(sparql);
-    if (result.type !== 'bindings') return [];
-    return result.bindings.map(row => ({
-      uri: row['subGraph'] ?? '',
-      name: stripLiteral(row['name'] ?? ''),
-      createdBy: row['createdBy'] ?? '',
-      createdAt: row['createdAt'] ? stripLiteral(row['createdAt']) : undefined,
-      description: row['description'] ? stripLiteral(row['description']) : undefined,
-    }));
+    return (await this.getCgMeta(contextGraphId)).subGraphs;
   }
 
   /**
@@ -906,7 +874,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     // Drop assertion graphs under the sub-graph prefix
     const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, sgPrefix);
     for (const g of allGraphs) {
       if (g.startsWith(sgPrefix)) {
         try { await this.store.dropGraph(g); } catch { /* graph may not exist */ }
@@ -916,6 +884,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     // Clear SWM ownership cache for this sub-graph
     const ownershipKey = `${contextGraphId}\0${subGraphName}`;
     this.publisher.clearSubGraphOwnership(ownershipKey);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -1006,6 +975,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     }
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     this.subscribeToContextGraph(opts.id);
@@ -1102,4 +1072,10 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
   // ── ENDORSE ─���────────────────────────────────────────────────────────
 
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -19,7 +19,7 @@ import {
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphSharedMemoryUri,
   contextGraphVerifiableMemoryUri, contextGraphVerifiableMemoryMetaUri,
-  contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
+  contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri, contextGraphCatalogUri,
   deriveCuratorDidFromCgId,
   MemoryLayer,
   computeACKDigest,
@@ -379,7 +379,73 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
+
+interface ContextGraphListRow {
+  id: string;
+  uri: string;
+  name: string;
+  description?: string;
+  creator?: string;
+  curator?: string;
+  accessPolicy?: string;
+  createdAt?: string;
+  isSystem: boolean;
+  subscribed: boolean;
+  synced: boolean;
+  onChainId?: string;
+  callerInvolved?: boolean;
+}
+
+type InternalContextGraphListRow = ContextGraphListRow & {
+  policyKnown?: boolean;
+};
+
+function listContextGraphsProjectionEnabled(): boolean {
+  const raw = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
+  if (!accessPolicy?.trim()) return false;
+  const t = accessPolicy.trim().replace(/^["']|["']$/g, '').toLowerCase();
+  return t === 'private';
+}
+
+async function applyContextGraphListPrivacy(
+  agent: DKGAgent,
+  rows: InternalContextGraphListRow[],
+  opts?: { callerAgentAddress?: string | null },
+): Promise<ContextGraphListRow[]> {
+  const scopedList = opts !== undefined && Object.prototype.hasOwnProperty.call(opts, 'callerAgentAddress');
+  const visibleRows = scopedList ? rows.filter((r) => r.policyKnown !== false) : rows;
+  let checksum: string | null = null;
+  const rawCaller = opts?.callerAgentAddress?.trim();
+  if (rawCaller && ethers.isAddress(rawCaller)) {
+    try {
+      checksum = ethers.getAddress(rawCaller);
+    } catch {
+      checksum = null;
+    }
+  }
+
+  if (!checksum) {
+    return visibleRows
+      .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy))
+      .map(({ policyKnown: _policyKnown, ...row }) => row);
+  }
+
+  const annotated = await Promise.all(visibleRows.map(async (r) => {
+    const curatorMatch = agent.curatorDidMatchesChecksumAgent(r.curator, checksum);
+    const allowlisted = await agent.callerIsAllowlistedAgentParticipant(r.id, checksum);
+    return { ...r, callerInvolved: curatorMatch || allowlisted };
+  }));
+
+  return annotated
+    .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy) || r.callerInvolved === true)
+    .map(({ policyKnown: _policyKnown, ...row }) => row);
+}
 
 function syncAuthAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
@@ -399,6 +465,59 @@ function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
 }
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
+  async getCgMeta(this: DKGAgent, contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    return this.contextGraphMetaProjection.get(contextGraphId);
+  }
+
+  async listContextGraphsFromProjection(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    const candidateIds = new Set(await this.contextGraphMetaProjection.listDeclaredContextGraphIds());
+    for (const [id] of this.subscribedContextGraphs) {
+      candidateIds.add(id);
+    }
+
+    const graphManager = new GraphManager(this.store);
+    for (const id of await graphManager.listContextGraphs()) {
+      candidateIds.add(id);
+    }
+
+    const rows = await Promise.all([...candidateIds].sort().map(async (id): Promise<InternalContextGraphListRow | null> => {
+      if (!id) return null;
+      const sub = this.subscribedContextGraphs.get(id);
+      const meta = await this.getCgMeta(id);
+      const hasProjectionGate = meta.hasAgentGate || meta.hasPeerGate || meta.hasLegacyParticipantGate;
+      const projectedAccessPolicy = meta.accessPolicy ?? (hasProjectionGate ? 'private' : undefined);
+      const policyKnown = meta.declared || projectedAccessPolicy !== undefined;
+
+      if (!meta.declared && !sub?.onChainId && !sub?.pendingMeta) {
+        if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) return null;
+        const hasContent = await this.contextGraphHasLocalContent(id);
+        if (!hasContent) return null;
+      }
+
+      return {
+        id,
+        uri: meta.uri || contextGraphDataUri(id),
+        name: meta.name ?? sub?.name ?? id,
+        description: meta.description,
+        creator: meta.creator,
+        curator: meta.curator,
+        accessPolicy: projectedAccessPolicy,
+        createdAt: meta.createdAt,
+        isSystem: meta.isSystem,
+        subscribed: sub?.subscribed ?? false,
+        synced: sub?.synced ?? false,
+        onChainId: sub?.onChainId ?? meta.onChainId,
+        policyKnown,
+      };
+    }));
+
+    return applyContextGraphListPrivacy(
+      this,
+      rows.filter((row): row is ContextGraphListRow => row !== null),
+      opts,
+    );
+  }
+
   /**
    * Check whether a context graph exists in local storage. Definition triples in
    * ONTOLOGY/_meta count, and storage-backed graph presence also counts so local
@@ -748,7 +867,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // authenticated request so the remote peer can verify our identity
     // against its allowlist.
     const hasLocalData = this.subscribedContextGraphs.get(contextGraphId)?.synced === true;
-    const needsAuth = isPrivate || !hasLocalData;
+    // OT-RFC-49 §7 — the catalog facet is public and served without the
+    // allowlist gate, so an outsider (no CG identity) requests it unauthenticated.
+    const needsAuth = phase !== 'catalog' && (isPrivate || !hasLocalData);
     const claimedAgentAddress = await this.findLocalAgentForContextGraph(contextGraphId);
     const claimedAgent = claimedAgentAddress ? this.localAgents.get(claimedAgentAddress) : undefined;
     return buildSyncRequestEnvelope({
@@ -773,6 +894,26 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       claimedAgentAddress: claimedAgentAddress,
       claimedAgentPrivateKey: claimedAgent?.privateKey,
     });
+  }
+
+  /**
+   * OT-RFC-49 §7 — fetch a (private) CG's PUBLIC catalog entry from a peer
+   * WITHOUT membership. The responder serves the bounded `_catalog` facet
+   * openly (no allowlist gate); the fetched DCAT dataset record is written to
+   * the local store's `_catalog` graph. Returns the catalog quads received.
+   * The peer serves ONLY `_catalog` — gated content is never returned.
+   */
+  public async fetchPublicCatalog(this: DKGAgent,
+    contextGraphId: string,
+    responderPeerId: string,
+    deadlineMs = 30_000,
+  ): Promise<Quad[]> {
+    const ctx = createOperationContext('sync');
+    const catalogGraph = contextGraphCatalogUri(contextGraphId);
+    const result = await this.fetchSyncPages(
+      ctx, responderPeerId, contextGraphId, false, 'catalog', catalogGraph, Date.now() + deadlineMs,
+    );
+    return result.quads;
   }
 
   computeSyncDigest(this: DKGAgent,
@@ -1347,6 +1488,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string[] | null> {
+    // RFC-49: the participant set is read from the in-memory meta projection
+    // (getCgMeta), NOT a direct store query — the projection is the only place
+    // that applies revokedAgents filtering, so a store-only read (main's A2
+    // form) would silently re-authorize revoked agents. `options.signal` is
+    // accepted for caller parity with the abort-hardened siblings but the
+    // projection read is in-memory and has no I/O to cancel.
+    void options;
     const merged: string[] = [];
     const seen = new Set<string>();
     const add = (value: string | undefined) => {
@@ -1356,49 +1504,24 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       seen.add(key);
       merged.push(value);
     };
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    const addAgent = (value: string | undefined) => {
+      if (!value || revoked.has(value.toLowerCase())) return;
+      add(value);
+    };
 
     const localAgentParticipants = this.subscribedContextGraphs.get(contextGraphId)?.participantAgents;
     if (localAgentParticipants) {
-      for (const p of localAgentParticipants) add(p);
+      for (const p of localAgentParticipants) addAgent(p);
     }
-
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
 
     // V10 agent model: local allowedAgent entries plus explicit on-chain
     // participantAgent entries both grant local curated access.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
-
+    for (const agent of meta.allowedAgents) addAgent(agent);
+    for (const agent of meta.participantAgents) addAgent(agent);
     // Legacy identity model: participantIdentityIds (numeric IDs as strings)
-    const metaResult = await this.store.query(
-      `SELECT ?identityId WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (metaResult.type === 'bindings') {
-      for (const row of metaResult.bindings) {
-        const raw = row['identityId'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
+    for (const identityId of meta.participantIdentityIds) add(identityId);
 
     if (merged.length > 0) return merged;
 
@@ -1585,6 +1708,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       throwIfSyncAuthAborted(options.signal);
       if (metaResult.quads.length > 0) {
         await this.store.insert(metaResult.quads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(metaResult.quads);
         this.syncCheckpoints.delete(metaResult.checkpointKey);
         this.log.info(ctx, `Meta refresh for "${contextGraphId}": ${metaResult.quads.length} triples from curator ${curatorPeerId.slice(-8)}`);
         return true;
@@ -1611,28 +1735,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * With a valid `callerAgentAddress` option, each row includes `callerInvolved`.
    * With no usable caller wallet, omit that field entirely so callers can infer membership from `curator`.
    */
-  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<Array<{
-    id: string;
-    uri: string;
-    name: string;
-    description?: string;
-    creator?: string;
-    /** Wallet-scoped curator DID (from _meta / ontology), if present. */
-    curator?: string;
-    /** Declared access policy literal, e.g. public / private. */
-    accessPolicy?: string;
-    createdAt?: string;
-    isSystem: boolean;
-    subscribed: boolean;
-    synced: boolean;
-    onChainId?: string;
-    /**
-     * When `callerAgentAddress` is omitted or invalid: property is omitted —
-     * clients fall back to comparing `curator` to identity (listing was not scoped to a caller).
-     * When a valid caller is provided: explicit true/false.
-     */
-    callerInvolved?: boolean;
-  }>> {
+  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    if (listContextGraphsProjectionEnabled()) {
+      return this.listContextGraphsFromProjection(opts);
+    }
+
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const result = await this.store.query(`
@@ -1827,51 +1934,26 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let rows = Array.from(seen.values());
 
     /**
-     * Open CGs replicate `DKG_CREATOR`/name/policy on ONTOLOGY but keep `DKG_CURATOR` in `_meta` only,
-     * so list rows lack `curator` and the sidebar cannot classify "mine" without a Bearer-scoped pass.
-     * Backfill once (parallelised) — also removes duplicate SPARQL in the involvement pass below.
+     * Normalize metadata through the keyed projection before privacy filtering.
+     * Raw discovery can see stale ONTOLOGY and authoritative AGENTS/_meta rows
+     * for the same CG; projection gives private policy precedence.
      */
     rows = await Promise.all(rows.map(async (r) => {
-      if (r.curator?.trim()) return r;
-      const c = await this.getContextGraphCurator(r.id);
-      return c ? { ...r, curator: c } : r;
+      const meta = await this.getCgMeta(r.id);
+      return {
+        ...r,
+        name: meta.name ?? r.name,
+        description: meta.description ?? r.description,
+        creator: meta.creator ?? r.creator,
+        curator: meta.curator ?? r.curator,
+        accessPolicy: meta.accessPolicy ?? r.accessPolicy,
+        createdAt: meta.createdAt ?? r.createdAt,
+        isSystem: meta.isSystem || r.isSystem,
+        onChainId: meta.onChainId ?? r.onChainId,
+      };
     }));
 
-    let checksum: string | null = null;
-    const rawCaller = opts?.callerAgentAddress?.trim();
-    if (rawCaller && ethers.isAddress(rawCaller)) {
-      try {
-        checksum = ethers.getAddress(rawCaller);
-      } catch {
-        checksum = null;
-      }
-    }
-
-    // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
-    // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
-    // keep private rows only when they are curator or allowlisted participant.
-    const isPrivateRow = (ap?: string): boolean => {
-      if (!ap?.trim()) return false;
-      const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
-      return t === 'private';
-    };
-
-    if (!checksum) {
-      // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
-      // curator-vs-identity fallback for OPEN graphs.
-      return rows.filter((r) => !isPrivateRow(r.accessPolicy));
-    }
-
-    const annotated = await Promise.all(rows.map(async (r) => {
-      const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
-      const allowlisted = await this.callerIsAllowlistedAgentParticipant(r.id, checksum);
-      // `callerInvolved` must reflect ONLY the provided caller wallet.
-      // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
-      const involved = curatorMatch || allowlisted;
-      return { ...r, callerInvolved: involved };
-    }));
-
-    return annotated.filter((r) => !isPrivateRow(r.accessPolicy) || r.callerInvolved === true);
+    return applyContextGraphListPrivacy(this, rows, opts);
   }
 
 }

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -652,6 +652,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     );
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
@@ -911,6 +912,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
       ]);
+      this.contextGraphMetaProjection.markDirty(id);
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);
       return curatorDid;
     };
@@ -1128,6 +1130,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         await this.store.insert([
           { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         return { onChainId: existingOnChainId, txHash: undefined };
       }
       this.log.warn(
@@ -1300,6 +1303,7 @@ export class ContextGraphMethods extends DKGAgentBase {
             graph: cgMetaGraph,
           },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         // Re-fetch participantAgents so the on-chain
         // registration also lists the calling agent (matches
         // what the local agent gate now enforces).
@@ -1400,6 +1404,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       // topic without re-reading the chain event.
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(id);
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
@@ -1526,6 +1531,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     });
 
     await this.store.insert(quadsToInsert);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
 
     // Issue #865 — log a clear warning AFTER the allowlist quad has
     // landed on a CG with an explicit `accessPolicy="public"` triple.
@@ -1689,6 +1695,8 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     await this.store.insert(quadsToInsert);
 
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
+
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
     // publishPolicy=curated + accessPolicy=public combination is a
@@ -1778,6 +1786,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT,
       object: `"${agentAddress}"`,
     }]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
     this.queueSharedMemoryGossipSubscription(contextGraphId);
     // Drop any cached sender-key send state for this CG so the next
@@ -1855,6 +1864,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: ontologyGraph },
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(ctx, `Renamed context graph "${contextGraphId}" to "${trimmed}"`);
   }
@@ -1863,8 +1873,6 @@ export class ContextGraphMethods extends DKGAgentBase {
    * List allowed agents for a context graph.
    */
   async getContextGraphAllowedAgents(this: DKGAgent, contextGraphId: string): Promise<string[]> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     // Subtract `dkg:revokedAgent` tombstones from the allowlist union
     // so a curator who has called `removeAgentFromContextGraph` sees
     // their authoritative view, not the union with peer-sync-replicated
@@ -1873,32 +1881,9 @@ export class ContextGraphMethods extends DKGAgentBase {
     // silently re-include a revoked agent the moment another node's
     // local CG metadata gossiped back (see C1 devnet harness for the
     // reproducer + `removeAgentFromContextGraph` for the write side).
-    const result = await this.store.query(
-      `SELECT ?agent ?revoked WHERE {
-        {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked
-          }
-        }
-      }`,
-    );
-    if (result.type !== 'bindings') return [];
-    const allowed: string[] = [];
-    const revoked = new Set<string>();
-    for (const row of result.bindings) {
-      const a = (row as Record<string, string>)['agent'];
-      const r = (row as Record<string, string>)['revoked'];
-      if (typeof a === 'string') {
-        allowed.push(a.replace(/^"|"$/g, ''));
-      }
-      if (typeof r === 'string') {
-        revoked.add(r.replace(/^"|"$/g, '').toLowerCase());
-      }
-    }
+    const meta = await this.getCgMeta(contextGraphId);
+    const allowed = meta.allowedAgents;
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     if (revoked.size === 0) return allowed;
     return allowed.filter((addr) => !revoked.has(addr.toLowerCase()));
   }

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -432,10 +432,13 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     const seen = new Set<string>();
     const agents: string[] = [];
     let sawAgentGate = false;
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     const add = (value: string | undefined) => {
       if (!value || !ethers.isAddress(value)) return;
       const checksum = ethers.getAddress(value);
       const key = checksum.toLowerCase();
+      if (revoked.has(key)) return;
       if (seen.has(key)) return;
       seen.add(key);
       agents.push(checksum);
@@ -447,27 +450,9 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
       add(agentAddress);
     }
 
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (result.type === 'bindings') {
-      if (result.bindings.length > 0) sawAgentGate = true;
-      for (const row of result.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') {
-          add(raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, ''));
-        }
-      }
-    }
+    if (meta.allowedAgents.length > 0 || meta.participantAgents.length > 0) sawAgentGate = true;
+    for (const agent of meta.allowedAgents) add(agent);
+    for (const agent of meta.participantAgents) add(agent);
 
     return sawAgentGate ? agents : null;
   }

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -700,8 +700,6 @@ export class OwnershipMethods extends DKGAgentBase {
   }
 
   async getContextGraphCurator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     // Multi-curator scenario: peer-to-peer sync of CG `_meta` triples
     // can replicate FOREIGN `dkg:curator` triples onto a node's local
     // store. The original behaviour (`LIMIT 1`) made ownership lookup
@@ -719,21 +717,7 @@ export class OwnershipMethods extends DKGAgentBase {
     // the first curator triple when no local match exists, preserving
     // the legacy "subscriber sees foreign owner" semantics for
     // membership/UI queries against CGs this node did not curate.
-    const curatorResult = await this.store.query(`
-      SELECT ?owner WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
-        }
-      }
-    `);
-    if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
-      return null;
-    }
-    const owners: string[] = [];
-    for (const b of curatorResult.bindings) {
-      const o = (b as Record<string, string>)['owner'];
-      if (o) owners.push(o);
-    }
+    const owners = (await this.getCgMeta(contextGraphId)).curators;
     if (owners.length === 0) return null;
     if (owners.length === 1) return owners[0];
     const selfDid = `did:dkg:agent:${this.peerId}`;
@@ -817,8 +801,6 @@ export class OwnershipMethods extends DKGAgentBase {
       merged.push(checksumAddress);
     };
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — the on-chain participant-agent list
     // is now the authoritative source for the host-mode envelope
     // authority check on cores (see `resolveOnChainParticipantAgents`
@@ -841,19 +823,13 @@ export class OwnershipMethods extends DKGAgentBase {
     // (those are persisted as PARTICIPANT triples). The merge below
     // is a UNION so any per-CG explicit list survives and just gets
     // augmented with whatever local allowlist exists.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        add(row['agent']);
-      }
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    for (const agent of meta.participantAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
+    }
+    for (const agent of meta.allowedAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
     }
     return merged;
   }
@@ -866,25 +842,7 @@ export class OwnershipMethods extends DKGAgentBase {
    * peers validating via `gossip-publish-handler` see a matching owner.
    */
   async getContextGraphCreator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(`
-      SELECT ?owner WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        }
-      }
-      LIMIT 1
-    `);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
+    return (await this.getCgMeta(contextGraphId)).creator ?? null;
   }
 
   public async listCclPolicyBindings(this: DKGAgent, opts: {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -149,6 +149,7 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
+import { emitPublicProjection, buildPublicProjection } from './context-graph-public-projection.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -1287,7 +1288,60 @@ export class PublishMethods extends DKGAgentBase {
     await this.broadcastPublish(contextGraphId, result, ctx);
     onPhase?.('broadcast', 'end');
     this.log.info(ctx, `Publish complete — status=${result.status} kaId=${result.kaId}`);
+
+    // OT-RFC-49 §5.9 — refresh the private CG's public projection now the root
+    // is committed. No-op unless configured; best-effort and error-isolated so
+    // it can never affect the publish just completed.
+    await this.emitPublicProjectionAfterPublish(contextGraphId, result, ctx);
+
     return result;
+  }
+
+  /**
+   * OT-RFC-49 §5.9.3 — emit/refresh the public projection of a private CG once
+   * its VM publish is confirmed on chain. Binds the private CG into the public
+   * graph as a discoverable, verifiable node (floor: `a dkg:PrivateContextGraph`,
+   * UAL, `dct:accessRights dkg:Private`, `dkg:committedRoot`) while disclosing
+   * nothing beyond chain state (§5.9.1).
+   *
+   * No-op unless `publicProjectionContextGraphId` is configured; skips public
+   * CGs (they are their own public face, handled inside `emitPublicProjection`)
+   * and the discovery CG itself (recursion guard). Fully error-isolated — a
+   * projection failure logs and returns, never affecting the triggering publish.
+   */
+  async emitPublicProjectionAfterPublish(
+    this: DKGAgent,
+    contextGraphId: string,
+    result: PublishResult,
+    ctx: OperationContext,
+  ): Promise<void> {
+    try {
+      const target = this.config.publicProjectionContextGraphId;
+      // Off unless configured; never project the discovery CG into itself.
+      if (!target || contextGraphId === target) return;
+      // Only a confirmed publish has a real on-chain committed root.
+      if (result.status !== 'confirmed' || result.merkleRoot.length !== 32) return;
+      const committedRoot = `0x${Buffer.from(result.merkleRoot).toString('hex')}`;
+
+      await emitPublicProjection(
+        {
+          isPrivateContextGraph: (id) => this.isPrivateContextGraph(id),
+          resolveUal: async () => result.ual,
+          projectionGraph: () => contextGraphDataGraphUri(target),
+          // The projection is PUBLIC content; the target is a public CG, so
+          // this.publish keeps it plaintext and emit no-ops on the inner call.
+          publishProjection: async (_id, quads) => { await this.publish(target, quads); },
+          log: (level, message) =>
+            level === 'warn' ? this.log.warn(ctx, message) : this.log.info(ctx, message),
+        },
+        contextGraphId,
+        committedRoot,
+      );
+    } catch (err) {
+      // Defense-in-depth: emitPublicProjection already isolates its own errors,
+      // but a bug in target/root resolution must never break a good publish.
+      this.log.warn(ctx, `public projection skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   async update(this: DKGAgent,
@@ -1517,6 +1571,7 @@ export class PublishMethods extends DKGAgentBase {
     ];
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(contextGraphId);
     await this.store.flush?.();
     this.subscribeToContextGraph(contextGraphId);
@@ -1595,6 +1650,21 @@ export class PublishMethods extends DKGAgentBase {
     );
     const metaGraph = contextGraphMetaUri(contextGraphId);
 
+    // OT-RFC-49 §5.9 — for a PRIVATE CG, write the public DCAT catalog entry
+    // into this same assertion via the NORMAL write path (so it lands in the
+    // correct wmGraphUri) BEFORE the seal reads it below. It becomes a public
+    // KA (subject = the CG UAL) committed in the CG's OWN merkle root; the
+    // publish-path partition keeps it out of the ciphertext and routes it to
+    // the public sink. Idempotent: identical quads dedupe in the store, so the
+    // double-finalize (explicit + promote) does not duplicate it.
+    if (await this.isPrivateContextGraph(contextGraphId)) {
+      const cgUal = contextGraphDataUri(contextGraphId);
+      // graph is a non-empty placeholder only (buildPublicProjection requires
+      // one); assertionWrite re-stamps it with the correct wmGraphUri.
+      const catalogQuads = buildPublicProjection({ ual: cgUal, accessPolicy: 'private', graph: assertionUri });
+      await this.publisher.assertionWrite(contextGraphId, name, agentAddress, catalogQuads, opts?.subGraphName);
+    }
+
     // 2. Pull the assertion's quads. Refuse to finalize an empty
     //    assertion — there's nothing to commit.
     const rawQuads = await this.publisher.assertionQuery(
@@ -1629,6 +1699,12 @@ export class PublishMethods extends DKGAgentBase {
       );
     }
 
+    // OT-RFC-49 §5.9 — inject the public DCAT catalog entry for a PRIVATE CG
+    // so it rides in the CG's OWN merkle root as a public KA (subject = the CG
+    // UAL). Persisted to the same WM graph so promote/reload carry it; the
+    // publish-path partition keeps it out of the ciphertext and routes it to
+    // the public sink. Idempotent across re-finalize (fresh filter + the seal
+    // already contains it on the second pass).
     // 3. Compute merkleRoot using the SAME algorithm the publisher
     //    uses at publish-time (V10: keccak256-based merkle, sort+dedupe
     //    leaves). Drift between these two compute paths is the silent
@@ -2802,7 +2878,7 @@ export class PublishMethods extends DKGAgentBase {
         ${sharedMemoryReadBothFilter(swmGraph)}
       }`;
     }
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.resolveLiftWorkspaceSlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1111,7 +1111,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     let markedDefaultAddr: string | undefined;
     const needsMigration: AgentKeyRecord[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.agentKeyMigration' });
       if (result.type !== 'bindings') return;
       const strip = (v?: string) => v?.replace(/^"|"$/g, '').replace(/"?\^\^.*$/, '') ?? '';
       for (const row of result.bindings) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -386,6 +386,13 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE = 32;
+
+function normalizeHostModeReconcileBatchSize(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE;
+  return Math.max(1, Math.floor(value));
+}
+
 export class SwmHostModeMethods extends DKGAgentBase {
   /**
    * OT-RFC-38 LU-6 — initialize the on-disk opaque ciphertext store
@@ -786,9 +793,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   /**
    * Periodic reconciler driven by `hostModeReconcilerTimer`. Sweeps
-   * every locally-known CG and ensures host-mode subscription is
-   * in sync. Cheap to call repeatedly because the per-CG
-   * reconciler is idempotent.
+   * a bounded slice of locally-known CGs and ensures host-mode
+   * subscription is in sync. The cursor rotates through the stable
+   * sorted set so large stores converge without each tick touching
+   * every known graph.
    *
    * Serialized via `hostModeReconcileInflight` so an overlap with
    * the cleanup timer (or a manual call from a test) doesn't
@@ -803,9 +811,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const inflight = (async () => {
       try {
         const graphManager = new GraphManager(this.store);
-        const knownCgs = await graphManager.listContextGraphs();
-        for (const cgId of knownCgs) {
-          await this.reconcileSwmHostModeSubscription(cgId);
+        const knownCgs = (await graphManager.listContextGraphs()).sort();
+        if (knownCgs.length === 0) {
+          this.hostModeReconcileCursor = 0;
+          return;
+        }
+        const batchSize = normalizeHostModeReconcileBatchSize(this.config.swmHostMode?.reconcileBatchSize);
+        const start = this.hostModeReconcileCursor % knownCgs.length;
+        const count = Math.min(batchSize, knownCgs.length);
+        for (let i = 0; i < count; i++) {
+          const index = (start + i) % knownCgs.length;
+          const cgId = knownCgs[index];
+          try {
+            await this.reconcileSwmHostModeSubscription(cgId);
+          } finally {
+            this.hostModeReconcileCursor = (index + 1) % knownCgs.length;
+          }
         }
       } finally {
         this.hostModeReconcileInflight = undefined;
@@ -1739,7 +1760,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const sparql = `SELECT ?o WHERE { ${graphClause} { <${subject}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`;
     let result;
     try {
-      result = await this.store.query(sparql);
+      result = await this.store.query(sparql, { source: 'agent.ciphertextChunkCatchup' });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `LU-11 chunk-catchup store query failed cg=${req.contextGraphId} chunkIndex=${req.chunkIndex}: ${reason}`);

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -543,6 +543,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
   }
 
   async reconcileSharedMemoryGossipSubscription(this: DKGAgent, contextGraphId: string): Promise<void> {
+    // Reconcile is the membership boundary; rebuild this CG's policy view
+    // before deciding whether to keep or drop the SWM subscription.
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — subscribe on the wire-form (hash) topic.
     // Members compute the hash from their local cleartext id via
     // {@link gossipWireIdFor}; cores hosting CGs they never joined
@@ -812,6 +815,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
+          getCgMeta: (id) => this.getCgMeta(id),
+          markCgMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
       );
@@ -825,6 +830,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         sharedMemoryOwnedEntities: this.workspaceOwnedEntities,
         writeLocks: this.writeLocks,
         localAgentAddresses: () => [...this.localAgents.keys()],
+        contextGraphMetaOracle: (cgId: string) => this.getCgMeta(cgId),
+        markContextGraphMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
         // OT-RFC-38 / LU-6 Phase B: chain-backed agent-allowlist
         // fallback. Cores hosting curated CGs they are NOT members
         // of have no local meta for the allowlist — without this,
@@ -1508,6 +1515,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         // resolve the on-chain id locally so per-cgId promotion still
         // fires and the RS prover sees the KC.
         (cgName: string) => this.getContextGraphOnChainId(cgName),
+        (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -781,6 +781,16 @@ export type ReplicationEventSink = (event: ReplicationEvent) => void;
 
 export interface DKGAgentConfig {
   name: string;
+  /**
+   * OT-RFC-49 §5.9 — public-projection target. When set, a private CG's
+   * confirmed VM publishes emit/refresh a verifiable public projection (the
+   * floor: existence, UAL, access class, committed root) into this PUBLIC
+   * context graph, binding the private CG into the public graph as a
+   * discoverable, verifiable node without disclosing its contents. The target
+   * MUST be a public CG (a curated target would encrypt the projection and
+   * also self-recurse). Unset → projections are off.
+   */
+  publicProjectionContextGraphId?: string;
   framework?: string;
   description?: string;
   listenPort?: number;
@@ -965,6 +975,8 @@ export interface DKGAgentConfig {
    *  - `registered`: TTL/byte-cap for on-chain registered CGs (typically larger).
    *  - `pruneIntervalMs`: how often the TTL/cap sweep runs.
    *  - `reconcileIntervalMs`: how often the host-mode subscription reconciler ensures cores are subscribed to all known curated CGs.
+   *  - `reconcileBatchSize`: max known CGs reconciled per tick. Default 32.
+   *  - `reconcileJitterRatio`: startup interval jitter ratio in [0, 1]. Default 0.15.
    */
   swmHostMode?: {
     enabled?: boolean;
@@ -972,6 +984,8 @@ export interface DKGAgentConfig {
     registered?: SwmHostModeStoreLimits;
     pruneIntervalMs?: number;
     reconcileIntervalMs?: number;
+    reconcileBatchSize?: number;
+    reconcileJitterRatio?: number;
     /**
      * OT-RFC-38 / LU-6 Phase B — discovery-beacon rate limits for
      * pre-registration (freemium-tier) ciphertext writes. All three

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1137,6 +1137,7 @@ export class DKGAgent extends DKGAgentBase {
         graph: ontoGraph,
       }]);
 
+      this.contextGraphMetaProjection.markDirty(p.name);
       this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
       discovered++;
     }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -43,11 +43,14 @@ export type ResolveContextGraphOnChainId = (
   contextGraphId: string,
 ) => Promise<string | null | undefined>;
 
+export type MarkContextGraphMetaDirtyFromQuads = (quads: readonly Quad[]) => void;
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly eventBus: EventBus | undefined;
   private readonly resolveContextGraphOnChainId: ResolveContextGraphOnChainId | undefined;
+  private readonly markContextGraphMetaDirtyFromQuads: MarkContextGraphMetaDirtyFromQuads | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
@@ -56,11 +59,13 @@ export class FinalizationHandler {
     chain: ChainAdapter | undefined,
     eventBus?: EventBus,
     resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
+    markContextGraphMetaDirtyFromQuads?: MarkContextGraphMetaDirtyFromQuads,
   ) {
     this.store = store;
     this.chain = chain;
     this.eventBus = eventBus;
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
+    this.markContextGraphMetaDirtyFromQuads = markContextGraphMetaDirtyFromQuads;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -314,7 +319,7 @@ export class FinalizationHandler {
       }
     }`;
 
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.finalization.sharedMemorySlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 
@@ -341,7 +346,7 @@ export class FinalizationHandler {
 
     const roots: Uint8Array[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.privateRoots' });
       if (result.type === 'bindings') {
         for (const row of result.bindings) {
           const hex = (row['root'] as string).replace(/^"(.*)".*$/, '$1').replace(/^0x/, '');
@@ -389,7 +394,7 @@ export class FinalizationHandler {
       }
     }`;
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.keepRootCopySignal' });
       if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
       let sawFalse = false;
       for (const row of result.bindings) {
@@ -435,7 +440,7 @@ export class FinalizationHandler {
     } LIMIT 1`;
 
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.publisherPeerId' });
       if (result.type === 'bindings' && result.bindings.length > 0) {
         const raw = result.bindings[0]['peerId'] as string;
         const peerId = raw.replace(/^"(.*)".*$/, '$1');
@@ -952,12 +957,14 @@ export class FinalizationHandler {
         } }`,
       );
       if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
-        await this.store.insert(generateSubGraphRegistration({
+        const regQuads = generateSubGraphRegistration({
           contextGraphId,
           subGraphName,
           createdBy: publisherAddress || 'finalization-discovery',
           timestamp: new Date(),
-        }));
+        });
+        await this.store.insert(regQuads);
+        this.markContextGraphMetaDirtyFromQuads?.(regQuads);
         this.log.info(ctx, `Finalization: auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}"`);
       }
     }

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -15,6 +15,7 @@ import {
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
 
@@ -35,6 +36,8 @@ export interface GossipPublishHandlerCallbacks {
    * callback returned `false`).
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
+  getCgMeta?: (id: string) => Promise<ContextGraphMetaRecord>;
+  markCgMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
 }
@@ -250,7 +253,7 @@ export class GossipPublishHandler {
           return;
         }
         const sparql = `SELECT DISTINCT ?s WHERE { GRAPH ?g { ?s ?p ?o } VALUES ?s { ${rootEntities.map(e => `<${e}>`).join(' ')} } FILTER(STRSTARTS(STR(?g), "${dataGraph}/_verifiable_memory/") || STR(?g) = "${dataGraph}") }`;
-        const result = await this.store.query(sparql);
+        const result = await this.store.query(sparql, { source: 'agent.gossipPublishValidation' });
         const existingEntities = new Set<string>(
           result.type === 'bindings' ? result.bindings.map(b => b['s']).filter(Boolean) : [],
         );
@@ -291,6 +294,7 @@ export class GossipPublishHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.callbacks.markCgMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.contextGraphId}" from gossip`);
         }
       }
@@ -298,6 +302,7 @@ export class GossipPublishHandler {
       phase?.('store', 'start');
       if (normalized.length > 0 && !isReplay) {
         await this.store.insert(normalized);
+        this.callbacks.markCgMetaDirtyFromQuads?.(normalized);
       }
 
       if (request.ual) {
@@ -346,6 +351,7 @@ export class GossipPublishHandler {
         // never trust self-reported on-chain status from gossip messages.
         const metaQuads = generateTentativeMetadata(kcMeta, kaMetadata);
         await this.store.insert(metaQuads);
+        this.callbacks.markCgMetaDirtyFromQuads?.(metaQuads);
         phase?.('store', 'end');
 
         // If the gossip message includes on-chain proof (txHash + blockNumber),
@@ -552,6 +558,11 @@ export class GossipPublishHandler {
   }
 
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    if (this.callbacks.getCgMeta) {
+      const peers = (await this.callbacks.getCgMeta(contextGraphId)).allowedPeers;
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaGraphUri(contextGraphId);
     const cgData = contextGraphDataGraphUri(contextGraphId);
     const result = await this.store.query(

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -1,6 +1,10 @@
 import { ethers } from 'ethers';
 
-export type SyncPhase = 'data' | 'meta' | 'snapshot';
+// 'catalog' (OT-RFC-49 §7) — the public facet open-serve: served to ANYONE
+// without the allowlist gate, bounded to exactly the `_catalog` named graph.
+// Backward-compatible: `phase` is not part of the signed digest and only
+// narrows results, so old responders ignore it and new ones honor it.
+export type SyncPhase = 'data' | 'meta' | 'snapshot' | 'catalog';
 
 export interface SyncRequestEnvelope {
   contextGraphId: string;

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -4,6 +4,7 @@ import {
   assertSafeIri,
   sparqlString,
   validateSubGraphName,
+  contextGraphCatalogUri,
 } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
@@ -471,6 +472,28 @@ export async function readDurableDataPage(params: {
       }
       : undefined,
     params.signal,
+  );
+}
+
+/**
+ * OT-RFC-49 §7 — read the public catalog facet. STRICTLY bounded to exactly the
+ * `_catalog` named graph (`did:dkg:context-graph:{cg}/_catalog`): it reads that
+ * one graph and nothing else, so the open-serve path cannot leak any gated
+ * quad. This is the only graph the §7 facet open-serve releases without auth.
+ */
+export async function readCatalogPage(params: {
+  store: TripleStore;
+  contextGraphId: string;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const catalogGraph = contextGraphCatalogUri(params.contextGraphId);
+  return readPagedRowsAcrossGraphs(
+    params.store,
+    [catalogGraph],
+    params.offset,
+    params.limit,
+    async () => true, // the single graph is already the bound; admit it
   );
 }
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -15,6 +15,7 @@ import {
   createResponderSyncRowListMemo,
   createResponderSubGraphRegistrationMemo,
   createResponderSwmAdmissionMemo,
+  readCatalogPage,
   readDurableDataPage,
   readDurableMetaPage,
   readSwmDataPage,
@@ -312,6 +313,18 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
 
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
+
+      // OT-RFC-49 §7 — facet open-serve. The public `_catalog` subgraph (a DCAT
+      // dataset record) is served to ANYONE, with NO allowlist auth, BEFORE the
+      // gate below. Bounded to exactly that one named graph (readCatalogPage), so
+      // no gated quad can leak. This is how outsiders discover a private CG.
+      if (phase === 'catalog') {
+        const rows = await raceAgainstAbort(readCatalogPage({ store, contextGraphId, offset, limit }), signal);
+        const serialized = serializeResponderRows(rows);
+        logDebug(createOperationContext('sync'), `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
+        return new TextEncoder().encode(serialized ?? '');
+      }
+
       const authStartedAt = Date.now();
       const authorized = await authorizeSyncRequest(request, peerId, { signal });
       const authDurationMs = Date.now() - authStartedAt;

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -73,6 +73,12 @@ describe('Genesis Knowledge', () => {
           object: 'did:dkg:agent:12D3KooWForeignCreatorPeer111111111111111111111111',
         },
       ]);
+      // The raw store.insert/deleteByPattern above forge a foreign-created CG
+      // out-of-band, bypassing the write path that would normally invalidate the
+      // ContextGraphMetaProjection (real sync calls markDirtyFromQuads after
+      // store.insert — see dkg-agent-lifecycle.ts). Invalidate it here so the
+      // projection re-reads the forged creator instead of the stale self-stamp.
+      (agent as any).contextGraphMetaProjection.markDirty('register-foreign-peer-only');
 
       await expect(agent.registerContextGraph('register-foreign-peer-only'))
         .rejects.toThrow(/has no address-scoped curator/);

--- a/packages/agent/test/combined-catalog-baseline.e2e.test.ts
+++ b/packages/agent/test/combined-catalog-baseline.e2e.test.ts
@@ -1,0 +1,109 @@
+/**
+ * OT-RFC-49 combined-model BASELINE (pre-catalog-injection) — curated e2e.
+ *
+ * The first end-to-end curated/private-CG VM publish on the devnet, via the
+ * PRODUCT path (write -> promote -> publishFromFinalizedAssertion). Uses the
+ * pre-staked genesis core nodes for the ACK quorum (lowered to 1), so the
+ * curated `nodeExists` signer check passes.
+ *
+ * Baseline invariant: a private CG publishing N data entities yields a KC of
+ * exactly N KAs. After the catalog injection lands, the SAME publish yields
+ * N+1 KAs (the extra one being the public DCAT catalog KA, subject == CG UAL).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
+import { DKGAgent } from '../src/index.js';
+import {
+  spawnHardhatEnv, killHardhat, setMinimumRequiredSignatures, HARDHAT_KEYS, type HardhatContext,
+} from '../../chain/test/hardhat-harness.js';
+
+let ctx: HardhatContext;
+const agents: DKGAgent[] = [];
+
+function chainConfig(opKey: string, adminKey: string) {
+  return { rpcUrl: ctx.rpcUrl, adminPrivateKey: adminKey, operationalKeys: [opKey], hubAddress: ctx.hubAddress, chainId: 'evm:31337' };
+}
+
+// A disk-backed dataDir is REQUIRED for SWM host mode — without it a core cannot
+// store the curated ciphertext chunks and declines the ACK (MISSING_CIPHERTEXT_CHUNKS).
+const mkDataDir = (name: string) => mkdtempSync(join(tmpdir(), `rfc49-${name}-`));
+
+describe('OT-RFC-49 baseline — curated CG product-path publish (pre-catalog)', () => {
+  let publisher: DKGAgent;
+  let curator: string;
+
+  beforeAll(async () => {
+    ctx = await spawnHardhatEnv(8553);
+    await setMinimumRequiredSignatures(ctx.provider, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER, 1);
+
+    // Genesis core nodes are pre-staked. Publisher = CORE_OP (curator/member);
+    // the connected REC1 core holds the curated ciphertext and supplies the ACK.
+    publisher = await DKGAgent.create({
+      kaNumberAllocator: makeTestKaNumberAllocator(), name: 'CatPublisher', nodeRole: 'core', listenPort: 0, skills: [],
+      dataDir: mkDataDir('pub'),
+      chainConfig: chainConfig(HARDHAT_KEYS.CORE_OP, HARDHAT_KEYS.CORE_ADMIN),
+    });
+    const ackCore = await DKGAgent.create({
+      kaNumberAllocator: makeTestKaNumberAllocator(), name: 'CatAckCore', nodeRole: 'core', listenPort: 0, skills: [],
+      dataDir: mkDataDir('ack'),
+      chainConfig: chainConfig(HARDHAT_KEYS.REC1_OP, HARDHAT_KEYS.REC1_ADMIN),
+    });
+    agents.push(publisher, ackCore);
+    await publisher.start(); await ackCore.start();
+    await ackCore.connectTo(publisher.multiaddrs[0]);
+    await new Promise((r) => setTimeout(r, 2000));
+    curator = publisher.defaultAgentAddress ?? publisher.peerId;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const a of agents) { try { await a.stop(); } catch {} }
+    killHardhat(ctx);
+  });
+
+  it('a private CG publishes via the product path and yields exactly N data KAs', async () => {
+    const CG = 'rfc49-baseline-private';
+    await publisher.createContextGraph({ id: CG, name: 'RFC49 Baseline Private', accessPolicy: 1, callerAgentAddress: curator });
+    await publisher.registerContextGraph(CG, { callerAgentAddress: curator });
+
+    const name = 'shipment';
+    await publisher.assertion.create(CG, name);
+    await publisher.assertion.write(CG, name, [
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"P-9"' },
+    ]);
+    // Explicit finalize = the daemon product path (POST /vm/publish does
+    // assertion.finalize then publishFromFinalizedAssertion). The catalog
+    // injection lives in assertionFinalize; promote then carries the sealed
+    // content (incl. the catalog KA) to SWM for reload.
+    await publisher.assertion.finalize(CG, name);
+    await publisher.assertion.promote(CG, name);
+
+    const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
+
+    expect(pub.status).toBe('confirmed');
+    // OT-RFC-49 combined model: the private publish now carries the data KA AND
+    // the public DCAT catalog KA (subject = the CG's own UAL), committed in the
+    // CG's own merkle root.
+    expect(pub.kaManifest.length).toBe(2);
+    const roots = pub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
+    expect(roots.some((r: string) => r.includes(CG))).toBe(true); // the catalog KA, keyed on the CG UAL
+
+    // The catalog entry persists PLAINTEXT in the public _catalog graph — a
+    // queryable, standards-compliant DCAT dataset record (NOT encrypted, unlike
+    // the private data which only exists as ciphertext chunks).
+    const cgUal = `did:dkg:context-graph:${CG}`;
+    const catalogGraph = `${cgUal}/_catalog`;
+    const res: any = await (publisher as any).store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${catalogGraph}> { <${cgUal}> ?p ?o } }`,
+    );
+    expect(res.type).toBe('bindings');
+    const triples = res.bindings.map((b: any) => ({ p: b.p, o: b.o }));
+    const types = triples.filter((t: any) => t.p === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type').map((t: any) => t.o);
+    expect(types).toContain('http://www.w3.org/ns/dcat#Dataset');             // standards-compliant DCAT
+    expect(types).toContain('https://dkg.network/ontology#PrivateContextGraph'); // dual-typed
+    const accessRights = triples.find((t: any) => t.p === 'http://purl.org/dc/terms/accessRights');
+    expect(accessRights?.o).toBe('http://publications.europa.eu/resource/authority/access-right/RESTRICTED');
+  });
+});

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -575,6 +575,112 @@ describe('listContextGraphs merge', () => {
     const unauthenticated = await agent.listContextGraphs();
     expect(unauthenticated.find(p => p.id === 'my-curated')).toBeUndefined();
   }, 15000);
+
+  it('listContextGraphs applies the same privacy rules to AGENTS-declared private CGs', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'agents-declared-private';
+    const myWallet = agent.getDefaultAgentAddress()!;
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await result.store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Declared Private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: metaGraph },
+    ]);
+
+    const otherWallet = ethers.Wallet.createRandom().address;
+    expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeUndefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === id)).toBeUndefined();
+    const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === id);
+    expect(visible).toBeDefined();
+    expect(visible?.accessPolicy).toBe('private');
+  }, 15000);
+
+  it('listContextGraphs projection mode preserves AGENTS privacy and root _meta discovery', async () => {
+    const previous = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+    process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = '1';
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const privateId = 'projection-list-agents-private';
+      const gateOnlyId = 'projection-list-gate-only-private';
+      const metaOnlyId = 'projection-list-meta-only';
+      const policyUnknownId = 'projection-list-policy-unknown';
+      const implicitPublicId = 'projection-list-implicit-public';
+      const myWallet = agent.getDefaultAgentAddress()!;
+      const privateUri = contextGraphDataGraphUri(privateId);
+      const gateOnlyUri = contextGraphDataGraphUri(gateOnlyId);
+      const metaOnlyUri = contextGraphDataGraphUri(metaOnlyId);
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      const privateMetaGraph = contextGraphMetaGraphUri(privateId);
+      const gateOnlyMetaGraph = contextGraphMetaGraphUri(gateOnlyId);
+      await result.store.insert([
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Agents Private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: privateMetaGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Gate Only Private"', graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: gateOnlyMetaGraph },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Meta Only"', graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: 'urn:projection-list-policy-unknown:root', predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Policy Unknown"', graph: contextGraphSharedMemoryUri(policyUnknownId) },
+      ]);
+      await agent.share(implicitPublicId, [
+        {
+          subject: 'urn:projection-list-implicit-public:root',
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Projection Implicit Public"',
+          graph: '',
+        },
+      ], { callerAgentAddress: myWallet });
+
+      const unscoped = await agent.listContextGraphs();
+      expect(unscoped.find(p => p.id === privateId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === metaOnlyId)?.name).toBe('Projection Meta Only');
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const otherWallet = ethers.Wallet.createRandom().address;
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === privateId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === privateId);
+      expect(visible).toBeDefined();
+      expect(visible?.accessPolicy).toBe('private');
+      expect(visible?.callerInvolved).toBe(true);
+      const gateVisible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === gateOnlyId);
+      expect(gateVisible).toBeDefined();
+      expect(gateVisible?.accessPolicy).toBe('private');
+      expect(gateVisible?.callerInvolved).toBe(true);
+      const implicitPublic = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === implicitPublicId);
+      expect(implicitPublic).toBeDefined();
+      expect(implicitPublic?.accessPolicy).toBe('public');
+      expect(implicitPublic?.callerInvolved).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+      } else {
+        process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = previous;
+      }
+    }
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import { generateSubGraphRegistration } from '@origintrail-official/dkg-publisher';
+import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection.js';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('ContextGraphMetaProjection', () => {
+  it('enumerates declared context graph ids from ontology, agents, and root _meta graphs', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const ontologyId = 'projection-list-ontology';
+    const agentsId = 'projection-list-agents';
+    const metaId = '0x0000000000000000000000000000000000000abc/projection-list-meta';
+
+    await store.insert([
+      {
+        subject: contextGraphDataGraphUri(ontologyId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(agentsId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: agentsGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(metaId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: contextGraphMetaGraphUri(metaId),
+      },
+    ]);
+
+    expect(await projection.listDeclaredContextGraphIds()).toEqual([
+      agentsId,
+      metaId,
+      ontologyId,
+    ].sort());
+  });
+
+  it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = '0x0000000000000000000000000000000000000abc/projection-agents-private';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000111', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: '"0x0000000000000000000000000000000000000333"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: '"0x0000000000000000000000000000000000000111"', graph: metaGraph },
+    ]);
+
+    const first = await projection.get(id);
+    expect(first.accessPolicy).toBe('private');
+    expect(first.curator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000111');
+    expect(first.allowedAgents).toEqual(['0x0000000000000000000000000000000000000111']);
+    expect(first.revokedAgents).toEqual(['0x0000000000000000000000000000000000000333']);
+
+    const addedAgent: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: '"0x0000000000000000000000000000000000000222"',
+      graph: metaGraph,
+    };
+    await store.insert([addedAgent]);
+    expect(projection.markDirtyFromQuads([addedAgent])).toEqual([id]);
+
+    const second = await projection.get(id);
+    expect(second.allowedAgents).toHaveLength(2);
+    expect(second.allowedAgents).toEqual(expect.arrayContaining([
+      '0x0000000000000000000000000000000000000111',
+      '0x0000000000000000000000000000000000000222',
+    ]));
+  });
+
+  it('does not dirty policy entries for unrelated tentative KC metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-tentative-no-thrash';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+    ]);
+
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+    ]);
+
+    const tentativeQuad: Quad = {
+      subject: `did:dkg:assertion:${id}:tentative`,
+      predicate: 'https://dkg.network/ontology#assertionStatus',
+      object: '"TENTATIVE"',
+      graph: metaGraph,
+    };
+    const rootLikeDataQuad: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+      object: '"Not authoritative metadata"',
+      graph: contextGraphDataGraphUri('projection-user-data'),
+    };
+    expect(projection.markDirtyFromQuads([tentativeQuad, rootLikeDataQuad])).toEqual([]);
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    projection.markDirty(id);
+    expect((await projection.get(id)).accessPolicy).toBe('private');
+  });
+
+  it('rebuilds for callers that arrive after invalidation during an in-flight rebuild', async () => {
+    let releaseFirstQuery!: () => void;
+    const firstQuery = new Promise<void>((resolve) => { releaseFirstQuery = resolve; });
+    let queryCalls = 0;
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const store = {
+      async query(sparql: string) {
+        queryCalls += 1;
+        const callNumber = queryCalls;
+        if (callNumber === 1) await firstQuery;
+        if (callNumber <= 4) return { type: 'bindings', bindings: [] };
+        if (sparql.includes(`<${agentsGraph}>`)) {
+          return {
+            type: 'bindings',
+            bindings: [{ p: DKG_ONTOLOGY.DKG_ACCESS_POLICY, o: '"private"' }],
+          };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+
+    const first = projection.get('projection-inflight-dirty');
+    projection.markDirty('projection-inflight-dirty');
+    const afterDirty = projection.get('projection-inflight-dirty');
+    releaseFirstQuery();
+
+    expect((await first).accessPolicy).toBeUndefined();
+    expect((await afterDirty).accessPolicy).toBe('private');
+    expect(queryCalls).toBeGreaterThan(4);
+  });
+
+  it('projects sub-graph registrations from the context graph meta graph', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-subgraphs';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const registration = generateSubGraphRegistration({
+      contextGraphId: id,
+      subGraphName: 'tasks',
+      createdBy: 'projection-test',
+      description: 'Task memory',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      ...registration,
+    ]);
+    projection.markDirtyFromQuads(registration);
+
+    expect((await projection.get(id)).subGraphs).toEqual([
+      {
+        uri: `${uri}/tasks`,
+        name: 'tasks',
+        createdBy: 'did:dkg:agent:projection-test',
+        createdAt: '2026-01-01T00:00:00Z',
+        description: 'Task memory',
+      },
+    ]);
+  });
+
+  it('filters projected revoked agents from private participant authorization lists', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      subscribedContextGraphs: new Map<string, { participantAgents?: string[] }>([
+        ['projection-agents-private', { participantAgents: [revoked] }],
+      ]),
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        participantIdentityIds: ['identity:legacy'],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getPrivateContextGraphParticipants(this: unknown, contextGraphId: string): Promise<string[] | null>;
+    }).getPrivateContextGraphParticipants.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active, 'identity:legacy']);
+  });
+
+  it('filters projected revoked agents from registration participant agents', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getContextGraphParticipantAgentAddresses(this: unknown, contextGraphId: string): Promise<string[]>;
+    }).getContextGraphParticipantAgentAddresses.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active]);
+  });
+});

--- a/packages/agent/test/context-graph-public-projection.test.ts
+++ b/packages/agent/test/context-graph-public-projection.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import {
+  buildPublicProjection,
+  blindedAnchor,
+  emitPublicProjection,
+  partitionCatalogQuads,
+  CATALOG_PREDICATES,
+  PUBLIC_PROJECTION_FLOOR_PREDICATES,
+  type PublicProjectionInput,
+  type ProjectionEmitDeps,
+} from '../src/context-graph-public-projection.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const q = (subject: string, predicate: string, object: string, graph = 'g'): Quad => ({ subject, predicate, object, graph });
+
+const UAL = 'did:dkg:otp:2043/0x5cadeface0000000000000000000000000000001/142';
+const ROOT = '0x' + '9f3c2a'.padEnd(64, '0');
+const GRAPH = `${UAL}/_projection`;
+
+const floorInput = (over: Partial<PublicProjectionInput> = {}): PublicProjectionInput => ({
+  ual: UAL,
+  accessPolicy: 'private',
+  graph: GRAPH,
+  ...over,
+});
+
+describe('OT-RFC-49 §5.9 public catalog entry — mandatory floor (DCAT)', () => {
+  it('emits a dual-typed DCAT dataset record as the bare floor', () => {
+    const quads = buildPublicProjection(floorInput());
+    expect(quads).toHaveLength(4); // rdf:type x2 (dcat:Dataset + dkg:PrivateContextGraph) + identifier + accessRights
+
+    // every floor triple is about the CG's UAL, in the catalog graph
+    for (const q of quads) {
+      expect(q.subject).toBe(UAL);
+      expect(q.graph).toBe(GRAPH);
+    }
+    const types = quads.filter(q => q.predicate === DKG_ONTOLOGY.RDF_TYPE).map(q => q.object);
+    expect(types).toContain(DKG_ONTOLOGY.DCAT_DATASET);            // interop type
+    expect(types).toContain(DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH); // dkg-native type
+    const accessRights = quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_ACCESS_RIGHTS);
+    expect(accessRights?.object).toBe(DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED); // standard EU vocab IRI, bare
+    expect(quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_IDENTIFIER)?.object).toBe(`"${UAL}"`);
+
+    // floor predicate set matches the exported invariant
+    expect([...new Set(quads.map(q => q.predicate))].sort()).toEqual([...PUBLIC_PROJECTION_FLOOR_PREDICATES].sort());
+  });
+
+  it('committedRoot is optional — omitted in the combined model, present + validated in the separate-KA model', () => {
+    expect(buildPublicProjection(floorInput()).some(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT)).toBe(false);
+    const withRoot = buildPublicProjection(floorInput({ committedRoot: ROOT }));
+    expect(withRoot).toHaveLength(5);
+    expect(withRoot.find(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT)?.object).toBe(`"${ROOT}"`);
+  });
+});
+
+describe('OT-RFC-49 §5.9.1 disclosure invariant — nothing leaks by default', () => {
+  it('the bare floor discloses no domain/schema/scale/entity predicate', () => {
+    const quads = buildPublicProjection(floorInput());
+    const leaky = [
+      DKG_ONTOLOGY.DCT_CONFORMS_TO,
+      DKG_ONTOLOGY.DKG_BLINDED_ANCHOR,
+      DKG_ONTOLOGY.SCHEMA_NAME,
+      DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+    ];
+    for (const p of leaky) expect(quads.some(q => q.predicate === p)).toBe(false);
+  });
+
+  it('refuses to project a public CG (a public CG is its own public face)', () => {
+    expect(() => buildPublicProjection(floorInput({ accessPolicy: 'public' }))).toThrow(/private-CG concept/);
+  });
+
+  it('refuses a malformed committed root when one is supplied (must be 0x + 64 hex)', () => {
+    expect(() => buildPublicProjection(floorInput({ committedRoot: '0xdead' }))).toThrow(/committedRoot/);
+    expect(() => buildPublicProjection(floorInput({ committedRoot: 'deadbeef' }))).toThrow(/committedRoot/);
+  });
+
+  it('requires UAL and target graph', () => {
+    expect(() => buildPublicProjection(floorInput({ ual: '  ' }))).toThrow(/UAL/);
+    expect(() => buildPublicProjection(floorInput({ graph: '' }))).toThrow(/graph/);
+  });
+});
+
+describe('OT-RFC-49 §5.9.2 recommended fields — opt-in, pseudonymizable', () => {
+  it('adds publisher + access service only when supplied', () => {
+    const quads = buildPublicProjection(floorInput({
+      publisher: 'did:dkg:identity:0x7bcgkey',
+      accessService: 'https://grants.example/dkg',
+    }));
+    expect(quads).toHaveLength(6); // 4 floor + publisher + accessService
+    const pub = quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_PUBLISHER);
+    expect(pub?.object).toBe('did:dkg:identity:0x7bcgkey'); // IRI, bare
+    const svc = quads.find(q => q.predicate === DKG_ONTOLOGY.DCAT_ACCESS_SERVICE);
+    expect(svc?.object).toBe('https://grants.example/dkg'); // dcat:accessService -> service IRI, bare
+  });
+});
+
+describe('OT-RFC-49 §5.9.4 opt-in tiers — each a deliberate addition', () => {
+  it('T1 conformsTo and T2 blinded anchors appear only when supplied', () => {
+    const quads = buildPublicProjection(floorInput({
+      conformsTo: ['https://gs1.org/voc/EPCIS'],
+      blindedAnchors: ['hmac:9a2f', 'hmac:1b7e'],
+    }));
+    expect(quads.filter(q => q.predicate === DKG_ONTOLOGY.DCT_CONFORMS_TO)).toHaveLength(1);
+    expect(quads.filter(q => q.predicate === DKG_ONTOLOGY.DKG_BLINDED_ANCHOR)).toHaveLength(2);
+  });
+});
+
+describe('OT-RFC-49 §5.9.4 T2 — blinded anchor primitive', () => {
+  it('is deterministic for the same secret + entity, and hides the entity', () => {
+    const a1 = blindedAnchor('consortium-secret', 'gtin:09506000134352');
+    const a2 = blindedAnchor('consortium-secret', 'gtin:09506000134352');
+    expect(a1).toBe(a2);
+    expect(a1).toMatch(/^hmac:[0-9a-f]{64}$/);
+    expect(a1).not.toContain('09506000134352'); // entity is not recoverable from the output
+  });
+
+  it('differs across secrets (public cannot match without the secret) and across entities', () => {
+    expect(blindedAnchor('secret-A', 'gtin:1')).not.toBe(blindedAnchor('secret-B', 'gtin:1'));
+    expect(blindedAnchor('secret-A', 'gtin:1')).not.toBe(blindedAnchor('secret-A', 'gtin:2'));
+  });
+});
+
+describe('OT-RFC-49 §5.9.3 emit orchestration — on VM publish', () => {
+  interface Published { contextGraphId: string; quads: Quad[]; graph: string; }
+
+  const makeDeps = (over: Partial<ProjectionEmitDeps> & { isPrivate?: boolean } = {}) => {
+    const published: Published[] = [];
+    const logs: Array<{ level: string; message: string }> = [];
+    const deps: ProjectionEmitDeps = {
+      isPrivateContextGraph: async () => over.isPrivate ?? true,
+      resolveUal: async () => UAL,
+      projectionGraph: () => GRAPH,
+      publishProjection: async (contextGraphId, quads, graph) => { published.push({ contextGraphId, quads, graph }); },
+      log: (level, message) => logs.push({ level, message }),
+      ...over,
+    };
+    return { deps, published, logs };
+  };
+
+  it('publishes the catalog entry for a private CG and reports emitted', async () => {
+    const { deps, published } = makeDeps();
+    const res = await emitPublicProjection(deps, 'cg-1', ROOT);
+    expect(res.emitted).toBe(true);
+    expect(published).toHaveLength(1);
+    expect(published[0].graph).toBe(GRAPH);
+    const types = published[0].quads.filter(q => q.predicate === DKG_ONTOLOGY.RDF_TYPE).map(q => q.object);
+    expect(types).toContain(DKG_ONTOLOGY.DCAT_DATASET); // DCAT dataset record
+    const root = published[0].quads.find(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT);
+    expect(root?.object).toBe(`"${ROOT}"`); // separate-KA model threads committedRoot through
+  });
+
+  it('is a no-op for a public CG (a public CG is its own public face)', async () => {
+    const { deps, published } = makeDeps({ isPrivate: false });
+    const res = await emitPublicProjection(deps, 'cg-pub', ROOT);
+    expect(res.emitted).toBe(false);
+    expect(published).toHaveLength(0);
+  });
+
+  it('threads recommended fields when deps surface them', async () => {
+    const { deps, published } = makeDeps({
+      publisherIdentity: () => 'did:dkg:identity:0xpseudo',
+      accessService: () => 'https://grants.example/dkg',
+    });
+    await emitPublicProjection(deps, 'cg-1', ROOT);
+    const preds = published[0].quads.map(q => q.predicate);
+    expect(preds).toContain(DKG_ONTOLOGY.DCT_PUBLISHER);
+    expect(preds).toContain(DKG_ONTOLOGY.DCAT_ACCESS_SERVICE);
+  });
+
+  it('isolates errors — a publish failure never throws, just logs and reports', async () => {
+    const { deps, logs } = makeDeps({
+      publishProjection: async () => { throw new Error('chain down'); },
+    });
+    const res = await emitPublicProjection(deps, 'cg-1', ROOT);
+    expect(res.emitted).toBe(false);
+    expect(res.error).toMatch(/chain down/);
+    expect(logs.some(l => l.level === 'warn' && /publish unaffected/.test(l.message))).toBe(true);
+  });
+});
+
+describe('OT-RFC-49 §4/§5.9 combined-model partition — catalog vs everything else (by-type, self-contained)', () => {
+  const CG_UAL = 'did:dkg:otp:2043/0x5cad/142';
+
+  it('separates the catalog entry from data via the dkg:PrivateContextGraph marker; total + order-preserving', () => {
+    const data = [
+      q('urn:acme:shipment/SH-42', DKG_ONTOLOGY.RDF_TYPE, 'urn:acme:Shipment'), // a data rdf:type — must NOT be catalog
+      q('urn:acme:shipment/SH-42', 'urn:acme:product', '"P-9"'),
+      q('urn:acme:shipment/SH-42', 'urn:acme:quantity', '"500"'),
+    ];
+    const catalog = buildPublicProjection({ ual: CG_UAL, accessPolicy: 'private', graph: 'g' }); // dual-typed floor
+    const mixed = [data[0], catalog[0], data[1], catalog[1], data[2], catalog[2], catalog[3]];
+
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(mixed);
+
+    expect(catalogQuads).toHaveLength(catalog.length);
+    expect(otherQuads).toHaveLength(data.length);
+    expect(catalogQuads.length + otherQuads.length).toBe(mixed.length); // total
+    expect(new Set(catalogQuads)).toEqual(new Set(catalog));             // exactly the catalog set
+    expect(catalogQuads.every(c => c.subject === CG_UAL)).toBe(true);    // all about the CG UAL
+    expect(otherQuads.some(o => o.subject === CG_UAL)).toBe(false);      // no data quad leaked in
+    // fail-safe: the data entity's rdf:type stays on the data side
+    expect(otherQuads).toContainEqual(data[0]);
+  });
+
+  it('fail-safe: a non-catalog predicate on the catalog subject stays on the encrypted path', () => {
+    const catalog = buildPublicProjection({ ual: CG_UAL, accessPolicy: 'private', graph: 'g' });
+    const leaky = q(CG_UAL, 'urn:acme:secret', '"do-not-leak"'); // CG UAL subject, non-catalog predicate
+    const { catalogQuads, otherQuads } = partitionCatalogQuads([...catalog, leaky]);
+    expect(catalogQuads).toHaveLength(catalog.length);
+    expect(otherQuads).toEqual([leaky]);
+  });
+
+  it('a private CG with no catalog entry yields all otherQuads (no accidental public leak)', () => {
+    const data = [q('urn:acme:x', 'urn:acme:p', '"v"')];
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(data);
+    expect(catalogQuads).toHaveLength(0);
+    expect(otherQuads).toEqual(data);
+  });
+
+  it('CATALOG_PREDICATES covers every predicate buildPublicProjection can emit', () => {
+    const full = buildPublicProjection({
+      ual: CG_UAL, accessPolicy: 'private', graph: 'g', committedRoot: '0x' + 'ab'.repeat(32),
+      publisher: 'did:dkg:identity:0xp', accessService: 'https://grants/x',
+      conformsTo: ['https://gs1.org/voc/EPCIS'], blindedAnchors: ['hmac:9a'],
+    });
+    for (const quad of full) expect(CATALOG_PREDICATES.has(quad.predicate)).toBe(true);
+  });
+});

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, GraphManager } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
 import {
   encodeFinalizationMessage, type FinalizationMessageMsg, encodePublishRequest, createOperationContext,
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -247,8 +247,16 @@ describe('FinalizationHandler', () => {
     const publisherAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const dirtyQuads: Quad[] = [];
+    const localHandler = new FinalizationHandler(
+      store,
+      undefined,
+      undefined,
+      undefined,
+      (quads) => { dirtyQuads.push(...quads); },
+    );
 
-    await (handler as any).promoteSharedMemoryToCanonical(
+    await (localHandler as any).promoteSharedMemoryToCanonical(
       CONTEXT_GRAPH,
       [{ subject: entity, predicate: 'http://schema.org/name', object: '"Alice"', graph: '' }],
       'did:dkg:evm:31337/0xABC/1',
@@ -276,6 +284,16 @@ describe('FinalizationHandler', () => {
     );
     expect(registration.type).toBe('boolean');
     if (registration.type === 'boolean') expect(registration.value).toBe(true);
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphUri,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: metaGraph,
+        }),
+      ]),
+    );
 
     const canonical = await store.query(
       `ASK { GRAPH <${subGraphUri}> { <${entity}> <http://schema.org/name> ?o } }`,

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -302,4 +302,25 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
       await agent.stop().catch(() => {});
     }
   });
+
+  it('AGENTS graph private declarations are treated as explicit private policy', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const id = 'issue-1138-agents-private';
+      const uri = `did:dkg:context-graph:${id}`;
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      await store.insert([
+        { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${await ownerAddress(agent)}`, graph: agentsGraph },
+      ]);
+
+      expect(await agent.getExplicitAccessPolicy(id)).toBe('private');
+      expect(await agent.isPrivateContextGraph(id)).toBe(true);
+      expect(await agent.readLocalAccessPolicyEnum(id)).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });

--- a/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
+++ b/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
@@ -28,6 +28,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DKGAgent } from '../../src/index.js';
 import { SwmHostModeStore } from '../../src/swm/host-mode-store.js';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 
 /**
  * Minimal in-memory gossip transport — mirrors the surface the agent
@@ -87,6 +88,9 @@ interface AgentInternals {
   swmHostModeSubscribed: Map<string, string>;
   swmHostModeHandlers: Map<string, unknown>;
   wireIdToLocalCgId: Map<string, string>;
+  config: { swmHostMode?: { reconcileBatchSize?: number } };
+  hostModeReconcileCursor: number;
+  reconcileSwmHostModeSubscription(contextGraphId: string): Promise<void>;
   enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void;
   awaitHostModePersistence(contextGraphId: string): Promise<void>;
   hostModePersistenceStoreKey(rawCgId: string): string;
@@ -129,6 +133,65 @@ describe('host-mode bookkeeping key canonicalisation', () => {
     await installHostModeStore(core, dataDir);
     return { core, bus };
   }
+
+  it('reconcileHostModeSubscriptions advances a bounded cursor instead of sweeping every CG per tick', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['cursor-cg-d', 'cursor-cg-b', 'cursor-cg-a', 'cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    expect(knownCgs.length).toBeGreaterThanOrEqual(4);
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+    };
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual(knownCgs.slice(0, 2));
+    expect(internals.hostModeReconcileCursor).toBe(2);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([...knownCgs.slice(0, 2), ...knownCgs.slice(2, 4)]);
+    expect(internals.hostModeReconcileCursor).toBe(4 % knownCgs.length);
+  });
+
+  it('reconcileHostModeSubscriptions advances past a failing CG so later CGs are not starved', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['failing-cursor-cg-a', 'failing-cursor-cg-b', 'failing-cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+      if (contextGraphId === knownCgs[0]) throw new Error('boom');
+    };
+
+    await expect(core.reconcileHostModeSubscriptions()).rejects.toThrow('boom');
+    expect(calls).toEqual([knownCgs[0]]);
+    expect(internals.hostModeReconcileCursor).toBe(1);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([knownCgs[0], knownCgs[1], knownCgs[2]]);
+  });
 
   it('cleartext subscribe followed by wire-hash subscribe for the same CG is idempotent', async () => {
     const { core } = await makeCore();

--- a/packages/agent/test/sync-catalog-p2p.test.ts
+++ b/packages/agent/test/sync-catalog-p2p.test.ts
@@ -1,0 +1,53 @@
+/**
+ * OT-RFC-49 §7 — facet open-serve, end-to-end over P2P (no chain/devnet).
+ * An OUTSIDER (non-member) fetches a private CG's public _catalog facet from a
+ * peer and receives the DCAT catalog entry — but never any gated data.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { DKGAgent, MockChainAdapter } from './agent.shared';
+import {
+  DKG_ONTOLOGY, contextGraphCatalogUri, contextGraphDataUri,
+} from '@origintrail-official/dkg-core';
+
+const agents: DKGAgent[] = [];
+afterEach(async () => { for (const a of agents) { try { await a.stop(); } catch {} } agents.length = 0; });
+
+async function mkAgent(name: string, addr: string) {
+  const chain = new MockChainAdapter('mock:31337', addr);
+  const agent = await DKGAgent.create({ name, listenPort: 0, skills: [], chainAdapter: chain });
+  agents.push(agent);
+  await agent.start();
+  return agent;
+}
+
+describe('OT-RFC-49 §7 — outsider fetches the _catalog facet over P2P (no membership)', () => {
+  it('serves the catalog to a non-member and never the gated data', async () => {
+    const publisher = await mkAgent('PublisherNode', '0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+    const outsider = await mkAgent('OutsiderNode', '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC');
+
+    const CG = 'p2p-catalog-cg';
+    const cgUal = contextGraphDataUri(CG);
+    const catalogGraph = contextGraphCatalogUri(CG);
+    const privateGraph = `did:dkg:context-graph:${CG}/_private`;
+
+    // Publisher holds a public catalog entry + gated private data.
+    await (publisher as any).store.insert([
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DCAT_DATASET, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, object: DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph: catalogGraph },
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: privateGraph },
+    ]);
+
+    await outsider.connectTo(publisher.multiaddrs[0]);
+    await new Promise((r) => setTimeout(r, 600));
+
+    const quads = await outsider.fetchPublicCatalog(CG, publisher.peerId);
+
+    // The outsider received the DCAT catalog entry...
+    const objs = quads.map((q) => String(q.object));
+    expect(objs).toContain(DKG_ONTOLOGY.DCAT_DATASET);
+    expect(objs).toContain(DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED);
+    // ...and NONE of the gated private data.
+    expect(objs.some((o) => o.includes('SECRET'))).toBe(false);
+  }, 60_000);
+});

--- a/packages/agent/test/sync-catalog-serve.test.ts
+++ b/packages/agent/test/sync-catalog-serve.test.ts
@@ -1,0 +1,61 @@
+/**
+ * OT-RFC-49 §7 — facet open-serve bounding. readCatalogPage MUST release only
+ * the public `_catalog` named graph and never any gated quad (private payload,
+ * VM data, or _meta). This is the safety boundary of the open-serve path.
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  contextGraphCatalogUri,
+  contextGraphDataUri,
+  contextGraphPrivateGraphUri,
+  contextGraphMetaGraphUri,
+  DKG_ONTOLOGY,
+} from '@origintrail-official/dkg-core';
+import { readCatalogPage } from '../src/sync/responder/graph-plan.js';
+
+describe('OT-RFC-49 §7 — readCatalogPage releases ONLY the _catalog graph', () => {
+  it('serves the public DCAT catalog entry and leaks nothing gated', async () => {
+    const store = new OxigraphStore();
+    const CG = 'cat-serve-test';
+    const cgUal = contextGraphDataUri(CG);                 // did:dkg:context-graph:cat-serve-test
+    const catalogGraph = contextGraphCatalogUri(CG);       // …/_catalog
+    const privateGraph = contextGraphPrivateGraphUri(CG);  // …/_private
+    const metaGraph = contextGraphMetaGraphUri(CG);        // …/_meta
+    const vmDataGraph = `did:dkg:context-graph:${CG}/_verifiable_memory/0xabc/0`;
+
+    await store.insert([
+      // public catalog entry (the only thing that may be served)
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DCAT_DATASET, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, object: DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph: catalogGraph },
+      // gated content — MUST NOT be served by the open path
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: privateGraph },
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: vmDataGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0xsecret', graph: metaGraph },
+    ]);
+
+    const rows = await readCatalogPage({ store, contextGraphId: CG, offset: 0, limit: 100 });
+
+    expect(rows.length).toBeGreaterThan(0);
+    // EVERY served row is from the _catalog graph
+    expect(rows.every((r) => r.g === catalogGraph)).toBe(true);
+    // the catalog entry IS served
+    expect(rows.some((r) => r.o === DKG_ONTOLOGY.DCAT_DATASET)).toBe(true);
+    expect(rows.some((r) => r.o === DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED)).toBe(true);
+    // NOTHING gated leaks — not private, not VM data, not _meta/curator
+    expect(rows.some((r) => String(r.o).includes('SECRET'))).toBe(false);
+    expect(rows.some((r) => r.g === privateGraph || r.g === vmDataGraph || r.g === metaGraph)).toBe(false);
+    expect(rows.some((r) => r.p === DKG_ONTOLOGY.DKG_CURATOR)).toBe(false);
+  });
+
+  it('returns nothing for a CG with no catalog entry', async () => {
+    const store = new OxigraphStore();
+    const CG = 'no-catalog';
+    await store.insert([
+      { subject: 'urn:x', predicate: 'urn:p', object: '"v"', graph: `did:dkg:context-graph:${CG}/_private` },
+    ]);
+    const rows = await readCatalogPage({ store, contextGraphId: CG, offset: 0, limit: 100 });
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -357,6 +357,12 @@ export interface QueryAccessConfig {
   rateLimitPerMinute?: number;
 }
 
+export interface GraphSetIndexConfig {
+  enabled?: boolean;
+  /** Revalidate the named-graph index after this many milliseconds. 0 means every read. */
+  revalidateMs?: number;
+}
+
 export interface DkgConfig {
   name: string;
   relay?: string;
@@ -455,7 +461,7 @@ export interface DkgConfig {
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
-  store?: { backend: string; options?: Record<string, unknown> };
+  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
   /**
    * Cap on how many persisted context-graph subscriptions a node ACTIVATES on
    * boot (gossip + sync). A large stale backlog otherwise fans out store work

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1243,6 +1243,7 @@ export async function runDaemonInner(
     storeConfig: runtimeStore ? {
       backend: runtimeStore.backend,
       options: runtimeStore.options,
+      graphSetIndex: runtimeStore.graphSetIndex,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -49,6 +49,10 @@ export function resolveManagedOxigraphPort(
 interface StoreConfigLike {
   backend?: unknown;
   options?: Record<string, unknown>;
+  graphSetIndex?: boolean | {
+    enabled?: boolean;
+    revalidateMs?: number;
+  };
 }
 
 interface ConfigLike {
@@ -79,6 +83,7 @@ export interface ManagedOxigraphPlan {
   storeConfigTemplate: {
     backend: 'sparql-http';
     options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
   };
   /**
    * largeLiteralStorage to apply when the operator didn't configure one.
@@ -140,16 +145,22 @@ export function planManagedOxigraph(
         }
       : undefined;
 
+  const graphSetIndex = config.store?.graphSetIndex;
+  const storeConfigTemplate: ManagedOxigraphPlan['storeConfigTemplate'] = {
+    backend: 'sparql-http',
+    // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
+    // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
+    options: { managedByDkg: true },
+  };
+  if (graphSetIndex !== undefined) {
+    storeConfigTemplate.graphSetIndex = graphSetIndex;
+  }
+
   return {
     port,
     location,
     cacheDir,
-    storeConfigTemplate: {
-      backend: 'sparql-http',
-      // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
-      // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
-      options: { managedByDkg: true },
-    },
+    storeConfigTemplate,
     largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage,
   };
@@ -158,7 +169,11 @@ export function planManagedOxigraph(
 export interface ManagedOxigraphResult {
   handle: OxigraphServerHandle;
   /** Drop-in replacement for `config.store`. */
-  storeConfig: { backend: 'sparql-http'; options: Record<string, unknown> };
+  storeConfig: {
+    backend: 'sparql-http';
+    options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
+  };
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
   /** Set only when the operator enabled the feature (else leave config as-is). */
   sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
@@ -206,16 +221,21 @@ export async function startManagedOxigraph(
     io: opts.serverIo,
   });
 
+  const storeConfig: ManagedOxigraphResult['storeConfig'] = {
+    backend: 'sparql-http',
+    options: {
+      ...plan.storeConfigTemplate.options,
+      queryEndpoint: handle.queryEndpoint,
+      updateEndpoint: handle.updateEndpoint,
+    },
+  };
+  if (plan.storeConfigTemplate.graphSetIndex !== undefined) {
+    storeConfig.graphSetIndex = plan.storeConfigTemplate.graphSetIndex;
+  }
+
   return {
     handle,
-    storeConfig: {
-      backend: 'sparql-http',
-      options: {
-        ...plan.storeConfigTemplate.options,
-        queryEndpoint: handle.queryEndpoint,
-        updateEndpoint: handle.updateEndpoint,
-      },
-    },
+    storeConfig,
     largeLiteralStorage: plan.largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: plan.sharedMemoryPublicSnapshotStorage,
   };

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -7,6 +7,7 @@
  * loopback endpoints + managedByDkg) without touching disk or processes.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 
 vi.mock('../src/daemon/oxigraph-binary.js', () => ({
   ensureOxigraphBinary: vi.fn(async () => '/cache/oxigraph-v0.5.8'),
@@ -43,12 +44,12 @@ describe('planManagedOxigraph', () => {
     const plan = planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data');
     expect(plan).not.toBeNull();
     expect(plan!.port).toBe(DEFAULT_OXIGRAPH_PORT);
-    expect(plan!.location).toBe('/data/oxigraph-data');
-    expect(plan!.cacheDir).toBe('/data/oxigraph');
+    expect(plan!.location).toBe(join('/data', 'oxigraph-data'));
+    expect(plan!.cacheDir).toBe(join('/data', 'oxigraph'));
     expect(plan!.largeLiteralStorage).toEqual({
       enabled: true,
       thresholdBytes: undefined,
-      directory: '/data/literal-blobs',
+      directory: join('/data', 'literal-blobs'),
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
@@ -99,6 +100,19 @@ describe('planManagedOxigraph', () => {
     });
   });
 
+  it('preserves graphSetIndex options through the managed store rewrite plan', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: { enabled: true, revalidateMs: 5_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.storeConfigTemplate.graphSetIndex).toEqual({ enabled: true, revalidateMs: 5_000 });
+  });
+
   it('leaves sharedMemoryPublicSnapshotStorage undefined when disabled/absent', () => {
     expect(
       planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data')!
@@ -125,7 +139,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.sharedMemoryPublicSnapshotStorage).toEqual({
       enabled: true,
-      directory: '/data/swm-public-snapshots',
+      directory: join('/data', 'swm-public-snapshots'),
     });
   });
 
@@ -176,6 +190,19 @@ describe('startManagedOxigraph', () => {
         updateEndpoint: `http://127.0.0.1:${DEFAULT_OXIGRAPH_PORT}/update`,
       },
     });
-    expect(result!.largeLiteralStorage.directory).toBe('/data/literal-blobs');
+    expect(result!.largeLiteralStorage.directory).toBe(join('/data', 'literal-blobs'));
+  });
+
+  it('preserves graphSetIndex options when starting the managed store', async () => {
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: false,
+        },
+      },
+      dataDir: '/data',
+    });
+    expect(result!.storeConfig.graphSetIndex).toBe(false);
   });
 });


### PR DESCRIPTION
Part **4/5** of the OT-RFC-49 stack · base: `rfc49/03-catalog-model-and-partition`. Largest PR in the stack (~1.8k lines).

The agent half of OT-RFC-49 §5.9 / §7 — public projection + facet open-serve:

- **Projection** — `ContextGraphMetaProjection` + `ContextGraphPublicProjection`: in-memory projections of CG metadata kept fresh via `markDirtyFromQuads`, plus the meta reads (access policy, participants, agent gate) routed through them. Preserves **revoked-agent filtering** — a store-only read would silently re-authorize revoked agents.
- **Facet open-serve** — cores serve the bounded `_catalog` subgraph to outsiders with **no allowlist auth** (`readCatalogPage` in graph-plan, the catalog branch in sync-handler, catalog admission in cg-resolve), while all gated data stays members-only.
- cli `oxigraph-managed` wiring + catalog/projection tests (25 green).

Please do not merge before review / out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Depends on #1167** — please merge that first.
