### PR TITLE
fix lu11 chunked self ack persistence

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2708,6 +2708,27 @@ export class PublishMethods extends DKGAgentBase {
         const payload = new Uint8Array(input.batchId.length + ct.length);
         payload.set(input.batchId, 0);
         payload.set(ct, input.batchId.length);
+        const persistCanonical = this.canonicalChunkStoreCgIdOrNull(contextGraphId);
+        const chunksGraph = ciphertextChunkStoreGraph(persistCanonical ?? contextGraphId);
+        const subject = ciphertextChunkStoreSubject(input.batchId, i);
+        const literal = `"${Buffer.from(ct).toString('base64')}"`;
+        try {
+          await this.store.insert([{
+            subject,
+            predicate: CIPHERTEXT_CHUNK_PREDICATE,
+            object: literal,
+            graph: chunksGraph,
+          }]);
+        } catch (err) {
+          log.warn(
+            ctx,
+            `LU-11: failed to persist local ciphertext chunk cgId=${contextGraphId} ` +
+            `batchId=${batchIdHex.slice(0, 18)}... op=${input.publishOperationId} chunkIndex=${i}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          throw err;
+        }
         const timestamp = new Date().toISOString();
         const signingPayload = computeGossipSigningPayloadV2(
           GOSSIP_TYPE_WORKSPACE_PUBLISH_CHUNKED,

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -7,6 +7,17 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { ethers } from 'ethers';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  ACK_PROTOCOL_VERSION_V2_LU11,
+  ciphertextChunkStoreGraph,
+  ciphertextChunkStoreSubject,
+  CIPHERTEXT_CHUNK_PREDICATE,
+  decodeStorageACK,
+  encodePublishIntent,
+  isStorageACKDecline,
+} from '@origintrail-official/dkg-core';
+import { StorageACKHandler } from '@origintrail-official/dkg-publisher';
 import { DKGAgent } from '../src/dkg-agent.js';
 
 function makeAgentLike(opts: {
@@ -159,6 +170,10 @@ describe('DKGAgent._resolveEncryptInlineChunked nonce domain', () => {
         error: vi.fn(),
         debug: vi.fn(),
       },
+      store: {
+        insert: vi.fn(async () => {}),
+      },
+      canonicalChunkStoreCgIdOrNull: vi.fn((cgId: string) => cgId),
       gossip: {
         publish: vi.fn(async () => {}),
       },
@@ -195,5 +210,98 @@ describe('DKGAgent._resolveEncryptInlineChunked nonce domain', () => {
 
     expect(Buffer.from(first.ciphertextChunksRoot).toString('hex'))
       .not.toBe(Buffer.from(second.ciphertextChunksRoot).toString('hex'));
+  });
+
+  it('persists emitted chunks locally before gossip so local self-ACK does not depend on loopback', async () => {
+    const gossipSigner = ethers.Wallet.createRandom();
+    const ackSigner = ethers.Wallet.createRandom();
+    const store = new OxigraphStore();
+    const insertSpy = vi.spyOn(store, 'insert');
+    const canonicalSwmCgId = '0x0609dca0015B271455C89D37501f530c89814a78';
+    const swmGraphId = `${canonicalSwmCgId}/test-kafka-endpoint-registration`;
+    const targetOnChainCgId = '40';
+    const batchId = ethers.getBytes(ethers.id('lu11-self-ack-batch'));
+
+    const agentLike = {
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      store,
+      canonicalChunkStoreCgIdOrNull: vi.fn((raw: string) => (raw === swmGraphId ? canonicalSwmCgId : null)),
+      gossip: {
+        publish: vi.fn(async () => {}),
+      },
+      gossipWireIdFor: vi.fn((cgId: string) => cgId),
+      _resolveCuratedChainKeyContext: vi.fn(async () => ({
+        chainKey: new Uint8Array(32).fill(7),
+        aeadCgId: targetOnChainCgId,
+      })),
+      resolveWorkspaceGossipSigningAgent: vi.fn(async () => ({
+        privateKey: gossipSigner.privateKey,
+        agentAddress: gossipSigner.address,
+      })),
+    } as any;
+
+    const encryptInlineChunked = await (DKGAgent.prototype as any)
+      ._resolveEncryptInlineChunked.call(agentLike, swmGraphId, undefined, undefined, targetOnChainCgId);
+    expect(encryptInlineChunked).toBeDefined();
+
+    const result = await encryptInlineChunked({
+      plaintextNquads: new TextEncoder().encode('<urn:self> <urn:p> "ack" <urn:g> .\n'),
+      batchId,
+      publishOperationId: 'publish-op-self-ack',
+    });
+
+    expect(result.ciphertextChunkCount).toBe(1);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy.mock.invocationCallOrder[0])
+      .toBeLessThan(agentLike.gossip.publish.mock.invocationCallOrder[0]);
+    expect(insertSpy.mock.calls[0][0][0]).toMatchObject({
+      subject: ciphertextChunkStoreSubject(batchId, 0),
+      predicate: CIPHERTEXT_CHUNK_PREDICATE,
+      graph: ciphertextChunkStoreGraph(canonicalSwmCgId),
+    });
+
+    const handler = new StorageACKHandler(
+      store as any,
+      {
+        nodeRole: 'core',
+        nodeIdentityId: 7n,
+        signerWallet: ackSigner,
+        chainId: 31337n,
+        kav10Address: '0x000000000000000000000000000000000000c10a',
+        contextGraphSharedMemoryUri: (cgId: string) => `did:dkg:context-graph:${cgId}/_shared_memory`,
+        isCgCurated: async () => true,
+        normalizeContextGraphIdForChunkStore: (raw: string) => (
+          raw === swmGraphId ? canonicalSwmCgId : null
+        ),
+        _v2ChunkLookupRetryPolicyForTests: { maxRetries: 0, delayMs: 0 },
+      },
+      { emit: vi.fn(), on: vi.fn(), off: vi.fn() } as any,
+    );
+
+    const intent = encodePublishIntent({
+      merkleRoot: batchId,
+      contextGraphId: targetOnChainCgId,
+      swmGraphId,
+      publisherPeerId: 'local-publisher-peer',
+      publicByteSize: result.totalCiphertextBytes,
+      isPrivate: false,
+      kaCount: 1,
+      merkleLeafCount: 1,
+      rootEntities: ['urn:self'],
+      stagingQuads: new Uint8Array(0),
+      ackProtocolVersion: ACK_PROTOCOL_VERSION_V2_LU11,
+      ciphertextChunksRoot: result.ciphertextChunksRoot,
+      ciphertextChunkCount: result.ciphertextChunkCount,
+    });
+
+    const ack = decodeStorageACK(await handler.handler(intent, { toString: () => 'local-publisher-peer' } as any));
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    expect(ack.contextGraphId).toBe(targetOnChainCgId);
   });
 });

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1672,6 +1672,24 @@ export async function runDaemonInner(
               },
               log,
             }),
+            publishEncryptionFactory: async (publishOptions) => {
+              const encryptInlinePayload = await agent._resolveEncryptInlinePayload(
+                publishOptions.contextGraphId,
+                publishOptions.subGraphName,
+                undefined,
+                publishOptions.publishContextGraphId,
+              );
+              const encryptInlineChunked = await agent._resolveEncryptInlineChunked(
+                publishOptions.contextGraphId,
+                publishOptions.subGraphName,
+                undefined,
+                publishOptions.publishContextGraphId,
+              );
+              return {
+                encryptInlinePayload,
+                encryptInlineChunked,
+              };
+            },
             log,
           });
           publisherRuntime = runtime;

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -27,6 +27,11 @@ interface ACKTransportFactory {
   log?: (message: string) => void;
 }
 
+type PublishEncryptionFactory = (publishOptions: PublishOptions) =>
+  | Promise<Pick<PublishOptions, 'encryptInlinePayload' | 'encryptInlineChunked'> | undefined>
+  | Pick<PublishOptions, 'encryptInlinePayload' | 'encryptInlineChunked'>
+  | undefined;
+
 export async function startPublisherRuntimeIfEnabled(args: {
   dataDir: string;
   config: DkgConfig;
@@ -41,6 +46,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
   };
   log: (message: string) => void;
   ackTransportFactory?: () => ACKTransportFactory;
+  publishEncryptionFactory?: PublishEncryptionFactory;
 }): Promise<PublisherRuntime | null> {
   if (!args.config.publisher?.enabled) {
     return null;
@@ -57,6 +63,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
       maxRetries: args.config.publisher.maxRetries,
       config: args.config,
       ackTransportFactory: args.ackTransportFactory,
+      publishEncryptionFactory: args.publishEncryptionFactory,
     });
     await runtime.runner.start();
     args.log(`Async publisher runner started (${runtime.walletIds.length} wallet${runtime.walletIds.length === 1 ? '' : 's'})`);
@@ -88,6 +95,7 @@ interface PublisherRuntimeBaseArgs {
   maxRetries?: number;
   ackTransportFactory?: () => ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
+  publishEncryptionFactory?: PublishEncryptionFactory;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   closeStoreOnStop: boolean;
 }
@@ -177,6 +185,7 @@ export async function createPublisherRuntimeFromAgent(args: {
   config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>;
   ackTransportFactory?: () => ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
+  publishEncryptionFactory?: PublishEncryptionFactory;
 }): Promise<PublisherRuntime> {
   return createPublisherRuntimeFromBase({
     dataDir: args.dataDir,
@@ -188,6 +197,7 @@ export async function createPublisherRuntimeFromAgent(args: {
     maxRetries: args.maxRetries,
     ackTransportFactory: args.ackTransportFactory,
     v10ACKProviderFactory: args.v10ACKProviderFactory,
+    publishEncryptionFactory: args.publishEncryptionFactory,
     publicSnapshotStore: createPublicSnapshotStore(args.dataDir, args.config),
     closeStoreOnStop: false,
   });
@@ -263,12 +273,18 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
       if (!publisher) {
         throw new Error(`No publisher configured for wallet ${walletId}`);
       }
-      const v10ACKProvider = publishOptions.v10ACKProvider
+      const encryption = await args.publishEncryptionFactory?.(publishOptions);
+      const publishOptionsWithEncryption: PublishOptions = {
+        ...publishOptions,
+        encryptInlinePayload: publishOptions.encryptInlinePayload ?? encryption?.encryptInlinePayload,
+        encryptInlineChunked: publishOptions.encryptInlineChunked ?? encryption?.encryptInlineChunked,
+      };
+      const v10ACKProvider = publishOptionsWithEncryption.v10ACKProvider
         ?? args.v10ACKProviderFactory?.()
         ?? createV10ACKProviderForPublisher(publisher, args.ackTransportFactory?.());
       const publishOptionsWithACKs = v10ACKProvider
-        ? { ...publishOptions, v10ACKProvider }
-        : publishOptions;
+        ? { ...publishOptionsWithEncryption, v10ACKProvider }
+        : publishOptionsWithEncryption;
       // Capability gate: use `isV10Ready()` (the authoritative V10 runtime
       // signal) rather than probing for `createKnowledgeAssets`. Since the
       // interface made the method required, `NoChainAdapter` now implements
@@ -363,6 +379,7 @@ function createV10ACKProviderForPublisher(
     subGraphName,
     merkleLeafCount,
     isEncryptedPayload,
+    chunkedCommitment,
   ) => {
     // Fail loud on non-numeric or non-positive CG ids. V10 publish requires
     // a real on-chain context graph; `ZeroContextGraphId` at
@@ -440,6 +457,7 @@ function createV10ACKProviderForPublisher(
       subGraphName,
       merkleLeafCount,
       isEncryptedPayload,
+      chunkedCommitment,
     });
     return result.acks;
   };

--- a/packages/cli/test/publisher-runner-lu11.test.ts
+++ b/packages/cli/test/publisher-runner-lu11.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ethers } from 'ethers';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import { generateEd25519Keypair, TypedEventBus } from '@origintrail-official/dkg-core';
+import { DKGPublisher, type PublishOptions } from '@origintrail-official/dkg-publisher';
+import { createTripleStore } from '@origintrail-official/dkg-storage';
+import { addPublisherWallet } from '../src/publisher-wallets.js';
+import { createPublisherRuntimeFromAgent } from '../src/publisher-runner.js';
+
+describe('publisher runner LU-11 runtime wiring', () => {
+  it('injects runtime-only chunked encryption callbacks into async lift publishes', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-lu11-'));
+    const wallet = ethers.Wallet.createRandom();
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const keypair = await generateEd25519Keypair();
+    await addPublisherWallet(dataDir, wallet.privateKey);
+
+    const writer = new DKGPublisher({
+      store,
+      chain: new NoChainAdapter(),
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: wallet.privateKey,
+    });
+    const write = await writer.writeToWorkspace('music-social', [
+      {
+        subject: 'urn:local:/rihana',
+        predicate: 'http://schema.org/name',
+        object: '"Rihana"',
+        graph: '',
+      },
+    ], { publisherPeerId: 'peer-1' });
+
+    let factoryInput: PublishOptions | undefined;
+    let chunkedInput:
+      | { plaintextNquads: Uint8Array; batchId: Uint8Array; publishOperationId: string }
+      | undefined;
+
+    const runtime = await createPublisherRuntimeFromAgent({
+      dataDir,
+      store,
+      keypair,
+      chainBase: undefined,
+      pollIntervalMs: 10,
+      errorBackoffMs: 10,
+      publishEncryptionFactory: (publishOptions) => {
+        factoryInput = publishOptions;
+        return {
+          encryptInlinePayload: async () => new Uint8Array([0x01]),
+          encryptInlineChunked: async (input) => {
+            chunkedInput = input;
+            return {
+              ciphertextChunksRoot: ethers.getBytes(ethers.id('async-lu11-chunk-root')),
+              ciphertextChunkCount: 1,
+              totalCiphertextBytes: 1,
+            };
+          },
+        };
+      },
+    });
+
+    const jobId = await runtime.publisher.lift({
+      swmId: 'swm-main',
+      shareOperationId: write.shareOperationId,
+      roots: ['urn:local:/rihana'],
+      contextGraphId: 'music-social',
+      namespace: 'aloha',
+      scope: 'person-profile',
+      transitionType: 'CREATE',
+      authority: { type: 'owner', proofRef: 'proof:owner:1' },
+    });
+
+    const processed = await runtime.publisher.processNext(wallet.address);
+
+    expect(processed?.jobId).toBe(jobId);
+    expect(factoryInput?.contextGraphId).toBe('music-social');
+    expect(chunkedInput?.batchId).toHaveLength(32);
+    expect(chunkedInput?.publishOperationId).toBeTruthy();
+
+    await runtime.stop();
+    await store.close();
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
           'test/store-wizard.test.ts',
           'test/blazegraph-docker.test.ts',
           'test/store-identity-tag.test.ts',
+          'test/publisher-runner-lu11.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic
           // + injected fetch/spawn/fs; no network, no real binary.
           'test/oxigraph-binary.test.ts',


### PR DESCRIPTION
## Summary

Fixes LU-11 chunked StorageACK self-ACK failures where a publishing core could emit ciphertext chunks over gossip but fail its own V2 ACK lookup with `MISSING_CIPHERTEXT_CHUNKS`.

Changes:
- Persist LU-11 ciphertext chunks into the publisher’s local chunk store synchronously before gossip publish.
- Use the same chunk graph/subject/predicate canonicalization as remote chunk ingest and `StorageACKHandler` lookup.
- Fail the publish if local chunk persistence fails, instead of starting ACK collection with missing local state.
- Wire async publisher runtime to resolve LU-5/LU-11 encryption callbacks at execution time.
- Pass `chunkedCommitment` through async V10 ACK collection so async/Kafka publishes use V2 chunked StorageACK.
- Add regressions for loopback-free self-ACK and async LU-11 runtime wiring.

## Validation

- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/publisher-runner-lu11.test.ts`
- `pnpm exec vitest run --config /private/tmp/dkg-agent-lu11-worktree-vitest.config.ts`

## Notes

The fix is committed on `codex/lu11-self-ack-fix` as `55031469`.