### PR TITLE
fix lu11 chunked ack intent fallback

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2676,6 +2676,7 @@ export class PublishMethods extends DKGAgentBase {
         ciphertextChunksRoot: Uint8Array;
         ciphertextChunkCount: number;
         totalCiphertextBytes: number;
+        ciphertextChunks: Uint8Array[];
       }>)
     | undefined
   > {
@@ -2704,6 +2705,7 @@ export class PublishMethods extends DKGAgentBase {
       ciphertextChunksRoot: Uint8Array;
       ciphertextChunkCount: number;
       totalCiphertextBytes: number;
+      ciphertextChunks: Uint8Array[];
     }> => {
       if (input.batchId.length !== 32) {
         throw new Error(
@@ -2792,6 +2794,7 @@ export class PublishMethods extends DKGAgentBase {
         ciphertextChunksRoot: root,
         ciphertextChunkCount: leafCount,
         totalCiphertextBytes,
+        ciphertextChunks,
       };
     };
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1441,6 +1441,7 @@ export class DKGAgent extends DKGAgentBase {
       chunkedCommitment?: {
         ciphertextChunksRoot: Uint8Array;
         ciphertextChunkCount: number;
+        ciphertextChunks?: Uint8Array[];
       },
     ) => {
       // Fail loud on non-numeric or non-positive CG ids: V10 publish requires

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -78,7 +78,13 @@ export const PublishIntentSchema = new Type('PublishIntent')
   // SWM gossip, verify the Merkle root, and ignore `stagingQuads`).
   // Sent over `PROTOCOL_STORAGE_ACK_V2` so pre-LU-11 receivers never
   // see this field and stay on v1 semantics.
-  .add(new Field('ackProtocolVersion', 17, 'uint32'));
+  .add(new Field('ackProtocolVersion', 17, 'uint32'))
+  // OT-RFC-38 LU-11: optional direct-ACK fallback carrying the already
+  // encrypted ciphertext chunks. This is additive and safe for old
+  // receivers: pre-field-18 decoders ignore it, while upgraded V2
+  // handlers still recompute and compare `ciphertextChunksRoot` before
+  // signing. Plaintext never travels here.
+  .add(new Field('ciphertextChunks', 18, 'bytes', 'repeated'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -165,6 +171,15 @@ export interface PublishIntentMsg {
    * on the LU-5 path.
    */
   ackProtocolVersion?: number;
+  /**
+   * OT-RFC-38 LU-11 direct-ACK fallback. Each entry is an encrypted
+   * ciphertext chunk in `swmMessageIndex` order. Cores may use these
+   * bytes only when local chunk-store lookup races SWM/gossip ingest;
+   * they MUST still recompute `ciphertextChunksRoot`, validate
+   * `ciphertextChunkCount` and `publicByteSize`, and decline on any
+   * mismatch before signing.
+   */
+  ciphertextChunks?: Uint8Array[];
 }
 
 /** Sent in `ackProtocolVersion` for LU-11 chunked ACKs. */

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -460,20 +460,27 @@ describe('PublishIntent — LU-11 fields (ciphertextChunksRoot, ciphertextChunkC
     expect(decoded.ciphertextChunksRoot?.length ?? 0).toBe(0);
     expect(decoded.ciphertextChunkCount ?? 0).toBe(0);
     expect(decoded.ackProtocolVersion ?? 0).toBe(0);
+    expect(decoded.ciphertextChunks ?? []).toHaveLength(0);
   });
 
-  it('encode → decode round-trips the three LU-11 fields together', () => {
+  it('encode → decode round-trips the LU-11 fields together', () => {
     const root = new Uint8Array(32).fill(0xcd);
+    const chunks = [
+      new Uint8Array([0x01, 0x02, 0x03]),
+      new Uint8Array([0x04, 0x05]),
+    ];
     const intent: PublishIntentMsg = {
       ...baseIntent(),
       isEncryptedPayload: true,
       ciphertextChunksRoot: root,
-      ciphertextChunkCount: 5,
+      ciphertextChunkCount: chunks.length,
+      ciphertextChunks: chunks,
       ackProtocolVersion: ACK_PROTOCOL_VERSION_V2_LU11,
     };
     const decoded = decodePublishIntent(encodePublishIntent(intent));
     expect(new Uint8Array(decoded.ciphertextChunksRoot!)).toEqual(root);
-    expect(decoded.ciphertextChunkCount).toBe(5);
+    expect(decoded.ciphertextChunkCount).toBe(chunks.length);
+    expect(decoded.ciphertextChunks?.map((chunk) => new Uint8Array(chunk))).toEqual(chunks);
     expect(decoded.ackProtocolVersion).toBe(ACK_PROTOCOL_VERSION_V2_LU11);
     // Legacy fields still round-trip verbatim.
     expect(decoded.contextGraphId).toBe('42');

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -4,6 +4,7 @@ import {
   PROTOCOL_STORAGE_UPDATE_ACK,
   ACK_PROTOCOL_VERSION_V1_LU5,
   ACK_PROTOCOL_VERSION_V2_LU11,
+  DEFAULT_MAX_READ_BYTES,
   encodePublishIntent,
   encodeUpdateIntent,
   decodeStorageACK,
@@ -91,6 +92,11 @@ export interface ACKCollectionResult {
 const DEFAULT_REQUIRED_ACKS = 3;
 const ACK_TIMEOUT_MS = 120_000;
 const MAX_RETRIES = 3;
+// V2 chunked ACK fallback is intentionally bounded. The storage-ack
+// protocol reader buffers at most DEFAULT_MAX_READ_BYTES (10 MiB), so
+// keep direct-wire ciphertext comfortably below that and let large
+// publishes use the normal SWM/chunk-store path instead.
+const MAX_DIRECT_ACK_CIPHERTEXT_CHUNKS_BYTES = Math.floor(DEFAULT_MAX_READ_BYTES / 2);
 // #887: transient declines (the core's SWM replica is still catching up
 // via gossip — NO_DATA_IN_SWM / MERKLE_MISMATCH_IN_SWM /
 // MISSING_CIPHERTEXT_CHUNKS) get their own, larger retry budget than
@@ -203,6 +209,7 @@ export class ACKCollector {
     chunkedCommitment?: {
       ciphertextChunksRoot: Uint8Array;
       ciphertextChunkCount: number;
+      ciphertextChunks?: Uint8Array[];
     };
   }): Promise<ACKCollectionResult> {
     const {
@@ -260,6 +267,15 @@ export class ACKCollector {
           `ACKCollector: chunkedCommitment.ciphertextChunksRoot must be 32 bytes; got ${params.chunkedCommitment.ciphertextChunksRoot.length}`,
         );
       }
+      if (
+        params.chunkedCommitment.ciphertextChunks
+        && params.chunkedCommitment.ciphertextChunks.length !== params.chunkedCommitment.ciphertextChunkCount
+      ) {
+        throw new Error(
+          `ACKCollector: chunkedCommitment.ciphertextChunks length must equal ciphertextChunkCount; ` +
+          `got ${params.chunkedCommitment.ciphertextChunks.length}/${params.chunkedCommitment.ciphertextChunkCount}`,
+        );
+      }
     }
     const ackProtocolVersion = params.chunkedCommitment
       ? ACK_PROTOCOL_VERSION_V2_LU11
@@ -273,6 +289,19 @@ export class ACKCollector {
     const ackProtocolId = params.chunkedCommitment
       ? PROTOCOL_STORAGE_ACK_V2
       : PROTOCOL_STORAGE_ACK;
+    let directFallbackCiphertextChunks: Uint8Array[] | undefined;
+    if (params.chunkedCommitment?.ciphertextChunks) {
+      const directFallbackBytes = params.chunkedCommitment.ciphertextChunks
+        .reduce((acc, chunk) => acc + chunk.length, 0);
+      if (directFallbackBytes <= MAX_DIRECT_ACK_CIPHERTEXT_CHUNKS_BYTES) {
+        directFallbackCiphertextChunks = params.chunkedCommitment.ciphertextChunks;
+      } else {
+        log(
+          `[ACKCollector] Omitting ${directFallbackBytes} ciphertext chunk bytes from V2 PublishIntent ` +
+          `(direct fallback cap=${MAX_DIRECT_ACK_CIPHERTEXT_CHUNKS_BYTES}); peers will use local chunk-store/SWM lookup`,
+        );
+      }
+    }
     const p2pMsg: PublishIntentMsg = {
       merkleRoot,
       contextGraphId: contextGraphIdStr,
@@ -293,6 +322,7 @@ export class ACKCollector {
       ciphertextChunksRoot: params.chunkedCommitment?.ciphertextChunksRoot,
       ciphertextChunkCount: params.chunkedCommitment?.ciphertextChunkCount,
       ackProtocolVersion: params.chunkedCommitment ? ackProtocolVersion : undefined,
+      ciphertextChunks: directFallbackCiphertextChunks,
     };
     const intentBytes = encodePublishIntent(p2pMsg);
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2014,6 +2014,7 @@ export class DKGPublisher implements Publisher {
     let chunkedCommitment: {
       ciphertextChunksRoot: Uint8Array;
       ciphertextChunkCount: number;
+      ciphertextChunks?: Uint8Array[];
     } | undefined;
     if (useChunkedInline) {
       const plaintextBytes = new TextEncoder().encode(nquadsStr);
@@ -2034,6 +2035,7 @@ export class DKGPublisher implements Publisher {
       chunkedCommitment = {
         ciphertextChunksRoot: chunked.ciphertextChunksRoot,
         ciphertextChunkCount: chunked.ciphertextChunkCount,
+        ciphertextChunks: chunked.ciphertextChunks,
       };
     } else if (useEncryptedInline) {
       const plaintextBytes = new TextEncoder().encode(nquadsStr);

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -102,6 +102,7 @@ export type V10ACKProvider = (
   chunkedCommitment?: {
     ciphertextChunksRoot: Uint8Array;
     ciphertextChunkCount: number;
+    ciphertextChunks?: Uint8Array[];
   },
 ) => Promise<V10CoreNodeACK[]>;
 
@@ -252,6 +253,7 @@ export interface PublishOptions {
   }) => Promise<{
     ciphertextChunksRoot: Uint8Array;
     ciphertextChunkCount: number;
+    ciphertextChunks?: Uint8Array[];
     /**
      * Ciphertext byte size the publisher signed into the V10 ACK
      * digest. Concatenation of every per-chunk ciphertext length —

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -427,17 +427,33 @@ export class StorageACKHandler {
       const graphClause = chunkStoreGraph
         ? `GRAPH <${chunkStoreGraph}>`
         : 'GRAPH ?g';
+      const suppliedCiphertextChunks = Array.isArray(intent.ciphertextChunks)
+        ? intent.ciphertextChunks
+        : [];
+      const fallbackChunksToPersist: Array<{ index: number; bytes: Uint8Array }> = [];
+      let usedIntentCiphertextFallback = false;
       const loadChunk = async (i: number): Promise<Uint8Array | null> => {
         const subject = ciphertextChunkStoreSubject(merkleRoot, i);
         const sparql = `SELECT ?o WHERE { ${graphClause} { <${subject}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`;
         const result = await this.store.query(sparql);
-        if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-        const literal = result.bindings[0]?.['o'];
-        if (typeof literal !== 'string') return null;
-        const base64 = literal.startsWith('"') && literal.endsWith('"')
-          ? literal.slice(1, -1)
-          : literal;
-        return Buffer.from(base64, 'base64');
+        if (result.type === 'bindings' && result.bindings.length > 0) {
+          const literal = result.bindings[0]?.['o'];
+          if (typeof literal === 'string') {
+            const base64 = literal.startsWith('"') && literal.endsWith('"')
+              ? literal.slice(1, -1)
+              : literal;
+            return Buffer.from(base64, 'base64');
+          }
+        }
+
+        const supplied = suppliedCiphertextChunks[i];
+        if (supplied === undefined) return null;
+        const bytes = supplied instanceof Uint8Array
+          ? supplied
+          : new Uint8Array(supplied as ArrayLike<number>);
+        usedIntentCiphertextFallback = true;
+        fallbackChunksToPersist.push({ index: i, bytes });
+        return bytes;
       };
       let pending = Array.from({ length: claimedChunkCount }, (_, i) => i);
       let missing: number[] = [];
@@ -484,9 +500,26 @@ export class StorageACKHandler {
       if (!bytesEqual(computed.root, claimedRoot)) {
         return this.encodeDecline(
           cgId,
-          STORAGE_ACK_DECLINE_CODES.CIPHERTEXT_ROOT_MISMATCH,
+          usedIntentCiphertextFallback
+            ? STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM
+            : STORAGE_ACK_DECLINE_CODES.CIPHERTEXT_ROOT_MISMATCH,
           `V2 chunked ACK root mismatch: recomputed root=${ethers.hexlify(computed.root).slice(0, 18)}... does not match publisher claim=${ethers.hexlify(claimedRoot).slice(0, 18)}...`,
         );
+      }
+      if (chunkStoreGraph && fallbackChunksToPersist.length > 0) {
+        try {
+          await this.store.insert(fallbackChunksToPersist.map(({ index, bytes }) => ({
+            subject: ciphertextChunkStoreSubject(merkleRoot, index),
+            predicate: CIPHERTEXT_CHUNK_PREDICATE,
+            object: `"${Buffer.from(bytes).toString('base64')}"`,
+            graph: chunkStoreGraph,
+          })));
+        } catch (err) {
+          console.warn(
+            '[StorageACKHandler] failed to persist V2 ciphertextChunks fallback:',
+            err instanceof Error ? err.message : String(err),
+          );
+        }
       }
 
       // OT-RFC-43 / V10: every publish mints exactly ONE Knowledge Asset.

--- a/packages/publisher/test/v10-ack-v2-chunked.test.ts
+++ b/packages/publisher/test/v10-ack-v2-chunked.test.ts
@@ -98,6 +98,7 @@ interface BuildIntentOpts {
    * ACK handler validates at lines 431-436 of `storage-ack-handler.ts`.
    */
   chunks: Uint8Array[];
+  ciphertextChunksOnWire?: Uint8Array[];
   /**
    * Optional overrides for fields the test wants to *lie* about
    * (e.g. flip the root to provoke `CIPHERTEXT_ROOT_MISMATCH`, or
@@ -138,6 +139,7 @@ function buildV2IntentBytes(opts: BuildIntentOpts): Uint8Array {
     ackProtocolVersion: ACK_PROTOCOL_VERSION_V2_LU11,
     ciphertextChunksRoot: opts.override?.ciphertextChunksRoot ?? trueRoot,
     ciphertextChunkCount: opts.override?.ciphertextChunkCount ?? opts.chunks.length,
+    ciphertextChunks: opts.ciphertextChunksOnWire,
     ...(opts.swmGraphId ? { swmGraphId: opts.swmGraphId } : {}),
   });
 }
@@ -263,6 +265,81 @@ describe('StorageACKHandler V2 chunked ACK — canonical CG keying (#729 Bug 4 r
       ? ack.merkleRoot
       : new Uint8Array(ack.merkleRoot);
     expect(Buffer.from(ackRoot).equals(Buffer.from(kcMerkleRoot))).toBe(true);
+  });
+
+  it('signs the V2 ACK when local chunk store is empty but PublishIntent carries valid ciphertextChunks fallback', async () => {
+    coreWallet = ethers.Wallet.createRandom();
+    const store = new OxigraphStore();
+
+    const chunks = [
+      new Uint8Array([0xA1, 0xA2]),
+      new Uint8Array([0xB1, 0xB2, 0xB3]),
+    ];
+    const kcMerkleRoot = ethers.getBytes(ethers.id('v2-direct-wire-chunks'));
+
+    const handler = new StorageACKHandler(
+      store,
+      createV2Config(coreWallet, {
+        normalizeContextGraphIdForChunkStore: () => CANONICAL_WIRE_FOR_CLEARTEXT,
+        _v2ChunkLookupRetryPolicyForTests: { maxRetries: 0, delayMs: 0 },
+      }),
+      makeEventBus() as any,
+    );
+
+    const intent = buildV2IntentBytes({
+      cgId: NUMERIC_CG_ID,
+      swmGraphId: CLEARTEXT_CG_ID,
+      merkleRoot: kcMerkleRoot,
+      chunks,
+      ciphertextChunksOnWire: chunks,
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    const persisted = await store.query(
+      `SELECT ?o WHERE { GRAPH <${ciphertextChunkStoreGraph(CANONICAL_WIRE_FOR_CLEARTEXT)}> { <${ciphertextChunkStoreSubject(kcMerkleRoot, 1)}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`,
+    );
+    expect(persisted.type).toBe('bindings');
+    expect(persisted.bindings).toHaveLength(1);
+  });
+
+  it('declines with MERKLE_MISMATCH_IN_SWM when direct-wire ciphertextChunks do not match ciphertextChunksRoot', async () => {
+    coreWallet = ethers.Wallet.createRandom();
+    const store = new OxigraphStore();
+
+    const claimedChunks = [
+      new Uint8Array([0xC1, 0xC2]),
+      new Uint8Array([0xD1, 0xD2]),
+    ];
+    const suppliedChunks = [
+      new Uint8Array([0xC1, 0xC2]),
+      new Uint8Array([0xEE, 0xEE]),
+    ];
+    const kcMerkleRoot = ethers.getBytes(ethers.id('v2-direct-wire-bad-root'));
+
+    const handler = new StorageACKHandler(
+      store,
+      createV2Config(coreWallet, {
+        normalizeContextGraphIdForChunkStore: () => CANONICAL_WIRE_FOR_CLEARTEXT,
+        _v2ChunkLookupRetryPolicyForTests: { maxRetries: 0, delayMs: 0 },
+      }),
+      makeEventBus() as any,
+    );
+
+    const intent = buildV2IntentBytes({
+      cgId: NUMERIC_CG_ID,
+      swmGraphId: CLEARTEXT_CG_ID,
+      merkleRoot: kcMerkleRoot,
+      chunks: claimedChunks,
+      ciphertextChunksOnWire: suppliedChunks,
+    });
+
+    const ack = decodeStorageACK(await handler.handler(intent, fakePeerId));
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
   });
 
   it('#729 Bug 4 regression: signs the V2 ACK even when swmGraphId is omitted and the normalizer returns null (widens to GRAPH ?g)', async () => {

--- a/packages/publisher/test/v10-remap-wire.test.ts
+++ b/packages/publisher/test/v10-remap-wire.test.ts
@@ -4,6 +4,9 @@ import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
 import { computeFlatKCRootV10, computeFlatKCMerkleLeafCountV10 } from '../src/merkle.js';
 import {
+  ACK_PROTOCOL_VERSION_V2_LU11,
+  buildCiphertextChunksRoot,
+  DEFAULT_MAX_READ_BYTES,
   encodePublishIntent,
   decodePublishIntent,
   encodeStorageACK,
@@ -210,6 +213,171 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
       seenIdentityIds.add(idKey);
     }
     expect(recoveredAddrs.size).toBe(3);
+  });
+
+  it('ACKCollector includes encrypted ciphertext chunks on the V2 chunked wire path', async () => {
+    let dispatchedIntent: Uint8Array | undefined;
+    const chunks = [
+      new Uint8Array([0x10, 0x11, 0x12]),
+      new Uint8Array([0x20, 0x21, 0x22, 0x23]),
+    ];
+    const { root: ciphertextChunksRoot } = buildCiphertextChunksRoot(chunks);
+    const ciphertextBytes = BigInt(chunks.reduce((acc, chunk) => acc + chunk.length, 0));
+    const peerWallets = [
+      ethers.Wallet.createRandom(),
+      ethers.Wallet.createRandom(),
+      ethers.Wallet.createRandom(),
+    ];
+
+    const chunkedDigest = computePublishACKDigest(
+      TEST_CHAIN_ID,
+      TEST_KAV10_ADDR,
+      TARGET_CG_ID_BIGINT,
+      merkleRoot,
+      BigInt(KA_COUNT),
+      ciphertextBytes,
+      EPOCHS,
+      TOKEN_AMOUNT,
+      BigInt(merkleLeafCount),
+      ciphertextChunksRoot,
+      BigInt(chunks.length),
+      false,
+    );
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (peerId, _protocol, data) => {
+        if (dispatchedIntent === undefined) dispatchedIntent = data;
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const sig = ethers.Signature.from(await peerWallets[idx].signMessage(chunkedDigest));
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: ethers.getBytes(sig.r),
+          coreNodeSignatureVS: ethers.getBytes(sig.yParityAndS),
+          contextGraphId: TARGET_CG_ID_STR,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: TARGET_CG_ID_BIGINT,
+      contextGraphIdStr: TARGET_CG_ID_STR,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: ciphertextBytes,
+      isPrivate: false,
+      kaCount: KA_COUNT,
+      rootEntities,
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      epochs: Number(EPOCHS),
+      tokenAmount: TOKEN_AMOUNT,
+      swmGraphId: SOURCE_SWM_GRAPH_ID,
+      merkleLeafCount,
+      isEncryptedPayload: true,
+      chunkedCommitment: {
+        ciphertextChunksRoot,
+        ciphertextChunkCount: chunks.length,
+        ciphertextChunks: chunks,
+      },
+    });
+
+    expect(result.acks).toHaveLength(3);
+    expect(dispatchedIntent).toBeDefined();
+    const decoded = decodePublishIntent(dispatchedIntent!);
+    expect(decoded.ackProtocolVersion).toBe(ACK_PROTOCOL_VERSION_V2_LU11);
+    expect(decoded.stagingQuads?.length ?? 0).toBe(0);
+    expect(Buffer.from(decoded.ciphertextChunksRoot ?? []).equals(Buffer.from(ciphertextChunksRoot))).toBe(true);
+    expect(decoded.ciphertextChunkCount).toBe(chunks.length);
+    expect(decoded.ciphertextChunks ?? []).toHaveLength(chunks.length);
+    for (let i = 0; i < chunks.length; i += 1) {
+      expect(Buffer.from(decoded.ciphertextChunks![i]).equals(Buffer.from(chunks[i]))).toBe(true);
+    }
+  });
+
+  it('ACKCollector omits encrypted ciphertext chunks when direct fallback would approach the P2P read cap', async () => {
+    let dispatchedIntent: Uint8Array | undefined;
+    const logs: string[] = [];
+    const chunks = [
+      new Uint8Array(Math.floor(DEFAULT_MAX_READ_BYTES / 2) + 1).fill(0x33),
+    ];
+    const { root: ciphertextChunksRoot } = buildCiphertextChunksRoot(chunks);
+    const ciphertextBytes = BigInt(chunks[0].length);
+    const peerWallets = [
+      ethers.Wallet.createRandom(),
+      ethers.Wallet.createRandom(),
+      ethers.Wallet.createRandom(),
+    ];
+
+    const chunkedDigest = computePublishACKDigest(
+      TEST_CHAIN_ID,
+      TEST_KAV10_ADDR,
+      TARGET_CG_ID_BIGINT,
+      merkleRoot,
+      BigInt(KA_COUNT),
+      ciphertextBytes,
+      EPOCHS,
+      TOKEN_AMOUNT,
+      BigInt(merkleLeafCount),
+      ciphertextChunksRoot,
+      BigInt(chunks.length),
+      false,
+    );
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (peerId, _protocol, data) => {
+        if (dispatchedIntent === undefined) dispatchedIntent = data;
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const sig = ethers.Signature.from(await peerWallets[idx].signMessage(chunkedDigest));
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: ethers.getBytes(sig.r),
+          coreNodeSignatureVS: ethers.getBytes(sig.yParityAndS),
+          contextGraphId: TARGET_CG_ID_STR,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: (msg) => { logs.push(msg); },
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: TARGET_CG_ID_BIGINT,
+      contextGraphIdStr: TARGET_CG_ID_STR,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: ciphertextBytes,
+      isPrivate: false,
+      kaCount: KA_COUNT,
+      rootEntities,
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      epochs: Number(EPOCHS),
+      tokenAmount: TOKEN_AMOUNT,
+      swmGraphId: SOURCE_SWM_GRAPH_ID,
+      merkleLeafCount,
+      isEncryptedPayload: true,
+      chunkedCommitment: {
+        ciphertextChunksRoot,
+        ciphertextChunkCount: chunks.length,
+        ciphertextChunks: chunks,
+      },
+    });
+
+    expect(result.acks).toHaveLength(3);
+    expect(dispatchedIntent).toBeDefined();
+    const decoded = decodePublishIntent(dispatchedIntent!);
+    expect(decoded.ackProtocolVersion).toBe(ACK_PROTOCOL_VERSION_V2_LU11);
+    expect(Buffer.from(decoded.ciphertextChunksRoot ?? []).equals(Buffer.from(ciphertextChunksRoot))).toBe(true);
+    expect(decoded.ciphertextChunkCount).toBe(chunks.length);
+    expect(decoded.ciphertextChunks ?? []).toHaveLength(0);
+    expect(logs.some((msg) => msg.includes('Omitting') && msg.includes('direct fallback cap'))).toBe(true);
   });
 
   it('ACKCollector elides swmGraphId when source equals target (direct publish)', async () => {


### PR DESCRIPTION
## Summary

Fix LU-11 chunked curated publish storage ACK failures by carrying already-encrypted ciphertext chunks in the V2 `PublishIntent` as a safe direct-ACK fallback.

ACK peers still prefer their local SWM ciphertext chunk store. If gossip/SWM ingest has not completed when the direct V2 ACK arrives, the handler can use the encrypted chunks carried on the ACK wire, recompute and validate the chunk root/count/byte size, then sign only after validation passes.

## Changes

- Add optional repeated bytes field `ciphertextChunks` as field 18 on `PublishIntent`.
- Return generated ciphertext chunks from the LU-11 chunked encrypt path.
- Thread `ciphertextChunks` through `chunkedCommitment`.
- Include chunks only for V2 chunked ACK intents; chunked path still keeps `stagingQuads` empty.
- In `StorageACKHandler`, lookup local chunk store first, fallback to intent chunks if missing, validate commitment before ACK, and persist validated fallback chunks.
- Add regression coverage for proto round-trip, empty-store ACK fallback, invalid supplied chunks, and ACKCollector V2 wire payload.

## Validation

- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/v10-proto.test.ts`
- `pnpm exec vitest run --config /private/tmp/dkg-publisher-lu11-vitest.config.ts`
- Scoped TypeScript builds for core/storage/chain/publisher/query/random-sampling/agent