### PR TITLE
fix(adapter-openclaw): write setup bookkeeping under config.dkgSetupState

### DIFF
--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -52,6 +52,17 @@
           }
         },
         "description": "DKG UI channel bridge"
+      },
+      "dkgSetupState": {
+        "type": "object",
+        "description": "Internal setup metadata for connect/disconnect round-trip restoration (previous tools profile, previous/merged dkg-ui channel shape, merged tools shape, previous memory-slot owner). Written and consumed only by adapter setup/unmerge — never read at runtime.",
+        "properties": {
+          "previousToolsProfile": { "type": ["string", "null"] },
+          "previousChannelsDkgUi": { "type": ["object", "null"] },
+          "mergedChannelsDkgUi": { "type": "object" },
+          "mergedToolsShape": { "type": "object" },
+          "previousMemorySlotOwner": { "type": "string" }
+        }
       }
     }
   }

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -860,6 +860,44 @@ export function mergeOpenClawConfig(
     log(`Set plugins.entries.${pluginId}.config.installedWorkspace = "${installedWorkspace}"`);
   }
 
+  // `dkgSetupState` holds the connect/disconnect bookkeeping (the pre-merge
+  // "previous" snapshots and the adapter-owned "merged" snapshots) that
+  // `unmergeOpenClawConfig` needs to reverse a merge. It lives INSIDE
+  // `entry.config` — the plugin-owned passthrough space — NOT at the entry root,
+  // where OpenClaw's gateway schema strict-rejects unknown keys (the same reason
+  // `installedWorkspace` lives in `entry.config`; see the comment above). The
+  // container is created lazily so a no-op merge that captures nothing leaves no
+  // empty object behind (preserving the `updated === raw` early return below).
+  const ensureSetupState = (): Record<string, any> => {
+    const existing = entryForConfig.config.dkgSetupState;
+    if (existing && typeof existing === 'object') return existing;
+    return (entryForConfig.config.dkgSetupState = {});
+  };
+
+  // Migrate bookkeeping written at the entry root by older adapter versions into
+  // `entry.config.dkgSetupState`. First-wins is preserved (a legacy value is
+  // adopted only when the container does not already own the key); the stale
+  // root key is always deleted so OpenClaw stops flagging it as an unknown
+  // config key on the next load. Runs before the capture sites below so their
+  // first-wins guards see the migrated values.
+  const SETUP_STATE_KEYS = [
+    'previousToolsProfile',
+    'previousChannelsDkgUi',
+    'mergedChannelsDkgUi',
+    'mergedToolsShape',
+    'previousMemorySlotOwner',
+  ] as const;
+  if (SETUP_STATE_KEYS.some((key) => key in entryForConfig)) {
+    const ss = ensureSetupState();
+    for (const key of SETUP_STATE_KEYS) {
+      if (key in entryForConfig) {
+        if (!(key in ss)) ss[key] = entryForConfig[key];
+        delete entryForConfig[key];
+      }
+    }
+    log(`Migrated adapter setup state from the entry root into config.dkgSetupState`);
+  }
+
   // Ensure plugin-registered tools are visible to the agent. Track whether THIS
   // merge pass actually mutates anything under `config.tools` so `mergedToolsShape`
   // can be refreshed only when we've genuinely written to the section. If the user
@@ -884,21 +922,23 @@ export function mergeOpenClawConfig(
   // plugin-registered tools out of the default `"coding"` profile, making
   // `dkg_*` invisible to the agent even when the plugin loads in full mode.
   //
-  // Capture the pre-merge profile onto the adapter entry so `unmergeOpenClawConfig`
-  // can restore it on disconnect. First-wins: once captured, re-running merge
-  // does not clobber the original (matches the `previousMemorySlotOwner` pattern).
-  // `null` sentinel = "absent before merge" → disconnect should delete the key.
-  const adapterEntryForCapture = config.plugins.entries[pluginId] as Record<string, any>;
+  // Capture the pre-merge profile into `config.dkgSetupState` so
+  // `unmergeOpenClawConfig` can restore it on disconnect. First-wins: once
+  // captured, re-running merge does not clobber the original (matches the
+  // `previousMemorySlotOwner` pattern). `null` sentinel = "absent before merge"
+  // → disconnect should delete the key.
   if (!config.tools.profile) {
-    if (adapterEntryForCapture && !('previousToolsProfile' in adapterEntryForCapture)) {
-      adapterEntryForCapture.previousToolsProfile = null;
+    const ss = ensureSetupState();
+    if (!('previousToolsProfile' in ss)) {
+      ss.previousToolsProfile = null;
     }
     config.tools.profile = 'full';
     mutatedTools = true;
     log('Set tools.profile = "full" to expose plugin tools');
   } else if (config.tools.profile === 'coding') {
-    if (adapterEntryForCapture && !('previousToolsProfile' in adapterEntryForCapture)) {
-      adapterEntryForCapture.previousToolsProfile = 'coding';
+    const ss = ensureSetupState();
+    if (!('previousToolsProfile' in ss)) {
+      ss.previousToolsProfile = 'coding';
     }
     config.tools.profile = 'full';
     mutatedTools = true;
@@ -945,17 +985,17 @@ export function mergeOpenClawConfig(
   // port) would otherwise leave a stale snapshot and break the deep-equal
   // ownership check on disconnect.
   const dkgUiChannel = config.channels['dkg-ui'];
-  const lastMergedChannel = adapterEntryForCapture?.mergedChannelsDkgUi as Record<string, unknown> | undefined;
+  const lastMergedChannel = (entryForConfig.config.dkgSetupState as Record<string, any> | undefined)
+    ?.mergedChannelsDkgUi as Record<string, unknown> | undefined;
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
     // Channel absent before merge → on disconnect, delete it (only if still
     // matches the shape we wrote).
     const created = { enabled: adapterChannelEnabled, port: adapterChannelPort };
-    if (adapterEntryForCapture) {
-      if (!('previousChannelsDkgUi' in adapterEntryForCapture)) {
-        adapterEntryForCapture.previousChannelsDkgUi = null; // first-wins
-      }
-      adapterEntryForCapture.mergedChannelsDkgUi = { ...created }; // always refresh
+    const ss = ensureSetupState();
+    if (!('previousChannelsDkgUi' in ss)) {
+      ss.previousChannelsDkgUi = null; // first-wins
     }
+    ss.mergedChannelsDkgUi = { ...created }; // always refresh
     config.channels['dkg-ui'] = created;
     log(`Created channels.dkg-ui with port ${adapterChannelPort} to keep plugin in full runtime mode`);
   } else {
@@ -964,12 +1004,11 @@ export function mergeOpenClawConfig(
     if (!hasNonEnabledKey) {
       // Degenerate shape → upgrade.
       const upgraded = { ...dkgUiChannel, port: adapterChannelPort };
-      if (adapterEntryForCapture) {
-        if (!('previousChannelsDkgUi' in adapterEntryForCapture)) {
-          adapterEntryForCapture.previousChannelsDkgUi = { ...dkgUiChannel }; // first-wins
-        }
-        adapterEntryForCapture.mergedChannelsDkgUi = { ...upgraded }; // always refresh
+      const ss = ensureSetupState();
+      if (!('previousChannelsDkgUi' in ss)) {
+        ss.previousChannelsDkgUi = { ...dkgUiChannel }; // first-wins
       }
+      ss.mergedChannelsDkgUi = { ...upgraded }; // always refresh
       config.channels['dkg-ui'] = upgraded;
       log(`Added port ${adapterChannelPort} to channels.dkg-ui to keep plugin in full runtime mode`);
     } else if (lastMergedChannel && isDeepStrictEqual(dkgUiChannel, lastMergedChannel)) {
@@ -980,9 +1019,7 @@ export function mergeOpenClawConfig(
       // channel instead of leaving the old adapter-written port in place.
       const refreshed: Record<string, unknown> = { ...dkgUiChannel, port: adapterChannelPort };
       if (!isDeepStrictEqual(refreshed, lastMergedChannel)) {
-        if (adapterEntryForCapture) {
-          adapterEntryForCapture.mergedChannelsDkgUi = { ...refreshed };
-        }
+        ensureSetupState().mergedChannelsDkgUi = { ...refreshed };
         config.channels['dkg-ui'] = refreshed;
         log(`Refreshed channels.dkg-ui.port to ${adapterChannelPort} (last merge output preserved)`);
       }
@@ -1011,8 +1048,8 @@ export function mergeOpenClawConfig(
   // skipped. On the no-op first merge (tools.profile already "full" + alsoAllow
   // already present), no snapshot is captured at all — also correct, because we
   // never took ownership of the section.
-  if (mutatedTools && adapterEntryForCapture) {
-    adapterEntryForCapture.mergedToolsShape = structuredClone(config.tools);
+  if (mutatedTools) {
+    ensureSetupState().mergedToolsShape = structuredClone(config.tools);
   }
 
   // Elect the adapter into OpenClaw's memory slot. Combined with
@@ -1038,12 +1075,12 @@ export function mergeOpenClawConfig(
     // losing the original owner if the slot gets manipulated between merges.
     const currentOwner = config.plugins.slots.memory;
     if (currentOwner && currentOwner !== pluginId) {
-      const adapterEntry = config.plugins.entries[pluginId];
-      if (adapterEntry && typeof adapterEntry === 'object' && !adapterEntry.previousMemorySlotOwner) {
-        adapterEntry.previousMemorySlotOwner = currentOwner;
+      const ss = ensureSetupState();
+      if (!ss.previousMemorySlotOwner) {
+        ss.previousMemorySlotOwner = currentOwner;
         log(`plugins.slots.memory was "${currentOwner}" — saved as previousMemorySlotOwner for restoration on disconnect`);
-      } else if (adapterEntry && typeof adapterEntry === 'object') {
-        log(`plugins.slots.memory was "${currentOwner}" — existing previousMemorySlotOwner="${adapterEntry.previousMemorySlotOwner}" preserved (first-wins)`);
+      } else {
+        log(`plugins.slots.memory was "${currentOwner}" — existing previousMemorySlotOwner="${ss.previousMemorySlotOwner}" preserved (first-wins)`);
       }
     }
     config.plugins.slots.memory = pluginId;
@@ -1166,28 +1203,44 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
   let mergedToolsShape: Record<string, unknown> | undefined;
   const entry = config.plugins?.entries?.[pluginId];
   if (entry && typeof entry === 'object') {
-    if (typeof entry.previousMemorySlotOwner === 'string') {
-      previousMemorySlotOwner = entry.previousMemorySlotOwner;
+    // Bookkeeping now lives in `entry.config.dkgSetupState` (current layout).
+    // Fall back to the entry root for configs written by older adapter versions
+    // that were never re-merged after upgrading — those carry the keys at the
+    // root. Either way the whole entry is deleted below, so both locations get
+    // cleaned up regardless of where the values were read from.
+    const setupState = (entry.config && typeof entry.config === 'object'
+      && entry.config.dkgSetupState && typeof entry.config.dkgSetupState === 'object')
+      ? entry.config.dkgSetupState as Record<string, any>
+      : undefined;
+    const hasKey = (key: string): boolean =>
+      (!!setupState && key in setupState) || (key in entry);
+    const readKey = (key: string): any =>
+      (setupState && key in setupState) ? setupState[key] : entry[key];
+
+    if (typeof readKey('previousMemorySlotOwner') === 'string') {
+      previousMemorySlotOwner = readKey('previousMemorySlotOwner');
     }
-    if ('previousToolsProfile' in entry) {
-      previousToolsProfile = entry.previousToolsProfile;
+    if (hasKey('previousToolsProfile')) {
+      previousToolsProfile = readKey('previousToolsProfile');
     }
-    if ('previousChannelsDkgUi' in entry) {
-      previousChannelsDkgUi = entry.previousChannelsDkgUi;
+    if (hasKey('previousChannelsDkgUi')) {
+      previousChannelsDkgUi = readKey('previousChannelsDkgUi');
     }
-    if (entry.mergedChannelsDkgUi && typeof entry.mergedChannelsDkgUi === 'object') {
-      mergedChannelsDkgUi = entry.mergedChannelsDkgUi as Record<string, unknown>;
+    const mc = readKey('mergedChannelsDkgUi');
+    if (mc && typeof mc === 'object') {
+      mergedChannelsDkgUi = mc as Record<string, unknown>;
     }
-    if (entry.mergedToolsShape && typeof entry.mergedToolsShape === 'object') {
-      mergedToolsShape = entry.mergedToolsShape as Record<string, unknown>;
+    const mt = readKey('mergedToolsShape');
+    if (mt && typeof mt === 'object') {
+      mergedToolsShape = mt as Record<string, unknown>;
     }
   }
 
   // Delete the adapter entry entirely. The adapter owns this entry — all of
-  // its fields (enabled, config, previousMemorySlotOwner) are setup-written,
-  // so there's no user-customizable state to preserve. A fresh merge will
-  // rebuild everything from scratch, including re-capturing the current slot
-  // owner into previousMemorySlotOwner.
+  // its fields (enabled, config — including config.dkgSetupState — and any
+  // legacy root bookkeeping) are setup-written, so there's no user-customizable
+  // state to preserve. A fresh merge will rebuild everything from scratch,
+  // including re-capturing the current slot owner into config.dkgSetupState.
   if (config.plugins && config.plugins.entries && pluginId in config.plugins.entries) {
     delete config.plugins.entries[pluginId];
     log(`Removed ${pluginId} from plugins.entries`);

--- a/packages/adapter-openclaw/test/setup.part-04.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-04.test.ts
@@ -145,6 +145,16 @@ describe('mergeOpenClawConfig', () => {
       memory: { enabled: true },
       channel: { enabled: true },
       installedWorkspace: defaultInstalledWorkspace,
+      // Connect/disconnect bookkeeping now lives under config (not the entry
+      // root). A minimal merge sets the tools profile + creates the dkg-ui
+      // channel, so those snapshots are captured; the empty slot means no
+      // previousMemorySlotOwner.
+      dkgSetupState: {
+        previousToolsProfile: null,
+        previousChannelsDkgUi: null,
+        mergedChannelsDkgUi: { enabled: true, port: 9201 },
+        mergedToolsShape: { profile: 'full', alsoAllow: ['group:plugins'] },
+      },
     });
   });
 
@@ -310,7 +320,9 @@ describe('mergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.slots.memory).toBe('adapter-openclaw');
-    expect(config.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
+    expect(config.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousMemorySlotOwner).toBe('memory-core');
+    // Bookkeeping must never leak back to the entry root (OpenClaw rejects it).
+    expect('previousMemorySlotOwner' in config.plugins.entries['adapter-openclaw']).toBe(false);
   });
 
   it('on a second merge, does NOT overwrite previousMemorySlotOwner with the adapter id (first-wins)', () => {
@@ -322,13 +334,83 @@ describe('mergeOpenClawConfig', () => {
     // First merge captures "memory-core" into the entry.
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(afterFirst.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousMemorySlotOwner).toBe('memory-core');
 
     // Second merge: slot is already the adapter, so the capture branch won't
     // fire — and even if it did, the first-wins guard keeps the original.
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(afterSecond.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousMemorySlotOwner).toBe('memory-core');
+  });
+
+  // Core regression: OpenClaw strict-rejects unknown keys at the plugin-entry
+  // root. A merge that captures EVERY bookkeeping value must keep them all under
+  // config.dkgSetupState and leave only `enabled` + `config` at the entry root.
+  it('keeps all bookkeeping under config.dkgSetupState — entry root is only {enabled, config}', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: { slots: { memory: 'memory-core' } },
+      tools: { profile: 'coding' },
+      // no channels → channel is created (captures previous/merged channel)
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const entry = JSON.parse(readFileSync(configPath, 'utf-8')).plugins.entries['adapter-openclaw'];
+    expect(Object.keys(entry).sort()).toEqual(['config', 'enabled']);
+    expect(entry.config.dkgSetupState).toEqual({
+      previousMemorySlotOwner: 'memory-core',
+      previousToolsProfile: 'coding',
+      previousChannelsDkgUi: null,
+      mergedChannelsDkgUi: { enabled: true, port: 9201 },
+      mergedToolsShape: { profile: 'full', alsoAllow: ['group:plugins'] },
+    });
+  });
+
+  // Migration: an older adapter wrote bookkeeping at the entry ROOT. The next
+  // merge must move it into config.dkgSetupState (first-wins — values are
+  // adopted verbatim, NOT re-captured from the already-merged current state) and
+  // delete the strict-rejected root keys so OpenClaw stops flagging them.
+  it('migrates legacy entry-root bookkeeping into config.dkgSetupState (first-wins preserved)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        allow: ['adapter-openclaw'],
+        slots: { memory: 'adapter-openclaw' },
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: { daemonUrl: 'http://127.0.0.1:9200', channel: { enabled: true, port: 9201 } },
+            // legacy bookkeeping at the entry root:
+            previousMemorySlotOwner: 'memory-core',
+            previousToolsProfile: 'coding',
+            previousChannelsDkgUi: null,
+            mergedChannelsDkgUi: { enabled: true, port: 9201 },
+            mergedToolsShape: { profile: 'full', alsoAllow: ['group:plugins'] },
+          },
+        },
+      },
+      tools: { profile: 'full', alsoAllow: ['group:plugins'] },
+      channels: { 'dkg-ui': { enabled: true, port: 9201 } },
+    }, null, 2) + '\n');
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const entry = JSON.parse(readFileSync(configPath, 'utf-8')).plugins.entries['adapter-openclaw'];
+    // No bookkeeping survives at the entry root.
+    for (const key of ['previousMemorySlotOwner', 'previousToolsProfile', 'previousChannelsDkgUi', 'mergedChannelsDkgUi', 'mergedToolsShape']) {
+      expect(key in entry).toBe(false);
+    }
+    // Values were adopted verbatim (NOT re-derived from the already-merged state:
+    // current profile is "full"/slot is the adapter, so a fresh capture would
+    // have produced different/absent values).
+    expect(entry.config.dkgSetupState).toEqual({
+      previousMemorySlotOwner: 'memory-core',
+      previousToolsProfile: 'coding',
+      previousChannelsDkgUi: null,
+      mergedChannelsDkgUi: { enabled: true, port: 9201 },
+      mergedToolsShape: { profile: 'full', alsoAllow: ['group:plugins'] },
+    });
   });
 
   // D2 — entry.config is the single source of truth for DkgNodePlugin runtime

--- a/packages/adapter-openclaw/test/setup.part-06.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-06.test.ts
@@ -187,7 +187,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterFirst.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
-    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
 
     // Simulate the user (or a later setup run) updating the adapter entry's
     // channel port to 9300 directly on the entry config.
@@ -202,7 +202,7 @@ describe('mergeOpenClawConfig', () => {
     expect(afterSecond.plugins.entries['adapter-openclaw'].config.channel.port).toBe(9300);
     expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
     // mergedChannelsDkgUi tracks the latest adapter output.
-    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
   });
 
   it('re-merge idempotency: unchanged adapter-owned channel produces byte-identical JSON', () => {
@@ -239,8 +239,8 @@ describe('mergeOpenClawConfig', () => {
     } as AdapterEntryConfig, defaultInstalledWorkspace);
 
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(afterFirst.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toBeNull();
-    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousChannelsDkgUi).toBeNull();
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
 
     // Simulate user deleting channels.dkg-ui. Also reset entry port so
     // post-merge resolution picks 9300.
@@ -254,9 +254,9 @@ describe('mergeOpenClawConfig', () => {
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
     // `previousChannelsDkgUi` stays first-wins (original absent → `null`).
-    expect(afterSecond.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toBeNull();
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousChannelsDkgUi).toBeNull();
     // `mergedChannelsDkgUi` tracks the LATEST output (9300, not stale 9201).
-    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
   });
 
   it('re-upgrade degenerate channel: mergedChannelsDkgUi tracks the NEW port, previousChannelsDkgUi stays first-wins', () => {
@@ -275,8 +275,8 @@ describe('mergeOpenClawConfig', () => {
     } as AdapterEntryConfig, defaultInstalledWorkspace);
 
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(afterFirst.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toEqual({ enabled: true });
-    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousChannelsDkgUi).toEqual({ enabled: true });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
 
     // Simulate user stripping channel back to degenerate + bumping entry port.
     afterFirst.channels['dkg-ui'] = { enabled: true };
@@ -288,9 +288,9 @@ describe('mergeOpenClawConfig', () => {
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
     // first-wins preserves the original degenerate shape.
-    expect(afterSecond.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toEqual({ enabled: true });
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousChannelsDkgUi).toEqual({ enabled: true });
     // Latest-output snapshot follows the new port.
-    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
   });
 
 });

--- a/packages/adapter-openclaw/test/setup.part-07.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-07.test.ts
@@ -139,7 +139,7 @@ describe('unmergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterMerge.plugins.slots.memory).toBe('adapter-openclaw');
-    expect(afterMerge.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
+    expect(afterMerge.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousMemorySlotOwner).toBe('memory-core');
 
     // Unmerge → restores "memory-core" and removes the entry entirely.
     unmergeOpenClawConfig(configPath);
@@ -156,7 +156,7 @@ describe('unmergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterMerge.plugins.slots.memory).toBe('adapter-openclaw');
-    expect(afterMerge.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBeUndefined();
+    expect(afterMerge.plugins.entries['adapter-openclaw'].config.dkgSetupState?.previousMemorySlotOwner).toBeUndefined();
 
     unmergeOpenClawConfig(configPath);
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
@@ -329,6 +329,46 @@ describe('unmergeOpenClawConfig', () => {
     expect(result).toEqual({ previousMemorySlotOwner: 'memory-core' });
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.plugins.entries['adapter-openclaw']).toBeUndefined();
+  });
+
+  // Legacy layout: older adapter versions wrote bookkeeping at the entry ROOT
+  // (not under config.dkgSetupState). A user who upgrades and disconnects WITHOUT
+  // re-running setup must still restore correctly via the entry-root fallback.
+  it('restores slot/profile/channel from LEGACY entry-root bookkeeping (no dkgSetupState)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        allow: ['adapter-openclaw'],
+        slots: { memory: 'adapter-openclaw' },
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: { daemonUrl: 'http://127.0.0.1:9200' },
+            // bookkeeping at the entry ROOT, as older versions wrote it:
+            previousMemorySlotOwner: 'memory-core',
+            previousToolsProfile: 'coding',
+            previousChannelsDkgUi: null,
+            mergedChannelsDkgUi: { enabled: true, port: 9201 },
+            mergedToolsShape: { profile: 'full', alsoAllow: ['group:plugins'] },
+          },
+        },
+      },
+      tools: { profile: 'full', alsoAllow: ['group:plugins'] },
+      channels: { 'dkg-ui': { enabled: true, port: 9201 } },
+    }, null, 2) + '\n');
+
+    const result = unmergeOpenClawConfig(configPath);
+    const after = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+    // Slot owner read from the legacy root location and restored.
+    expect(result).toEqual({ previousMemorySlotOwner: 'memory-core' });
+    expect(after.plugins.slots.memory).toBe('memory-core');
+    // tools.profile reverted to the captured "coding" (mergedToolsShape matched).
+    expect(after.tools.profile).toBe('coding');
+    // channels.dkg-ui deleted (previousChannelsDkgUi === null + mergedChannelsDkgUi matched).
+    expect(after.channels?.['dkg-ui']).toBeUndefined();
+    // Entry fully removed, so the strict-rejected root keys are gone too.
+    expect(after.plugins.entries['adapter-openclaw']).toBeUndefined();
   });
 
   it('returns an empty object when openclaw.json is absent', () => {

--- a/packages/adapter-openclaw/test/setup.part-08.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-08.test.ts
@@ -292,9 +292,9 @@ describe('unmergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterFirst.tools.profile).toBe('full');
-    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedToolsShape)
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedToolsShape)
       .toEqual({ alsoAllow: ['group:plugins'], profile: 'full' });
-    expect(afterFirst.plugins.entries['adapter-openclaw'].previousToolsProfile).toBe('coding');
+    expect(afterFirst.plugins.entries['adapter-openclaw'].config.dkgSetupState.previousToolsProfile).toBe('coding');
 
     // User switches to "minimal" and adds a post-merge field.
     afterFirst.tools = { profile: 'minimal', alsoAllow: ['group:plugins'], web: { enabled: false } };
@@ -307,7 +307,7 @@ describe('unmergeOpenClawConfig', () => {
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterSecond.tools.profile).toBe('minimal');
     // Snapshot still reflects the FIRST merge's output, not the user's current shape.
-    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedToolsShape)
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.dkgSetupState.mergedToolsShape)
       .toEqual({ alsoAllow: ['group:plugins'], profile: 'full' });
 
     // Unmerge: current tools (`minimal`, with `web` field) ≠ snapshot (`full`)
@@ -331,8 +331,11 @@ describe('unmergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.tools.profile).toBe('full');
-    // No mutation ⇒ no capture. previousToolsProfile also stays absent.
-    expect(config.plugins.entries['adapter-openclaw'].mergedToolsShape).toBeUndefined();
+    // No mutation ⇒ no capture. previousToolsProfile also stays absent — in
+    // dkgSetupState (whether or not the channel path created the container) AND
+    // never at the entry root.
+    expect(config.plugins.entries['adapter-openclaw'].config.dkgSetupState?.mergedToolsShape).toBeUndefined();
+    expect('previousToolsProfile' in (config.plugins.entries['adapter-openclaw'].config.dkgSetupState ?? {})).toBe(false);
     expect('previousToolsProfile' in config.plugins.entries['adapter-openclaw']).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

`dkg openclaw setup` (and the node-UI **Connect** button) produced an OpenClaw warning and a degraded config:

```
Config invalid; doctor will run with best-effort config.
Unknown config keys:
 - plugins.entries.adapter-openclaw.previousToolsProfile
 - plugins.entries.adapter-openclaw.previousChannelsDkgUi
 - plugins.entries.adapter-openclaw.mergedChannelsDkgUi
 - plugins.entries.adapter-openclaw.mergedToolsShape
```

**Root cause:** `mergeOpenClawConfig` wrote its internal connect/disconnect bookkeeping at the **plugin-entry root** (`plugins.entries["adapter-openclaw"].<key>`), as siblings of `enabled` and `config`. OpenClaw's gateway schema strict-rejects unknown keys at the entry root — only `enabled` and `config` are allowed. `entry.config` is the plugin-owned passthrough space where `daemonUrl`/`stateDir`/`installedWorkspace`/`memory`/`channel` already correctly live; the code documents this at `setup.ts` (it moved `installedWorkspace` into `config` for exactly this reason) but the bookkeeping keys were left at the root.

There are **five** such keys (the warning lists four; `previousMemorySlotOwner` is the fifth and only appears when the adapter displaces a prior memory-slot owner).

## What changed

- **`src/setup.ts` — `mergeOpenClawConfig`**: relocate all five keys into a single namespaced object `entry.config.dkgSetupState`. A lazy `ensureSetupState()` helper means a no-op merge that captures nothing leaves no empty container behind (idempotency preserved). A one-time migration moves any legacy entry-root keys into `config.dkgSetupState` (first-wins preserved — values are adopted verbatim, **not** re-captured from the already-merged state) and deletes the stale root keys so the warning stops on existing broken configs.
- **`src/setup.ts` — `unmergeOpenClawConfig`** (the Disconnect/uninstall path): reads the five keys from `config.dkgSetupState` with an **entry-root fallback**, so a config that was upgraded but never re-merged still restores `slots.memory` / `tools.profile` / `channels['dkg-ui']` on Disconnect. The existing whole-entry delete cleans up both locations.
- **`openclaw.plugin.json`**: declare `dkgSetupState` in `configSchema` (null-tolerant types), matching the existing `installedWorkspace`/`stateDirSource` "internal setup metadata" precedent.

Chose a nested `dkgSetupState` object (vs. flat keys under `config`) to isolate pure round-trip bookkeeping from runtime config keys and avoid re-coupling with the adapter's config classifier (which returns the whole `entry.config` as an overlay).

No daemon/node-UI/CLI source changes were needed: `reverseLocalAgentSetupForUi` reads `entry.config.installedWorkspace` (already under `config`) and delegates key handling to `unmergeOpenClawConfig`.

## Files changed

- `packages/adapter-openclaw/src/setup.ts` — merge + unmerge
- `packages/adapter-openclaw/openclaw.plugin.json` — configSchema declaration
- `packages/adapter-openclaw/test/setup.part-04/06/07/08.test.ts` — assertions relocated + new tests

## Test plan

- Relocated all entry-root assertions to `config.dkgSetupState` across the four setup test files.
- Added tests: **migration** (legacy entry-root keys → `dkgSetupState`, first-wins preserved, root keys gone), **legacy unmerge** (entry-root fallback restores slot/profile/channel without a re-merge), and an **entry-root invariant** (`Object.keys(entry) === ['config','enabled']` after a merge that captures every bookkeeping value).
- Full adapter suite green: **1118 passing**, 1 skipped, 0 failing (83 files).
- Adapter typecheck/build clean.
- CLI `daemon-openclaw` connect/disconnect integration green: **111 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)