### PR TITLE
Track C — indexed context graph resolution and projection

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -164,6 +164,43 @@ export class ContextGraphMetaProjection {
     return [...touched];
   }
 
+  async listDeclaredContextGraphIds(options: QueryOptions = {}): Promise<string[]> {
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+
+    const result = await this.store.query(`
+      SELECT DISTINCT ?ctxGraph WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH ?g {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+          }
+        }
+      }
+    `, options);
+    if (result.type !== 'bindings') return [];
+
+    const ids = new Set<string>();
+    for (const row of result.bindings) {
+      const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+      const id = contextGraphIdFromContextGraphUri(uri);
+      if (id) ids.add(id);
+    }
+    return [...ids].sort();
+  }
+
   private async rebuild(contextGraphId: string, options: QueryOptions): Promise<ContextGraphMetaRecord> {
     const uri = contextGraphDataUri(contextGraphId);
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -172,38 +172,64 @@ export class ContextGraphMetaProjection {
     assertSafeIri(agentsGraph);
 
     const result = await this.store.query(`
-      SELECT DISTINCT ?ctxGraph ?source WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
-            BIND("ontology" AS ?source)
-          }
-        } UNION {
-          GRAPH <${agentsGraph}> {
-            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
-            BIND("agents" AS ?source)
-          }
-        } UNION {
+      SELECT DISTINCT ?ctxGraph WHERE {
+        VALUES ?sourceGraph { <${ontologyGraph}> <${agentsGraph}> }
+        GRAPH ?sourceGraph {
+          ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+        }
+      }
+    `, options);
+
+    const ids = new Set<string>();
+    if (result.type === 'bindings') {
+      for (const row of result.bindings) {
+        const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+        const id = contextGraphIdFromContextGraphUri(uri);
+        if (id) ids.add(id);
+      }
+    }
+
+    for (const id of await this.listRootMetaDeclaredContextGraphIds(options)) {
+      ids.add(id);
+    }
+
+    return [...ids].sort();
+  }
+
+  private async listRootMetaDeclaredContextGraphIds(options: QueryOptions): Promise<string[]> {
+    const graphUris = (await this.listGraphsByPrefix(CONTEXT_GRAPH_PREFIX, options))
+      .filter((graphUri) => {
+        const id = contextGraphIdFromMetaGraphUri(graphUri);
+        return id !== null && isRootContextGraphId(id);
+      });
+    if (graphUris.length === 0) return [];
+
+    const ids = new Set<string>();
+    for (const chunk of chunks(graphUris, 128)) {
+      for (const graphUri of chunk) assertSafeIri(graphUri);
+      const result = await this.store.query(`
+        SELECT DISTINCT ?ctxGraph WHERE {
+          VALUES ?g { ${chunk.map((graphUri) => `<${graphUri}>`).join(' ')} }
           GRAPH ?g {
             ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
             FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
             FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
-            BIND("meta" AS ?source)
           }
         }
+      `, options);
+      if (result.type !== 'bindings') continue;
+      for (const row of result.bindings) {
+        const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+        const id = contextGraphIdFromContextGraphUri(uri);
+        if (id && isRootContextGraphId(id)) ids.add(id);
       }
-    `, options);
-    if (result.type !== 'bindings') return [];
-
-    const ids = new Set<string>();
-    for (const row of result.bindings) {
-      const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
-      const id = contextGraphIdFromContextGraphUri(uri);
-      const source = typeof row['source'] === 'string' ? stripTerm(row['source']) : '';
-      if (source === 'meta' && id && !isRootContextGraphId(id)) continue;
-      if (id) ids.add(id);
     }
     return [...ids].sort();
+  }
+
+  private async listGraphsByPrefix(prefix: string, options: QueryOptions): Promise<string[]> {
+    if (this.store.listGraphsByPrefix) return this.store.listGraphsByPrefix(prefix, options);
+    return (await this.store.listGraphs(options)).filter((graphUri) => graphUri.startsWith(prefix));
   }
 
   private async rebuild(contextGraphId: string, options: QueryOptions): Promise<ContextGraphMetaRecord> {
@@ -429,6 +455,14 @@ function contextGraphIdFromContextGraphUri(uri: string): string | null {
 function isRootContextGraphId(id: string): boolean {
   if (!id.includes('/')) return true;
   return /^0x[0-9a-fA-F]{40}\/[^/]+$/.test(id);
+}
+
+function chunks<T>(items: readonly T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    result.push([...items.slice(i, i + size)]);
+  }
+  return result;
 }
 
 function contextGraphIdFromMetaGraphUri(uri: string): string | null {

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  assertSafeIri,
+  contextGraphDataGraphUri,
+  contextGraphDataUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { Quad, QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
+import { strip, stripLiteral } from './dkg-agent-utils.js';
+
+export interface ContextGraphSubGraphMeta {
+  uri: string;
+  name: string;
+  createdBy: string;
+  createdAt?: string;
+  description?: string;
+}
+
+export interface ContextGraphMetaRecord {
+  id: string;
+  uri: string;
+  declared: boolean;
+  isSystem: boolean;
+  name?: string;
+  description?: string;
+  creator?: string;
+  creators: string[];
+  curator?: string;
+  curators: string[];
+  accessPolicy?: string;
+  createdAt?: string;
+  allowedPeers: string[];
+  allowedAgents: string[];
+  participantAgents: string[];
+  participantIdentityIds: string[];
+  revokedAgents: string[];
+  onChainId?: string;
+  subGraphs: ContextGraphSubGraphMeta[];
+  hasAgentGate: boolean;
+  hasPeerGate: boolean;
+  hasLegacyParticipantGate: boolean;
+}
+
+interface ProjectionEntry {
+  value?: ContextGraphMetaRecord;
+  inflight?: Promise<ContextGraphMetaRecord>;
+  dirty: boolean;
+  invalidationVersion: number;
+}
+
+const DKG_NS = 'https://dkg.network/ontology#';
+const LEGACY_DKG_NS = 'http://dkg.io/ontology/';
+const LEGACY_SCHEMA_NS = 'http://schema.org/';
+const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SUB_GRAPH_TYPE_URIS = new Set([
+  `${DKG_NS}SubGraph`,
+  `${LEGACY_DKG_NS}SubGraph`,
+]);
+
+const DIRECT_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  DKG_ONTOLOGY.DKG_CREATOR,
+  DKG_ONTOLOGY.DKG_CURATOR,
+  DKG_ONTOLOGY.DKG_CREATED_AT,
+  DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+  DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+  DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+  DKG_ONTOLOGY.DKG_REVOKED_AGENT,
+  DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+  DKG_ONTOLOGY.DKG_PUBLISH_POLICY,
+  DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`,
+]);
+
+const SUB_GRAPH_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  `${DKG_NS}parentContextGraph`,
+  `${LEGACY_DKG_NS}parentContextGraph`,
+  `${DKG_NS}createdBy`,
+  `${LEGACY_DKG_NS}createdBy`,
+  `${DKG_NS}createdAt`,
+  `${LEGACY_DKG_NS}createdAt`,
+  `${DKG_NS}authorizedWriter`,
+  `${LEGACY_DKG_NS}authorizedWriter`,
+]);
+
+export class ContextGraphMetaProjection {
+  private readonly entries = new Map<string, ProjectionEntry>();
+
+  constructor(private readonly store: TripleStore) {}
+
+  async get(contextGraphId: string, options: QueryOptions = {}): Promise<ContextGraphMetaRecord> {
+    const existing = this.entries.get(contextGraphId);
+    if (existing?.value && !existing.dirty) return existing.value;
+    if (existing?.inflight) {
+      if (!existing.dirty) return existing.inflight;
+      await existing.inflight;
+      return this.get(contextGraphId, options);
+    }
+
+    const entry = existing ?? { dirty: true, invalidationVersion: 0 };
+    const rebuildVersion = entry.invalidationVersion;
+    entry.dirty = false;
+    const inflight = this.rebuild(contextGraphId, options)
+      .then((record) => {
+        entry.value = record;
+        entry.inflight = undefined;
+        entry.dirty = entry.invalidationVersion !== rebuildVersion;
+        this.entries.set(contextGraphId, entry);
+        return record;
+      })
+      .catch((err) => {
+        entry.inflight = undefined;
+        entry.dirty = true;
+        this.entries.set(contextGraphId, entry);
+        throw err;
+      });
+
+    entry.inflight = inflight;
+    this.entries.set(contextGraphId, entry);
+    return inflight;
+  }
+
+  markDirty(contextGraphId: string): void {
+    const existing = this.entries.get(contextGraphId);
+    if (existing) {
+      existing.dirty = true;
+      existing.invalidationVersion += 1;
+      return;
+    }
+    this.entries.set(contextGraphId, { dirty: true, invalidationVersion: 1 });
+  }
+
+  markAllDirty(): void {
+    for (const entry of this.entries.values()) {
+      entry.dirty = true;
+      entry.invalidationVersion += 1;
+    }
+  }
+
+  markDirtyFromQuads(quads: readonly Quad[]): string[] {
+    const touched = new Set<string>();
+    for (const quad of quads) {
+      const contextGraphId = this.contextGraphIdTouchedByQuad(quad);
+      if (!contextGraphId) continue;
+      touched.add(contextGraphId);
+      this.markDirty(contextGraphId);
+    }
+    return [...touched];
+  }
+
+  private async rebuild(contextGraphId: string, options: QueryOptions): Promise<ContextGraphMetaRecord> {
+    const uri = contextGraphDataUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+
+    assertSafeIri(uri);
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+    assertSafeIri(metaGraph);
+
+    const record: ContextGraphMetaRecord = {
+      id: contextGraphId,
+      uri,
+      declared: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      isSystem: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      creators: [],
+      curators: [],
+      allowedPeers: [],
+      allowedAgents: [],
+      participantAgents: [],
+      participantIdentityIds: [],
+      revokedAgents: [],
+      subGraphs: [],
+      hasAgentGate: false,
+      hasPeerGate: false,
+      hasLegacyParticipantGate: false,
+    };
+
+    const graphUris = [ontologyGraph, agentsGraph, metaGraph];
+    for (const graphUri of graphUris) {
+      await this.loadContextGraphFacts(graphUri, uri, record, options);
+    }
+    record.subGraphs = await this.loadSubGraphs(contextGraphId, options);
+
+    record.hasAgentGate = record.allowedAgents.length > 0 || record.participantAgents.length > 0;
+    record.hasPeerGate = record.allowedPeers.length > 0;
+    record.hasLegacyParticipantGate = record.participantIdentityIds.length > 0;
+    return record;
+  }
+
+  private async loadContextGraphFacts(
+    graphUri: string,
+    contextGraphUri: string,
+    record: ContextGraphMetaRecord,
+    options: QueryOptions,
+  ): Promise<void> {
+    const result = await this.store.query(
+      `SELECT ?p ?o WHERE {
+        GRAPH <${graphUri}> {
+          <${contextGraphUri}> ?p ?o .
+        }
+      }`,
+      options,
+    );
+    if (result.type !== 'bindings') return;
+
+    for (const row of result.bindings) {
+      const predicate = typeof row['p'] === 'string' ? strip(row['p']) : undefined;
+      const object = typeof row['o'] === 'string' ? stripTerm(row['o']) : undefined;
+      if (!predicate || object === undefined) continue;
+      this.applyFact(record, predicate, object);
+    }
+  }
+
+  private applyFact(record: ContextGraphMetaRecord, predicate: string, object: string): void {
+    switch (predicate) {
+      case DKG_ONTOLOGY.RDF_TYPE:
+        if (object === DKG_ONTOLOGY.DKG_CONTEXT_GRAPH) record.declared = true;
+        if (object === DKG_ONTOLOGY.DKG_SYSTEM_CONTEXT_GRAPH) record.isSystem = true;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_NAME:
+      case `${LEGACY_SCHEMA_NS}name`:
+        record.name ??= object;
+        break;
+      case DKG_ONTOLOGY.SCHEMA_DESCRIPTION:
+      case `${LEGACY_SCHEMA_NS}description`:
+        record.description ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CREATOR:
+        pushUnique(record.creators, object);
+        record.creator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_CURATOR:
+        pushUnique(record.curators, object);
+        record.curator ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ACCESS_POLICY:
+        applyAccessPolicy(record, object);
+        break;
+      case DKG_ONTOLOGY.DKG_CREATED_AT:
+        record.createdAt ??= object;
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_PEER:
+        pushUnique(record.allowedPeers, object);
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_AGENT:
+        pushUnique(record.allowedAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT:
+        pushUnique(record.participantAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID:
+        pushUnique(record.participantIdentityIds, object);
+        break;
+      case DKG_ONTOLOGY.DKG_REVOKED_AGENT:
+        pushUnique(record.revokedAgents, object);
+        break;
+      case `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`:
+        record.onChainId ??= object;
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async loadSubGraphs(contextGraphId: string, options: QueryOptions): Promise<ContextGraphSubGraphMeta[]> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?subGraph ?name ?createdBy ?createdAt ?description WHERE {
+        GRAPH <${metaGraph}> {
+          ?subGraph ?typePred ?subGraphType ;
+                    ?namePred ?name ;
+                    ?createdByPred ?createdBy .
+          VALUES ?typePred { <${DKG_ONTOLOGY.RDF_TYPE}> }
+          VALUES ?subGraphType { <${DKG_NS}SubGraph> <${LEGACY_DKG_NS}SubGraph> }
+          VALUES ?namePred { <${DKG_ONTOLOGY.SCHEMA_NAME}> <${LEGACY_SCHEMA_NS}name> }
+          VALUES ?createdByPred { <${DKG_NS}createdBy> <${LEGACY_DKG_NS}createdBy> }
+          OPTIONAL {
+            ?subGraph ?createdAtPred ?createdAt .
+            VALUES ?createdAtPred { <${DKG_NS}createdAt> <${LEGACY_DKG_NS}createdAt> }
+          }
+          OPTIONAL {
+            ?subGraph ?descriptionPred ?description .
+            VALUES ?descriptionPred { <${DKG_ONTOLOGY.SCHEMA_DESCRIPTION}> <${LEGACY_SCHEMA_NS}description> }
+          }
+        }
+      }`,
+      options,
+    );
+    if (result.type !== 'bindings') return [];
+
+    const byUri = new Map<string, ContextGraphSubGraphMeta>();
+    for (const row of result.bindings) {
+      const uri = typeof row['subGraph'] === 'string' ? stripTerm(row['subGraph']) : '';
+      if (!uri) continue;
+      const current = byUri.get(uri) ?? {
+        uri,
+        name: row['name'] ? stripTerm(String(row['name'])) : '',
+        createdBy: row['createdBy'] ? stripTerm(String(row['createdBy'])) : '',
+      };
+      if (!current.name && row['name']) current.name = stripTerm(String(row['name']));
+      if (!current.createdBy && row['createdBy']) current.createdBy = stripTerm(String(row['createdBy']));
+      if (!current.createdAt && row['createdAt']) current.createdAt = stripTerm(String(row['createdAt']));
+      if (!current.description && row['description']) current.description = stripTerm(String(row['description']));
+      byUri.set(uri, current);
+    }
+    return [...byUri.values()];
+  }
+
+  private contextGraphIdTouchedByQuad(quad: Quad): string | null {
+    const subject = stripTerm(quad.subject);
+    const predicate = strip(quad.predicate);
+    const object = stripTerm(quad.object);
+    const graph = stripTerm(quad.graph);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaContextGraphId = contextGraphIdFromMetaGraphUri(graph);
+
+    if (metaContextGraphId) {
+      const contextGraphUri = contextGraphDataUri(metaContextGraphId);
+      if (subject === contextGraphUri && DIRECT_META_PREDICATES.has(predicate)) {
+        return metaContextGraphId;
+      }
+
+      if (!subject.startsWith(`${contextGraphUri}/`)) return null;
+      if (!SUB_GRAPH_META_PREDICATES.has(predicate)) return null;
+      if (predicate === DKG_ONTOLOGY.RDF_TYPE && !SUB_GRAPH_TYPE_URIS.has(object)) return null;
+      return metaContextGraphId;
+    }
+
+    if ((graph === ontologyGraph || graph === agentsGraph) && DIRECT_META_PREDICATES.has(predicate)) {
+      return contextGraphIdFromContextGraphUri(subject);
+    }
+
+    return null;
+  }
+}
+
+function pushUnique(target: string[], value: string): void {
+  const key = value.toLowerCase();
+  if (target.some((existing) => existing.toLowerCase() === key)) return;
+  target.push(value);
+}
+
+function stripTerm(value: string): string {
+  return stripLiteral(strip(value));
+}
+
+function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'private') {
+    record.accessPolicy = 'private';
+    return;
+  }
+  if (normalized === 'public') {
+    if (record.accessPolicy !== 'private') record.accessPolicy = 'public';
+    return;
+  }
+  record.accessPolicy ??= value;
+}
+
+function contextGraphIdFromContextGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX)) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length);
+  if (!tail) return null;
+  return tail;
+}
+
+function contextGraphIdFromMetaGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_meta')) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_meta'.length);
+  if (!tail) return null;
+  return tail;
+}

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -106,10 +106,10 @@ export class ContextGraphMetaProjection {
 
   async get(contextGraphId: string, options: QueryOptions = {}): Promise<ContextGraphMetaRecord> {
     const existing = this.entries.get(contextGraphId);
-    if (existing?.value && !existing.dirty) return existing.value;
+    if (existing?.value && !existing.dirty) return cloneMetaRecord(existing.value);
     if (existing?.inflight) {
-      if (!existing.dirty) return existing.inflight;
-      await existing.inflight;
+      if (!existing.dirty) return cloneMetaRecord(await raceAgainstAbort(existing.inflight, options.signal));
+      await raceAgainstAbort(existing.inflight, options.signal);
       return this.get(contextGraphId, options);
     }
 
@@ -133,7 +133,7 @@ export class ContextGraphMetaProjection {
 
     entry.inflight = inflight;
     this.entries.set(contextGraphId, entry);
-    return inflight;
+    return cloneMetaRecord(await raceAgainstAbort(inflight, options.signal));
   }
 
   markDirty(contextGraphId: string): void {
@@ -172,20 +172,23 @@ export class ContextGraphMetaProjection {
     assertSafeIri(agentsGraph);
 
     const result = await this.store.query(`
-      SELECT DISTINCT ?ctxGraph WHERE {
+      SELECT DISTINCT ?ctxGraph ?source WHERE {
         {
           GRAPH <${ontologyGraph}> {
             ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            BIND("ontology" AS ?source)
           }
         } UNION {
           GRAPH <${agentsGraph}> {
             ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            BIND("agents" AS ?source)
           }
         } UNION {
           GRAPH ?g {
             ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
             FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
             FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+            BIND("meta" AS ?source)
           }
         }
       }
@@ -196,6 +199,8 @@ export class ContextGraphMetaProjection {
     for (const row of result.bindings) {
       const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
       const id = contextGraphIdFromContextGraphUri(uri);
+      const source = typeof row['source'] === 'string' ? stripTerm(row['source']) : '';
+      if (source === 'meta' && id && !isRootContextGraphId(id)) continue;
       if (id) ids.add(id);
     }
     return [...ids].sort();
@@ -421,9 +426,49 @@ function contextGraphIdFromContextGraphUri(uri: string): string | null {
   return tail;
 }
 
+function isRootContextGraphId(id: string): boolean {
+  if (!id.includes('/')) return true;
+  return /^0x[0-9a-fA-F]{40}\/[^/]+$/.test(id);
+}
+
 function contextGraphIdFromMetaGraphUri(uri: string): string | null {
   if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_meta')) return null;
   const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_meta'.length);
   if (!tail) return null;
   return tail;
+}
+
+function cloneMetaRecord(record: ContextGraphMetaRecord): ContextGraphMetaRecord {
+  return {
+    ...record,
+    creators: [...record.creators],
+    curators: [...record.curators],
+    allowedPeers: [...record.allowedPeers],
+    allowedAgents: [...record.allowedAgents],
+    participantAgents: [...record.participantAgents],
+    participantIdentityIds: [...record.participantIdentityIds],
+    revokedAgents: [...record.revokedAgents],
+    subGraphs: record.subGraphs.map((subGraph) => ({ ...subGraph })),
+  };
+}
+
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  const reason = signal.reason;
+  throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -440,6 +440,10 @@ function stripTerm(value: string): string {
 function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
   const normalized = value.trim().toLowerCase();
   if (normalized === 'private' || normalized === 'public') {
+    // First value wins because rebuild() loads _meta, then AGENTS, then ONTOLOGY.
+    // This is safe for CG-level policy: curated writers put private in _meta,
+    // public writers put public in ONTOLOGY, gossip drops /_meta quads, and
+    // AGENTS precedes ONTOLOGY to preserve agents-declared-private rows.
     record.accessPolicy ??= normalized;
     return;
   }

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -298,16 +298,16 @@ export class ContextGraphMetaProjection {
         pushUnique(record.allowedPeers, object);
         break;
       case DKG_ONTOLOGY.DKG_ALLOWED_AGENT:
-        pushUnique(record.allowedAgents, object);
+        pushUniqueCaseInsensitive(record.allowedAgents, object);
         break;
       case DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT:
-        pushUnique(record.participantAgents, object);
+        pushUniqueCaseInsensitive(record.participantAgents, object);
         break;
       case DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID:
         pushUnique(record.participantIdentityIds, object);
         break;
       case DKG_ONTOLOGY.DKG_REVOKED_AGENT:
-        pushUnique(record.revokedAgents, object);
+        pushUniqueCaseInsensitive(record.revokedAgents, object);
         break;
       case `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`:
         record.onChainId ??= object;
@@ -391,6 +391,11 @@ export class ContextGraphMetaProjection {
 }
 
 function pushUnique(target: string[], value: string): void {
+  if (target.includes(value)) return;
+  target.push(value);
+}
+
+function pushUniqueCaseInsensitive(target: string[], value: string): void {
   const key = value.toLowerCase();
   if (target.some((existing) => existing.toLowerCase() === key)) return;
   target.push(value);
@@ -402,12 +407,8 @@ function stripTerm(value: string): string {
 
 function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'private') {
-    record.accessPolicy = 'private';
-    return;
-  }
-  if (normalized === 'public') {
-    if (record.accessPolicy !== 'private') record.accessPolicy = 'public';
+  if (normalized === 'private' || normalized === 'public') {
+    record.accessPolicy ??= normalized;
     return;
   }
   record.accessPolicy ??= value;

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -116,7 +116,8 @@ export class ContextGraphMetaProjection {
     const entry = existing ?? { dirty: true, invalidationVersion: 0 };
     const rebuildVersion = entry.invalidationVersion;
     entry.dirty = false;
-    const inflight = this.rebuild(contextGraphId, options)
+    const rebuildOptions = options.source ? { source: options.source } : {};
+    const inflight = this.rebuild(contextGraphId, rebuildOptions)
       .then((record) => {
         entry.value = record;
         entry.inflight = undefined;

--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -230,7 +230,7 @@ export class ContextGraphMetaProjection {
       hasLegacyParticipantGate: false,
     };
 
-    const graphUris = [ontologyGraph, agentsGraph, metaGraph];
+    const graphUris = [metaGraph, agentsGraph, ontologyGraph];
     for (const graphUri of graphUris) {
       await this.loadContextGraphFacts(graphUri, uri, record, options);
     }

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -380,6 +380,7 @@ import {
   deserializeSwmSenderReceiveState,
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
+import { ContextGraphMetaProjection } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 function readNonNegativeNumberEnv(name: string, fallback: number): number {
@@ -400,10 +401,18 @@ function isSparqlUpdateStatement(sparql: string): boolean {
 export function createListContextGraphsCacheInvalidatingStore(
   innerStore: TripleStore,
   invalidate: () => void,
+  markProjectionDirty?: (quads?: readonly Quad[]) => void,
 ): TripleStore {
-  const invalidateAfterMutation = async <T>(work: () => Promise<T>, changed: (result: T) => boolean): Promise<T> => {
+  const invalidateAfterMutation = async <T>(
+    work: () => Promise<T>,
+    changed: (result: T) => boolean,
+    markDirty?: (result: T) => void,
+  ): Promise<T> => {
     const result = await work();
-    if (changed(result)) invalidate();
+    if (changed(result)) {
+      invalidate();
+      markDirty?.(result);
+    }
     return result;
   };
   const wrapper: TripleStore & { readonly innerStore: TripleStore } = {
@@ -415,24 +424,28 @@ export function createListContextGraphsCacheInvalidatingStore(
       return invalidateAfterMutation(
         () => innerStore.insert(quads),
         () => quads.length > 0,
+        () => markProjectionDirty?.(quads),
       );
     },
     delete(quads) {
       return invalidateAfterMutation(
         () => innerStore.delete(quads),
         () => quads.length > 0,
+        () => markProjectionDirty?.(),
       );
     },
     deleteByPattern(pattern) {
       return invalidateAfterMutation(
         () => innerStore.deleteByPattern(pattern),
         removed => removed > 0,
+        () => markProjectionDirty?.(),
       );
     },
     query(sparql, options) {
       return invalidateAfterMutation(
         () => innerStore.query(sparql, options),
         () => isSparqlUpdateStatement(sparql),
+        () => markProjectionDirty?.(),
       );
     },
     hasGraph(graphUri) {
@@ -445,15 +458,22 @@ export function createListContextGraphsCacheInvalidatingStore(
       return invalidateAfterMutation(
         () => innerStore.dropGraph(graphUri),
         () => true,
+        () => markProjectionDirty?.(),
       );
     },
     listGraphs(options) {
       return innerStore.listGraphs(options);
     },
+    listGraphsByPrefix(prefix, options) {
+      return innerStore.listGraphsByPrefix
+        ? innerStore.listGraphsByPrefix(prefix, options)
+        : innerStore.listGraphs(options).then((graphs) => graphs.filter((graph) => graph.startsWith(prefix)));
+    },
     deleteBySubjectPrefix(graphUri, prefix) {
       return invalidateAfterMutation(
         () => innerStore.deleteBySubjectPrefix(graphUri, prefix),
         removed => removed > 0,
+        () => markProjectionDirty?.(),
       );
     },
     countQuads(graphUri) {
@@ -502,6 +522,7 @@ export class DKGAgentBase {
   protected readonly chain: ChainAdapter;
   /** Shared memory-owned root entities per context graph: entity → creatorPeerId. Used by publisher and shared memory handler. */
   protected readonly workspaceOwnedEntities: Map<string, Map<string, string>>;
+  protected readonly contextGraphMetaProjection: ContextGraphMetaProjection;
   /**
    * OT-RFC-38 / LU-6 Phase B (Codex PR #610 round-2 #2) — highest
    * `nextSeqno` already consumed per (contextGraphId, hostPeerId)
@@ -889,7 +910,10 @@ export class DKGAgentBase {
 
   protected async insertSyncedQuadsAndInvalidateListCache(quads: Quad[]): Promise<void> {
     await this.store.insert(quads);
-    if (quads.length > 0) this.invalidateListContextGraphsCache();
+    if (quads.length > 0) {
+      this.invalidateListContextGraphsCache();
+      this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+    }
   }
   protected readonly gossipRegistered = new Set<string>();
   protected readonly sharedMemoryGossipRegistered = new Set<string>();
@@ -1313,6 +1337,7 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
+    this.contextGraphMetaProjection = new ContextGraphMetaProjection(store);
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -602,6 +602,8 @@ export class DKGAgentBase {
   protected readonly swmHostModeHandlers = new Map<string, (topic: string, data: Uint8Array, from: string) => void>();
   /** Async lock for the host-mode reconciler so simultaneous calls don't double-subscribe. */
   protected hostModeReconcileInflight?: Promise<void>;
+  /** Rotating cursor for bounded host-mode reconcile sweeps over known context graphs. */
+  protected hostModeReconcileCursor = 0;
   /**
    * OT-RFC-43 A2 — the KA-number allocator, retained on the agent (also
    * forwarded to the publisher as `kaAllocator`). Held here so

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -706,20 +706,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return undefined;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-        UNION
-        { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-      } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
-    const raw = result.bindings[0]?.['policy'];
-    if (typeof raw !== 'string') return undefined;
-    const stripped = raw.replace(/^"|"$/g, '');
+    const stripped = (await this.getCgMeta(contextGraphId)).accessPolicy;
     if (stripped === 'public') return 0;
     if (stripped === 'private') return 1;
     return undefined;
@@ -778,19 +765,8 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string[] | null> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
-      { signal: options.signal },
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) {
-      return null;
-    }
-    return result.bindings
-      .map(row => row['peer'])
-      .filter((v): v is string => typeof v === 'string')
-      .map(v => v.replace(/^"|"$/g, ''));
+    const peers = (await this.getCgMeta(contextGraphId, { signal: options.signal })).allowedPeers;
+    return peers.length > 0 ? peers : null;
   }
 
   // ── Sub-Graph Management ───────────────────────────────────────────────
@@ -847,6 +823,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     await gm.ensureSubGraph(contextGraphId, subGraphName);
     await this.store.insert(registrationQuads);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -866,17 +843,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     createdAt?: string;
     description?: string;
   }>> {
-    const { subGraphDiscoverySparql } = await import('@origintrail-official/dkg-publisher');
-    const sparql = subGraphDiscoverySparql(contextGraphId);
-    const result = await this.store.query(sparql);
-    if (result.type !== 'bindings') return [];
-    return result.bindings.map(row => ({
-      uri: row['subGraph'] ?? '',
-      name: stripLiteral(row['name'] ?? ''),
-      createdBy: row['createdBy'] ?? '',
-      createdAt: row['createdAt'] ? stripLiteral(row['createdAt']) : undefined,
-      description: row['description'] ? stripLiteral(row['description']) : undefined,
-    }));
+    return (await this.getCgMeta(contextGraphId)).subGraphs;
   }
 
   /**
@@ -921,6 +888,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     // Clear SWM ownership cache for this sub-graph
     const ownershipKey = `${contextGraphId}\0${subGraphName}`;
     this.publisher.clearSubGraphOwnership(ownershipKey);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -1011,6 +979,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     }
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     this.subscribeToContextGraph(opts.id);

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -911,7 +911,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     // Drop assertion graphs under the sub-graph prefix
     const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, sgPrefix);
     for (const g of allGraphs) {
       if (g.startsWith(sgPrefix)) {
         try { await this.store.dropGraph(g); } catch { /* graph may not exist */ }
@@ -1107,4 +1107,10 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
   // ── ENDORSE ─���────────────────────────────────────────────────────────
 
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -2085,6 +2085,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       );
       if (!metaRead.ok) {
         cacheable = false;
+        // Projection is the authoritative privacy source. The pre-projection
+        // seed in `privacyByUri` can come from possibly-stale ONTOLOGY
+        // discovery and may be stale-public for a CG that is authoritatively
+        // private (_meta/AGENTS). If projection times out, drop the seed so
+        // resolveRowPrivacy() routes through the scoped legacy authoritative
+        // lookup / fail-closed path instead of serving it as explicit-public.
+        privacyByUri.delete(r.uri);
         return r;
       }
       const meta = metaRead.value;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -1482,21 +1482,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string | undefined> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-
-    const curatorResult = await this.store.query(
-      `SELECT ?curator WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?curator
-        }
-      } LIMIT 1`,
-      { signal: options.signal },
-    );
-    if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    const curatorDid = meta.curator ?? meta.curators[0] ?? '';
+    if (!curatorDid) {
       return undefined;
     }
-    const curatorDid = (curatorResult.bindings[0] as Record<string, string>)['curator'] ?? '';
     const didPrefix = 'did:dkg:agent:';
     if (!curatorDid.startsWith(didPrefix)) {
       return undefined;
@@ -1512,31 +1502,20 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     if (curatorIdentifier.startsWith('0x')) {
       let resolved = false;
 
-      // Preferred: look up the creator peer ID from the ontology definition
-      // graph or the _meta graph. The dkg:creator triple uses the libp2p
-      // peer ID while dkg:curator uses the wallet address.
-      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      const creatorResult = await this.store.query(
-        `SELECT ?creator WHERE {
-          {
-            GRAPH <${ontologyGraph}> {
-              <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?creator
-            }
-          } UNION {
-            GRAPH <${cgMetaGraph}> {
-              <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?creator
-            }
-          }
-        } LIMIT 1`,
-        { signal: options.signal },
-      );
-      if (creatorResult.type === 'bindings' && creatorResult.bindings.length > 0) {
-        const creatorDid = (creatorResult.bindings[0] as Record<string, string>)['creator'] ?? '';
+      // Preferred: use the same projected metadata resolution as privacy and
+      // listing reads. AGENTS-only declarations can mark a graph private, so
+      // the refresh path must be able to discover their creator route too.
+      const creatorCandidates = [
+        meta.creator,
+        ...meta.creators,
+      ].filter((value): value is string => Boolean(value));
+      for (const creatorDid of creatorCandidates) {
         if (creatorDid.startsWith(didPrefix)) {
           const creatorId = creatorDid.slice(didPrefix.length);
           if (!creatorId.startsWith('0x')) {
             curatorPeerId = creatorId;
             resolved = true;
+            break;
           }
         }
       }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -586,7 +586,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       FILTER(!STRENDS(STR(?g), "/_meta"))
       FILTER(!STRENDS(STR(?g), "/_shared_memory_meta"))
     }`;
-    const result = await this.store.query(sparql, { signal: options.signal });
+    const result = await this.store.query(sparql, {
+      signal: options.signal,
+      source: 'agent.contextGraphHasLocalContent',
+    });
     if (result.type === 'boolean') return result.value;
     return result.type === 'bindings' && result.bindings.length > 0;
   }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -430,6 +430,10 @@ type InternalContextGraphListRow = ListContextGraphsRow & {
 };
 
 function listContextGraphsProjectionEnabled(): boolean {
+  // Before enabling this default-on: thread the caller signal into getCgMeta
+  // and wrap per-row reads in withBudget (per A1's LIST_CONTEXT_GRAPHS_*_BUDGET_MS);
+  // this projection path currently lacks the per-read budgets/abort-signal the
+  // legacy path has. (Track C security review.)
   const raw = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION?.trim().toLowerCase();
   return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
 }
@@ -497,6 +501,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
   }
 
   async listContextGraphsFromProjection(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ListContextGraphsRow[]> {
+    // Before enabling this default-on: thread the caller signal into getCgMeta
+    // and wrap per-row reads in withBudget (per A1's LIST_CONTEXT_GRAPHS_*_BUDGET_MS);
+    // this projection path currently lacks the per-read budgets/abort-signal the
+    // legacy path has. (Track C security review.)
     const candidateIds = new Set(await this.contextGraphMetaProjection.listDeclaredContextGraphIds());
     for (const [id] of this.subscribedContextGraphs) {
       candidateIds.add(id);
@@ -2067,7 +2075,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     /**
      * Normalize metadata through the keyed projection before privacy filtering.
      * Raw discovery can see stale ONTOLOGY and authoritative AGENTS/_meta rows
-     * for the same CG; projection gives private policy precedence.
+     * for the same CG; projection resolves policy with _meta-first source
+     * precedence, then AGENTS, then ONTOLOGY.
      */
     const projectedRows = await Promise.allSettled(rows.map(async (r) => {
       const metaRead = await withBudget(

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -434,10 +434,15 @@ function listContextGraphsProjectionEnabled(): boolean {
   return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
 }
 
-function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
-  if (!accessPolicy?.trim()) return false;
+function contextGraphListRowPrivacy(accessPolicy?: string): ListContextGraphsPrivacy {
+  if (!accessPolicy?.trim()) return 'unknown';
   const t = accessPolicy.trim().replace(/^["']|["']$/g, '').toLowerCase();
-  return t === 'private';
+  if (t === 'private' || t === 'public') return t;
+  return 'unknown';
+}
+
+function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
+  return contextGraphListRowPrivacy(accessPolicy) === 'private';
 }
 
 async function applyContextGraphListPrivacy(
@@ -459,7 +464,12 @@ async function applyContextGraphListPrivacy(
 
   if (!checksum) {
     return visibleRows
-      .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy))
+      .filter((r) => {
+        const privacy = contextGraphListRowPrivacy(r.accessPolicy);
+        if (privacy === 'private') return false;
+        if (privacy === 'unknown') return !scopedList;
+        return true;
+      })
       .map(({ policyKnown: _policyKnown, ...row }) => row);
   }
 
@@ -470,7 +480,10 @@ async function applyContextGraphListPrivacy(
   }));
 
   return annotated
-    .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy) || r.callerInvolved === true)
+    .filter((r) => {
+      if (r.callerInvolved === true) return true;
+      return contextGraphListRowPrivacy(r.accessPolicy) === 'public';
+    })
     .map(({ policyKnown: _policyKnown, ...row }) => row);
 }
 

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -2086,12 +2086,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       if (!metaRead.ok) {
         cacheable = false;
         // Projection is the authoritative privacy source. The pre-projection
-        // seed in `privacyByUri` can come from possibly-stale ONTOLOGY
-        // discovery and may be stale-public for a CG that is authoritatively
-        // private (_meta/AGENTS). If projection times out, drop the seed so
-        // resolveRowPrivacy() routes through the scoped legacy authoritative
+        // seed in `privacyByUri` can come from possibly-stale ONTOLOGY discovery
+        // and may be stale-public for a CG that is authoritatively private
+        // (_meta/AGENTS). If projection times out, drop only stale-public seeds
+        // so resolveRowPrivacy() routes through the scoped legacy authoritative
         // lookup / fail-closed path instead of serving it as explicit-public.
-        privacyByUri.delete(r.uri);
+        // Preserve existing private seeds as a conservative fail-closed signal.
+        if (privacyByUri.get(r.uri) === 'public') privacyByUri.delete(r.uri);
         return r;
       }
       const meta = metaRead.value;

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -425,6 +425,55 @@ function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw syncAuthAbortError(signal.reason);
 }
 
+type InternalContextGraphListRow = ListContextGraphsRow & {
+  policyKnown?: boolean;
+};
+
+function listContextGraphsProjectionEnabled(): boolean {
+  const raw = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
+  if (!accessPolicy?.trim()) return false;
+  const t = accessPolicy.trim().replace(/^["']|["']$/g, '').toLowerCase();
+  return t === 'private';
+}
+
+async function applyContextGraphListPrivacy(
+  agent: DKGAgent,
+  rows: InternalContextGraphListRow[],
+  opts?: { callerAgentAddress?: string | null },
+): Promise<ListContextGraphsRow[]> {
+  const scopedList = opts !== undefined;
+  const visibleRows = scopedList ? rows.filter((r) => r.policyKnown !== false) : rows;
+  let checksum: string | null = null;
+  const rawCaller = opts?.callerAgentAddress?.trim();
+  if (rawCaller && ethers.isAddress(rawCaller)) {
+    try {
+      checksum = ethers.getAddress(rawCaller);
+    } catch {
+      checksum = null;
+    }
+  }
+
+  if (!checksum) {
+    return visibleRows
+      .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy))
+      .map(({ policyKnown: _policyKnown, ...row }) => row);
+  }
+
+  const annotated = await Promise.all(visibleRows.map(async (r) => {
+    const curatorMatch = agent.curatorDidMatchesChecksumAgent(r.curator, checksum);
+    const allowlisted = await agent.callerIsAllowlistedAgentParticipant(r.id, checksum);
+    return { ...r, callerInvolved: curatorMatch || allowlisted };
+  }));
+
+  return annotated
+    .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy) || r.callerInvolved === true)
+    .map(({ policyKnown: _policyKnown, ...row }) => row);
+}
+
 export class ContextGraphResolveMethods extends DKGAgentBase {
   async getCgMeta(
     this: DKGAgent,
@@ -432,6 +481,55 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     options: { signal?: AbortSignal } = {},
   ): Promise<ContextGraphMetaRecord> {
     return this.contextGraphMetaProjection.get(contextGraphId, { signal: options.signal });
+  }
+
+  async listContextGraphsFromProjection(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ListContextGraphsRow[]> {
+    const candidateIds = new Set(await this.contextGraphMetaProjection.listDeclaredContextGraphIds());
+    for (const [id] of this.subscribedContextGraphs) {
+      candidateIds.add(id);
+    }
+
+    const graphManager = new GraphManager(this.store);
+    for (const id of await graphManager.listContextGraphs()) {
+      candidateIds.add(id);
+    }
+
+    const rows = await Promise.all([...candidateIds].sort().map(async (id): Promise<InternalContextGraphListRow | null> => {
+      if (!id) return null;
+      const sub = this.subscribedContextGraphs.get(id);
+      const meta = await this.getCgMeta(id);
+      const hasProjectionGate = meta.hasAgentGate || meta.hasPeerGate || meta.hasLegacyParticipantGate;
+      const projectedAccessPolicy = meta.accessPolicy ?? (hasProjectionGate ? 'private' : undefined);
+      const policyKnown = meta.declared || projectedAccessPolicy !== undefined;
+
+      if (!meta.declared && !sub?.onChainId && !sub?.pendingMeta) {
+        if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) return null;
+        const hasContent = await this.contextGraphHasLocalContent(id);
+        if (!hasContent) return null;
+      }
+
+      return {
+        id,
+        uri: meta.uri || contextGraphDataUri(id),
+        name: meta.name ?? sub?.name ?? id,
+        description: meta.description,
+        creator: meta.creator,
+        curator: meta.curator,
+        accessPolicy: projectedAccessPolicy,
+        createdAt: meta.createdAt,
+        isSystem: meta.isSystem,
+        subscribed: sub?.subscribed ?? false,
+        synced: sub?.synced ?? false,
+        onChainId: sub?.onChainId ?? meta.onChainId,
+        policyKnown,
+      };
+    }));
+
+    return applyContextGraphListPrivacy(
+      this,
+      rows.filter((row): row is InternalContextGraphListRow => row !== null),
+      opts,
+    );
   }
 
   /**
@@ -1575,6 +1673,10 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * With no usable caller wallet, omit that field entirely so callers can infer membership from `curator`.
    */
   async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ListContextGraphsRow[]> {
+    if (listContextGraphsProjectionEnabled()) {
+      return this.listContextGraphsFromProjection(opts);
+    }
+
     const scopedListing = opts !== undefined;
     let checksum: string | null = null;
     const rawCaller = opts?.callerAgentAddress?.trim();

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -405,6 +405,7 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 function syncAuthAbortError(reason: unknown): Error {
@@ -425,6 +426,14 @@ function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
 }
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
+  async getCgMeta(
+    this: DKGAgent,
+    contextGraphId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<ContextGraphMetaRecord> {
+    return this.contextGraphMetaProjection.get(contextGraphId, { signal: options.signal });
+  }
+
   /**
    * Check whether a context graph exists in local storage. Definition triples in
    * ONTOLOGY/_meta count, and storage-backed graph presence also counts so local
@@ -604,20 +613,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * optimistic denial inference, not access control decisions).
    */
   async contextGraphIsCurated(this: DKGAgent, contextGraphId: string): Promise<boolean> {
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     try {
-      const res = await this.store.query(
-        `SELECT ?ap WHERE {
-          { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?ap } }
-          UNION
-          { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?ap } }
-        } LIMIT 1`,
-      );
-      if (res.type !== 'bindings' || res.bindings.length === 0) return false;
-      const ap = res.bindings[0]?.['ap']?.replace(/^"|"$/g, '');
-      return ap === 'private';
+      return (await this.getExplicitAccessPolicy(contextGraphId)) === 'private';
     } catch {
       return false;
     }
@@ -1228,27 +1225,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return null;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
-          }
-        }
-      } LIMIT 1`,
-      { signal: options.signal },
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    const policyValue = result.bindings[0]?.['policy'];
-    if (policyValue === '"public"') return 'public';
-    if (policyValue === '"private"') return 'private';
+    const policyValue = (await this.getCgMeta(contextGraphId, { signal: options.signal })).accessPolicy?.trim().toLowerCase();
+    if (policyValue === 'public') return 'public';
+    if (policyValue === 'private') return 'private';
     // Defensive: any unknown literal (e.g. a future policy value the
     // older agent code doesn't recognize) is reported as `null` so
     // callers fall through to the legacy heuristic instead of
@@ -1317,9 +1296,6 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       return false;
     }
 
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-
     // Issue #865 — explicit `accessPolicy` ALWAYS wins over the allowlist
     // heuristic below. The previous behavior fell through to the ASK
     // check whenever `policy` was anything other than `"private"`, which
@@ -1353,23 +1329,8 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // the legacy peer-ID model need to be recognized here so the
     // store-discovery path doesn't misclassify a freshly-invited CG
     // as "open / discoverable only" and skip the same-connect catchup.
-    const allowlistResult = await this.store.query(
-      `ASK WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?participantAgent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (allowlistResult.type === 'boolean' && allowlistResult.value === true) {
-      return true;
-    }
-
-    return false;
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    return meta.hasAgentGate || meta.hasPeerGate;
   }
 
   async getPrivateContextGraphParticipants(
@@ -1386,49 +1347,21 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       seen.add(key);
       merged.push(value);
     };
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    const addAgent = (value: string | undefined) => {
+      if (!value || revoked.has(value.toLowerCase())) return;
+      add(value);
+    };
 
     const localAgentParticipants = this.subscribedContextGraphs.get(contextGraphId)?.participantAgents;
     if (localAgentParticipants) {
-      for (const p of localAgentParticipants) add(p);
+      for (const p of localAgentParticipants) addAgent(p);
     }
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-
-    // V10 agent model: local allowedAgent entries plus explicit on-chain
-    // participantAgent entries both grant local curated access.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
-
-    // Legacy identity model: participantIdentityIds (numeric IDs as strings)
-    const metaResult = await this.store.query(
-      `SELECT ?identityId WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (metaResult.type === 'bindings') {
-      for (const row of metaResult.bindings) {
-        const raw = row['identityId'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
+    for (const agent of meta.allowedAgents) addAgent(agent);
+    for (const agent of meta.participantAgents) addAgent(agent);
+    for (const identityId of meta.participantIdentityIds) add(identityId);
 
     if (merged.length > 0) return merged;
 
@@ -1969,10 +1902,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
 
     const storedRead = await withBudget(
       async (signal) => {
-        const graphs = await this.store.listGraphs({ signal });
+        const graphs = this.store.listGraphsByPrefix
+          ? await this.store.listGraphsByPrefix(prefix, { signal })
+          : (await this.store.listGraphs({ signal })).filter((graph) => graph.startsWith(prefix));
         const contextGraphs = new Set<string>();
         for (const graph of graphs) {
-          if (!graph.startsWith(prefix)) continue;
           const rest = graph.slice(prefix.length);
           const id = rest.endsWith('/_meta')
             ? rest.slice(0, -6)
@@ -2034,10 +1968,40 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let rows = Array.from(seen.values());
 
     /**
-     * Open CGs replicate `DKG_CREATOR`/name/policy on ONTOLOGY but keep `DKG_CURATOR` in `_meta` only,
-     * so list rows lack `curator` and the sidebar cannot classify "mine" without a Bearer-scoped pass.
-     * Backfill once (parallelised) — also removes duplicate SPARQL in the involvement pass below.
+     * Normalize metadata through the keyed projection before privacy filtering.
+     * Raw discovery can see stale ONTOLOGY and authoritative AGENTS/_meta rows
+     * for the same CG; projection gives private policy precedence.
      */
+    const projectedRows = await Promise.allSettled(rows.map(async (r) => {
+      const metaRead = await withBudget(
+        (signal) => this.getCgMeta(r.id, { signal }),
+        `projection lookup for ${r.id}`,
+      );
+      if (!metaRead.ok) {
+        cacheable = false;
+        return r;
+      }
+      const meta = metaRead.value;
+      const accessPolicy = meta.accessPolicy ?? r.accessPolicy;
+      const privacy = policyPrivacy(accessPolicy);
+      if (privacy !== 'unknown') privacyByUri.set(r.uri, privacy);
+      return {
+        ...r,
+        name: meta.name ?? r.name,
+        description: meta.description ?? r.description,
+        creator: meta.creator ?? r.creator,
+        curator: meta.curator ?? r.curator,
+        ...(accessPolicy ? { accessPolicy } : {}),
+        createdAt: meta.createdAt ?? r.createdAt,
+        isSystem: meta.isSystem || r.isSystem,
+        onChainId: meta.onChainId ?? r.onChainId,
+      };
+    }));
+    rows = projectedRows.map((entry) => {
+      if (entry.status === 'fulfilled') return entry.value;
+      throw entry.reason;
+    });
+
     const curatorBackfills = await Promise.allSettled(rows.map(async (r) => {
       if (r.curator?.trim()) return r;
       const c = await optional(

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -653,6 +653,7 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     await this.store.insert(quads);
     this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
@@ -913,6 +914,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
       ]);
       this.invalidateListContextGraphsCache();
+      this.contextGraphMetaProjection.markDirty(id);
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);
       return curatorDid;
     };
@@ -1130,6 +1132,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         await this.store.insert([
           { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         return { onChainId: existingOnChainId, txHash: undefined };
       }
       this.log.warn(
@@ -1302,6 +1305,7 @@ export class ContextGraphMethods extends DKGAgentBase {
             graph: cgMetaGraph,
           },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         // Re-fetch participantAgents so the on-chain
         // registration also lists the calling agent (matches
         // what the local agent gate now enforces).
@@ -1403,6 +1407,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
     ]);
     this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirty(id);
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
@@ -1530,6 +1535,7 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     await this.store.insert(quadsToInsert);
     this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
 
     // Issue #865 — log a clear warning AFTER the allowlist quad has
     // landed on a CG with an explicit `accessPolicy="public"` triple.
@@ -1694,6 +1700,8 @@ export class ContextGraphMethods extends DKGAgentBase {
     await this.store.insert(quadsToInsert);
     this.invalidateListContextGraphsCache();
 
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
+
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
     // publishPolicy=curated + accessPolicy=public combination is a
@@ -1784,6 +1792,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       object: `"${agentAddress}"`,
     }]);
     this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
     this.queueSharedMemoryGossipSubscription(contextGraphId);
     // Drop any cached sender-key send state for this CG so the next
@@ -1862,6 +1871,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: cgMetaGraph },
     ]);
     this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(ctx, `Renamed context graph "${contextGraphId}" to "${trimmed}"`);
   }
@@ -1870,8 +1880,6 @@ export class ContextGraphMethods extends DKGAgentBase {
    * List allowed agents for a context graph.
    */
   async getContextGraphAllowedAgents(this: DKGAgent, contextGraphId: string): Promise<string[]> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     // Subtract `dkg:revokedAgent` tombstones from the allowlist union
     // so a curator who has called `removeAgentFromContextGraph` sees
     // their authoritative view, not the union with peer-sync-replicated
@@ -1880,32 +1888,9 @@ export class ContextGraphMethods extends DKGAgentBase {
     // silently re-include a revoked agent the moment another node's
     // local CG metadata gossiped back (see C1 devnet harness for the
     // reproducer + `removeAgentFromContextGraph` for the write side).
-    const result = await this.store.query(
-      `SELECT ?agent ?revoked WHERE {
-        {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked
-          }
-        }
-      }`,
-    );
-    if (result.type !== 'bindings') return [];
-    const allowed: string[] = [];
-    const revoked = new Set<string>();
-    for (const row of result.bindings) {
-      const a = (row as Record<string, string>)['agent'];
-      const r = (row as Record<string, string>)['revoked'];
-      if (typeof a === 'string') {
-        allowed.push(a.replace(/^"|"$/g, ''));
-      }
-      if (typeof r === 'string') {
-        revoked.add(r.replace(/^"|"$/g, '').toLowerCase());
-      }
-    }
+    const meta = await this.getCgMeta(contextGraphId);
+    const allowed = meta.allowedAgents;
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     if (revoked.size === 0) return allowed;
     return allowed.filter((addr) => !revoked.has(addr.toLowerCase()));
   }

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -432,10 +432,13 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     const seen = new Set<string>();
     const agents: string[] = [];
     let sawAgentGate = false;
+    const meta = await this.getCgMeta(contextGraphId, { signal: options.signal });
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     const add = (value: string | undefined) => {
       if (!value || !ethers.isAddress(value)) return;
       const checksum = ethers.getAddress(value);
       const key = checksum.toLowerCase();
+      if (revoked.has(key)) return;
       if (seen.has(key)) return;
       seen.add(key);
       agents.push(checksum);
@@ -447,27 +450,9 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
       add(agentAddress);
     }
 
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (result.type === 'bindings') {
-      if (result.bindings.length > 0) sawAgentGate = true;
-      for (const row of result.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') {
-          add(raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, ''));
-        }
-      }
-    }
+    if (meta.allowedAgents.length > 0 || meta.participantAgents.length > 0) sawAgentGate = true;
+    for (const agent of meta.allowedAgents) add(agent);
+    for (const agent of meta.participantAgents) add(agent);
 
     return sawAgentGate ? agents : null;
   }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -395,6 +395,18 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
+
+function jitteredIntervalMs(intervalMs: number, ratio: number | undefined): number {
+  const normalizedRatio =
+    typeof ratio === 'number' && Number.isFinite(ratio)
+      ? Math.min(1, Math.max(0, ratio))
+      : DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO;
+  if (normalizedRatio === 0) return intervalMs;
+  const delta = intervalMs * normalizedRatio;
+  return Math.max(1, Math.round(intervalMs - delta + Math.random() * delta * 2));
+}
+
 export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
@@ -2040,6 +2052,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // store's TTL/cap prune.
     if (this.swmHostModeStore) {
       const reconcileEveryMs = this.config.swmHostMode?.reconcileIntervalMs ?? 30_000;
+      const reconcileTimerMs = jitteredIntervalMs(
+        reconcileEveryMs,
+        this.config.swmHostMode?.reconcileJitterRatio,
+      );
       const pruneEveryMs = this.config.swmHostMode?.pruneIntervalMs ?? 5 * 60_000;
       this.reconcileHostModeSubscriptions().catch(() => {});
       this.hostModeReconcilerTimer = setInterval(() => {
@@ -2047,7 +2063,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           const msg = err instanceof Error ? err.message : String(err);
           this.log.warn(createOperationContext('system'), `Host-mode reconciler tick failed: ${msg}`);
         });
-      }, reconcileEveryMs);
+      }, reconcileTimerMs);
       if (this.hostModeReconcilerTimer.unref) this.hostModeReconcilerTimer.unref();
       this.hostModePruneTimer = setInterval(() => {
         this.swmHostModeStore?.prune().catch((err: unknown) => {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4066,7 +4066,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           }
 
           // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + bucket.
-          const wsGraphs = (await this.store.listGraphs()).filter(g => g === wsGraph || g.startsWith(`${wsGraph}/`));
+          const wsGraphs = await listGraphFamily(this.store, wsGraph);
           for (const re of rootEntities) {
             for (const g of wsGraphs) {
               // Exact root only; then skolemized descendants only (prefix would over-delete e.g. urn:foo vs urn:foobar)
@@ -4144,4 +4144,18 @@ async function isKnownContextGraphUri(store: TripleStore, contextGraphUri: strin
     }
   `);
   return result.type === 'boolean' && result.value;
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -704,8 +704,6 @@ export class OwnershipMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string | null> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     // Multi-curator scenario: peer-to-peer sync of CG `_meta` triples
     // can replicate FOREIGN `dkg:curator` triples onto a node's local
     // store. The original behaviour (`LIMIT 1`) made ownership lookup
@@ -723,21 +721,7 @@ export class OwnershipMethods extends DKGAgentBase {
     // the first curator triple when no local match exists, preserving
     // the legacy "subscriber sees foreign owner" semantics for
     // membership/UI queries against CGs this node did not curate.
-    const curatorResult = await this.store.query(`
-      SELECT ?owner WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
-        }
-      }
-    `, { signal: options.signal });
-    if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
-      return null;
-    }
-    const owners: string[] = [];
-    for (const b of curatorResult.bindings) {
-      const o = (b as Record<string, string>)['owner'];
-      if (o) owners.push(o);
-    }
+    const owners = (await this.getCgMeta(contextGraphId, { signal: options.signal })).curators;
     if (owners.length === 0) return null;
     if (owners.length === 1) return owners[0];
     const selfDid = `did:dkg:agent:${this.peerId}`;
@@ -827,8 +811,6 @@ export class OwnershipMethods extends DKGAgentBase {
       merged.push(checksumAddress);
     };
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — the on-chain participant-agent list
     // is now the authoritative source for the host-mode envelope
     // authority check on cores (see `resolveOnChainParticipantAgents`
@@ -851,19 +833,13 @@ export class OwnershipMethods extends DKGAgentBase {
     // (those are persisted as PARTICIPANT triples). The merge below
     // is a UNION so any per-CG explicit list survives and just gets
     // augmented with whatever local allowlist exists.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        add(row['agent']);
-      }
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    for (const agent of meta.participantAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
+    }
+    for (const agent of meta.allowedAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
     }
     return merged;
   }
@@ -876,25 +852,7 @@ export class OwnershipMethods extends DKGAgentBase {
    * peers validating via `gossip-publish-handler` see a matching owner.
    */
   async getContextGraphCreator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(`
-      SELECT ?owner WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        }
-      }
-      LIMIT 1
-    `);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
+    return (await this.getCgMeta(contextGraphId)).creator ?? null;
   }
 
   public async listCclPolicyBindings(this: DKGAgent, opts: {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1517,6 +1517,7 @@ export class PublishMethods extends DKGAgentBase {
     ];
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(contextGraphId);
     await this.store.flush?.();
     this.subscribeToContextGraph(contextGraphId);

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2803,7 +2803,7 @@ export class PublishMethods extends DKGAgentBase {
         ${sharedMemoryReadBothFilter(swmGraph)}
       }`;
     }
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.resolveLiftWorkspaceSlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1111,7 +1111,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     let markedDefaultAddr: string | undefined;
     const needsMigration: AgentKeyRecord[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.agentKeyMigration' });
       if (result.type !== 'bindings') return;
       const strip = (v?: string) => v?.replace(/^"|"$/g, '').replace(/"?\^\^.*$/, '') ?? '';
       for (const row of result.bindings) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -386,6 +386,13 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE = 32;
+
+function normalizeHostModeReconcileBatchSize(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE;
+  return Math.max(1, Math.floor(value));
+}
+
 export class SwmHostModeMethods extends DKGAgentBase {
   /**
    * OT-RFC-38 LU-6 — initialize the on-disk opaque ciphertext store
@@ -786,9 +793,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   /**
    * Periodic reconciler driven by `hostModeReconcilerTimer`. Sweeps
-   * every locally-known CG and ensures host-mode subscription is
-   * in sync. Cheap to call repeatedly because the per-CG
-   * reconciler is idempotent.
+   * a bounded slice of locally-known CGs and ensures host-mode
+   * subscription is in sync. The cursor rotates through the stable
+   * sorted set so large stores converge without each tick touching
+   * every known graph.
    *
    * Serialized via `hostModeReconcileInflight` so an overlap with
    * the cleanup timer (or a manual call from a test) doesn't
@@ -803,9 +811,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const inflight = (async () => {
       try {
         const graphManager = new GraphManager(this.store);
-        const knownCgs = await graphManager.listContextGraphs();
-        for (const cgId of knownCgs) {
-          await this.reconcileSwmHostModeSubscription(cgId);
+        const knownCgs = (await graphManager.listContextGraphs()).sort();
+        if (knownCgs.length === 0) {
+          this.hostModeReconcileCursor = 0;
+          return;
+        }
+        const batchSize = normalizeHostModeReconcileBatchSize(this.config.swmHostMode?.reconcileBatchSize);
+        const start = this.hostModeReconcileCursor % knownCgs.length;
+        const count = Math.min(batchSize, knownCgs.length);
+        for (let i = 0; i < count; i++) {
+          const index = (start + i) % knownCgs.length;
+          const cgId = knownCgs[index];
+          try {
+            await this.reconcileSwmHostModeSubscription(cgId);
+          } finally {
+            this.hostModeReconcileCursor = (index + 1) % knownCgs.length;
+          }
         }
       } finally {
         this.hostModeReconcileInflight = undefined;
@@ -1739,7 +1760,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const sparql = `SELECT ?o WHERE { ${graphClause} { <${subject}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`;
     let result;
     try {
-      result = await this.store.query(sparql);
+      result = await this.store.query(sparql, { source: 'agent.ciphertextChunkCatchup' });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `LU-11 chunk-catchup store query failed cg=${req.contextGraphId} chunkIndex=${req.chunkIndex}: ${reason}`);

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -543,6 +543,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
   }
 
   async reconcileSharedMemoryGossipSubscription(this: DKGAgent, contextGraphId: string): Promise<void> {
+    // Reconcile is the membership boundary; rebuild this CG's policy view
+    // before deciding whether to keep or drop the SWM subscription.
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — subscribe on the wire-form (hash) topic.
     // Members compute the hash from their local cleartext id via
     // {@link gossipWireIdFor}; cores hosting CGs they never joined
@@ -813,6 +816,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           setContextGraphSubscription: (id, next, options) => this.setContextGraphSubscription(id, next, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
+          getCgMeta: (id) => this.getCgMeta(id),
+          markCgMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
         { requireContextGraphSubscriptionSetter: true },
@@ -827,6 +832,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         sharedMemoryOwnedEntities: this.workspaceOwnedEntities,
         writeLocks: this.writeLocks,
         localAgentAddresses: () => [...this.localAgents.keys()],
+        contextGraphMetaOracle: (cgId: string) => this.getCgMeta(cgId),
+        markContextGraphMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
         // OT-RFC-38 / LU-6 Phase B: chain-backed agent-allowlist
         // fallback. Cores hosting curated CGs they are NOT members
         // of have no local meta for the allowlist — without this,
@@ -1510,6 +1517,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         // resolve the on-chain id locally so per-cgId promotion still
         // fires and the RS prover sees the KC.
         (cgName: string) => this.getContextGraphOnChainId(cgName),
+        (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -965,6 +965,8 @@ export interface DKGAgentConfig {
    *  - `registered`: TTL/byte-cap for on-chain registered CGs (typically larger).
    *  - `pruneIntervalMs`: how often the TTL/cap sweep runs.
    *  - `reconcileIntervalMs`: how often the host-mode subscription reconciler ensures cores are subscribed to all known curated CGs.
+   *  - `reconcileBatchSize`: max known CGs reconciled per tick. Default 32.
+   *  - `reconcileJitterRatio`: startup interval jitter ratio in [0, 1]. Default 0.15.
    */
   swmHostMode?: {
     enabled?: boolean;
@@ -972,6 +974,8 @@ export interface DKGAgentConfig {
     registered?: SwmHostModeStoreLimits;
     pruneIntervalMs?: number;
     reconcileIntervalMs?: number;
+    reconcileBatchSize?: number;
+    reconcileJitterRatio?: number;
     /**
      * OT-RFC-38 / LU-6 Phase B — discovery-beacon rate limits for
      * pre-registration (freemium-tier) ciphertext writes. All three

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -572,9 +572,17 @@ export class DKGAgent extends DKGAgentBase {
       (!configuredPublisherAddress || publisherAddressMatchesLegacyKey),
     );
     let agentRef: DKGAgent | undefined;
-    const agentStore = createListContextGraphsCacheInvalidatingStore(store, () => {
-      agentRef?.invalidateListContextGraphsCache();
-    });
+    const agentStore = createListContextGraphsCacheInvalidatingStore(
+      store,
+      () => {
+        agentRef?.invalidateListContextGraphsCache();
+      },
+      (quads) => {
+        if (!agentRef) return;
+        if (quads) agentRef.contextGraphMetaProjection.markDirtyFromQuads(quads);
+        else agentRef.contextGraphMetaProjection.markAllDirty();
+      },
+    );
 
     const publisher = new DKGPublisher({
       store: agentStore,
@@ -1144,6 +1152,7 @@ export class DKGAgent extends DKGAgentBase {
         graph: ontoGraph,
       }]);
 
+      this.contextGraphMetaProjection.markDirty(p.name);
       this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
       discovered++;
     }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -43,11 +43,14 @@ export type ResolveContextGraphOnChainId = (
   contextGraphId: string,
 ) => Promise<string | null | undefined>;
 
+export type MarkContextGraphMetaDirtyFromQuads = (quads: readonly Quad[]) => void;
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly eventBus: EventBus | undefined;
   private readonly resolveContextGraphOnChainId: ResolveContextGraphOnChainId | undefined;
+  private readonly markContextGraphMetaDirtyFromQuads: MarkContextGraphMetaDirtyFromQuads | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
@@ -56,11 +59,13 @@ export class FinalizationHandler {
     chain: ChainAdapter | undefined,
     eventBus?: EventBus,
     resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
+    markContextGraphMetaDirtyFromQuads?: MarkContextGraphMetaDirtyFromQuads,
   ) {
     this.store = store;
     this.chain = chain;
     this.eventBus = eventBus;
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
+    this.markContextGraphMetaDirtyFromQuads = markContextGraphMetaDirtyFromQuads;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -952,12 +957,14 @@ export class FinalizationHandler {
         } }`,
       );
       if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
-        await this.store.insert(generateSubGraphRegistration({
+        const regQuads = generateSubGraphRegistration({
           contextGraphId,
           subGraphName,
           createdBy: publisherAddress || 'finalization-discovery',
           timestamp: new Date(),
-        }));
+        });
+        await this.store.insert(regQuads);
+        this.markContextGraphMetaDirtyFromQuads?.(regQuads);
         this.log.info(ctx, `Finalization: auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}"`);
       }
     }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -319,7 +319,7 @@ export class FinalizationHandler {
       }
     }`;
 
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.finalization.sharedMemorySlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 
@@ -346,7 +346,7 @@ export class FinalizationHandler {
 
     const roots: Uint8Array[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.privateRoots' });
       if (result.type === 'bindings') {
         for (const row of result.bindings) {
           const hex = (row['root'] as string).replace(/^"(.*)".*$/, '$1').replace(/^0x/, '');
@@ -394,7 +394,7 @@ export class FinalizationHandler {
       }
     }`;
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.keepRootCopySignal' });
       if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
       let sawFalse = false;
       for (const row of result.bindings) {
@@ -440,7 +440,7 @@ export class FinalizationHandler {
     } LIMIT 1`;
 
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.publisherPeerId' });
       if (result.type === 'bindings' && result.bindings.length > 0) {
         const raw = result.bindings[0]['peerId'] as string;
         const peerId = raw.replace(/^"(.*)".*$/, '$1');

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -282,7 +282,7 @@ export class GossipPublishHandler {
           return;
         }
         const sparql = `SELECT DISTINCT ?s WHERE { GRAPH ?g { ?s ?p ?o } VALUES ?s { ${rootEntities.map(e => `<${e}>`).join(' ')} } FILTER(STRSTARTS(STR(?g), "${dataGraph}/_verifiable_memory/") || STR(?g) = "${dataGraph}") }`;
-        const result = await this.store.query(sparql);
+        const result = await this.store.query(sparql, { source: 'agent.gossipPublishValidation' });
         const existingEntities = new Set<string>(
           result.type === 'bindings' ? result.bindings.map(b => b['s']).filter(Boolean) : [],
         );

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -15,6 +15,7 @@ import {
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { ContextGraphSub } from './dkg-agent-types.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
@@ -37,6 +38,8 @@ export interface GossipPublishHandlerCallbacks {
    * callback returned `false`).
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
+  getCgMeta?: (id: string) => Promise<ContextGraphMetaRecord>;
+  markCgMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
 }
@@ -320,6 +323,7 @@ export class GossipPublishHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.callbacks.markCgMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.contextGraphId}" from gossip`);
         }
       }
@@ -327,6 +331,7 @@ export class GossipPublishHandler {
       phase?.('store', 'start');
       if (normalized.length > 0 && !isReplay) {
         await this.store.insert(normalized);
+        this.callbacks.markCgMetaDirtyFromQuads?.(normalized);
       }
 
       if (request.ual) {
@@ -375,6 +380,7 @@ export class GossipPublishHandler {
         // never trust self-reported on-chain status from gossip messages.
         const metaQuads = generateTentativeMetadata(kcMeta, kaMetadata);
         await this.store.insert(metaQuads);
+        this.callbacks.markCgMetaDirtyFromQuads?.(metaQuads);
         phase?.('store', 'end');
 
         // If the gossip message includes on-chain proof (txHash + blockNumber),
@@ -581,6 +587,11 @@ export class GossipPublishHandler {
   }
 
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    if (this.callbacks.getCgMeta) {
+      const peers = (await this.callbacks.getCgMeta(contextGraphId)).allowedPeers;
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaGraphUri(contextGraphId);
     const cgData = contextGraphDataGraphUri(contextGraphId);
     const result = await this.store.query(

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -58,6 +58,8 @@ describe('Genesis Knowledge', () => {
         predicate: DKG_ONTOLOGY.DKG_CURATOR,
         object: `did:dkg:agent:${agent.peerId}`,
       }]);
+      (agent as unknown as { contextGraphMetaProjection: { markDirty(id: string): void } })
+        .contextGraphMetaProjection.markDirty('register-legacy-peer-curator');
       await expect(agent.registerContextGraph('register-legacy-peer-curator', { callerAgentAddress: nonDefaultAddr }))
         .resolves.toMatchObject({ onChainId: expect.any(String) });
 
@@ -75,6 +77,8 @@ describe('Genesis Knowledge', () => {
           object: 'did:dkg:agent:12D3KooWForeignCreatorPeer111111111111111111111111',
         },
       ]);
+      (agent as unknown as { contextGraphMetaProjection: { markDirty(id: string): void } })
+        .contextGraphMetaProjection.markDirty('register-foreign-peer-only');
 
       await expect(agent.registerContextGraph('register-foreign-peer-only'))
         .rejects.toThrow(/has no address-scoped curator/);

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -63,11 +63,13 @@ describe('Genesis Knowledge', () => {
 
       await agent.createContextGraph({ id: 'register-foreign-peer-only', name: 'Foreign Peer Only' });
       const contextGraphUri = 'did:dkg:context-graph:register-foreign-peer-only';
-      await store.deleteByPattern({ graph: 'did:dkg:context-graph:register-foreign-peer-only/_meta', subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
+      const foreignMetaGraph = 'did:dkg:context-graph:register-foreign-peer-only/_meta';
+      await store.deleteByPattern({ graph: foreignMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
+      await store.deleteByPattern({ graph: foreignMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
       await store.deleteByPattern({ graph: 'did:dkg:context-graph:ontology', subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
       await store.insert([
         {
-          graph: 'did:dkg:context-graph:ontology',
+          graph: foreignMetaGraph,
           subject: contextGraphUri,
           predicate: DKG_ONTOLOGY.DKG_CREATOR,
           object: 'did:dkg:agent:12D3KooWForeignCreatorPeer111111111111111111111111',

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1984,6 +1984,60 @@ describe('listContextGraphs merge', () => {
       }
     }
   }, 15000);
+
+  it('listContextGraphs projection mode reuses the graph index and cached projected metadata', async () => {
+    const previous = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+    process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = '1';
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const owner = agent.getDefaultAgentAddress()!;
+      await agent.ensureContextGraphLocal({
+        id: 'projection-list-perf-public',
+        name: 'Projection List Perf Public',
+      });
+      await agent.createContextGraph({
+        id: 'projection-list-perf-private',
+        name: 'Projection List Perf Private',
+        accessPolicy: 1,
+        allowedAgents: [owner],
+      });
+
+      const listGraphsSpy = vi.spyOn(result.store, 'listGraphs');
+      const listGraphsByPrefixSpy = vi.spyOn(result.store, 'listGraphsByPrefix');
+      const querySpy = vi.spyOn(result.store, 'query');
+      const projectionRecordQueries = () => querySpy.mock.calls.filter(([query]) => {
+        const text = String(query);
+        return text.includes('SELECT ?p ?o WHERE') ||
+          text.includes('SELECT ?subGraph ?name ?createdBy ?createdAt ?description WHERE');
+      }).length;
+      const unboundMetaDiscoveryScans = () => querySpy.mock.calls.filter(([query]) => {
+        const text = String(query);
+        return text.includes('GRAPH ?g') && !text.includes('VALUES ?g');
+      }).length;
+
+      await agent.listContextGraphs({ callerAgentAddress: owner });
+      const firstListGraphsCalls = listGraphsSpy.mock.calls.length;
+      const firstPrefixCalls = listGraphsByPrefixSpy.mock.calls.length;
+      const firstProjectionRecordQueries = projectionRecordQueries();
+
+      await agent.listContextGraphs({ callerAgentAddress: owner });
+
+      expect(firstPrefixCalls).toBeGreaterThan(0);
+      expect(listGraphsByPrefixSpy.mock.calls.length).toBeGreaterThan(firstPrefixCalls);
+      expect(listGraphsSpy.mock.calls.length).toBe(firstListGraphsCalls);
+      expect(projectionRecordQueries()).toBe(firstProjectionRecordQueries);
+      expect(unboundMetaDiscoveryScans()).toBe(0);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+      } else {
+        process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = previous;
+      }
+    }
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -896,7 +896,7 @@ describe('listContextGraphs merge', () => {
 
     const originalQuery = store.query.bind(store);
     vi.spyOn(store, 'query').mockImplementation(async (query: string) => {
-      if (query.includes('SELECT ?policy WHERE') && query.includes(DKG_ONTOLOGY.DKG_ACCESS_POLICY)) {
+      if (query.includes('SELECT ?p ?o WHERE') && query.includes('did:dkg:context-graph:policy-unknown-storage')) {
         return new Promise<any>(() => {});
       }
       return originalQuery(query);
@@ -1873,6 +1873,36 @@ describe('listContextGraphs merge', () => {
     expect((agent as any).store).not.toBe(store);
     expect((agent as any).store.innerStore).toBe(store);
   }, 15000);
+
+  it('listContextGraphs applies the same privacy rules to AGENTS-declared private CGs', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'agents-declared-private';
+    const myWallet = agent.getDefaultAgentAddress()!;
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await result.store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Declared Private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: metaGraph },
+    ]);
+
+    const otherWallet = ethers.Wallet.createRandom().address;
+    expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeUndefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === id)).toBeUndefined();
+    const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === id);
+    expect(visible).toBeDefined();
+    expect(visible?.accessPolicy).toBe('private');
+  }, 15000);
+
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -909,6 +909,102 @@ describe('listContextGraphs merge', () => {
     expect(ownerLocal.find(p => p.id === 'policy-unknown-storage')).toBeDefined();
   }, 15000);
 
+  it('drops stale public discovery seeds from scoped output when authoritative projection lookup times out', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    const originalAuthBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 25,
+      configurable: true,
+    });
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+      value: 25,
+      configurable: true,
+    });
+    try {
+      const assertScopedTimeoutDropsRow = async (callerAgentAddress: string | null) => {
+        const store = sparqlHttpStoreBackedBy(new OxigraphStore());
+        const result = await createTestAgent({ store });
+        agent = result.agent;
+        await agent.start();
+        try {
+          const id = 'projection-timeout-stale-public-private';
+          const uri = contextGraphDataGraphUri(id);
+          const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+          const metaGraph = contextGraphMetaGraphUri(id);
+          await store.insert([
+            {
+              subject: uri,
+              predicate: DKG_ONTOLOGY.RDF_TYPE,
+              object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+              graph: ontologyGraph,
+            },
+            {
+              subject: uri,
+              predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+              object: '"Projection Timeout Stale Public"',
+              graph: ontologyGraph,
+            },
+            {
+              subject: uri,
+              predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+              object: '"public"',
+              graph: ontologyGraph,
+            },
+            {
+              subject: uri,
+              predicate: DKG_ONTOLOGY.RDF_TYPE,
+              object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+              graph: metaGraph,
+            },
+            {
+              subject: uri,
+              predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+              object: '"private"',
+              graph: metaGraph,
+            },
+          ]);
+
+          const originalQuery = store.query.bind(store);
+          let blockedProjectionReads = 0;
+          vi.spyOn(store, 'query').mockImplementation(async (query: string, options?: any) => {
+            if (
+              blockedProjectionReads === 0
+              && query.includes('SELECT ?p ?o WHERE')
+              && query.includes(`<${metaGraph}>`)
+              && query.includes(`<${uri}> ?p ?o`)
+            ) {
+              blockedProjectionReads += 1;
+              return new Promise<any>(() => {});
+            }
+            return originalQuery(query, options);
+          });
+
+          const rows = await agent.listContextGraphs({ callerAgentAddress });
+          expect(rows.find(p => p.id === id)).toBeUndefined();
+          expect(blockedProjectionReads).toBe(1);
+          expect((agent as any).listContextGraphsCache.size).toBe(0);
+        } finally {
+          await result.agent.stop().catch(() => {});
+          if (agent === result.agent) {
+            agent = undefined;
+          }
+        }
+      };
+
+      await assertScopedTimeoutDropsRow(null);
+      await assertScopedTimeoutDropsRow(ethers.Wallet.createRandom().address);
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_AUTH_BUDGET_MS', {
+        value: originalAuthBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('keeps storage-only rows in scoped output when legacy privacy lookup confirms public', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1005,6 +1005,70 @@ describe('listContextGraphs merge', () => {
     }
   }, 15000);
 
+  it('preserves private discovery seeds when authoritative projection lookup times out', async () => {
+    const originalRowBudget = DKGAgentBase.LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS;
+    Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+      value: 25,
+      configurable: true,
+    });
+    try {
+      const result = await createTestAgent();
+      const localAgent = result.agent;
+      agent = localAgent;
+      await localAgent.start();
+
+      const id = 'projection-timeout-private-seed';
+      const uri = contextGraphDataGraphUri(id);
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      await result.store.insert([
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.RDF_TYPE,
+          object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+          graph: agentsGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Projection Timeout Private Seed"',
+          graph: agentsGraph,
+        },
+        {
+          subject: uri,
+          predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+          object: '"private"',
+          graph: agentsGraph,
+        },
+      ]);
+
+      const originalGetCgMeta = localAgent.getCgMeta.bind(localAgent);
+      let blockedProjectionReads = 0;
+      const getCgMetaSpy = vi.spyOn(localAgent, 'getCgMeta').mockImplementation(async (
+        contextGraphId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
+        if (contextGraphId === id && blockedProjectionReads === 0) {
+          blockedProjectionReads += 1;
+          return new Promise<any>(() => {});
+        }
+        return originalGetCgMeta(contextGraphId, options);
+      });
+      try {
+        const rows = await localAgent.listContextGraphs();
+        expect(rows.find(p => p.id === id)).toBeUndefined();
+        expect(blockedProjectionReads).toBe(1);
+        expect((localAgent as any).listContextGraphsCache.size).toBe(0);
+      } finally {
+        getCgMetaSpy.mockRestore();
+      }
+    } finally {
+      Object.defineProperty(DKGAgentBase, 'LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS', {
+        value: originalRowBudget,
+        configurable: true,
+      });
+    }
+  }, 15000);
+
   it('keeps storage-only rows in scoped output when legacy privacy lookup confirms public', async () => {
     const store = new OxigraphStore();
     const result = await createTestAgent({ store });

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1920,6 +1920,7 @@ describe('listContextGraphs merge', () => {
       const privateUri = contextGraphDataGraphUri(privateId);
       const gateOnlyUri = contextGraphDataGraphUri(gateOnlyId);
       const metaOnlyUri = contextGraphDataGraphUri(metaOnlyId);
+      const policyUnknownUri = contextGraphDataGraphUri(policyUnknownId);
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
       const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
       const privateMetaGraph = contextGraphMetaGraphUri(privateId);
@@ -1937,6 +1938,9 @@ describe('listContextGraphs merge', () => {
         { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: gateOnlyMetaGraph },
         { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: contextGraphMetaGraphUri(metaOnlyId) },
         { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Meta Only"', graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: policyUnknownUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: policyUnknownUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Unknown Policy"', graph: agentsGraph },
+        { subject: policyUnknownUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"membersOnly"', graph: agentsGraph },
         { subject: 'urn:projection-list-policy-unknown:root', predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Policy Unknown"', graph: contextGraphSharedMemoryUri(policyUnknownId) },
       ]);
       await agent.share(implicitPublicId, [
@@ -1952,6 +1956,7 @@ describe('listContextGraphs merge', () => {
       expect(unscoped.find(p => p.id === privateId)).toBeUndefined();
       expect(unscoped.find(p => p.id === gateOnlyId)).toBeUndefined();
       expect(unscoped.find(p => p.id === metaOnlyId)?.name).toBe('Projection Meta Only');
+      expect(unscoped.find(p => p.id === policyUnknownId)?.accessPolicy).toBe('membersOnly');
       expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === policyUnknownId)).toBeUndefined();
 
       const otherWallet = ethers.Wallet.createRandom().address;

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -1903,6 +1903,82 @@ describe('listContextGraphs merge', () => {
     expect(visible?.accessPolicy).toBe('private');
   }, 15000);
 
+  it('listContextGraphs projection mode preserves AGENTS privacy and root _meta discovery', async () => {
+    const previous = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+    process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = '1';
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const privateId = 'projection-list-agents-private';
+      const gateOnlyId = 'projection-list-gate-only-private';
+      const metaOnlyId = 'projection-list-meta-only';
+      const policyUnknownId = 'projection-list-policy-unknown';
+      const implicitPublicId = 'projection-list-implicit-public';
+      const myWallet = agent.getDefaultAgentAddress()!;
+      const privateUri = contextGraphDataGraphUri(privateId);
+      const gateOnlyUri = contextGraphDataGraphUri(gateOnlyId);
+      const metaOnlyUri = contextGraphDataGraphUri(metaOnlyId);
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      const privateMetaGraph = contextGraphMetaGraphUri(privateId);
+      const gateOnlyMetaGraph = contextGraphMetaGraphUri(gateOnlyId);
+      await result.store.insert([
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Agents Private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: privateMetaGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Gate Only Private"', graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: gateOnlyMetaGraph },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Meta Only"', graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: 'urn:projection-list-policy-unknown:root', predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Policy Unknown"', graph: contextGraphSharedMemoryUri(policyUnknownId) },
+      ]);
+      await agent.share(implicitPublicId, [
+        {
+          subject: 'urn:projection-list-implicit-public:root',
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Projection Implicit Public"',
+          graph: '',
+        },
+      ], { callerAgentAddress: myWallet });
+
+      const unscoped = await agent.listContextGraphs();
+      expect(unscoped.find(p => p.id === privateId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === metaOnlyId)?.name).toBe('Projection Meta Only');
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const otherWallet = ethers.Wallet.createRandom().address;
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === privateId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === privateId);
+      expect(visible).toBeDefined();
+      expect(visible?.accessPolicy).toBe('private');
+      expect(visible?.callerInvolved).toBe(true);
+      const gateVisible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === gateOnlyId);
+      expect(gateVisible).toBeDefined();
+      expect(gateVisible?.accessPolicy).toBe('private');
+      expect(gateVisible?.callerInvolved).toBe(true);
+      const implicitPublic = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === implicitPublicId);
+      expect(implicitPublic).toBeDefined();
+      expect(implicitPublic?.accessPolicy).toBe('public');
+      expect(implicitPublic?.callerInvolved).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+      } else {
+        process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = previous;
+      }
+    }
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import { generateSubGraphRegistration } from '@origintrail-official/dkg-publisher';
+import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection.js';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('ContextGraphMetaProjection', () => {
+  it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = '0x0000000000000000000000000000000000000abc/projection-agents-private';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000111', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: '"0x0000000000000000000000000000000000000333"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: '"0x0000000000000000000000000000000000000111"', graph: metaGraph },
+    ]);
+
+    const first = await projection.get(id);
+    expect(first.accessPolicy).toBe('private');
+    expect(first.curator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000111');
+    expect(first.allowedAgents).toEqual(['0x0000000000000000000000000000000000000111']);
+    expect(first.revokedAgents).toEqual(['0x0000000000000000000000000000000000000333']);
+
+    const addedAgent: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: '"0x0000000000000000000000000000000000000222"',
+      graph: metaGraph,
+    };
+    await store.insert([addedAgent]);
+    expect(projection.markDirtyFromQuads([addedAgent])).toEqual([id]);
+
+    const second = await projection.get(id);
+    expect(second.allowedAgents).toHaveLength(2);
+    expect(second.allowedAgents).toEqual(expect.arrayContaining([
+      '0x0000000000000000000000000000000000000111',
+      '0x0000000000000000000000000000000000000222',
+    ]));
+  });
+
+  it('does not dirty policy entries for unrelated tentative KC metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-tentative-no-thrash';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+    ]);
+
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+    ]);
+
+    const tentativeQuad: Quad = {
+      subject: `did:dkg:assertion:${id}:tentative`,
+      predicate: 'https://dkg.network/ontology#assertionStatus',
+      object: '"TENTATIVE"',
+      graph: metaGraph,
+    };
+    const rootLikeDataQuad: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+      object: '"Not authoritative metadata"',
+      graph: contextGraphDataGraphUri('projection-user-data'),
+    };
+    expect(projection.markDirtyFromQuads([tentativeQuad, rootLikeDataQuad])).toEqual([]);
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    projection.markDirty(id);
+    expect((await projection.get(id)).accessPolicy).toBe('private');
+  });
+
+  it('rebuilds for callers that arrive after invalidation during an in-flight rebuild', async () => {
+    let releaseFirstQuery!: () => void;
+    const firstQuery = new Promise<void>((resolve) => { releaseFirstQuery = resolve; });
+    let queryCalls = 0;
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const store = {
+      async query(sparql: string) {
+        queryCalls += 1;
+        const callNumber = queryCalls;
+        if (callNumber === 1) await firstQuery;
+        if (callNumber <= 4) return { type: 'bindings', bindings: [] };
+        if (sparql.includes(`<${agentsGraph}>`)) {
+          return {
+            type: 'bindings',
+            bindings: [{ p: DKG_ONTOLOGY.DKG_ACCESS_POLICY, o: '"private"' }],
+          };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+
+    const first = projection.get('projection-inflight-dirty');
+    projection.markDirty('projection-inflight-dirty');
+    const afterDirty = projection.get('projection-inflight-dirty');
+    releaseFirstQuery();
+
+    expect((await first).accessPolicy).toBeUndefined();
+    expect((await afterDirty).accessPolicy).toBe('private');
+    expect(queryCalls).toBeGreaterThan(4);
+  });
+
+  it('projects sub-graph registrations from the context graph meta graph', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-subgraphs';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const registration = generateSubGraphRegistration({
+      contextGraphId: id,
+      subGraphName: 'tasks',
+      createdBy: 'projection-test',
+      description: 'Task memory',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      ...registration,
+    ]);
+    projection.markDirtyFromQuads(registration);
+
+    expect((await projection.get(id)).subGraphs).toEqual([
+      {
+        uri: `${uri}/tasks`,
+        name: 'tasks',
+        createdBy: 'did:dkg:agent:projection-test',
+        createdAt: '2026-01-01T00:00:00Z',
+        description: 'Task memory',
+      },
+    ]);
+  });
+
+  it('filters projected revoked agents from private participant authorization lists', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      subscribedContextGraphs: new Map<string, { participantAgents?: string[] }>([
+        ['projection-agents-private', { participantAgents: [revoked] }],
+      ]),
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        participantIdentityIds: ['identity:legacy'],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getPrivateContextGraphParticipants(this: unknown, contextGraphId: string): Promise<string[] | null>;
+    }).getPrivateContextGraphParticipants.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active, 'identity:legacy']);
+  });
+
+  it('filters projected revoked agents from registration participant agents', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getContextGraphParticipantAgentAddresses(this: unknown, contextGraphId: string): Promise<string[]>;
+    }).getContextGraphParticipantAgentAddresses.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active]);
+  });
+});

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -6,6 +6,43 @@ import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection
 import { DKGAgent } from '../src/dkg-agent.js';
 
 describe('ContextGraphMetaProjection', () => {
+  it('enumerates declared context graph ids from ontology, agents, and root _meta graphs', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const ontologyId = 'projection-list-ontology';
+    const agentsId = 'projection-list-agents';
+    const metaId = '0x0000000000000000000000000000000000000abc/projection-list-meta';
+
+    await store.insert([
+      {
+        subject: contextGraphDataGraphUri(ontologyId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(agentsId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: agentsGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(metaId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: contextGraphMetaGraphUri(metaId),
+      },
+    ]);
+
+    expect(await projection.listDeclaredContextGraphIds()).toEqual([
+      agentsId,
+      metaId,
+      ontologyId,
+    ].sort());
+  });
+
   it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -14,6 +14,7 @@ describe('ContextGraphMetaProjection', () => {
     const ontologyId = 'projection-list-ontology';
     const agentsId = 'projection-list-agents';
     const metaId = '0x0000000000000000000000000000000000000abc/projection-list-meta';
+    const metaSubGraphId = `${metaId}/tasks`;
 
     await store.insert([
       {
@@ -33,6 +34,12 @@ describe('ContextGraphMetaProjection', () => {
         predicate: DKG_ONTOLOGY.RDF_TYPE,
         object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
         graph: contextGraphMetaGraphUri(metaId),
+      },
+      {
+        subject: contextGraphDataGraphUri(metaSubGraphId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: contextGraphMetaGraphUri(metaSubGraphId),
       },
     ]);
 
@@ -258,6 +265,31 @@ describe('ContextGraphMetaProjection', () => {
     expect(queryCalls).toBeGreaterThan(4);
   });
 
+  it('honors caller cancellation while waiting on a shared in-flight rebuild', async () => {
+    let releaseQuery!: () => void;
+    const blockedQuery = new Promise<void>((resolve) => { releaseQuery = resolve; });
+    let queryCalls = 0;
+    const store = {
+      async query() {
+        queryCalls += 1;
+        await blockedQuery;
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+    const first = projection.get('projection-abort-inflight');
+    await Promise.resolve();
+
+    const controller = new AbortController();
+    const second = projection.get('projection-abort-inflight', { signal: controller.signal });
+    controller.abort(new Error('projection aborted'));
+
+    await expect(second).rejects.toThrow('projection aborted');
+    releaseQuery();
+    await expect(first).resolves.toMatchObject({ id: 'projection-abort-inflight' });
+    expect(queryCalls).toBeGreaterThan(0);
+  });
+
   it('projects sub-graph registrations from the context graph meta graph', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);
@@ -287,6 +319,34 @@ describe('ContextGraphMetaProjection', () => {
         description: 'Task memory',
       },
     ]);
+  });
+
+  it('returns defensive copies of cached array metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-defensive-copy';
+    const uri = contextGraphDataGraphUri(id);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    const registration = generateSubGraphRegistration({
+      contextGraphId: id,
+      subGraphName: 'copy-safe',
+      createdBy: 'projection-test',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER, object: '"12D3KooWCopySafePeer111111111111111111111111"', graph: metaGraph },
+      ...registration,
+    ]);
+
+    const first = await projection.get(id);
+    first.allowedPeers.push('poisoned-peer');
+    first.subGraphs[0]!.name = 'poisoned-subgraph';
+
+    const second = await projection.get(id);
+    expect(second.allowedPeers).toEqual(['12D3KooWCopySafePeer111111111111111111111111']);
+    expect(second.subGraphs[0]?.name).toBe('copy-safe');
   });
 
   it('filters projected revoked agents from private participant authorization lists', async () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -43,6 +43,47 @@ describe('ContextGraphMetaProjection', () => {
     ].sort());
   });
 
+  it('lets root _meta scalar fields override older ontology and agents declarations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-meta-authoritative';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Old ontology name"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000001', graph: ontologyGraph },
+      { subject: uri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: '"101"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION, object: '"Old agents description"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000002', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Fresh meta name"', graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION, object: '"Fresh meta description"', graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000003', graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000004', graph: metaGraph },
+      { subject: uri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: '"202"', graph: metaGraph },
+    ]);
+
+    const meta = await projection.get(id);
+    expect(meta.name).toBe('Fresh meta name');
+    expect(meta.description).toBe('Fresh meta description');
+    expect(meta.creator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000003');
+    expect(meta.curator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000004');
+    expect(meta.onChainId).toBe('202');
+    expect(meta.creators).toEqual([
+      'did:dkg:agent:0x0000000000000000000000000000000000000003',
+      'did:dkg:agent:0x0000000000000000000000000000000000000002',
+    ]);
+    expect(meta.curators).toEqual([
+      'did:dkg:agent:0x0000000000000000000000000000000000000004',
+      'did:dkg:agent:0x0000000000000000000000000000000000000001',
+    ]);
+  });
+
   it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -311,6 +311,38 @@ describe('ContextGraphMetaProjection', () => {
     expect(participants).toEqual([active, 'identity:legacy']);
   });
 
+  it('routes AGENTS-only wallet curators through projected creator peer metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-agents-curator-route';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const curatorAddress = '0x0000000000000000000000000000000000000abc';
+    const creatorPeerId = '12D3KooWAgentsCreatorPeer111111111111111111111111';
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${curatorAddress}`, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `did:dkg:agent:${creatorPeerId}`, graph: agentsGraph },
+    ]);
+
+    const agentLike = {
+      getCgMeta: (contextGraphId: string) => projection.get(contextGraphId),
+      discovery: {
+        findAgents: async () => {
+          throw new Error('registry fallback should not be needed');
+        },
+      },
+    };
+
+    const curatorPeerId = await (DKGAgent.prototype as unknown as {
+      resolveCuratorPeerId(this: unknown, contextGraphId: string): Promise<string | undefined>;
+    }).resolveCuratorPeerId.call(agentLike, id);
+
+    expect(curatorPeerId).toBe(creatorPeerId);
+  });
+
   it('filters projected revoked agents from registration participant agents', async () => {
     const revoked = '0x0000000000000000000000000000000000000111';
     const active = '0x0000000000000000000000000000000000000222';

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -290,6 +290,45 @@ describe('ContextGraphMetaProjection', () => {
     expect(queryCalls).toBeGreaterThan(0);
   });
 
+  it('does not let the first caller abort poison a shared in-flight rebuild', async () => {
+    let queryStarted!: () => void;
+    const started = new Promise<void>((resolve) => { queryStarted = resolve; });
+    let releaseQuery!: () => void;
+    const blockedQuery = new Promise<void>((resolve) => { releaseQuery = resolve; });
+    let queryCalls = 0;
+    const store = {
+      async query(_sparql: string, options?: { signal?: AbortSignal }) {
+        queryCalls += 1;
+        if (queryCalls === 1) {
+          queryStarted();
+          await new Promise<void>((resolve, reject) => {
+            const onAbort = () => {
+              reject(options?.signal?.reason);
+            };
+            options?.signal?.addEventListener('abort', onAbort, { once: true });
+            blockedQuery.then(() => {
+              options?.signal?.removeEventListener('abort', onAbort);
+              resolve();
+            }, reject);
+          });
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+    const firstCaller = new AbortController();
+    const first = projection.get('projection-first-abort-shared', { signal: firstCaller.signal });
+    await started;
+
+    const second = projection.get('projection-first-abort-shared');
+    firstCaller.abort(new Error('first caller aborted'));
+
+    await expect(first).rejects.toThrow('first caller aborted');
+    releaseQuery();
+    await expect(second).resolves.toMatchObject({ id: 'projection-first-abort-shared' });
+    expect(queryCalls).toBeGreaterThan(0);
+  });
+
   it('projects sub-graph registrations from the context graph meta graph', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -84,6 +84,69 @@ describe('ContextGraphMetaProjection', () => {
     ]);
   });
 
+  it('lets root _meta public access policy override older private declarations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-meta-public-after-private';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: metaGraph },
+    ]);
+
+    expect((await projection.get(id)).accessPolicy).toBe('public');
+  });
+
+  it('preserves case-sensitive projected metadata while folding address-only lists', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-case-sensitive-metadata';
+    const uri = contextGraphDataGraphUri(id);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    const address = '0x0000000000000000000000000000000000000aBc';
+    const addressVariant = '0x0000000000000000000000000000000000000AbC';
+    const peer = '12D3KooWCaseSensitivePeer';
+    const peerVariant = '12d3koowcasesensitivepeer';
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER, object: `"${peer}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER, object: `"${peerVariant}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `"did:dkg:agent:${peer}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `"did:dkg:agent:${peerVariant}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID, object: `"identity:${peer}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID, object: `"identity:${peerVariant}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${address}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${addressVariant}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT, object: `"${address}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT, object: `"${addressVariant}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: `"${address}"`, graph: metaGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: `"${addressVariant}"`, graph: metaGraph },
+    ]);
+
+    const meta = await projection.get(id);
+    expect(meta.allowedPeers).toHaveLength(2);
+    expect(meta.allowedPeers).toEqual(expect.arrayContaining([peer, peerVariant]));
+    expect(meta.creators).toHaveLength(2);
+    expect(meta.creators).toEqual(expect.arrayContaining([`did:dkg:agent:${peer}`, `did:dkg:agent:${peerVariant}`]));
+    expect(meta.participantIdentityIds).toHaveLength(2);
+    expect(meta.participantIdentityIds).toEqual(expect.arrayContaining([`identity:${peer}`, `identity:${peerVariant}`]));
+    expect(meta.allowedAgents).toHaveLength(1);
+    expect(meta.allowedAgents[0]?.toLowerCase()).toBe(address.toLowerCase());
+    expect(meta.participantAgents).toHaveLength(1);
+    expect(meta.participantAgents[0]?.toLowerCase()).toBe(address.toLowerCase());
+    expect(meta.revokedAgents).toHaveLength(1);
+    expect(meta.revokedAgents[0]?.toLowerCase()).toBe(address.toLowerCase());
+  });
+
   it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
     const store = new OxigraphStore();
     const projection = new ContextGraphMetaProjection(store);

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, GraphManager } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
 import {
   encodeFinalizationMessage, type FinalizationMessageMsg, encodePublishRequest, createOperationContext,
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -247,8 +247,16 @@ describe('FinalizationHandler', () => {
     const publisherAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const dirtyQuads: Quad[] = [];
+    const localHandler = new FinalizationHandler(
+      store,
+      undefined,
+      undefined,
+      undefined,
+      (quads) => { dirtyQuads.push(...quads); },
+    );
 
-    await (handler as any).promoteSharedMemoryToCanonical(
+    await (localHandler as any).promoteSharedMemoryToCanonical(
       CONTEXT_GRAPH,
       [{ subject: entity, predicate: 'http://schema.org/name', object: '"Alice"', graph: '' }],
       'did:dkg:evm:31337/0xABC/1',
@@ -276,6 +284,16 @@ describe('FinalizationHandler', () => {
     );
     expect(registration.type).toBe('boolean');
     if (registration.type === 'boolean') expect(registration.value).toBe(true);
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphUri,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: metaGraph,
+        }),
+      ]),
+    );
 
     const canonical = await store.query(
       `ASK { GRAPH <${subGraphUri}> { <${entity}> <http://schema.org/name> ?o } }`,

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -302,4 +302,25 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
       await agent.stop().catch(() => {});
     }
   });
+
+  it('AGENTS graph private declarations are treated as explicit private policy', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const id = 'issue-1138-agents-private';
+      const uri = `did:dkg:context-graph:${id}`;
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      await store.insert([
+        { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${await ownerAddress(agent)}`, graph: agentsGraph },
+      ]);
+
+      expect(await agent.getExplicitAccessPolicy(id)).toBe('private');
+      expect(await agent.isPrivateContextGraph(id)).toBe(true);
+      expect(await agent.readLocalAccessPolicyEnum(id)).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });

--- a/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
+++ b/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
@@ -28,6 +28,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DKGAgent } from '../../src/index.js';
 import { SwmHostModeStore } from '../../src/swm/host-mode-store.js';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 
 /**
  * Minimal in-memory gossip transport — mirrors the surface the agent
@@ -87,6 +88,9 @@ interface AgentInternals {
   swmHostModeSubscribed: Map<string, string>;
   swmHostModeHandlers: Map<string, unknown>;
   wireIdToLocalCgId: Map<string, string>;
+  config: { swmHostMode?: { reconcileBatchSize?: number } };
+  hostModeReconcileCursor: number;
+  reconcileSwmHostModeSubscription(contextGraphId: string): Promise<void>;
   enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void;
   awaitHostModePersistence(contextGraphId: string): Promise<void>;
   hostModePersistenceStoreKey(rawCgId: string): string;
@@ -129,6 +133,65 @@ describe('host-mode bookkeeping key canonicalisation', () => {
     await installHostModeStore(core, dataDir);
     return { core, bus };
   }
+
+  it('reconcileHostModeSubscriptions advances a bounded cursor instead of sweeping every CG per tick', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['cursor-cg-d', 'cursor-cg-b', 'cursor-cg-a', 'cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    expect(knownCgs.length).toBeGreaterThanOrEqual(4);
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+    };
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual(knownCgs.slice(0, 2));
+    expect(internals.hostModeReconcileCursor).toBe(2);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([...knownCgs.slice(0, 2), ...knownCgs.slice(2, 4)]);
+    expect(internals.hostModeReconcileCursor).toBe(4 % knownCgs.length);
+  });
+
+  it('reconcileHostModeSubscriptions advances past a failing CG so later CGs are not starved', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['failing-cursor-cg-a', 'failing-cursor-cg-b', 'failing-cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+      if (contextGraphId === knownCgs[0]) throw new Error('boom');
+    };
+
+    await expect(core.reconcileHostModeSubscriptions()).rejects.toThrow('boom');
+    expect(calls).toEqual([knownCgs[0]]);
+    expect(internals.hostModeReconcileCursor).toBe(1);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([knownCgs[0], knownCgs[1], knownCgs[2]]);
+  });
 
   it('cleartext subscribe followed by wire-hash subscribe for the same CG is idempotent', async () => {
     const { core } = await makeCore();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -357,6 +357,12 @@ export interface QueryAccessConfig {
   rateLimitPerMinute?: number;
 }
 
+export interface GraphSetIndexConfig {
+  enabled?: boolean;
+  /** Revalidate the named-graph index after this many milliseconds. 0 means every read. */
+  revalidateMs?: number;
+}
+
 export interface DkgConfig {
   name: string;
   relay?: string;
@@ -455,7 +461,7 @@ export interface DkgConfig {
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
-  store?: { backend: string; options?: Record<string, unknown> };
+  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
   /**
    * Cap on how many persisted context-graph subscriptions a node ACTIVATES on
    * boot (gossip + sync). A large stale backlog otherwise fans out store work

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1243,6 +1243,7 @@ export async function runDaemonInner(
     storeConfig: runtimeStore ? {
       backend: runtimeStore.backend,
       options: runtimeStore.options,
+      graphSetIndex: runtimeStore.graphSetIndex,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -49,6 +49,10 @@ export function resolveManagedOxigraphPort(
 interface StoreConfigLike {
   backend?: unknown;
   options?: Record<string, unknown>;
+  graphSetIndex?: boolean | {
+    enabled?: boolean;
+    revalidateMs?: number;
+  };
 }
 
 interface ConfigLike {
@@ -79,6 +83,7 @@ export interface ManagedOxigraphPlan {
   storeConfigTemplate: {
     backend: 'sparql-http';
     options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
   };
   /**
    * largeLiteralStorage to apply when the operator didn't configure one.
@@ -140,16 +145,22 @@ export function planManagedOxigraph(
         }
       : undefined;
 
+  const graphSetIndex = config.store?.graphSetIndex;
+  const storeConfigTemplate: ManagedOxigraphPlan['storeConfigTemplate'] = {
+    backend: 'sparql-http',
+    // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
+    // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
+    options: { managedByDkg: true },
+  };
+  if (graphSetIndex !== undefined) {
+    storeConfigTemplate.graphSetIndex = graphSetIndex;
+  }
+
   return {
     port,
     location,
     cacheDir,
-    storeConfigTemplate: {
-      backend: 'sparql-http',
-      // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
-      // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
-      options: { managedByDkg: true },
-    },
+    storeConfigTemplate,
     largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage,
   };
@@ -158,7 +169,11 @@ export function planManagedOxigraph(
 export interface ManagedOxigraphResult {
   handle: OxigraphServerHandle;
   /** Drop-in replacement for `config.store`. */
-  storeConfig: { backend: 'sparql-http'; options: Record<string, unknown> };
+  storeConfig: {
+    backend: 'sparql-http';
+    options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
+  };
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
   /** Set only when the operator enabled the feature (else leave config as-is). */
   sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
@@ -206,16 +221,21 @@ export async function startManagedOxigraph(
     io: opts.serverIo,
   });
 
+  const storeConfig: ManagedOxigraphResult['storeConfig'] = {
+    backend: 'sparql-http',
+    options: {
+      ...plan.storeConfigTemplate.options,
+      queryEndpoint: handle.queryEndpoint,
+      updateEndpoint: handle.updateEndpoint,
+    },
+  };
+  if (plan.storeConfigTemplate.graphSetIndex !== undefined) {
+    storeConfig.graphSetIndex = plan.storeConfigTemplate.graphSetIndex;
+  }
+
   return {
     handle,
-    storeConfig: {
-      backend: 'sparql-http',
-      options: {
-        ...plan.storeConfigTemplate.options,
-        queryEndpoint: handle.queryEndpoint,
-        updateEndpoint: handle.updateEndpoint,
-      },
-    },
+    storeConfig,
     largeLiteralStorage: plan.largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: plan.sharedMemoryPublicSnapshotStorage,
   };

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -7,6 +7,7 @@
  * loopback endpoints + managedByDkg) without touching disk or processes.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 
 vi.mock('../src/daemon/oxigraph-binary.js', () => ({
   ensureOxigraphBinary: vi.fn(async () => '/cache/oxigraph-v0.5.8'),
@@ -43,12 +44,12 @@ describe('planManagedOxigraph', () => {
     const plan = planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data');
     expect(plan).not.toBeNull();
     expect(plan!.port).toBe(DEFAULT_OXIGRAPH_PORT);
-    expect(plan!.location).toBe('/data/oxigraph-data');
-    expect(plan!.cacheDir).toBe('/data/oxigraph');
+    expect(plan!.location).toBe(join('/data', 'oxigraph-data'));
+    expect(plan!.cacheDir).toBe(join('/data', 'oxigraph'));
     expect(plan!.largeLiteralStorage).toEqual({
       enabled: true,
       thresholdBytes: undefined,
-      directory: '/data/literal-blobs',
+      directory: join('/data', 'literal-blobs'),
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
@@ -99,6 +100,19 @@ describe('planManagedOxigraph', () => {
     });
   });
 
+  it('preserves graphSetIndex options through the managed store rewrite plan', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: { enabled: true, revalidateMs: 5_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.storeConfigTemplate.graphSetIndex).toEqual({ enabled: true, revalidateMs: 5_000 });
+  });
+
   it('leaves sharedMemoryPublicSnapshotStorage undefined when disabled/absent', () => {
     expect(
       planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data')!
@@ -125,7 +139,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.sharedMemoryPublicSnapshotStorage).toEqual({
       enabled: true,
-      directory: '/data/swm-public-snapshots',
+      directory: join('/data', 'swm-public-snapshots'),
     });
   });
 
@@ -176,6 +190,19 @@ describe('startManagedOxigraph', () => {
         updateEndpoint: `http://127.0.0.1:${DEFAULT_OXIGRAPH_PORT}/update`,
       },
     });
-    expect(result!.largeLiteralStorage.directory).toBe('/data/literal-blobs');
+    expect(result!.largeLiteralStorage.directory).toBe(join('/data', 'literal-blobs'));
+  });
+
+  it('preserves graphSetIndex options when starting the managed store', async () => {
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: false,
+        },
+      },
+      dataDir: '/data',
+    });
+    expect(result!.storeConfig.graphSetIndex).toBe(false);
   });
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -61,6 +61,20 @@ export {
 
 const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
 
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
 /**
  * Minimal structural view of the OT-RFC-43 Option-1 KA-number allocator the
  * publisher needs to mint deterministic packed ids. The concrete
@@ -3533,25 +3547,35 @@ export class DKGPublisher implements Publisher {
     const SWM_META_SUFFIX = '/_shared_memory_meta';
     const CG_PREFIX = 'did:dkg:context-graph:';
     try {
-      const contextGraphs = await this.graphManager.listContextGraphs();
+      const allContextGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       let total = 0;
 
       // Build list of (ownershipKey, swmMetaGraphUri) pairs: root + sub-graph scoped
       const targets: Array<{ ownershipKey: string; swmMetaGraph: string }> = [];
-      const allGraphs = await this.store.listGraphs();
-      for (const cgId of contextGraphs) {
-        targets.push({ ownershipKey: cgId, swmMetaGraph: this.graphManager.sharedMemoryMetaUri(cgId) });
-
-        // Discover sub-graph SWM meta graphs: did:dkg:context-graph:{cgId}/{sgName}/_shared_memory_meta
-        const sgPrefix = `${CG_PREFIX}${cgId}/`;
-        for (const g of allGraphs) {
-          if (g.startsWith(sgPrefix) && g.endsWith(SWM_META_SUFFIX)) {
-            const middle = g.slice(sgPrefix.length, g.length - SWM_META_SUFFIX.length);
-            if (middle && !middle.includes('/')) {
-              targets.push({ ownershipKey: `${cgId}\0${middle}`, swmMetaGraph: g });
-            }
-          }
-        }
+      const targetKeys = new Set<string>();
+      const swmMetaGraphs = allContextGraphs
+        .filter((graph) => graph.endsWith(SWM_META_SUFFIX))
+        .map((graph) => ({
+          graph,
+          cgPath: graph.slice(CG_PREFIX.length, graph.length - SWM_META_SUFFIX.length),
+        }))
+        .filter(({ cgPath }) => cgPath.length > 0);
+      for (const { graph, cgPath } of swmMetaGraphs) {
+        const slash = cgPath.lastIndexOf('/');
+        const rootId = slash > 0 ? cgPath.slice(0, slash) : '';
+        const subGraphName = slash > 0 ? cgPath.slice(slash + 1) : '';
+        const isRegisteredSubGraph =
+          rootId.length > 0 &&
+          subGraphName.length > 0 &&
+          !subGraphName.includes('/') &&
+          await this.isSubGraphRegistered(rootId, subGraphName);
+        const ownershipKey =
+          isRegisteredSubGraph
+            ? `${rootId}\0${subGraphName}`
+            : cgPath;
+        if (targetKeys.has(ownershipKey)) continue;
+        targetKeys.add(ownershipKey);
+        targets.push({ ownershipKey, swmMetaGraph: graph });
       }
 
       for (const { ownershipKey, swmMetaGraph } of targets) {
@@ -3772,9 +3796,9 @@ export class DKGPublisher implements Publisher {
 
     try {
       const peerToAddress = new Map<string, string | null>();
-      const allGraphs = await this.store.listGraphs();
+      const allGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       // GH #748 Codex round 6 (user report): enumerate `_shared_memory_meta`
-      // graphs directly via `store.listGraphs()`. The earlier approach used
+      // graphs directly from the store's context-graph prefix. The earlier approach used
       // `graphManager.listContextGraphs()`, but that helper filters out CG
       // IDs containing a slash (storage/graph-manager.ts:104) to dedupe
       // sub-graph paths — which also excludes legitimate curated CGs of the
@@ -4223,8 +4247,7 @@ export class DKGPublisher implements Publisher {
    * graph is intentionally excluded — it is not under the `/` prefix).
    */
   private async swmGraphsUnder(bucketGraph: string): Promise<string[]> {
-    const all = await this.store.listGraphs();
-    return all.filter((g) => g === bucketGraph || g.startsWith(`${bucketGraph}/`));
+    return listGraphFamily(this.store, bucketGraph);
   }
 
   async assertionCreate(

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -189,7 +189,7 @@ export class PublishHandler {
       const swmGraph = this.graphManager.sharedMemoryUri(pending.contextGraphId);
       const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(pending.contextGraphId);
       // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + the bucket.
-      const swmGraphs = (await this.store.listGraphs()).filter(g => g === swmGraph || g.startsWith(`${swmGraph}/`));
+      const swmGraphs = await listGraphFamily(this.store, swmGraph);
       const rootEntities = new Set(pending.dataQuads.map(q => q.subject));
       for (const rootEntity of rootEntities) {
         for (const g of swmGraphs) {
@@ -573,6 +573,20 @@ export class PublishHandler {
       rejectionReason: reason,
     });
   }
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }
 
 // ── Helpers ──

--- a/packages/publisher/src/workspace-agent-recipients.ts
+++ b/packages/publisher/src/workspace-agent-recipients.ts
@@ -74,6 +74,7 @@ async function getWorkspaceAccessMetadata(
   const cgData = contextGraphDataUri(contextGraphId);
   const cgMeta = contextGraphMetaUri(contextGraphId);
   const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  const agentsGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
   const swmGraph = contextGraphSharedMemoryUri(contextGraphId);
   // Flattened UNION: Blazegraph rejects nested UnionNode inside a
   // GRAPH block that is itself a UNION branch. Semantically identical
@@ -90,6 +91,14 @@ async function getWorkspaceAccessMetadata(
         GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${ontologyGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${swmGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       }

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -47,6 +47,14 @@ export type WorkspaceSenderKeyDecryptor = (
   ctx: OperationContext,
 ) => Promise<Uint8Array>;
 
+export interface ContextGraphMetaOracleRecord {
+  allowedPeers?: readonly string[];
+  allowedAgents?: readonly string[];
+  participantAgents?: readonly string[];
+  revokedAgents?: readonly string[];
+  accessPolicy?: string;
+}
+
 /**
  * Outcome of one `SharedMemoryHandler.handle()` invocation. Added
  * in rc.9 PR-C (codex R3) so the new substrate fan-out receiver
@@ -170,6 +178,10 @@ export class SharedMemoryHandler {
   private readonly sharedMemoryOwnedEntities: Map<string, Map<string, string>> = new Map();
   private readonly writeLocks: Map<string, Promise<void>>;
   private readonly localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+  private readonly contextGraphMetaOracle?: (
+    contextGraphId: string,
+  ) => Promise<ContextGraphMetaOracleRecord | null>;
+  private readonly markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed fallback for the agent
    * allowlist read. Returns the participant-agent EOA set for a
@@ -285,6 +297,10 @@ export class SharedMemoryHandler {
       sharedMemoryOwnedEntities?: Map<string, Map<string, string>>;
       writeLocks?: Map<string, Promise<void>>;
       localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+      contextGraphMetaOracle?: (
+        contextGraphId: string,
+      ) => Promise<ContextGraphMetaOracleRecord | null>;
+      markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
       /**
        * OT-RFC-38 / LU-6 Phase B chain-backed agent-allowlist
        * fallback. See {@link SharedMemoryHandler#chainAgentGateOracle}.
@@ -340,6 +356,8 @@ export class SharedMemoryHandler {
     }
     this.writeLocks = options?.writeLocks ?? new Map();
     this.localAgentAddresses = options?.localAgentAddresses;
+    this.contextGraphMetaOracle = options?.contextGraphMetaOracle;
+    this.markContextGraphMetaDirtyFromQuads = options?.markContextGraphMetaDirtyFromQuads;
     this.chainAgentGateOracle = options?.chainAgentGateOracle;
     this.beaconCuratorOracle = options?.beaconCuratorOracle;
     this.workspaceRecipientPrivateKeys = options?.workspaceRecipientPrivateKeys;
@@ -966,6 +984,7 @@ export class SharedMemoryHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.markContextGraphMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}" from SWM`);
         }
       }
@@ -1452,6 +1471,12 @@ export class SharedMemoryHandler {
    * is set (open CG — all peers allowed).
    */
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected) {
+      const peers = [...new Set((projected.allowedPeers ?? []).filter((v): v is string => typeof v === 'string'))];
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
@@ -1472,6 +1497,18 @@ export class SharedMemoryHandler {
    * DKG_PARTICIPANT_AGENT metadata.
    */
   private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected) {
+      const revoked = new Set((projected.revokedAgents ?? []).map((v) => v.toLowerCase()));
+      const projectedAgents = [...(projected.allowedAgents ?? []), ...(projected.participantAgents ?? [])];
+      const agents = projectedAgents
+        .filter((v): v is string => typeof v === 'string' && ethers.isAddress(v) && !revoked.has(v.toLowerCase()))
+        .map((v) => ethers.getAddress(v));
+      const unique = [...new Set(agents)];
+      if (unique.length > 0) return unique;
+      if (projectedAgents.length > 0) return [];
+    }
+
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
@@ -1550,6 +1587,11 @@ export class SharedMemoryHandler {
   private async contextGraphHasPrivateAccessPolicy(contextGraphId: string): Promise<boolean> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return false;
+    }
+
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected?.accessPolicy) {
+      return projected.accessPolicy.trim().toLowerCase() === 'private';
     }
 
     const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1591,6 +1591,10 @@ export class SharedMemoryHandler {
 
     const projected = await this.contextGraphMetaOracle?.(contextGraphId);
     if (projected?.accessPolicy) {
+      // Projection uses _meta-first source precedence. This SWM gate keeps that
+      // safe because curated writers put private in _meta, public writers put
+      // public in ONTOLOGY, gossip drops /_meta quads, and AGENTS precedes
+      // ONTOLOGY to preserve agents-declared-private rows.
       return projected.accessPolicy.trim().toLowerCase() === 'private';
     }
 

--- a/packages/publisher/test/workspace-agent-recipients.test.ts
+++ b/packages/publisher/test/workspace-agent-recipients.test.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   computeWorkspaceAgentEncryptionKeyProofPayload,
   computeWorkspaceAgentEncryptionKeyRevocationPayload,
@@ -17,6 +18,7 @@ import { resolveWorkspaceAgentRecipients } from '../src/index.js';
 const CONTEXT_GRAPH_ID = 'workspace-agent-recipient-resolution';
 const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
 const META_GRAPH = contextGraphMetaUri(CONTEXT_GRAPH_ID);
+const AGENTS_GRAPH = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
 const DKG = 'https://dkg.network/ontology#';
 const DKG_PUBLIC_ENCRYPTION_KEY = `${DKG}publicEncryptionKey`;
 const DKG_ENCRYPTION_KEY_ALGORITHM = `${DKG}encryptionKeyAlgorithm`;
@@ -181,6 +183,32 @@ describe('resolveWorkspaceAgentRecipients', () => {
     expect(resolution.recipients).toHaveLength(1);
     expect(resolution.recipients[0]?.recipientId).toBe(agentUri(wallet.address));
     expect(resolution.recipients[0]?.encryptionKeyAlgorithm).toBe(WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519);
+  });
+
+  it('resolves AGENTS-graph private declarations through the sender-key recipient path', async () => {
+    const store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    await store.insert([
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: AGENTS_GRAPH,
+      },
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${wallet.address}"`,
+        graph: AGENTS_GRAPH,
+      },
+    ]);
+    await insertAgentEncryptionKey(store, wallet);
+
+    const resolution = await resolveWorkspaceAgentRecipients(store, { contextGraphId: CONTEXT_GRAPH_ID });
+
+    expect(resolution.requiresEncryption).toBe(true);
+    expect(resolution.recipients).toHaveLength(1);
+    expect(resolution.recipients[0]?.agentAddress).toBe(ethers.getAddress(wallet.address));
   });
 
   it('preserves peer-only non-private graphs as legacy plaintext-compatible SWM', async () => {

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -205,6 +205,33 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     await expectStoredName('Private Agent Signed');
   });
 
+  it('rejects signed SWM gossip when the projection oracle tombstones the agent', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    const recipientKey = recipientKeyFor(allowed.address);
+    let recipientLookups = 0;
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+      workspaceRecipientPrivateKeys: () => {
+        recipientLookups += 1;
+        return [recipientKey];
+      },
+      contextGraphMetaOracle: async () => ({
+        accessPolicy: 'private',
+        allowedAgents: [allowed.address],
+        revokedAgents: [allowed.address],
+      }),
+    });
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+
+    const raw = workspaceMessage('Projection Revoked', 'ws-agent-gate-projection-revoked');
+    const encrypted = await encryptWorkspaceMessage(allowed.address, raw, recipientKey);
+    await handler.handle(await signWorkspaceMessage(allowed, encrypted), PEER_ID);
+
+    await expectWorkspaceEmpty();
+    expect(recipientLookups).toBe(0);
+  });
+
   it.each([
     ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
     ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -585,6 +585,107 @@ describe('Workspace: ownership persistence and reconstruction', () => {
     expect(freshOwned.get(CONTEXT_GRAPH)?.get(entity2)).toBe('peerB');
   });
 
+  it('reconstructs ownership for slash-shaped context graph ids from SWM meta graph names', async () => {
+    const curatedContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const curatedEntity = 'urn:test:entity:curated';
+    const swmMetaGraph = `did:dkg:context-graph:${curatedContextGraph}/_shared_memory_meta`;
+    const op = 'urn:test:op:curated';
+    await store.insert([
+      q('urn:test:root-marker', 'http://schema.org/name', '"Root"', WORKSPACE_META_GRAPH),
+      q(curatedEntity, 'http://dkg.io/ontology/workspaceOwner', '"peerCurated"', swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', curatedEntity, swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerCurated"', swmMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(curatedContextGraph)?.get(curatedEntity)).toBe('peerCurated');
+  });
+
+  it('reconstructs registered sub-graph ownership under the sub-graph key', async () => {
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:registered-subgraph';
+    const op = 'urn:test:op:registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${CONTEXT_GRAPH}\0${subGraphName}`)?.get(entity)).toBe('peerSubGraph');
+  });
+
+  it('reconstructs registered sub-graph ownership under slash-shaped context graph ids', async () => {
+    const slashContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${slashContextGraph}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:slash-registered-subgraph';
+    const op = 'urn:test:op:slash-registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSlashSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSlashSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${slashContextGraph}\0${subGraphName}`)?.get(entity)).toBe('peerSlashSubGraph');
+    expect(freshOwned.get(`${slashContextGraph}/${subGraphName}`)?.get(entity)).toBeUndefined();
+  });
+
   it('clears ownership quads on publishFromSharedMemory with clearSharedMemoryAfter', async () => {
     const quads = [q(ENTITY, 'http://schema.org/name', '"Enshrine"')];
     await publisher.share(CONTEXT_GRAPH, quads, { publisherPeerId: 'peer1' });

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -764,6 +764,39 @@ describe('SharedMemoryHandler', () => {
     expect(workspaceOwned.get(CONTEXT_GRAPH)?.has(ENTITY)).toBe(true);
   });
 
+  it('notifies context-graph meta invalidation after SWM sub-graph auto-registration', async () => {
+    const dirtyQuads: Quad[] = [];
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      markContextGraphMetaDirtyFromQuads: (quads) => { dirtyQuads.push(...quads); },
+    });
+    const subGraphName = 'tasks';
+    const subGraphGraph = `${DATA_GRAPH}/${subGraphName}`;
+    const nquads = `<${ENTITY}> <http://schema.org/name> "SubGraph Handler Test" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      subGraphName,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'ws-handler-subgraph-dirty',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphGraph,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: `${DATA_GRAPH}/_meta`,
+        }),
+      ]),
+    );
+  });
+
   it('rejects raw workspace gossip when the context graph is agent-gated', async () => {
     const wallet = ethers.Wallet.createRandom();
     await store.insert([{

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -564,7 +564,7 @@ export class DKGQueryEngine implements QueryEngine {
   }
 
   private async discoverGraphsByPrefix(prefix: string): Promise<string[]> {
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     return allGraphs.filter(
       (g) => g.startsWith(prefix) && !g.includes('/_meta') && !g.includes('/staging/'),
     );
@@ -646,7 +646,7 @@ export class DKGQueryEngine implements QueryEngine {
       : await this.discoverRegisteredSubGraphNames(contextGraphId);
     const registeredAssertionGraphs = await this.discoverRegisteredAssertionGraphs(contextGraphId);
     const knownChildContextGraphs = await this.discoverKnownChildContextGraphUris(contextGraphId);
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphFamily(this.store, `did:dkg:context-graph:${contextGraphId}`);
 
     for (const graph of allGraphs) {
       if (
@@ -945,6 +945,20 @@ function assertNoCallerDatasetClauses(sparql: string): void {
       'FROM clauses are not allowed on scoped local queries',
     );
   }
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
 }
 
 function hasCallerDatasetClause(sparql: string): boolean {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -107,6 +107,12 @@ export interface SparqlHttpStoreOptions {
    * Marker used by higher-level daemon flows to distinguish daemon-owned
    * endpoints from operator-provided URLs. Graph-list indexing is handled by
    * GraphSetIndexStore rather than this adapter.
+   *
+   * Compatibility note: direct `new SparqlHttpStore({ managedByDkg: true })`
+   * callers no longer get adapter-local `listGraphs()` caching. Use
+   * `createTripleStore({ backend: 'sparql-http', options: { managedByDkg: true } })`
+   * or wrap this store in `GraphSetIndexStore` to preserve the managed-endpoint
+   * graph-list index/revalidation behavior.
    */
   managedByDkg?: boolean;
   /** Emit sampled slow-query events after this duration. Default 10_000 ms; set 0 to disable. */

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -31,6 +31,8 @@ import type {
   AskResult,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { createHash } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 
 function composeAbortSignals(
   primary: AbortSignal | undefined,
@@ -73,6 +75,25 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }
 
+const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
+const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
+const monotonicNow = (): number => performance.now();
+
+export interface SparqlHttpQueryOptions extends QueryOptions {
+  /** Caller tag used in slow-query telemetry, e.g. `agent.listContextGraphs`. */
+  source?: string;
+}
+
+export interface SparqlHttpSlowQueryEvent {
+  source: string;
+  operation: 'select' | 'ask' | 'construct' | 'describe' | 'unknown';
+  elapsedMs: number;
+  thresholdMs: number;
+  endpoint: string;
+  queryHash: string;
+  queryBytes: number;
+}
+
 export interface SparqlHttpStoreOptions {
   /** SPARQL query endpoint URL (required). */
   queryEndpoint: string;
@@ -88,9 +109,15 @@ export interface SparqlHttpStoreOptions {
    * GraphSetIndexStore rather than this adapter.
    */
   managedByDkg?: boolean;
+  /** Emit sampled slow-query events after this duration. Default 10_000 ms; set 0 to disable. */
+  slowQueryThresholdMs?: number;
+  /** Sampling rate for slow-query events, from 0 to 1. Default 1. */
+  slowQuerySampleRate?: number;
+  /** Optional sink for sampled slow-query events; defaults to a compact console warning. */
+  onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
   /**
-   * Deprecated compatibility option. Graph-list revalidation clocks are owned
-   * by GraphSetIndexStore.
+   * Monotonic clock for slow-query telemetry. Graph-list revalidation clocks
+   * are owned by GraphSetIndexStore.
    */
   now?: () => number;
 }
@@ -103,6 +130,10 @@ export class SparqlHttpStore implements TripleStore {
   private readonly timeout: number;
   private readonly headers: Record<string, string>;
 
+  private readonly now: () => number;
+  private readonly slowQueryThresholdMs: number;
+  private readonly slowQuerySampleRate: number;
+  private readonly onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
   constructor(options: SparqlHttpStoreOptions) {
     if (!options.queryEndpoint?.trim()) {
       throw new Error('sparql-http adapter requires options.queryEndpoint');
@@ -110,6 +141,16 @@ export class SparqlHttpStore implements TripleStore {
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? 30_000;
+    this.now = options.now ?? monotonicNow;
+    this.slowQueryThresholdMs = normalizeNonNegativeNumber(
+      options.slowQueryThresholdMs,
+      DEFAULT_SLOW_QUERY_THRESHOLD_MS,
+    );
+    this.slowQuerySampleRate = normalizeSampleRate(
+      options.slowQuerySampleRate,
+      DEFAULT_SLOW_QUERY_SAMPLE_RATE,
+    );
+    this.onSlowQuery = options.onSlowQuery;
     // Content-Type is set per-request in postQuery/postUpdate (direct POST:
     // application/sparql-query | application/sparql-update). Only shared
     // headers (e.g. Authorization) belong here.
@@ -119,7 +160,7 @@ export class SparqlHttpStore implements TripleStore {
     }
   }
 
-  private async postQuery(sparql: string, accept: string, options?: QueryOptions): Promise<Response> {
+  private async postQuery(sparql: string, accept: string, options?: SparqlHttpQueryOptions): Promise<Response> {
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
     // data. Form-encoded bodies (`query=...`) are parsed by the server's
@@ -231,43 +272,54 @@ export class SparqlHttpStore implements TripleStore {
     return Math.max(0, before - after);
   }
 
-  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+  async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {
+    const startedAt = this.now();
     throwIfAborted(options?.signal);
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');
     const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    const operation = inferQueryOperation(trimmed);
 
-    if (isConstruct) {
-      return this.queryConstruct(trimmed, options);
-    }
-
-    const res = await this.postQuery(trimmed, 'application/sparql-results+json', options);
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
-    }
-
-    const json = (await res.json()) as W3CSelectResponse | W3CAskResponse;
-
-    if (isAsk || 'boolean' in json) {
-      return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
-    }
-
-    const sr = json as W3CSelectResponse;
-    const vars = sr.head?.vars ?? [];
-    const bindings: Array<Record<string, string>> = (sr.results?.bindings ?? []).map((row) => {
-      const obj: Record<string, string> = {};
-      for (const v of vars) {
-        const cell = row[v];
-        if (cell) obj[v] = w3cTermToString(cell);
+    try {
+      if (isConstruct) {
+        return await this.queryConstruct(trimmed, options);
       }
-      return obj;
-    });
-    return { type: 'bindings', bindings } satisfies SelectResult;
+
+      const res = await this.postQuery(trimmed, 'application/sparql-results+json', options);
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
+      }
+
+      const json = (await res.json()) as W3CSelectResponse | W3CAskResponse;
+
+      if (isAsk || 'boolean' in json) {
+        return { type: 'boolean', value: (json as W3CAskResponse).boolean } satisfies AskResult;
+      }
+
+      const sr = json as W3CSelectResponse;
+      const vars = sr.head?.vars ?? [];
+      const bindings: Array<Record<string, string>> = (sr.results?.bindings ?? []).map((row) => {
+        const obj: Record<string, string> = {};
+        for (const v of vars) {
+          const cell = row[v];
+          if (cell) obj[v] = w3cTermToString(cell);
+        }
+        return obj;
+      });
+      return { type: 'bindings', bindings } satisfies SelectResult;
+    } finally {
+      this.maybeEmitSlowQuery({
+        sparql: trimmed,
+        source: options?.source,
+        operation,
+        startedAt,
+      });
+    }
   }
 
-  private async queryConstruct(sparql: string, options?: QueryOptions): Promise<ConstructResult> {
+  private async queryConstruct(sparql: string, options?: SparqlHttpQueryOptions): Promise<ConstructResult> {
     const res = await this.postQuery(sparql, 'application/n-quads, text/n-quads', options);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -279,7 +331,10 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   async hasGraph(graphUri: string): Promise<boolean> {
-    const r = await this.query(`ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`);
+    const r = await this.query(
+      `ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`,
+      { source: 'sparql-http.hasGraph' },
+    );
     return r.type === 'boolean' && r.value;
   }
 
@@ -298,7 +353,10 @@ export class SparqlHttpStore implements TripleStore {
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
-    const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }', options);
+    const r = await this.query(
+      'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
+      { ...options, source: options?.source ?? 'sparql-http.listGraphs' },
+    );
     return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
   }
 
@@ -306,7 +364,7 @@ export class SparqlHttpStore implements TripleStore {
     const sparql = graphUri
       ? `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`
       : `SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }`;
-    const r = await this.query(sparql);
+    const r = await this.query(sparql, { source: 'sparql-http.countQuads' });
     if (r.type === 'bindings' && r.bindings.length > 0) {
       const c = String(r.bindings[0].c ?? '');
       const stripped = c.replace(/^"|"$/g, '');
@@ -315,8 +373,88 @@ export class SparqlHttpStore implements TripleStore {
     return 0;
   }
 
+  private maybeEmitSlowQuery(input: {
+    sparql: string;
+    source?: string;
+    operation: SparqlHttpSlowQueryEvent['operation'];
+    startedAt: number;
+  }): void {
+    if (this.slowQueryThresholdMs <= 0 || this.slowQuerySampleRate <= 0) return;
+    const elapsedMs = this.now() - input.startedAt;
+    if (elapsedMs < this.slowQueryThresholdMs) return;
+    if (this.slowQuerySampleRate < 1 && Math.random() >= this.slowQuerySampleRate) return;
+
+    const event: SparqlHttpSlowQueryEvent = {
+      source: normalizeQuerySource(input.source),
+      operation: input.operation,
+      elapsedMs,
+      thresholdMs: this.slowQueryThresholdMs,
+      endpoint: sanitizeEndpointForTelemetry(this.queryEndpoint),
+      queryHash: hashQuery(input.sparql),
+      queryBytes: Buffer.byteLength(input.sparql, 'utf8'),
+    };
+
+    if (this.onSlowQuery) {
+      try {
+        this.onSlowQuery(event);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`SPARQL HTTP slow query hook failed: ${reason}`);
+      }
+      return;
+    }
+    console.warn(
+      `SPARQL HTTP slow query source=${event.source} operation=${event.operation} ` +
+      `elapsedMs=${Math.round(event.elapsedMs)} thresholdMs=${event.thresholdMs} ` +
+      `queryHash=${event.queryHash} queryBytes=${event.queryBytes} endpoint=${event.endpoint}`,
+    );
+  }
+
   async close(): Promise<void> {
     // Remote service — nothing to close.
+  }
+}
+
+function normalizeNonNegativeNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+}
+
+function normalizeSampleRate(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.min(1, Math.max(0, value));
+}
+
+function normalizeQuerySource(source: string | undefined): string {
+  const trimmed = source?.trim();
+  if (!trimmed) return 'unknown';
+  return trimmed.replace(/[^\w:./-]/g, '_').slice(0, 120) || 'unknown';
+}
+
+function inferQueryOperation(sparql: string): SparqlHttpSlowQueryEvent['operation'] {
+  const upper = sparql.trimStart().toUpperCase();
+  if (upper.startsWith('SELECT')) return 'select';
+  if (upper.startsWith('ASK')) return 'ask';
+  if (upper.startsWith('CONSTRUCT')) return 'construct';
+  if (upper.startsWith('DESCRIBE')) return 'describe';
+  return 'unknown';
+}
+
+function hashQuery(sparql: string): string {
+  return createHash('sha256').update(sparql).digest('hex').slice(0, 16);
+}
+
+function sanitizeEndpointForTelemetry(endpoint: string): string {
+  try {
+    const url = new URL(endpoint);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return endpoint.split(/[?#]/, 1)[0];
   }
 }
 

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -31,15 +31,6 @@ import type {
   AskResult,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
-import { performance } from 'node:perf_hooks';
-
-/**
- * Monotonic clock for the listGraphs cache TTL. Unlike `Date.now()`,
- * `performance.now()` never moves backwards on an NTP step / VM resume / manual
- * clock change, so the TTL can't be silently extended past its window (which
- * would defeat the outage re-validation guarantee).
- */
-const monotonicNow = (): number => performance.now();
 
 function composeAbortSignals(
   primary: AbortSignal | undefined,
@@ -82,32 +73,6 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }
 
-function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
-  if (!signal) return work;
-  throwIfAborted(signal);
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => {
-      const reason = signal.reason;
-      reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
-    };
-    signal.addEventListener('abort', onAbort, { once: true });
-    work.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
-  });
-}
-
-/**
- * R6-A: how long a managed-endpoint `listGraphs()` result may be served from
- * cache before it is re-validated against the store. The cache is also cleared
- * eagerly on every local write, so this TTL only bounds *non-write* staleness:
- * it collapses the peer-churn-driven burst of reconcile enumerations to at most
- * one scan per window (the actual CPU win) while guaranteeing the graph set is
- * re-read at least this often — so a managed-store outage/restart surfaces
- * within the window instead of being masked indefinitely (review round 1).
- */
-export const LIST_GRAPHS_CACHE_TTL_MS = 30_000;
-
 export interface SparqlHttpStoreOptions {
   /** SPARQL query endpoint URL (required). */
   queryEndpoint: string;
@@ -118,24 +83,14 @@ export interface SparqlHttpStoreOptions {
   /** Optional Authorization header value (e.g. "Bearer <token>" or "Basic <base64>"). */
   auth?: string;
   /**
-   * True when the daemon owns this endpoint end-to-end (a CLI-managed local
-   * `oxigraph-server`, signalled by `oxigraph-managed.ts`). When set, no
-   * external writer can mutate the store behind our back, so `listGraphs()`
-   * is served from an in-memory cache that is invalidated on every local
-   * write AND expires after {@link LIST_GRAPHS_CACHE_TTL_MS}. This kills the
-   * data-proportional `SELECT DISTINCT ?g` full scan that the 30 s host-mode
-   * reconcile (and on-demand CG enumeration) would otherwise re-run every
-   * cycle on an idle, data-rich node (R6-A).
-   *
-   * Leave false/undefined for operator-provided endpoints: a shared/external
-   * SPARQL server can gain graphs we did not write, which the cache would
-   * miss — so caching is unsafe there and `listGraphs()` always queries.
+   * Marker used by higher-level daemon flows to distinguish daemon-owned
+   * endpoints from operator-provided URLs. Graph-list indexing is handled by
+   * GraphSetIndexStore rather than this adapter.
    */
   managedByDkg?: boolean;
   /**
-   * Clock for the `listGraphs()` cache TTL. Test seam only; defaults to the
-   * monotonic {@link monotonicNow} (`performance.now`), never `Date.now`, so a
-   * backwards wall-clock jump can't extend the cache past its TTL.
+   * Deprecated compatibility option. Graph-list revalidation clocks are owned
+   * by GraphSetIndexStore.
    */
   now?: () => number;
 }
@@ -148,38 +103,6 @@ export class SparqlHttpStore implements TripleStore {
   private readonly timeout: number;
   private readonly headers: Record<string, string>;
 
-  /** R6-A: cache `listGraphs()` only for daemon-owned (managed) endpoints. */
-  private readonly cacheGraphList: boolean;
-  /** Monotonic clock for the cache TTL (defaults to performance.now). */
-  private readonly now: () => number;
-  /** Cached graph-name list; null = not built / invalidated by a write. */
-  private graphListCache: string[] | null = null;
-  /** Wall-clock (via {@link now}) when {@link graphListCache} was last built. */
-  private graphListCacheAt = 0;
-  /**
-   * Bumped on every local write. `listGraphs()` captures it before its
-   * async query and only stores the result if it is unchanged on return —
-   * so a write that lands while a rebuild is in flight discards the
-   * possibly-stale result instead of caching it.
-   */
-  private graphListCacheGen = 0;
-  /**
-   * In-flight rebuild promise (managed endpoints). Concurrent callers on a
-   * cold/expired cache share this single scan instead of each issuing their
-   * own `SELECT DISTINCT ?g` — without it, a burst of overlapping enumerations
-   * (reconcile + metrics CG-count + status) at startup or each TTL boundary
-   * would still run duplicate full scans, the exact load this fix targets.
-   */
-  private graphListInflight: Promise<string[]> | null = null;
-  /**
-   * The generation {@link graphListInflight} was started at. A caller may only
-   * join the in-flight scan when this still equals {@link graphListCacheGen};
-   * a write that bumps the generation mid-scan means the in-flight result is
-   * pre-write, so a later caller must start a fresh scan rather than observe a
-   * stale graph set (read-your-writes).
-   */
-  private graphListInflightGen = -1;
-
   constructor(options: SparqlHttpStoreOptions) {
     if (!options.queryEndpoint?.trim()) {
       throw new Error('sparql-http adapter requires options.queryEndpoint');
@@ -187,8 +110,6 @@ export class SparqlHttpStore implements TripleStore {
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? 30_000;
-    this.cacheGraphList = options.managedByDkg === true;
-    this.now = options.now ?? monotonicNow;
     // Content-Type is set per-request in postQuery/postUpdate (direct POST:
     // application/sparql-query | application/sparql-update). Only shared
     // headers (e.g. Authorization) belong here.
@@ -196,18 +117,6 @@ export class SparqlHttpStore implements TripleStore {
     if (options.auth) {
       this.headers['Authorization'] = options.auth;
     }
-  }
-
-  /**
-   * Invalidate the cached graph list after a local write. A no-op when
-   * caching is disabled (external endpoints). Bumping the generation also
-   * causes any concurrently in-flight `listGraphs()` rebuild to drop its
-   * result rather than cache a pre-write snapshot.
-   */
-  private invalidateGraphListCache(): void {
-    if (!this.cacheGraphList) return;
-    this.graphListCache = null;
-    this.graphListCacheGen++;
   }
 
   private async postQuery(sparql: string, accept: string, options?: QueryOptions): Promise<Response> {
@@ -265,7 +174,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP insert failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a new graph may have appeared
   }
 
   async delete(quads: DKGQuad[]): Promise<void> {
@@ -284,7 +192,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP delete failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a graph may now be empty (gone from listGraphs)
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {
@@ -307,7 +214,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteByPattern failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // a graph may now be empty (gone from listGraphs)
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -321,7 +227,6 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteBySubjectPrefix failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // the graph may now be empty (gone from listGraphs)
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -389,70 +294,12 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP dropGraph failed (${res.status}): ${text.slice(0, 300)}`);
     }
-    this.invalidateGraphListCache(); // the graph is gone from listGraphs
   }
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
-    // R6-A: on a managed (daemon-owned) endpoint the graph set only changes
-    // when *we* write, so serve a warm cache and skip the full
-    // `SELECT DISTINCT ?g` quad-store scan — the dominant idle-node CPU cost
-    // on a data-rich node (re-run by the 30 s host-mode reconcile and every
-    // on-demand CG enumeration). The cache is cleared on every write and also
-    // expires after LIST_GRAPHS_CACHE_TTL_MS, so the burst of churn-driven
-    // re-enumerations collapses to one scan per window while a store
-    // outage/restart still surfaces within the TTL. Returns a copy so callers
-    // can't mutate it.
-    if (
-      this.cacheGraphList &&
-      this.graphListCache !== null &&
-      this.now() - this.graphListCacheAt < LIST_GRAPHS_CACHE_TTL_MS
-    ) {
-      return [...this.graphListCache];
-    }
-    // External (non-managed) endpoint: never cache (an outside writer could
-    // add a graph we'd miss), so just scan.
-    if (!this.cacheGraphList) {
-      return [...(await this.scanGraphs(this.graphListCacheGen, options))];
-    }
-    // Managed, cold/expired cache: coalesce concurrent callers onto one
-    // in-flight scan so a startup or TTL-boundary burst doesn't fan out into
-    // duplicate full scans (the very load this fix removes) — but only while no
-    // write has invalidated the cache since that scan started. A caller
-    // arriving after a write must not join the pre-write scan (it would observe
-    // a stale graph set); it starts a fresh one instead.
-    if (this.graphListInflight && this.graphListInflightGen === this.graphListCacheGen) {
-      return [...(await raceAgainstAbort(this.graphListInflight, options?.signal))];
-    }
-    const startGen = this.graphListCacheGen;
-    let scan!: Promise<string[]>;
-    scan = this.scanGraphs(startGen).finally(() => {
-      // Clear only if a newer scan hasn't already replaced this one, so a
-      // post-write rebuild started while this scan was resolving isn't lost.
-      if (this.graphListInflight === scan) {
-        this.graphListInflight = null;
-        this.graphListInflightGen = -1;
-      }
-    });
-    this.graphListInflight = scan;
-    this.graphListInflightGen = startGen;
-    return [...(await raceAgainstAbort(scan, options?.signal))];
-  }
-
-  /**
-   * Run the `SELECT DISTINCT ?g` enumeration and (for managed endpoints) cache
-   * the result, unless a write landed during the scan — the generation guard
-   * (`startGen` vs the current generation) discards a snapshot that may predate
-   * that write so the next call rebuilds.
-   */
-  private async scanGraphs(startGen: number, options?: QueryOptions): Promise<string[]> {
     const r = await this.query('SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }', options);
-    const graphs = r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
-    if (this.cacheGraphList && startGen === this.graphListCacheGen) {
-      this.graphListCache = graphs;
-      this.graphListCacheAt = this.now();
-    }
-    return graphs;
+    return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
   }
 
   async countQuads(graphUri?: string): Promise<number> {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -397,7 +397,8 @@ export class SparqlHttpStore implements TripleStore {
       return [...this.listGraphsCache];
     }
 
-    const inFlight = this.listGraphsInFlight ?? this.refreshListGraphsCache(options);
+    const refreshOptions = options?.source ? { source: options.source } : undefined;
+    const inFlight = this.listGraphsInFlight ?? this.refreshListGraphsCache(refreshOptions);
     const graphs = await raceAgainstAbort(inFlight, options?.signal);
     return [...graphs];
   }

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -75,8 +75,24 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
 }
 
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
 const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
 const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
+const MANAGED_LIST_GRAPHS_CACHE_MS = 30_000;
 const monotonicNow = (): number => performance.now();
 
 export interface SparqlHttpQueryOptions extends QueryOptions {
@@ -105,14 +121,14 @@ export interface SparqlHttpStoreOptions {
   auth?: string;
   /**
    * Marker used by higher-level daemon flows to distinguish daemon-owned
-   * endpoints from operator-provided URLs. Graph-list indexing is handled by
-   * GraphSetIndexStore rather than this adapter.
+   * endpoints from operator-provided URLs.
    *
    * Compatibility note: direct `new SparqlHttpStore({ managedByDkg: true })`
-   * callers no longer get adapter-local `listGraphs()` caching. Use
+   * callers keep the legacy adapter-local `listGraphs()` cache. The
    * `createTripleStore({ backend: 'sparql-http', options: { managedByDkg: true } })`
-   * or wrap this store in `GraphSetIndexStore` to preserve the managed-endpoint
-   * graph-list index/revalidation behavior.
+   * path suppresses that adapter-local cache and wraps the store in
+   * GraphSetIndexStore so managed daemon flows still have a single graph-list
+   * index/revalidation owner.
    */
   managedByDkg?: boolean;
   /** Emit sampled slow-query events after this duration. Default 10_000 ms; set 0 to disable. */
@@ -135,11 +151,17 @@ export class SparqlHttpStore implements TripleStore {
   private readonly updateEndpoint: string;
   private readonly timeout: number;
   private readonly headers: Record<string, string>;
+  private readonly managedByDkg: boolean;
 
   private readonly now: () => number;
   private readonly slowQueryThresholdMs: number;
   private readonly slowQuerySampleRate: number;
   private readonly onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
+  private listGraphsCache: string[] | null = null;
+  private listGraphsCachedAt = 0;
+  private listGraphsGeneration = 0;
+  private listGraphsInFlight: Promise<string[]> | null = null;
+
   constructor(options: SparqlHttpStoreOptions) {
     if (!options.queryEndpoint?.trim()) {
       throw new Error('sparql-http adapter requires options.queryEndpoint');
@@ -147,6 +169,7 @@ export class SparqlHttpStore implements TripleStore {
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? 30_000;
+    this.managedByDkg = options.managedByDkg === true;
     this.now = options.now ?? monotonicNow;
     this.slowQueryThresholdMs = normalizeNonNegativeNumber(
       options.slowQueryThresholdMs,
@@ -221,6 +244,7 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP insert failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    this.invalidateListGraphsCache();
   }
 
   async delete(quads: DKGQuad[]): Promise<void> {
@@ -239,6 +263,7 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP delete failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    this.invalidateListGraphsCache();
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {
@@ -261,6 +286,7 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteByPattern failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    this.invalidateListGraphsCache();
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -274,6 +300,7 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP deleteBySubjectPrefix failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    this.invalidateListGraphsCache();
     const after = await this.countQuads(graphUri);
     return Math.max(0, before - after);
   }
@@ -355,15 +382,59 @@ export class SparqlHttpStore implements TripleStore {
       const text = await res.text().catch(() => '');
       throw new Error(`SPARQL HTTP dropGraph failed (${res.status}): ${text.slice(0, 300)}`);
     }
+    this.invalidateListGraphsCache();
   }
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {
+    if (!this.managedByDkg) {
+      return this.listGraphsDirect(options);
+    }
+    throwIfAborted(options?.signal);
+    if (
+      this.listGraphsCache &&
+      this.now() - this.listGraphsCachedAt < MANAGED_LIST_GRAPHS_CACHE_MS
+    ) {
+      return [...this.listGraphsCache];
+    }
+
+    const inFlight = this.listGraphsInFlight ?? this.refreshListGraphsCache(options);
+    const graphs = await raceAgainstAbort(inFlight, options?.signal);
+    return [...graphs];
+  }
+
+  private async listGraphsDirect(options?: QueryOptions): Promise<string[]> {
     throwIfAborted(options?.signal);
     const r = await this.query(
       'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
       { ...options, source: options?.source ?? 'sparql-http.listGraphs' },
     );
     return r.type === 'bindings' ? r.bindings.map((b) => b.g).filter(Boolean) : [];
+  }
+
+  private refreshListGraphsCache(options?: QueryOptions): Promise<string[]> {
+    const generation = this.listGraphsGeneration;
+    const task = (async () => {
+      try {
+        const graphs = await this.listGraphsDirect(options);
+        const cached = [...graphs];
+        if (generation === this.listGraphsGeneration) {
+          this.listGraphsCache = cached;
+          this.listGraphsCachedAt = this.now();
+        }
+        return cached;
+      } finally {
+        if (this.listGraphsGeneration === generation) this.listGraphsInFlight = null;
+      }
+    })();
+    this.listGraphsInFlight = task;
+    return task;
+  }
+
+  private invalidateListGraphsCache(): void {
+    this.listGraphsGeneration++;
+    this.listGraphsCache = null;
+    this.listGraphsCachedAt = 0;
+    this.listGraphsInFlight = null;
   }
 
   async countQuads(graphUri?: string): Promise<number> {

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -15,6 +15,12 @@ import {
 
 const CG_PREFIX = 'did:dkg:context-graph:';
 
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
+
 export class ContextGraphManager {
   private readonly store: TripleStore;
   private readonly ensuredContextGraphs = new Set<string>();
@@ -87,7 +93,7 @@ export class ContextGraphManager {
   }
 
   async listContextGraphs(): Promise<string[]> {
-    const graphs = await this.store.listGraphs();
+    const graphs = await listGraphsByPrefix(this.store, CG_PREFIX);
     const contextGraphs = new Set<string>();
     for (const g of graphs) {
       if (g.startsWith(CG_PREFIX)) {
@@ -116,7 +122,7 @@ export class ContextGraphManager {
    */
   async listSubGraphs(contextGraphId: string): Promise<string[]> {
     const prefix = `${CG_PREFIX}${contextGraphId}/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, prefix);
     const subGraphNames = new Set<string>();
     const reservedPrefixes = ['_', 'assertion/', 'draft/', 'context/'];
     for (const g of allGraphs) {

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -53,6 +53,7 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   private readonly inner: TripleStore;
+  private readonly enabled: boolean;
   private readonly revalidateMs: number;
   private readonly now: () => number;
   private readonly onMutation?: (event: GraphSetMutationEvent) => void;
@@ -64,12 +65,17 @@ export class GraphSetIndexStore implements TripleStore {
 
   constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
     this.inner = inner;
+    this.enabled = options.enabled !== false;
     this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
     this.now = options.now ?? (() => performance.now());
     this.onMutation = options.onMutation;
   }
 
   async insert(quads: Quad[]): Promise<void> {
+    if (!this.enabled) {
+      await this.inner.insert(quads);
+      return;
+    }
     await this.inner.insert(quads);
     const touched = namedGraphsFromQuads(quads);
     if (touched.length === 0) return;
@@ -78,6 +84,10 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async delete(quads: Quad[]): Promise<void> {
+    if (!this.enabled) {
+      await this.inner.delete(quads);
+      return;
+    }
     await this.inner.delete(quads);
     const touched = namedGraphsFromQuads(quads);
     if (touched.length === 0) return;
@@ -86,6 +96,9 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    if (!this.enabled) {
+      return this.inner.deleteByPattern(pattern);
+    }
     const removed = await this.inner.deleteByPattern(pattern);
     if (removed <= 0) return removed;
     this.bumpMutation();
@@ -99,6 +112,9 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    if (!this.enabled) {
+      return this.inner.query(sparql, options);
+    }
     const result = await this.inner.query(sparql, options);
     if (isSparqlUpdate(sparql)) {
       this.bumpMutation();
@@ -110,6 +126,9 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async hasGraph(graphUri: string): Promise<boolean> {
+    if (!this.enabled) {
+      return this.inner.hasGraph(graphUri);
+    }
     const hasGraph = await this.inner.hasGraph(graphUri);
     const indexed = this.graphs?.has(graphUri);
     if (this.graphs && indexed !== hasGraph) {
@@ -125,22 +144,38 @@ export class GraphSetIndexStore implements TripleStore {
   }
 
   async dropGraph(graphUri: string): Promise<void> {
+    if (!this.enabled) {
+      await this.inner.dropGraph(graphUri);
+      return;
+    }
     await this.inner.dropGraph(graphUri);
     this.bumpMutation();
     this.removeGraphs([graphUri], 'dropGraph');
   }
 
   async listGraphs(options?: QueryOptions): Promise<string[]> {
+    if (!this.enabled) {
+      return this.inner.listGraphs(options);
+    }
     const graphs = await this.ensureGraphSet(options);
     return [...graphs];
   }
 
   async listGraphsByPrefix(prefix: string, options?: QueryOptions): Promise<string[]> {
+    if (!this.enabled) {
+      if (this.inner.listGraphsByPrefix) {
+        return this.inner.listGraphsByPrefix(prefix, options);
+      }
+      return (await this.inner.listGraphs(options)).filter((graph) => graph.startsWith(prefix));
+    }
     const graphs = await this.ensureGraphSet(options);
     return [...graphs].filter((graph) => graph.startsWith(prefix));
   }
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    if (!this.enabled) {
+      return this.inner.deleteBySubjectPrefix(graphUri, prefix);
+    }
     const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix);
     if (removed <= 0) return removed;
     this.bumpMutation();

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -1,0 +1,296 @@
+import { performance } from 'node:perf_hooks';
+import type { Quad, QueryOptions, QueryResult, TripleStore } from './triple-store.js';
+
+export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
+
+export type GraphSetMutationSource =
+  | 'seed'
+  | 'revalidate'
+  | 'insert'
+  | 'delete'
+  | 'deleteByPattern'
+  | 'deleteBySubjectPrefix'
+  | 'dropGraph'
+  | 'query';
+
+type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query';
+
+export type GraphSetMutationEvent =
+  | {
+      type: 'graph-added';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-removed';
+      graph: string;
+      source: GraphSetMutationSource;
+    }
+  | {
+      type: 'graph-set-revalidated';
+      added: string[];
+      removed: string[];
+      source: GraphSetRefreshSource;
+    };
+
+export interface GraphSetIndexStoreOptions {
+  enabled?: boolean;
+  /** Revalidate after this interval. Use 0 to revalidate on every read. */
+  revalidateMs?: number;
+  now?: () => number;
+  onMutation?: (event: GraphSetMutationEvent) => void;
+}
+
+/**
+ * Write-through named-graph index for stores whose `listGraphs()` implementation
+ * is a full-store scan. The index follows the repo's existing graph semantics:
+ * only graphs containing at least one quad are listed; empty `createGraph()`
+ * calls are not visible until data is inserted.
+ */
+export class GraphSetIndexStore implements TripleStore {
+  get queryCancellation() {
+    return this.inner.queryCancellation;
+  }
+
+  private readonly inner: TripleStore;
+  private readonly revalidateMs: number;
+  private readonly now: () => number;
+  private readonly onMutation?: (event: GraphSetMutationEvent) => void;
+
+  private graphs: Set<string> | null = null;
+  private validatedAt = 0;
+  private mutationGeneration = 0;
+  private refreshInFlight: Promise<Set<string>> | null = null;
+
+  constructor(inner: TripleStore, options: GraphSetIndexStoreOptions = {}) {
+    this.inner = inner;
+    this.revalidateMs = Math.max(0, options.revalidateMs ?? DEFAULT_GRAPH_SET_REVALIDATE_MS);
+    this.now = options.now ?? (() => performance.now());
+    this.onMutation = options.onMutation;
+  }
+
+  async insert(quads: Quad[]): Promise<void> {
+    await this.inner.insert(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    this.addGraphs(touched, 'insert');
+  }
+
+  async delete(quads: Quad[]): Promise<void> {
+    await this.inner.delete(quads);
+    const touched = namedGraphsFromQuads(quads);
+    if (touched.length === 0) return;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs(touched, 'delete'));
+  }
+
+  async deleteByPattern(pattern: Partial<Quad>): Promise<number> {
+    const removed = await this.inner.deleteByPattern(pattern);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    const graph = pattern.graph;
+    if (graph) {
+      await this.maintainIndex(() => this.refreshTouchedGraphs([graph], 'deleteByPattern'));
+    } else {
+      await this.maintainIndex(() => this.refreshIndex('deleteByPattern'));
+    }
+    return removed;
+  }
+
+  async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
+    const result = await this.inner.query(sparql, options);
+    if (isSparqlUpdate(sparql)) {
+      this.bumpMutation();
+      if (this.graphs || this.refreshInFlight) {
+        await this.maintainIndex(() => this.refreshIndex('query'));
+      }
+    }
+    return result;
+  }
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    const hasGraph = await this.inner.hasGraph(graphUri);
+    const indexed = this.graphs?.has(graphUri);
+    if (this.graphs && indexed !== hasGraph) {
+      this.bumpMutation();
+      if (hasGraph) this.addGraphs([graphUri], 'revalidate');
+      else this.removeGraphs([graphUri], 'revalidate');
+    }
+    return hasGraph;
+  }
+
+  async createGraph(graphUri: string): Promise<void> {
+    await this.inner.createGraph(graphUri);
+  }
+
+  async dropGraph(graphUri: string): Promise<void> {
+    await this.inner.dropGraph(graphUri);
+    this.bumpMutation();
+    this.removeGraphs([graphUri], 'dropGraph');
+  }
+
+  async listGraphs(options?: QueryOptions): Promise<string[]> {
+    const graphs = await this.ensureGraphSet(options);
+    return [...graphs];
+  }
+
+  async listGraphsByPrefix(prefix: string, options?: QueryOptions): Promise<string[]> {
+    const graphs = await this.ensureGraphSet(options);
+    return [...graphs].filter((graph) => graph.startsWith(prefix));
+  }
+
+  async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    const removed = await this.inner.deleteBySubjectPrefix(graphUri, prefix);
+    if (removed <= 0) return removed;
+    this.bumpMutation();
+    await this.maintainIndex(() => this.refreshTouchedGraphs([graphUri], 'deleteBySubjectPrefix'));
+    return removed;
+  }
+
+  async countQuads(graphUri?: string): Promise<number> {
+    return this.inner.countQuads(graphUri);
+  }
+
+  async flush(): Promise<void> {
+    await this.inner.flush?.();
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+
+  private async ensureGraphSet(options?: QueryOptions): Promise<Set<string>> {
+    throwIfAborted(options?.signal);
+    if (
+      this.graphs &&
+      this.revalidateMs > 0 &&
+      this.now() - this.validatedAt < this.revalidateMs
+    ) {
+      return this.graphs;
+    }
+    return raceAgainstAbort(
+      this.refreshIndex(this.graphs ? 'revalidate' : 'seed'),
+      options?.signal,
+    );
+  }
+
+  private async refreshIndex(source: GraphSetRefreshSource): Promise<Set<string>> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    const task = this.refreshIndexLoop(source);
+    this.refreshInFlight = task;
+    try {
+      return await task;
+    } finally {
+      if (this.refreshInFlight === task) this.refreshInFlight = null;
+    }
+  }
+
+  private async refreshIndexLoop(source: GraphSetRefreshSource): Promise<Set<string>> {
+    for (;;) {
+      const generation = this.mutationGeneration;
+      const next = new Set((await this.inner.listGraphs()).filter(Boolean));
+      if (generation !== this.mutationGeneration) continue;
+      this.replaceGraphSet(next, source);
+      return this.graphs!;
+    }
+  }
+
+  private bumpMutation(): void {
+    this.mutationGeneration++;
+  }
+
+  private async maintainIndex(task: () => Promise<unknown>): Promise<void> {
+    try {
+      await task();
+    } catch {
+      this.clearIndex();
+    }
+  }
+
+  private clearIndex(): void {
+    this.graphs = null;
+    this.validatedAt = 0;
+  }
+
+  private replaceGraphSet(next: Set<string>, source: GraphSetRefreshSource): void {
+    const previous = this.graphs ?? new Set<string>();
+    const added = [...next].filter((graph) => !previous.has(graph)).sort();
+    const removed = [...previous].filter((graph) => !next.has(graph)).sort();
+    this.graphs = next;
+    this.validatedAt = this.now();
+    if (added.length > 0 || removed.length > 0 || source !== 'seed') {
+      this.emit({ type: 'graph-set-revalidated', added, removed, source });
+    }
+  }
+
+  private addGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || this.graphs.has(graph)) continue;
+      this.graphs.add(graph);
+      this.emit({ type: 'graph-added', graph, source });
+    }
+  }
+
+  private removeGraphs(graphs: string[], source: GraphSetMutationSource): void {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph || !this.graphs.delete(graph)) continue;
+      this.emit({ type: 'graph-removed', graph, source });
+    }
+  }
+
+  private async refreshTouchedGraphs(graphs: string[], source: GraphSetMutationSource): Promise<void> {
+    if (!this.graphs) return;
+    for (const graph of graphs) {
+      if (!graph) continue;
+      if (await this.inner.hasGraph(graph)) {
+        this.addGraphs([graph], source);
+      } else {
+        this.removeGraphs([graph], source);
+      }
+    }
+  }
+
+  private emit(event: GraphSetMutationEvent): void {
+    try {
+      this.onMutation?.(event);
+    } catch {
+      // Observability hooks must not make already-committed store writes fail.
+    }
+  }
+}
+
+function namedGraphsFromQuads(quads: Quad[]): string[] {
+  return [...new Set(quads.map((quad) => quad.graph).filter(Boolean))];
+}
+
+function isSparqlUpdate(sparql: string): boolean {
+  const withoutPrologue = sparql
+    .trimStart()
+    .replace(/^(?:(?:#[^\r\n]*(?:\r?\n|$))|(?:PREFIX\s+(?:[A-Za-z][\w-]*)?:\s*<[^>]*>|BASE\s*<[^>]*>)\s*)+/i, '')
+    .trimStart();
+  return /^(?:INSERT|DELETE|WITH|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i.test(withoutPrologue);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  const reason = signal.reason;
+  throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
+}
+
+function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return work;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error(String(reason ?? 'aborted')));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -22,6 +22,13 @@ export {
   SharedMemoryLiteralBlobStore,
   type SharedMemoryLiteralBlobStoreOptions,
 } from './shared-memory-literal-blob-store.js';
+export {
+  DEFAULT_GRAPH_SET_REVALIDATE_MS,
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+  type GraphSetMutationEvent,
+  type GraphSetMutationSource,
+} from './graph-set-index-store.js';
 
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -8,6 +8,7 @@ export {
   type AskResult,
   type TripleStoreConfig,
   type TripleStoreBackend,
+  type TripleStoreQueryOptions,
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   createTripleStore,
@@ -33,7 +34,12 @@ export {
 export { OxigraphStore } from './adapters/oxigraph.js';
 export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
 export { BlazegraphStore } from './adapters/blazegraph.js';
-export { SparqlHttpStore, type SparqlHttpStoreOptions } from './adapters/sparql-http.js';
+export {
+  SparqlHttpStore,
+  type SparqlHttpStoreOptions,
+  type SparqlHttpQueryOptions,
+  type SparqlHttpSlowQueryEvent,
+} from './adapters/sparql-http.js';
 export { ContextGraphManager, GraphManager } from './graph-manager.js';
 export { PrivateContentStore } from './private-store.js';
 

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -108,6 +108,12 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return this.inner.listGraphs(options);
   }
 
+  async listGraphsByPrefix(prefix: string, options?: QueryOptions): Promise<string[]> {
+    return this.inner.listGraphsByPrefix
+      ? this.inner.listGraphsByPrefix(prefix, options)
+      : (await this.inner.listGraphs(options)).filter((graph) => graph.startsWith(prefix));
+  }
+
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
     return this.inner.deleteBySubjectPrefix(graphUri, prefix);
   }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,
   SharedMemoryLiteralBlobStore,
 } from './shared-memory-literal-blob-store.js';
+import {
+  GraphSetIndexStore,
+  type GraphSetIndexStoreOptions,
+} from './graph-set-index-store.js';
 
 export interface Quad {
   subject: string;
@@ -61,6 +65,7 @@ export interface TripleStore {
   createGraph(graphUri: string): Promise<void>;
   dropGraph(graphUri: string): Promise<void>;
   listGraphs(options?: QueryOptions): Promise<string[]>;
+  listGraphsByPrefix?(prefix: string, options?: QueryOptions): Promise<string[]>;
 
   deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number>;
 
@@ -159,6 +164,7 @@ export interface TripleStoreConfig {
   backend: TripleStoreBackend;
   options?: Record<string, unknown>;
   largeLiteralStorage?: LargeLiteralStorageConfig;
+  graphSetIndex?: boolean | GraphSetIndexStoreOptions;
 }
 
 type AdapterFactory = (
@@ -186,8 +192,34 @@ export async function createTripleStore(
   }
   const store = await factory(config.options);
   const largeLiteralStorage = resolveLargeLiteralStorageOptions(config);
-  if (!largeLiteralStorage) return store;
-  return new SharedMemoryLiteralBlobStore(store, largeLiteralStorage);
+  const withLargeLiteralStorage = largeLiteralStorage
+    ? new SharedMemoryLiteralBlobStore(store, largeLiteralStorage)
+    : store;
+  return wrapGraphSetIndex(withLargeLiteralStorage, config);
+}
+
+function wrapGraphSetIndex(
+  store: TripleStore,
+  config: TripleStoreConfig,
+): TripleStore {
+  const graphSetIndex = config.graphSetIndex;
+  if (graphSetIndex === false) return store;
+  if (typeof graphSetIndex === 'object' && graphSetIndex.enabled === false) return store;
+  if (!shouldEnableGraphSetIndex(config)) return store;
+  const options = typeof graphSetIndex === 'object' ? graphSetIndex : undefined;
+  return new GraphSetIndexStore(store, options);
+}
+
+function shouldEnableGraphSetIndex(config: TripleStoreConfig): boolean {
+  if (config.graphSetIndex === true || typeof config.graphSetIndex === 'object') return true;
+  if (isDefaultLocalGraphSetIndexBackend(config.backend)) return true;
+  return config.options?.managedByDkg === true;
+}
+
+function isDefaultLocalGraphSetIndexBackend(backend: TripleStoreBackend): boolean {
+  return backend === 'oxigraph'
+    || backend === 'oxigraph-persistent'
+    || backend === 'oxigraph-worker';
 }
 
 function resolveLargeLiteralStorageOptions(

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -194,7 +194,7 @@ export async function createTripleStore(
         `Registered: [${[...adapterRegistry.keys()].join(', ')}]`,
     );
   }
-  const store = await factory(config.options);
+  const store = await factory(resolveAdapterOptions(config));
   const largeLiteralStorage = resolveLargeLiteralStorageOptions(config);
   const withLargeLiteralStorage = largeLiteralStorage
     ? new SharedMemoryLiteralBlobStore(store, largeLiteralStorage)
@@ -202,16 +202,34 @@ export async function createTripleStore(
   return wrapGraphSetIndex(withLargeLiteralStorage, config);
 }
 
+function resolveAdapterOptions(config: TripleStoreConfig): Record<string, unknown> | undefined {
+  if (
+    config.backend !== 'sparql-http' ||
+    config.options?.managedByDkg !== true ||
+    isGraphSetIndexExplicitlyDisabled(config.graphSetIndex) ||
+    !shouldEnableGraphSetIndex(config)
+  ) {
+    return config.options;
+  }
+  return { ...config.options, managedByDkg: false };
+}
+
 function wrapGraphSetIndex(
   store: TripleStore,
   config: TripleStoreConfig,
 ): TripleStore {
   const graphSetIndex = config.graphSetIndex;
-  if (graphSetIndex === false) return store;
-  if (typeof graphSetIndex === 'object' && graphSetIndex.enabled === false) return store;
+  if (isGraphSetIndexExplicitlyDisabled(graphSetIndex)) return store;
   if (!shouldEnableGraphSetIndex(config)) return store;
   const options = typeof graphSetIndex === 'object' ? graphSetIndex : undefined;
   return new GraphSetIndexStore(store, options);
+}
+
+function isGraphSetIndexExplicitlyDisabled(
+  graphSetIndex: TripleStoreConfig['graphSetIndex'],
+): boolean {
+  return graphSetIndex === false ||
+    (typeof graphSetIndex === 'object' && graphSetIndex.enabled === false);
 }
 
 function shouldEnableGraphSetIndex(config: TripleStoreConfig): boolean {

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -40,6 +40,8 @@ export type QueryResult = SelectResult | ConstructResult | AskResult;
 export type QueryCancellationMode = 'interruptible' | 'pre-dispatch';
 
 export interface QueryOptions {
+  /** Human-readable caller tag used by adapters for diagnostics/telemetry. */
+  source?: string;
   /**
    * Best-effort caller cancellation. Async backends should reject promptly when
    * aborted; synchronous embedded backends may only observe the signal before
@@ -47,6 +49,8 @@ export interface QueryOptions {
    */
   signal?: AbortSignal;
 }
+
+export type TripleStoreQueryOptions = QueryOptions;
 
 export interface TripleStore {
   /**

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -1,0 +1,312 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  GraphSetIndexStore,
+  OxigraphStore,
+  createTripleStore,
+  registerTripleStoreAdapter,
+  type Quad,
+  type QueryResult,
+  type TripleStore,
+} from '../src/index.js';
+
+function q(graph: string, subject = 'urn:s'): Quad {
+  return {
+    subject,
+    predicate: 'urn:p',
+    object: '"v"',
+    graph,
+  };
+}
+
+class CountingStore implements TripleStore {
+  listGraphsCalls = 0;
+  listGraphsGate: Promise<void> | null = null;
+  failListGraphs = false;
+
+  constructor(protected readonly inner: TripleStore) {}
+
+  insert(quads: Quad[]): Promise<void> { return this.inner.insert(quads); }
+  delete(quads: Quad[]): Promise<void> { return this.inner.delete(quads); }
+  deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.inner.deleteByPattern(pattern); }
+  query(sparql: string): Promise<QueryResult> { return this.inner.query(sparql); }
+  hasGraph(graphUri: string): Promise<boolean> { return this.inner.hasGraph(graphUri); }
+  createGraph(graphUri: string): Promise<void> { return this.inner.createGraph(graphUri); }
+  dropGraph(graphUri: string): Promise<void> { return this.inner.dropGraph(graphUri); }
+  deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {
+    return this.inner.deleteBySubjectPrefix(graphUri, prefix);
+  }
+  countQuads(graphUri?: string): Promise<number> { return this.inner.countQuads(graphUri); }
+  flush(): Promise<void> { return this.inner.flush?.() ?? Promise.resolve(); }
+  close(): Promise<void> { return this.inner.close(); }
+
+  async listGraphs(): Promise<string[]> {
+    this.listGraphsCalls++;
+    if (this.listGraphsGate) await this.listGraphsGate;
+    if (this.failListGraphs) throw new Error('listGraphs failed');
+    return this.inner.listGraphs();
+  }
+}
+
+class FailingMaintenanceStore extends CountingStore {
+  failHasGraph = false;
+
+  async hasGraph(graphUri: string): Promise<boolean> {
+    if (this.failHasGraph) throw new Error('hasGraph failed');
+    return super.hasGraph(graphUri);
+  }
+}
+
+class MutatingQueryStore extends CountingStore {
+  async query(sparql: string): Promise<QueryResult> {
+    if (/^\s*(?:#[^\r\n]*(?:\r?\n|$)\s*)*INSERT\s+DATA\b/i.test(sparql)) {
+      await this.inner.insert([q('did:dkg:context-graph:query-created')]);
+      return { type: 'bindings', bindings: [] };
+    }
+    return this.inner.query(sparql);
+  }
+}
+
+describe('GraphSetIndexStore', () => {
+  it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([
+      q('did:dkg:context-graph:alpha'),
+      q('did:dkg:context-graph:beta'),
+    ]);
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting);
+
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:a')).resolves.toEqual([
+      'did:dkg:context-graph:alpha',
+    ]);
+    await expect(store.listGraphs()).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:alpha', 'did:dkg:context-graph:beta']),
+    );
+    expect(counting.listGraphsCalls).toBe(1);
+  });
+
+  it('maintains the graph set through local insert/delete/drop/deleteBySubjectPrefix mutators', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    const graph = 'did:dkg:context-graph:mutators';
+    const root = 'urn:root';
+    const child = `${root}/.well-known/genid/1`;
+    await store.insert([q(graph, root), q(graph, child)]);
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:mut')).resolves.toEqual([graph]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.delete([q(graph, child)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    await store.deleteBySubjectPrefix(graph, root);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.insert([q(graph)]);
+    await store.dropGraph(graph);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('refreshes the full index after graph-wide deleteByPattern without a graph constraint', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await store.insert([q('did:dkg:context-graph:one'), q('did:dkg:context-graph:two')]);
+    await expect(store.listGraphs()).resolves.toHaveLength(2);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.deleteByPattern({ predicate: 'urn:p' });
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('revalidates after the configured interval to discover out-of-contract writers', async () => {
+    let now = 1_000;
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 100, now: () => now });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:external')]);
+
+    now += 99;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    now += 1;
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:external']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('treats revalidateMs 0 as always expired', async () => {
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const store = new GraphSetIndexStore(counting, { revalidateMs: 0 });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    await inner.insert([q('did:dkg:context-graph:zero-revalidate')]);
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:zero-revalidate']);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('coalesces concurrent refresh callers onto one listGraphs scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:coalesced')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const calls = Promise.all([
+      store.listGraphs(),
+      store.listGraphsByPrefix('did:dkg:context-graph:'),
+      store.listGraphs(),
+    ]);
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+    counting.listGraphsGate = null;
+    release();
+
+    const [a, b, c] = await calls;
+    expect(a).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(b).toEqual(['did:dkg:context-graph:coalesced']);
+    expect(c).toEqual(['did:dkg:context-graph:coalesced']);
+  });
+
+  it('restarts an in-flight refresh when a local write lands during the scan', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:before')]);
+    const counting = new CountingStore(inner);
+    let release!: () => void;
+    counting.listGraphsGate = new Promise<void>((resolve) => { release = resolve; });
+    const store = new GraphSetIndexStore(counting);
+
+    const listed = store.listGraphs();
+    await Promise.resolve();
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.insert([q('did:dkg:context-graph:after')]);
+    counting.listGraphsGate = null;
+    release();
+
+    await expect(listed).resolves.toEqual(
+      expect.arrayContaining(['did:dkg:context-graph:before', 'did:dkg:context-graph:after']),
+    );
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
+  it('refreshes after successful mutating SPARQL passed through query()', async () => {
+    const counting = new MutatingQueryStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await expect(store.listGraphs()).resolves.toEqual([]);
+
+    await store.query('# cleanup\nINSERT DATA { GRAPH <ignored> { <urn:s> <urn:p> "v" } }');
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:query-created']);
+  });
+
+  it('does not let observer failures reject committed writes', async () => {
+    const store = new GraphSetIndexStore(new CountingStore(new OxigraphStore()), {
+      onMutation: () => {
+        throw new Error('observer failed');
+      },
+    });
+    await store.listGraphs();
+
+    await expect(store.insert([q('did:dkg:context-graph:observer')])).resolves.toBeUndefined();
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:observer']);
+  });
+
+  it('clears the index instead of rejecting after post-commit maintenance failures', async () => {
+    const graph = 'did:dkg:context-graph:maintenance-failure';
+    const failing = new FailingMaintenanceStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failHasGraph = true;
+    await expect(store.delete([q(graph)])).resolves.toBeUndefined();
+
+    failing.failHasGraph = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('clears the index instead of rejecting after post-commit full refresh failures', async () => {
+    const graph = 'did:dkg:context-graph:refresh-failure';
+    const failing = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(failing);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    failing.failListGraphs = true;
+    await expect(store.deleteByPattern({ predicate: 'urn:p' })).resolves.toBe(1);
+
+    failing.failListGraphs = false;
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('createTripleStore wraps local and managed stores by default, composes outside large-literal storage, and can be disabled', async () => {
+    const defaultStore = await createTripleStore({ backend: 'oxigraph' });
+    expect(typeof defaultStore.listGraphsByPrefix).toBe('function');
+    await defaultStore.close();
+
+    const disabledStore = await createTripleStore({ backend: 'oxigraph', graphSetIndex: false });
+    expect(disabledStore.listGraphsByPrefix).toBeUndefined();
+    await disabledStore.close();
+
+    const blobDir = await mkdtemp(join(tmpdir(), 'dkg-graph-set-index-'));
+    try {
+      const composedStore = await createTripleStore({
+        backend: 'oxigraph',
+        largeLiteralStorage: { directory: blobDir, thresholdBytes: 1 },
+      });
+      expect(typeof composedStore.listGraphsByPrefix).toBe('function');
+      await composedStore.insert([q('did:dkg:context-graph:composed')]);
+      await expect(composedStore.listGraphsByPrefix!('did:dkg:context-graph:comp')).resolves.toEqual([
+        'did:dkg:context-graph:composed',
+      ]);
+      await composedStore.close();
+    } finally {
+      await rm(blobDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves operator-managed external stores uncached unless explicitly enabled', async () => {
+    const operatorStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+    });
+    expect(operatorStore.listGraphsByPrefix).toBeUndefined();
+    await operatorStore.close();
+
+    const managedStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query', managedByDkg: true },
+    });
+    expect(typeof managedStore.listGraphsByPrefix).toBe('function');
+    await managedStore.close();
+
+    const optedInStore = await createTripleStore({
+      backend: 'sparql-http',
+      options: { queryEndpoint: 'http://example.invalid/query' },
+      graphSetIndex: { revalidateMs: 0 },
+    });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+
+  it('leaves custom backends uncached unless explicitly enabled', async () => {
+    const backend = 'custom-remote-graph-set-index-test';
+    registerTripleStoreAdapter(backend, async () => new OxigraphStore());
+
+    const defaultStore = await createTripleStore({ backend });
+    expect(defaultStore.listGraphsByPrefix).toBeUndefined();
+    await defaultStore.close();
+
+    const optedInStore = await createTripleStore({ backend, graphSetIndex: true });
+    expect(typeof optedInStore.listGraphsByPrefix).toBe('function');
+    await optedInStore.close();
+  });
+});

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -88,6 +88,26 @@ describe('GraphSetIndexStore', () => {
     expect(counting.listGraphsCalls).toBe(1);
   });
 
+  it('honors enabled false for direct callers by passing graph reads through', async () => {
+    const inner = new OxigraphStore();
+    const counting = new CountingStore(inner);
+    const events: unknown[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      enabled: false,
+      onMutation: (event) => events.push(event),
+    });
+
+    await store.insert([q('did:dkg:context-graph:disabled')]);
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:dis')).resolves.toEqual([
+      'did:dkg:context-graph:disabled',
+    ]);
+    await expect(store.listGraphsByPrefix('did:dkg:context-graph:dis')).resolves.toEqual([
+      'did:dkg:context-graph:disabled',
+    ]);
+    expect(counting.listGraphsCalls).toBe(2);
+    expect(events).toEqual([]);
+  });
+
   it('maintains the graph set through local insert/delete/drop/deleteBySubjectPrefix mutators', async () => {
     const counting = new CountingStore(new OxigraphStore());
     const store = new GraphSetIndexStore(counting);

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1,7 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { SparqlHttpStore, createTripleStore, type Quad } from '../src/index.js';
-import { LIST_GRAPHS_CACHE_TTL_MS } from '../src/adapters/sparql-http.js';
 
 let server: Server;
 let queryUrl: string;
@@ -9,8 +8,6 @@ let updateUrl: string;
 const insertedQuads: string[] = [];
 /** How many times the server received the `SELECT DISTINCT ?g` listGraphs scan. */
 let listGraphsHits = 0;
-/** When set, the server holds every listGraphs response until this resolves. */
-let listGraphsGate: Promise<void> | null = null;
 
 function startTestServer(): Promise<void> {
   return new Promise((resolve) => {
@@ -48,9 +45,7 @@ function startTestServer(): Promise<void> {
                 results: { bindings: [{ g: { type: 'uri', value: 'http://ex.org/g1' } }] },
               }));
             };
-            // Optionally hold the response so a test can keep a scan in flight.
-            if (listGraphsGate) void listGraphsGate.then(respond);
-            else respond();
+            respond();
             return;
           }
           res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
@@ -263,150 +258,19 @@ describe('SparqlHttpStore (test server)', () => {
     expect(result.type).toBe('bindings');
   });
 
-  // R6-A: on a daemon-owned (managed) endpoint, listGraphs() is served from an
-  // in-memory cache invalidated on writes — eliminating the data-proportional
-  // `SELECT DISTINCT ?g` full scan that the 30s host-mode reconcile (and
-  // on-demand CG enumeration) would otherwise re-run every cycle on an idle,
-  // data-rich node. External (non-managed) endpoints must NOT cache, since an
-  // outside writer could add a graph we never see.
-  describe('listGraphs() cache (R6-A)', () => {
-    const managedStore = () =>
-      new SparqlHttpStore({ queryEndpoint: queryUrl, updateEndpoint: updateUrl, managedByDkg: true });
-    const g = (graph: string) =>
-      [{ subject: 'http://ex.org/s', predicate: 'http://ex.org/p', object: '"v"', graph }];
-
-    it('managed endpoint serves repeated listGraphs() from cache (one scan)', async () => {
+  describe('listGraphs()', () => {
+    it('scans directly even when managedByDkg is set; GraphSetIndexStore owns caching', async () => {
       listGraphsHits = 0;
-      const store = managedStore();
-      const a = await store.listGraphs();
-      const b = await store.listGraphs();
-      expect(a).toContain('http://ex.org/g1');
-      expect(b).toContain('http://ex.org/g1');
-      expect(listGraphsHits).toBe(1); // second call hit the cache, not the server
-    });
-
-    it.each(['insert', 'delete', 'deleteByPattern', 'dropGraph', 'deleteBySubjectPrefix'] as const)(
-      'invalidates the cache on %s so the next listGraphs() re-scans',
-      async (method) => {
-        listGraphsHits = 0;
-        const store = managedStore();
-        await store.listGraphs();
-        await store.listGraphs();
-        expect(listGraphsHits).toBe(1); // warm
-
-        switch (method) {
-          case 'insert': await store.insert(g('http://ex.org/g2')); break;
-          case 'delete': await store.delete(g('http://ex.org/g')); break;
-          case 'deleteByPattern': await store.deleteByPattern({ graph: 'http://ex.org/g' }); break;
-          case 'dropGraph': await store.dropGraph('http://ex.org/g'); break;
-          case 'deleteBySubjectPrefix': await store.deleteBySubjectPrefix('http://ex.org/g', 'http://ex.org/'); break;
-        }
-
-        await store.listGraphs();
-        expect(listGraphsHits).toBe(2); // write invalidated the cache
-      },
-    );
-
-    it('does NOT cache for a non-managed (external) endpoint', async () => {
-      listGraphsHits = 0;
-      const store = new SparqlHttpStore({ queryEndpoint: queryUrl, updateEndpoint: updateUrl });
-      await store.listGraphs();
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(2); // every call queries the server
-    });
-
-    it('re-scans after the cache TTL expires, so a store outage cannot be masked forever', async () => {
-      listGraphsHits = 0;
-      let clock = 1_000_000;
       const store = new SparqlHttpStore({
         queryEndpoint: queryUrl,
         updateEndpoint: updateUrl,
         managedByDkg: true,
-        now: () => clock,
       });
-      await store.listGraphs();
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(1); // within TTL: served from cache
-
-      clock += LIST_GRAPHS_CACHE_TTL_MS + 1; // advance past the TTL
-      await store.listGraphs();
-      expect(listGraphsHits).toBe(2); // expired: re-validated against the store
-    });
-
-    it('coalesces concurrent cold-cache callers onto a single scan', async () => {
-      // Without in-flight coalescing, simultaneous callers (reconcile + metrics
-      // CG-count + status) on a cold/expired cache each issue their own
-      // `SELECT DISTINCT ?g` — duplicate full scans, the load this fix removes.
-      listGraphsHits = 0;
-      const store = managedStore();
-      const [a, b, c] = await Promise.all([
-        store.listGraphs(),
-        store.listGraphs(),
-        store.listGraphs(),
-      ]);
+      const a = await store.listGraphs();
+      const b = await store.listGraphs();
       expect(a).toContain('http://ex.org/g1');
       expect(b).toContain('http://ex.org/g1');
-      expect(c).toContain('http://ex.org/g1');
-      expect(listGraphsHits).toBe(1); // all three shared one in-flight scan
-    });
-
-    it('lets aborted callers detach without cancelling the shared managed scan', async () => {
-      listGraphsHits = 0;
-      let release!: () => void;
-      listGraphsGate = new Promise<void>((r) => { release = r; });
-      const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-      const store = managedStore();
-      const firstController = new AbortController();
-      try {
-        const first = store.listGraphs({ signal: firstController.signal });
-        await delay(30);
-        expect(listGraphsHits).toBe(1);
-
-        firstController.abort(new Error('first caller left'));
-        await expect(first).rejects.toThrow(/first caller left/);
-
-        const second = store.listGraphs();
-        await delay(30);
-        expect(listGraphsHits).toBe(1);
-
-        release();
-        await expect(second).resolves.toContain('http://ex.org/g1');
-      } finally {
-        listGraphsGate = null;
-      }
-    });
-
-    it('a write during an in-flight scan forces the next caller to re-scan, not join stale work', async () => {
-      // Read-your-writes: if a scan is in flight and a write invalidates the
-      // cache before it resolves, a caller arriving after the write must start
-      // a fresh scan rather than join the pre-write in-flight one.
-      listGraphsHits = 0;
-      let release!: () => void;
-      listGraphsGate = new Promise<void>((r) => { release = r; });
-      const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-      const store = managedStore();
-      try {
-        const p1 = store.listGraphs();             // caller 1: scan in flight (held by gate)
-        await delay(30);                           // request reaches the server (hits=1)
-        await store.insert(g('http://ex.org/g2')); // write invalidates the cache (gen bump)
-        const p2 = store.listGraphs();             // caller 2: must NOT join the pre-write scan
-        await delay(30);                           // caller 2 issues its own request (hits=2)
-        release();
-        await Promise.all([p1, p2]);
-        expect(listGraphsHits).toBe(2);            // post-write caller ran a fresh scan
-      } finally {
-        listGraphsGate = null;
-      }
-    });
-
-    it('returns a defensive copy that cannot mutate the cached set', async () => {
-      listGraphsHits = 0;
-      const store = managedStore();
-      const first = await store.listGraphs();
-      first.push('http://ex.org/injected');
-      const second = await store.listGraphs();
-      expect(second).not.toContain('http://ex.org/injected');
-      expect(listGraphsHits).toBe(1); // second served from cache, copy was independent
+      expect(listGraphsHits).toBe(2);
     });
   });
 });

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -381,6 +381,55 @@ describe('SparqlHttpStore (test server)', () => {
       expect(listGraphsHits).toBe(2);
     });
 
+    it('does not let one aborted managed listGraphs caller poison the shared refresh', async () => {
+      const originalFetch = globalThis.fetch;
+      let fetchStarted!: () => void;
+      let resolveFetch!: (response: Response) => void;
+      let rejectFetch!: (reason?: unknown) => void;
+      const started = new Promise<void>((resolve) => {
+        fetchStarted = resolve;
+      });
+      const pendingFetch = new Promise<Response>((resolve, reject) => {
+        resolveFetch = resolve;
+        rejectFetch = reject;
+      });
+      globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+        fetchStarted();
+        init?.signal?.addEventListener('abort', () => {
+          // If the shared refresh is incorrectly wired to the first caller's
+          // signal, this makes the second caller observe the poisoned promise.
+          rejectFetch(init.signal?.reason);
+        }, { once: true });
+        return pendingFetch;
+      }) as typeof fetch;
+      try {
+        const store = new SparqlHttpStore({
+          queryEndpoint: 'http://example.test/query',
+          managedByDkg: true,
+          timeout: 30_000,
+        });
+        const firstCaller = new AbortController();
+        const first = store.listGraphs({ signal: firstCaller.signal });
+        await started;
+
+        firstCaller.abort(new Error('first caller aborted'));
+        await expect(first).rejects.toThrow(/first caller aborted/);
+
+        const second = store.listGraphs();
+        resolveFetch(new Response(JSON.stringify({
+          head: { vars: ['g'] },
+          results: { bindings: [{ g: { type: 'uri', value: 'http://ex.org/g1' } }] },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+json' },
+        }));
+
+        await expect(second).resolves.toEqual(['http://ex.org/g1']);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it('uses GraphSetIndexStore as the only cache owner for managed factory stores', async () => {
       listGraphsHits = 0;
       const store = await createTripleStore({

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { SparqlHttpStore, createTripleStore, type Quad } from '../src/index.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { SparqlHttpStore, createTripleStore, type Quad, type SparqlHttpSlowQueryEvent } from '../src/index.js';
 
 let server: Server;
 let queryUrl: string;
@@ -22,7 +22,7 @@ function startTestServer(): Promise<void> {
           res.end();
           return;
         }
-        if (req.url === '/query') {
+        if (req.url?.startsWith('/query')) {
           if (decoded.includes('ASK')) {
             res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
             res.end(JSON.stringify({ boolean: true }));
@@ -164,6 +164,105 @@ describe('SparqlHttpStore (test server)', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('emits sampled slow-query events with source tags and query fingerprints', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const taggedStore = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 10,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = taggedStore.query(
+      'SELECT ?name WHERE { GRAPH <http://ex.org/g1> { <http://ex.org/alice> <http://schema.org/name> ?name } }',
+      { source: 'unit test/source' },
+    );
+    clock = 25;
+    await pending;
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      source: 'unit_test/source',
+      operation: 'select',
+      elapsedMs: 25,
+      thresholdMs: 10,
+      endpoint: queryUrl,
+    });
+    expect(events[0].queryHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].queryBytes).toBeGreaterThan(0);
+    expect(events[0]).not.toHaveProperty('sparql');
+  });
+
+  it('honors slow-query sample rate zero', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const sampledOutStore = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      slowQuerySampleRate: 0,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = sampledOutStore.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+      source: 'sampled-out',
+    });
+    clock = 50;
+    await pending;
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not let slow-query hook failures fail the query', async () => {
+    let clock = 0;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = new SparqlHttpStore({
+      queryEndpoint: queryUrl,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      onSlowQuery: () => { throw new Error('sink down'); },
+      now: () => clock,
+    });
+
+    try {
+      const pending = store.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+        source: 'throwing-hook',
+      });
+      clock = 50;
+      const result = await pending;
+      expect(result.type).toBe('boolean');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('slow query hook failed'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('redacts endpoint query strings from slow-query telemetry', async () => {
+    let clock = 0;
+    const events: SparqlHttpSlowQueryEvent[] = [];
+    const store = new SparqlHttpStore({
+      queryEndpoint: `${queryUrl}?token=secret#fragment`,
+      updateEndpoint: updateUrl,
+      slowQueryThresholdMs: 1,
+      onSlowQuery: (event) => events.push(event),
+      now: () => clock,
+    });
+
+    const pending = store.query('ASK { GRAPH <http://ex.org/g> { ?s ?p ?o } }', {
+      source: 'secret-endpoint',
+    });
+    clock = 50;
+    await pending;
+
+    expect(events).toHaveLength(1);
+    expect(events[0].endpoint).toBe(queryUrl);
+    expect(events[0].endpoint).not.toContain('secret');
+    expect(events[0].endpoint).not.toContain('#fragment');
   });
 
   it('query ASK returns boolean', async () => {

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -358,7 +358,7 @@ describe('SparqlHttpStore (test server)', () => {
   });
 
   describe('listGraphs()', () => {
-    it('scans directly even when managedByDkg is set; GraphSetIndexStore owns caching', async () => {
+    it('preserves adapter-local listGraphs caching for direct managedByDkg callers', async () => {
       listGraphsHits = 0;
       const store = new SparqlHttpStore({
         queryEndpoint: queryUrl,
@@ -369,7 +369,41 @@ describe('SparqlHttpStore (test server)', () => {
       const b = await store.listGraphs();
       expect(a).toContain('http://ex.org/g1');
       expect(b).toContain('http://ex.org/g1');
+      expect(listGraphsHits).toBe(1);
+
+      await store.insert([{
+        subject: 'http://ex.org/s',
+        predicate: 'http://ex.org/p',
+        object: '"v"',
+        graph: 'http://ex.org/g2',
+      }]);
+      await expect(store.listGraphs()).resolves.toContain('http://ex.org/g1');
       expect(listGraphsHits).toBe(2);
+    });
+
+    it('uses GraphSetIndexStore as the only cache owner for managed factory stores', async () => {
+      listGraphsHits = 0;
+      const store = await createTripleStore({
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: queryUrl,
+          updateEndpoint: updateUrl,
+          managedByDkg: true,
+        },
+        graphSetIndex: { revalidateMs: 0 },
+      });
+      try {
+        expect(typeof store.listGraphsByPrefix).toBe('function');
+        await expect(store.listGraphsByPrefix!('http://ex.org/')).resolves.toEqual([
+          'http://ex.org/g1',
+        ]);
+        await expect(store.listGraphsByPrefix!('http://ex.org/')).resolves.toEqual([
+          'http://ex.org/g1',
+        ]);
+        expect(listGraphsHits).toBe(2);
+      } finally {
+        await store.close();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds the C1 `GraphSetIndexStore` storage decorator so graph-family enumeration resolves through one write-through graph-set index with revalidation for out-of-contract writers.
- Adds the C2/C3 `ContextGraphMetaProjection` and optional projection-backed `listContextGraphs` path while preserving the A/B gate security semantics: AGENTS declarations, degrade-closed unknown policies, revocation filtering, and exact preflight behavior.
- Adds C4 host-mode sweep bounds/cursor/jitter plus SPARQL HTTP query-source tagging and sampled slow-query telemetry. `SparqlHttpStore.listGraphs()` remains a direct scan; `GraphSetIndexStore` is the single graph-list cache/index owner.

## Related

- Part of #1138 Track C; structural follow-up after A/B landed on `main`.
- Supersedes the older split Track C draft PRs #1150, #1151, #1152, and #1153, which were authored against pre-gate code and target the old integration flow.
- Addresses the residual scan/idle-CPU growth-proofing from #1066 via indexed resolve-by-key graph enumeration and source-tag observability.

## Files changed

| Area | What |
| --- | --- |
| `packages/storage` | `GraphSetIndexStore`, `listGraphsByPrefix`, query `source` tags, SPARQL slow-query telemetry |
| `packages/agent` | Context graph metadata projection, projection-backed list mode, policy/membership read path wiring, host-mode bounded sweep |
| `packages/publisher` integration paths | Preserved oracle/gate behavior through projection-backed reads |
| `packages/cli` guardrails | Existing write-path preflight behavior verified against Track C changes |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-storage build`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg-storage exec vitest run test/graph-set-index-store.test.ts test/sparql-http.test.ts --reporter verbose` (35 tests)
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/context-graph-discovery.test.ts test/context-graph-meta-projection.test.ts test/swm/host-mode-key-canonicalization.test.ts --reporter verbose` (86 tests)
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/workspace-agent-recipients.test.ts test/workspace-handler-agent-gate.test.ts --reporter verbose` (37 tests)
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/context-graph-write-path-validation.test.ts --reporter verbose` (39 tests; after building CLI import dependencies)
- [x] `pnpm --filter @origintrail-official/dkg-agent... build`
