### PR TITLE
Reduce edge agents metadata sync load

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2795,6 +2795,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphIds,
       onPhase,
       onAccessDenied,
+      syncAgentsMeta: this.config.nodeRole === 'core' ? true : this.config.syncAgentsMeta,
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
       sinceBatchIdFor,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -807,6 +807,13 @@ export interface DKGAgentConfig {
   sharedMemoryPublicSnapshotStorage?: SharedMemoryPublicSnapshotStorageConfig;
   /** When false, peer-connect sync skips SWM catch-up and relies on gossip for new SWM writes. */
   syncSharedMemoryOnConnect?: boolean;
+  /**
+   * When false, durable sync skips the large system `agents/_meta` graph while
+   * still syncing `agents` data as the phonebook. Defaults to true for
+   * compatibility; only honored for edge nodes that do not need full KA/KC
+   * lifecycle metadata for the system agents graph. Core nodes always sync it.
+   */
+  syncAgentsMeta?: boolean;
   /** Node deployment tier: 'core' (cloud, relay) or 'edge' (personal, behind NAT). Default: 'edge'. */
   nodeRole?: 'core' | 'edge';
   /**

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -4,6 +4,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { PhaseCallback } from '@origintrail-official/dkg-publisher';
 import { didSyncPeerRespond, isSyncTransportFailure } from '../error-tags.js';
+import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 
 export interface DurableSyncSummary {
@@ -40,6 +41,7 @@ interface DurableSyncContext {
    * but have very different operator meanings.
    */
   onAccessDenied?: (contextGraphId: string) => void;
+  syncAgentsMeta?: boolean;
   createContextGraphSyncDeadline: (remainingContextGraphs: number) => number;
   fetchSyncPages: (
     ctx: OperationContext,
@@ -84,6 +86,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     contextGraphIds,
     onPhase,
     onAccessDenied,
+    syncAgentsMeta = true,
     createContextGraphSyncDeadline,
     fetchSyncPages,
     sinceBatchIdFor,
@@ -158,8 +161,22 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
 
       startPhase('fetch');
       const fetchStartedAt = Date.now();
-      const metaResult = await fetchSyncPages(ctx, remotePeerId, pid, false, 'meta', metaGraph, deadline);
-      peerRespondedForContextGraph = true;
+      const skipAgentsMeta = pid === SYSTEM_CONTEXT_GRAPHS.AGENTS && syncAgentsMeta === false;
+      if (skipAgentsMeta) {
+        logInfo(ctx, `Skipping agents meta sync from ${remotePeerId} (syncAgentsMeta=false)`);
+      }
+      const metaResult: SyncPageResult = skipAgentsMeta
+        ? {
+            quads: [],
+            bytesReceived: 0,
+            resumedFromOffset: 0,
+            nextOffset: 0,
+            checkpointKey: getSyncCheckpointKey(remotePeerId, pid, false, 'meta'),
+            completed: true,
+            timedOut: false,
+          }
+        : await fetchSyncPages(ctx, remotePeerId, pid, false, 'meta', metaGraph, deadline);
+      if (!skipAgentsMeta) peerRespondedForContextGraph = true;
       const dataResult = await fetchSyncPages(ctx, remotePeerId, pid, false, 'data', dataGraph, deadline, undefined, sinceBatchIdFor?.(pid));
       peerRespondedForContextGraph = true;
       endPhase();

--- a/packages/agent/test/durable-sync-since-threading.test.ts
+++ b/packages/agent/test/durable-sync-since-threading.test.ts
@@ -1,59 +1,84 @@
 import { describe, it, expect } from 'vitest';
-import { createOperationContext } from '@origintrail-official/dkg-core';
+import { createOperationContext, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import { runDurableSync } from '../src/sync/requester/durable-sync.js';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
 
 interface FetchCall {
+  contextGraphId: string;
   phase: string;
+  graphUri: string;
   snapshotRef: string | undefined;
   sinceBatchId: string | undefined;
 }
 
-function makeContext(sinceBatchIdFor?: (cg: string) => string | undefined) {
+function makeContext(options: {
+  sinceBatchIdFor?: (cg: string) => string | undefined;
+  contextGraphIds?: string[];
+  syncAgentsMeta?: boolean;
+  processResult?: {
+    verifiedData?: Quad[];
+    verifiedMeta?: Quad[];
+    totalFetchedDataQuads?: number;
+    totalFetchedMetaQuads?: number;
+  };
+} = {}) {
   const calls: FetchCall[] = [];
+  const processCalls: Array<{ dataCount: number; metaCount: number; acceptUnverified: boolean }> = [];
+  const insertedBatches: Quad[][] = [];
+  const deletedCheckpoints: string[] = [];
   const page = (phase: 'data' | 'meta'): SyncPageResult => ({
-    quads: [],
-    bytesReceived: 0,
+    quads: phase === 'data' ? ([{ id: 'data' }] as never[]) : ([{ id: 'meta' }] as never[]),
+    bytesReceived: phase === 'data' ? 20 : 10,
     resumedFromOffset: 0,
-    nextOffset: 0,
+    nextOffset: phase === 'data' ? 1 : 2,
     checkpointKey: `cp|${phase}`,
     completed: true,
     timedOut: false,
   });
+  const verifiedData = options.processResult?.verifiedData ?? [];
+  const verifiedMeta = options.processResult?.verifiedMeta ?? [];
   return {
     calls,
+    processCalls,
+    insertedBatches,
+    deletedCheckpoints,
     context: {
       ctx: createOperationContext('sync'),
       remotePeerId: 'peerR',
-      contextGraphIds: ['mfacts'],
+      contextGraphIds: options.contextGraphIds ?? ['mfacts'],
+      syncAgentsMeta: options.syncAgentsMeta,
       createContextGraphSyncDeadline: () => Date.now() + 10_000,
       fetchSyncPages: async (
         _ctx: unknown,
         _peer: string,
-        _cg: string,
+        contextGraphId: string,
         _swm: boolean,
         phase: 'data' | 'meta',
-        _graphUri: string,
+        graphUri: string,
         _deadline: number,
         snapshotRef?: string,
         sinceBatchId?: string,
       ) => {
-        calls.push({ phase, snapshotRef, sinceBatchId });
+        calls.push({ contextGraphId, phase, graphUri, snapshotRef, sinceBatchId });
         return page(phase);
       },
-      sinceBatchIdFor,
-      processDurableBatchInWorker: async () => ({
-        verifiedData: [],
-        verifiedMeta: [],
-        totalFetchedDataQuads: 0,
-        totalFetchedMetaQuads: 0,
-        rejectedKcs: 0,
-        emptyResponses: 0,
-        metaOnlyResponses: 0,
-        dataRejectedMissingMeta: 0,
-      }),
-      storeInsert: async () => undefined,
-      deleteCheckpoint: () => undefined,
+      sinceBatchIdFor: options.sinceBatchIdFor,
+      processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[], _ctx: unknown, acceptUnverified: boolean) => {
+        processCalls.push({ dataCount: dataQuads.length, metaCount: metaQuads.length, acceptUnverified });
+        return {
+          verifiedData,
+          verifiedMeta,
+          totalFetchedDataQuads: options.processResult?.totalFetchedDataQuads ?? dataQuads.length,
+          totalFetchedMetaQuads: options.processResult?.totalFetchedMetaQuads ?? metaQuads.length,
+          rejectedKcs: 0,
+          emptyResponses: 0,
+          metaOnlyResponses: 0,
+          dataRejectedMissingMeta: 0,
+        };
+      },
+      storeInsert: async (quads: Quad[]) => { insertedBatches.push(quads); },
+      deleteCheckpoint: (key: string) => { deletedCheckpoints.push(key); },
       setCheckpoint: () => undefined,
       logInfo: () => undefined,
       logWarn: () => undefined,
@@ -64,7 +89,7 @@ function makeContext(sinceBatchIdFor?: (cg: string) => string | undefined) {
 
 describe('runDurableSync sinceBatchId threading', () => {
   it('passes sinceBatchIdFor() to the DATA fetch only, not the META fetch', async () => {
-    const { calls, context } = makeContext(() => '7');
+    const { calls, context } = makeContext({ sinceBatchIdFor: () => '7' });
     await runDurableSync(context);
 
     const meta = calls.find((c) => c.phase === 'meta')!;
@@ -75,16 +100,92 @@ describe('runDurableSync sinceBatchId threading', () => {
   });
 
   it('passes undefined when no high-water mark resolver is wired', async () => {
-    const { calls, context } = makeContext(undefined);
+    const { calls, context } = makeContext();
     await runDurableSync(context);
     const data = calls.find((c) => c.phase === 'data')!;
     expect(data.sinceBatchId).toBeUndefined();
   });
 
   it('passes undefined when the resolver returns undefined for the CG', async () => {
-    const { calls, context } = makeContext(() => undefined);
+    const { calls, context } = makeContext({ sinceBatchIdFor: () => undefined });
     await runDurableSync(context);
     const data = calls.find((c) => c.phase === 'data')!;
     expect(data.sinceBatchId).toBeUndefined();
+  });
+});
+
+describe('runDurableSync agents meta routing', () => {
+  it('skips agents meta when syncAgentsMeta=false but still fetches and inserts agents data', async () => {
+    const { calls, context, processCalls, insertedBatches, deletedCheckpoints } = makeContext({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.AGENTS],
+      syncAgentsMeta: false,
+      processResult: {
+        verifiedData: [{ id: 'verified-data' } as never],
+        totalFetchedDataQuads: 1,
+        totalFetchedMetaQuads: 0,
+      },
+    });
+
+    await runDurableSync(context);
+
+    expect(calls.map((c) => c.phase)).toEqual(['data']);
+    expect(calls[0]).toMatchObject({
+      contextGraphId: SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      phase: 'data',
+    });
+    expect(calls[0].graphUri).toBe('did:dkg:context-graph:agents');
+    expect(processCalls).toEqual([{ dataCount: 1, metaCount: 0, acceptUnverified: true }]);
+    expect(insertedBatches).toEqual([[{ id: 'verified-data' }]]);
+    expect(deletedCheckpoints).toContain(`peerR|${SYSTEM_CONTEXT_GRAPHS.AGENTS}|durable|meta`);
+  });
+
+  it('fetches agents meta by default', async () => {
+    const { calls, context, processCalls } = makeContext({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.AGENTS],
+    });
+
+    await runDurableSync(context);
+
+    expect(calls.map((c) => c.phase)).toEqual(['meta', 'data']);
+    expect(calls[0]).toMatchObject({
+      contextGraphId: SYSTEM_CONTEXT_GRAPHS.AGENTS,
+      phase: 'meta',
+      graphUri: 'did:dkg:context-graph:agents/_meta',
+    });
+    expect(processCalls).toEqual([{ dataCount: 1, metaCount: 1, acceptUnverified: true }]);
+  });
+
+  it('still fetches metadata for normal context graphs when agents meta sync is disabled', async () => {
+    const { calls, context, processCalls } = makeContext({
+      contextGraphIds: ['normal-cg'],
+      syncAgentsMeta: false,
+    });
+
+    await runDurableSync(context);
+
+    expect(calls.map((c) => c.phase)).toEqual(['meta', 'data']);
+    expect(calls[0]).toMatchObject({
+      contextGraphId: 'normal-cg',
+      phase: 'meta',
+      graphUri: 'did:dkg:context-graph:normal-cg/_meta',
+    });
+    expect(processCalls).toEqual([{ dataCount: 1, metaCount: 1, acceptUnverified: false }]);
+  });
+
+  it('still fetches ontology metadata when agents meta sync is disabled', async () => {
+    const { calls, context, processCalls } = makeContext({
+      contextGraphIds: [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY],
+      syncAgentsMeta: false,
+    });
+
+    await runDurableSync(context);
+
+    expect(calls.map((c) => c.phase)).toEqual(['meta', 'data']);
+    expect(calls[0]).toMatchObject({
+      contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+      phase: 'meta',
+      graphUri: 'did:dkg:context-graph:ontology/_meta',
+    });
+    expect(processCalls).toEqual([{ dataCount: 1, metaCount: 1, acceptUnverified: true }]);
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       'test/swm/host-mode-key-canonicalization.test.ts',
       'test/profile-fix-verify.test.ts',
       'test/sync-verify-collapsed.test.ts',
+      'test/durable-sync-since-threading.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -471,6 +471,13 @@ export interface DkgConfig {
   /** Disable expensive peer-connect SWM catch-up for bulk benchmark/devnet runs. */
   syncSharedMemoryOnConnect?: boolean;
   /**
+   * Keep durable sync of `did:dkg:context-graph:agents/_meta` enabled by
+   * default. Edge-node operators can set this to false to sync the `agents`
+   * phonebook data without pulling the large system KA/KC lifecycle metadata.
+   * Ignored on core nodes, which always sync system graph metadata.
+   */
+  syncAgentsMeta?: boolean;
+  /**
    * Generic local agent integration registry used by node-owned connect/install
    * flows. Framework-specific bridges (OpenClaw now, Hermes next) should store
    * status/capabilities here instead of relying on one-off config flags.

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1247,6 +1247,7 @@ export async function runDaemonInner(
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,
     syncSharedMemoryOnConnect: config.syncSharedMemoryOnConnect,
+    syncAgentsMeta: role === 'core' ? true : config.syncAgentsMeta,
     queryAccess: config.queryAccess,
     chainAdapter: mockChainAdapter,
     // Only forward chain to the agent when both required fields resolved.

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -350,6 +350,20 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.relayReservationCount).toBe(5);
   });
 
+  it('round-trips syncAgentsMeta=false through saveConfig/loadConfig (edge store-load optimization)', async () => {
+    await saveConfig({
+      name: 'test-node',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'edge',
+      syncAgentsMeta: false,
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.nodeRole).toBe('edge');
+    expect(loaded.syncAgentsMeta).toBe(false);
+  });
+
   it('omits relayReservationCount when not set (so DKGNode.start() applies the default)', async () => {
     await saveConfig({
       name: 'test-node',


### PR DESCRIPTION
## Summary

Adds a conservative, config-gated edge-node optimization to skip durable sync of the large system graph metadata graph `did:dkg:context-graph:agents/_meta`, while continuing to sync the `agents` graph itself.

`syncAgentsMeta` defaults to existing behavior. Edge operators can set `syncAgentsMeta: false` to avoid pulling `agents/_meta`; core nodes always sync it.

## Changes

- Added `syncAgentsMeta?: boolean` to CLI and agent config.
- Threaded the setting through daemon agent construction.
- Updated durable sync to skip only `SYSTEM_CONTEXT_GRAPHS.AGENTS` meta when disabled.
- Uses the real durable meta checkpoint key when synthesizing the skipped meta result, so stale checkpoints are cleared correctly.
- Preserves `ontology/_meta` and all normal context graph metadata sync.
- Keeps system graph verification behavior unchanged with `acceptUnverified=true`.

## Tests

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/durable-sync-since-threading.test.ts`
- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/config.test.ts`
- `pnpm run build:runtime:packages`
- `git diff --check`