### PR TITLE
Expose deterministic context graph rehydration cap diagnostics

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -886,6 +886,7 @@ export class DKGAgentBase {
   protected started = false;
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
+  protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;
     rows: Array<Record<string, unknown>>;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -331,6 +331,7 @@ import {
   type ChatSendResult,
   type ContextGraphSub,
   type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
   type ContextGraphMemberPrincipalType,
   type ContextGraphMemberStatus,
@@ -884,6 +885,7 @@ export class DKGAgentBase {
   protected readonly config: DKGAgentConfig;
   protected started = false;
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
+  protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;
     rows: Array<Record<string, unknown>>;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -891,6 +891,7 @@ export class DKGAgentBase {
   protected readonly contextGraphSubscriptionPersistAppliedRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistCanceledRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistPendingRevisions = new Map<string, Set<number>>();
+  protected readonly contextGraphSubscriptionPersistChains = new Map<string, Promise<void>>();
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;
     rows: Array<Record<string, unknown>>;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -890,6 +890,7 @@ export class DKGAgentBase {
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistAppliedRevisions = new Map<string, number>();
   protected readonly contextGraphSubscriptionPersistCanceledRevisions = new Map<string, number>();
+  protected readonly contextGraphSubscriptionPersistPendingRevisions = new Map<string, Set<number>>();
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;
     rows: Array<Record<string, unknown>>;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -886,6 +886,7 @@ export class DKGAgentBase {
   protected started = false;
   protected readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
+  protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -888,6 +888,8 @@ export class DKGAgentBase {
   protected contextGraphSubscriptionRehydrationStatus: ContextGraphSubscriptionRehydrationStatus | null = null;
   protected readonly contextGraphSubscriptionRehydrationAccountedIds = new Set<string>();
   protected readonly contextGraphSubscriptionPersistRevisions = new Map<string, number>();
+  protected readonly contextGraphSubscriptionPersistAppliedRevisions = new Map<string, number>();
+  protected readonly contextGraphSubscriptionPersistCanceledRevisions = new Map<string, number>();
   protected readonly listContextGraphsCache = new Map<string, {
     expiresAt: number;
     rows: Array<Record<string, unknown>>;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3579,8 +3579,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
     }
     if (options?.persist !== false) {
-      this.clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(contextGraphId, existing, next);
-      this.persistContextGraphSubscription(contextGraphId);
+      const clearRehydrationStatusOnSuccess =
+        this.shouldClearContextGraphSubscriptionRehydrationStatusOnPersist(contextGraphId, existing, next);
+      this.persistContextGraphSubscription(contextGraphId, { clearRehydrationStatusOnSuccess });
       if (next.subscribed) {
         this.persistLocalNodeMembership(contextGraphId);
       } else {
@@ -3596,28 +3597,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
   }
 
-  clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(this: DKGAgent,
+  shouldClearContextGraphSubscriptionRehydrationStatusOnPersist(this: DKGAgent,
     contextGraphId: string,
     existing?: ContextGraphSub,
     next?: ContextGraphSub,
-  ): void {
+  ): boolean {
     const status = this.contextGraphSubscriptionRehydrationStatus;
-    if (!status) return;
-    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return;
+    if (!status) return false;
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return false;
     const wasDormant = status.dormantIds.includes(contextGraphId);
     const subscriptionShapeChanged = !existing || !next ||
       existing.subscribed !== next.subscribed ||
       existing.coreHosted !== next.coreHosted;
-    if (wasDormant || subscriptionShapeChanged) {
-      this.contextGraphSubscriptionRehydrationStatus = null;
-    }
+    return wasDormant || subscriptionShapeChanged;
   }
 
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
-    const existing = this.subscribedContextGraphs.get(contextGraphId);
     this.invalidateListContextGraphsCache();
     this.forceClearVmReconcileStateForContextGraph(contextGraphId);
-    this.clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(contextGraphId, existing);
     return this.subscribedContextGraphs.delete(contextGraphId);
   }
 
@@ -3625,7 +3622,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.persistContextGraphSubscription(contextGraphId);
   }
 
-  persistContextGraphSubscription(this: DKGAgent, contextGraphId: string): void {
+  persistContextGraphSubscription(this: DKGAgent,
+    contextGraphId: string,
+    options?: { clearRehydrationStatusOnSuccess?: boolean },
+  ): void {
     this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
@@ -3635,12 +3635,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // during a publish remembers it hosts the CG and fills its gap. Drop the
     // row only when the node neither subscribes to nor hosts the CG.
     if (!sub?.subscribed && !sub?.coreHosted) {
-      void store.delete(contextGraphId).catch((err) => {
-        this.log.warn(
-          createOperationContext('system'),
-          `Failed to delete persisted context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      void store.delete(contextGraphId)
+        .then(() => {
+          if (options?.clearRehydrationStatusOnSuccess) {
+            this.contextGraphSubscriptionRehydrationStatus = null;
+          }
+        })
+        .catch((err) => {
+          this.log.warn(
+            createOperationContext('system'),
+            `Failed to delete persisted context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
       return;
     }
     void store.save({
@@ -3655,6 +3661,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       lastReconciledOrdinal: sub.lastReconciledOrdinal,
       coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
+    }).then(() => {
+      if (options?.clearRehydrationStatusOnSuccess) {
+        this.contextGraphSubscriptionRehydrationStatus = null;
+      }
     }).catch((err) => {
       this.log.warn(
         createOperationContext('system'),

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3572,7 +3572,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     next: ContextGraphSub,
     options?: { persist?: boolean; updateRehydrationStatus?: boolean },
   ): ContextGraphSub {
-    const existing = this.subscribedContextGraphs.get(contextGraphId);
     this.invalidateListContextGraphsCache();
     this.subscribedContextGraphs.set(contextGraphId, next);
     if (!next.subscribed && !next.coreHosted) {
@@ -3583,8 +3582,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.persistContextGraphSubscription(
         contextGraphId,
         {
-          existing,
-          next,
           revision,
           updateRehydrationStatus: options?.updateRehydrationStatus !== false,
         },
@@ -3616,7 +3613,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
     contextGraphId: string,
-    existing?: ContextGraphSub,
     next?: ContextGraphSub,
   ): void {
     const status = this.contextGraphSubscriptionRehydrationStatus;
@@ -3626,8 +3622,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const sortIds = (ids: string[]): string[] => [...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const wasDormant = status.dormantIds.includes(contextGraphId);
     const hostedActivatedIds = status.hostedActivatedIds ?? [];
-    const wasHosted = hostedActivatedIds.includes(contextGraphId);
-    const wasPersisted = wasDormant || wasHosted || existing?.subscribed === true || existing?.coreHosted === true;
+    const wasAccounted = this.contextGraphSubscriptionRehydrationAccountedIds.has(contextGraphId);
     const isPersisted = next?.subscribed === true || next?.coreHosted === true;
 
     let persistedTotal = status.persistedTotal;
@@ -3641,15 +3636,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (isPersisted) {
       if (wasDormant) {
         activated += 1;
-      } else if (!wasPersisted) {
+      } else if (!wasAccounted) {
         persistedTotal += 1;
         activated += 1;
       }
-    } else if (wasPersisted) {
+      this.contextGraphSubscriptionRehydrationAccountedIds.add(contextGraphId);
+    } else if (wasAccounted) {
       persistedTotal = Math.max(0, persistedTotal - 1);
       if (!wasDormant) {
         activated = Math.max(0, activated - 1);
       }
+      this.contextGraphSubscriptionRehydrationAccountedIds.delete(contextGraphId);
     }
 
     this.contextGraphSubscriptionRehydrationStatus = {
@@ -3681,8 +3678,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
     for (const id of new Set(clearedIds)) {
       if (systemContextGraphs.has(id)) continue;
+      const wasAccounted = this.contextGraphSubscriptionRehydrationAccountedIds.delete(id);
       const wasDormant = removeFrom(dormantIds, id);
       removeFrom(hostedActivatedIds, id);
+      if (!wasAccounted) continue;
       persistedTotal = Math.max(0, persistedTotal - 1);
       if (!wasDormant) {
         activated = Math.max(0, activated - 1);
@@ -3717,8 +3716,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   persistContextGraphSubscription(this: DKGAgent,
     contextGraphId: string,
     options?: {
-      existing?: ContextGraphSub;
-      next?: ContextGraphSub;
       revision?: number;
       updateRehydrationStatus?: boolean;
     },
@@ -3738,7 +3735,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             options?.updateRehydrationStatus === true &&
             this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
           ) {
-            this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, undefined);
+            this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, undefined);
           }
         })
         .catch((err) => {
@@ -3766,7 +3763,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         options?.updateRehydrationStatus === true &&
         this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
       ) {
-        this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, sub);
+        this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, sub);
       }
     }).catch((err) => {
       this.log.warn(
@@ -3937,6 +3934,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
       }
       const skipped = dormantRows.length;
+      this.contextGraphSubscriptionRehydrationAccountedIds.clear();
+      for (const row of rows) {
+        this.contextGraphSubscriptionRehydrationAccountedIds.add(row.id);
+      }
       this.contextGraphSubscriptionRehydrationStatus = {
         persistedTotal: persistedRows.length,
         systemExcluded: persistedRows.length - rows.length,
@@ -4042,7 +4043,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // + coreHosted CGs, so this only drops the cleared non-hosted user entries.)
     for (const id of activeUserIds) {
       try {
-        this.unsubscribeFromContextGraph(id, { updateRehydrationStatus: false });
+        this.unsubscribeFromContextGraph(id, { persist: false, updateRehydrationStatus: false });
+        this.deleteContextGraphMember(id, 'node', this.peerId);
       } catch {
         /* best-effort teardown */
       }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3570,7 +3570,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   setContextGraphSubscription(this: DKGAgent,
     contextGraphId: string,
     next: ContextGraphSub,
-    options?: { persist?: boolean },
+    options?: { persist?: boolean; updateRehydrationStatus?: boolean },
   ): ContextGraphSub {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     this.invalidateListContextGraphsCache();
@@ -3579,9 +3579,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
     }
     if (options?.persist !== false) {
-      const clearRehydrationStatusOnSuccess =
-        this.shouldClearContextGraphSubscriptionRehydrationStatusOnPersist(contextGraphId, existing, next);
-      this.persistContextGraphSubscription(contextGraphId, { clearRehydrationStatusOnSuccess });
+      this.persistContextGraphSubscription(
+        contextGraphId,
+        options?.updateRehydrationStatus === false ? undefined : { existing, next },
+      );
       if (next.subscribed) {
         this.persistLocalNodeMembership(contextGraphId);
       } else {
@@ -3597,19 +3598,89 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
   }
 
-  shouldClearContextGraphSubscriptionRehydrationStatusOnPersist(this: DKGAgent,
+  updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
     contextGraphId: string,
     existing?: ContextGraphSub,
     next?: ContextGraphSub,
-  ): boolean {
+  ): void {
     const status = this.contextGraphSubscriptionRehydrationStatus;
-    if (!status) return false;
-    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return false;
+    if (!status) return;
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return;
+
+    const sortIds = (ids: string[]): string[] => [...ids].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const wasDormant = status.dormantIds.includes(contextGraphId);
-    const subscriptionShapeChanged = !existing || !next ||
-      existing.subscribed !== next.subscribed ||
-      existing.coreHosted !== next.coreHosted;
-    return wasDormant || subscriptionShapeChanged;
+    const hostedActivatedIds = status.hostedActivatedIds ?? [];
+    const wasHosted = hostedActivatedIds.includes(contextGraphId);
+    const wasPersisted = wasDormant || wasHosted || existing?.subscribed === true || existing?.coreHosted === true;
+    const isPersisted = next?.subscribed === true || next?.coreHosted === true;
+
+    let persistedTotal = status.persistedTotal;
+    let activated = status.activated;
+    let dormantIds = status.dormantIds.filter((id) => id !== contextGraphId);
+    let nextHostedActivatedIds = hostedActivatedIds.filter((id) => id !== contextGraphId);
+    if (next?.coreHosted === true) {
+      nextHostedActivatedIds = sortIds([...nextHostedActivatedIds, contextGraphId]);
+    }
+
+    if (isPersisted) {
+      if (wasDormant) {
+        activated += 1;
+      } else if (!wasPersisted) {
+        persistedTotal += 1;
+        activated += 1;
+      }
+    } else if (wasPersisted) {
+      persistedTotal = Math.max(0, persistedTotal - 1);
+      if (!wasDormant) {
+        activated = Math.max(0, activated - 1);
+      }
+    }
+
+    this.contextGraphSubscriptionRehydrationStatus = {
+      ...status,
+      persistedTotal,
+      hostedActivated: nextHostedActivatedIds.length,
+      hostedActivatedIds: nextHostedActivatedIds,
+      activated,
+      dormant: dormantIds.length,
+      dormantIds,
+    };
+  }
+
+  updateContextGraphSubscriptionRehydrationStatusAfterClear(this: DKGAgent, clearedIds: Iterable<string>): void {
+    const status = this.contextGraphSubscriptionRehydrationStatus;
+    if (!status) return;
+    const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
+    const dormantIds = [...status.dormantIds];
+    const hostedActivatedIds = [...(status.hostedActivatedIds ?? [])];
+    const removeFrom = (ids: string[], id: string): boolean => {
+      const index = ids.indexOf(id);
+      if (index < 0) return false;
+      ids.splice(index, 1);
+      return true;
+    };
+    let persistedTotal = status.persistedTotal;
+    let activated = status.activated;
+
+    for (const id of new Set(clearedIds)) {
+      if (systemContextGraphs.has(id)) continue;
+      const wasDormant = removeFrom(dormantIds, id);
+      removeFrom(hostedActivatedIds, id);
+      persistedTotal = Math.max(0, persistedTotal - 1);
+      if (!wasDormant) {
+        activated = Math.max(0, activated - 1);
+      }
+    }
+
+    this.contextGraphSubscriptionRehydrationStatus = {
+      ...status,
+      persistedTotal,
+      hostedActivated: hostedActivatedIds.length,
+      hostedActivatedIds,
+      activated,
+      dormant: dormantIds.length,
+      dormantIds,
+    };
   }
 
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
@@ -3624,7 +3695,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   persistContextGraphSubscription(this: DKGAgent,
     contextGraphId: string,
-    options?: { clearRehydrationStatusOnSuccess?: boolean },
+    options?: { existing?: ContextGraphSub; next?: ContextGraphSub },
   ): void {
     this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
@@ -3637,8 +3708,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!sub?.subscribed && !sub?.coreHosted) {
       void store.delete(contextGraphId)
         .then(() => {
-          if (options?.clearRehydrationStatusOnSuccess) {
-            this.contextGraphSubscriptionRehydrationStatus = null;
+          if (options) {
+            this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, undefined);
           }
         })
         .catch((err) => {
@@ -3662,8 +3733,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     }).then(() => {
-      if (options?.clearRehydrationStatusOnSuccess) {
-        this.contextGraphSubscriptionRehydrationStatus = null;
+      if (options) {
+        this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, sub);
       }
     }).catch((err) => {
       this.log.warn(
@@ -3740,6 +3811,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!status) return null;
     return {
       ...status,
+      hostedActivatedIds: [...(status.hostedActivatedIds ?? [])],
       dormantIds: [...status.dormantIds],
     };
   }
@@ -3837,6 +3909,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         persistedTotal: persistedRows.length,
         systemExcluded: persistedRows.length - rows.length,
         hostedActivated: hostedRows.length,
+        hostedActivatedIds: hostedRows.map((r) => r.id),
         activated: toActivate.length,
         dormant: skipped,
         activationCap: cap,
@@ -3937,7 +4010,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // + coreHosted CGs, so this only drops the cleared non-hosted user entries.)
     for (const id of activeUserIds) {
       try {
-        this.unsubscribeFromContextGraph(id);
+        this.unsubscribeFromContextGraph(id, { updateRehydrationStatus: false });
       } catch {
         /* best-effort teardown */
       }
@@ -3950,6 +4023,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // reported as cleared, or this recovery endpoint would answer 200 "all
     // gone" while stale rows survive in the store.
     let cleared = persistedUserIds.length;
+    const clearedIds: string[] = [];
     let failed = 0;
     if (store) {
       cleared = 0;
@@ -3957,6 +4031,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         try {
           await store.delete(id);
           cleared++;
+          clearedIds.push(id);
         } catch (err) {
           failed++;
           this.log.warn(
@@ -3968,7 +4043,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
     if (cleared > 0) {
-      this.contextGraphSubscriptionRehydrationStatus = null;
+      this.updateContextGraphSubscriptionRehydrationStatusAfterClear(clearedIds);
     }
 
     this.log.info(

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3607,8 +3607,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return revision;
   }
 
-  canApplyContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): boolean {
-    return revision != null && this.contextGraphSubscriptionPersistRevisions.get(contextGraphId) === revision;
+  cancelContextGraphSubscriptionPersistRevisions(this: DKGAgent, contextGraphId: string): void {
+    const revision = this.nextContextGraphSubscriptionPersistRevision(contextGraphId);
+    this.contextGraphSubscriptionPersistCanceledRevisions.set(contextGraphId, revision);
+  }
+
+  claimContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): boolean {
+    if (revision == null) return false;
+    const canceledRevision = this.contextGraphSubscriptionPersistCanceledRevisions.get(contextGraphId) ?? 0;
+    if (revision <= canceledRevision) return false;
+    const appliedRevision = this.contextGraphSubscriptionPersistAppliedRevisions.get(contextGraphId) ?? 0;
+    if (revision <= appliedRevision) return false;
+    this.contextGraphSubscriptionPersistAppliedRevisions.set(contextGraphId, revision);
+    return true;
   }
 
   updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
@@ -3661,7 +3672,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     };
   }
 
-  updateContextGraphSubscriptionRehydrationStatusAfterClear(this: DKGAgent, clearedIds: Iterable<string>): void {
+  updateContextGraphSubscriptionRehydrationStatusAfterClear(this: DKGAgent,
+    clearedIds: Iterable<string>,
+    deactivatedIds: Iterable<string> = [],
+  ): void {
     const status = this.contextGraphSubscriptionRehydrationStatus;
     if (!status) return;
     const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
@@ -3675,8 +3689,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     };
     let persistedTotal = status.persistedTotal;
     let activated = status.activated;
+    const clearedSet = new Set(clearedIds);
 
-    for (const id of new Set(clearedIds)) {
+    for (const id of clearedSet) {
       if (systemContextGraphs.has(id)) continue;
       const wasAccounted = this.contextGraphSubscriptionRehydrationAccountedIds.delete(id);
       const wasDormant = removeFrom(dormantIds, id);
@@ -3687,6 +3702,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         activated = Math.max(0, activated - 1);
       }
     }
+    for (const id of new Set(deactivatedIds)) {
+      if (systemContextGraphs.has(id) || clearedSet.has(id)) continue;
+      if (!this.contextGraphSubscriptionRehydrationAccountedIds.has(id)) continue;
+      removeFrom(hostedActivatedIds, id);
+      if (!dormantIds.includes(id)) {
+        activated = Math.max(0, activated - 1);
+        dormantIds.push(id);
+      }
+    }
+    dormantIds.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 
     this.contextGraphSubscriptionRehydrationStatus = {
       ...status,
@@ -3733,7 +3758,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         .then(() => {
           if (
             options?.updateRehydrationStatus === true &&
-            this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
+            this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
           ) {
             this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, undefined);
           }
@@ -3761,7 +3786,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     }).then(() => {
       if (
         options?.updateRehydrationStatus === true &&
-        this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
+        this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
       ) {
         this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, sub);
       }
@@ -4035,7 +4060,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const total = persistedUserIds.length;
     // Cancel any in-flight save callbacks that started before this bulk clear.
     for (const id of new Set([...persistedUserIds, ...activeUserIds])) {
-      this.nextContextGraphSubscriptionPersistRevision(id);
+      this.cancelContextGraphSubscriptionPersistRevisions(id);
     }
 
     // Tear down active in-memory USER subscriptions (gossip topics + sync scope),
@@ -4062,6 +4087,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // gone" while stale rows survive in the store.
     let cleared = persistedUserIds.length;
     const clearedIds: string[] = [];
+    const deactivatedIds: string[] = [];
+    const activeUserIdSet = new Set(activeUserIds);
     let failed = 0;
     if (store) {
       cleared = 0;
@@ -4072,6 +4099,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           clearedIds.push(id);
         } catch (err) {
           failed++;
+          if (activeUserIdSet.has(id)) {
+            deactivatedIds.push(id);
+          }
           this.log.warn(
             ctx,
             `clearContextGraphSubscriptions: failed to delete persisted subscription "${id}": ` +
@@ -4080,8 +4110,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
       }
     }
-    if (cleared > 0) {
-      this.updateContextGraphSubscriptionRehydrationStatusAfterClear(clearedIds);
+    if (cleared > 0 || deactivatedIds.length > 0) {
+      this.updateContextGraphSubscriptionRehydrationStatusAfterClear(clearedIds, deactivatedIds);
     }
 
     this.log.info(

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3572,12 +3572,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     next: ContextGraphSub,
     options?: { persist?: boolean },
   ): ContextGraphSub {
+    const existing = this.subscribedContextGraphs.get(contextGraphId);
     this.invalidateListContextGraphsCache();
     this.subscribedContextGraphs.set(contextGraphId, next);
     if (!next.subscribed && !next.coreHosted) {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
     }
     if (options?.persist !== false) {
+      this.clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(contextGraphId, existing, next);
       this.persistContextGraphSubscription(contextGraphId);
       if (next.subscribed) {
         this.persistLocalNodeMembership(contextGraphId);
@@ -3594,9 +3596,28 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
   }
 
+  clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(this: DKGAgent,
+    contextGraphId: string,
+    existing?: ContextGraphSub,
+    next?: ContextGraphSub,
+  ): void {
+    const status = this.contextGraphSubscriptionRehydrationStatus;
+    if (!status) return;
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return;
+    const wasDormant = status.dormantIds.includes(contextGraphId);
+    const subscriptionShapeChanged = !existing || !next ||
+      existing.subscribed !== next.subscribed ||
+      existing.coreHosted !== next.coreHosted;
+    if (wasDormant || subscriptionShapeChanged) {
+      this.contextGraphSubscriptionRehydrationStatus = null;
+    }
+  }
+
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
+    const existing = this.subscribedContextGraphs.get(contextGraphId);
     this.invalidateListContextGraphsCache();
     this.forceClearVmReconcileStateForContextGraph(contextGraphId);
+    this.clearContextGraphSubscriptionRehydrationStatusIfBacklogChanged(contextGraphId, existing);
     return this.subscribedContextGraphs.delete(contextGraphId);
   }
 
@@ -3935,6 +3956,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           );
         }
       }
+    }
+    if (cleared > 0) {
+      this.contextGraphSubscriptionRehydrationStatus = null;
     }
 
     this.log.info(

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -237,8 +237,9 @@ import { createCursorState, type CursorState } from './reconcile-cursor.js';
  * Default cap on how many persisted context-graph subscriptions are activated
  * (gossip-subscribed + sync-tracked) on startup. A large backlog of stale
  * subscriptions otherwise fans out store-touching gossip/sync work that
- * starves authenticated store-backed routes (issue #997). Override via
- * `DKGAgentConfig.maxRehydratedContextGraphSubscriptions` (0 disables).
+ * starves authenticated store-backed routes (issue #997). Rows beyond the cap
+ * remain persisted/dormant and are exposed through subscription diagnostics.
+ * Override via `DKGAgentConfig.maxRehydratedContextGraphSubscriptions` (0 disables).
  */
 const DEFAULT_MAX_REHYDRATED_SUBSCRIPTIONS = 64;
 /** Yield to the event loop every N activations so concurrent store work can interleave. */
@@ -343,6 +344,7 @@ import {
   type ChatSendResult,
   type ContextGraphSub,
   type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
   type ContextGraphMemberPrincipalType,
   type ContextGraphMemberStatus,
@@ -3702,6 +3704,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
   }
 
+  getContextGraphSubscriptionRehydrationStatus(this: DKGAgent): ContextGraphSubscriptionRehydrationStatus | null {
+    const status = this.contextGraphSubscriptionRehydrationStatus;
+    if (!status) return null;
+    return {
+      ...status,
+      dormantIds: [...status.dormantIds],
+    };
+  }
+
   async rehydrateContextGraphSubscriptions(this: DKGAgent): Promise<void> {
     const store = this.config.contextGraphSubscriptionStore;
     if (!store) return;
@@ -3713,7 +3724,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // would let them consume activation slots and leave USER subscriptions
       // dormant. Exclude them from the rehydration set entirely.
       const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
-      const rows = (await store.loadAll()).filter((r) => !systemContextGraphs.has(r.id));
+      const persistedRows = await store.loadAll();
+      const rows = persistedRows.filter((r) => !systemContextGraphs.has(r.id));
       // Cap how many subscriptions we ACTIVATE on boot. Activation
       // (in-memory restore + sync-track + gossip subscribe + member persist)
       // does store-touching work per row; a large stale backlog fans this out
@@ -3749,13 +3761,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // reconcile / host-mode path depends on it — so EXEMPT them from the cap.
       // The cap (a #997 anti-wedge measure) applies only to the non-hosted
       // user-subscription backlog, which is what fans out and starves the store
-      // on boot. Prioritise subscribed rows within the capped set.
-      const hostedRows = rows.filter((r) => r.coreHosted);
+      // on boot. Sort every group explicitly so the dormant set is stable and
+      // operator diagnostics identify the same IDs across restarts.
+      const byId = (a: ContextGraphSubscriptionRecord, b: ContextGraphSubscriptionRecord): number =>
+        a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      const hostedRows = rows.filter((r) => r.coreHosted).sort(byId);
       const userRows = [...rows.filter((r) => !r.coreHosted)].sort(
-        (a, b) => (b.subscribed ? 1 : 0) - (a.subscribed ? 1 : 0),
+        (a, b) => (b.subscribed ? 1 : 0) - (a.subscribed ? 1 : 0) || byId(a, b),
       );
       const cappedUserRows = cap > 0 ? userRows.slice(0, cap) : userRows;
       const toActivate = [...hostedRows, ...cappedUserRows];
+      const dormantRows = cap > 0 ? userRows.slice(cap) : [];
       for (let i = 0; i < toActivate.length; i++) {
         const row = toActivate[i];
         this.setContextGraphSubscription(row.id, {
@@ -3769,6 +3785,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           lastReconciledOrdinal: row.lastReconciledOrdinal,
           coreHosted: row.coreHosted,
         }, { persist: false });
+        if (row.onChainHash) {
+          this.recordCgWireId(row.id, row.onChainHash);
+        }
         if (row.syncScoped) {
           this.trackSyncContextGraph(row.id);
         }
@@ -3782,11 +3801,22 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
       }
-      const skipped = userRows.length - cappedUserRows.length;
+      const skipped = dormantRows.length;
+      this.contextGraphSubscriptionRehydrationStatus = {
+        persistedTotal: persistedRows.length,
+        systemExcluded: persistedRows.length - rows.length,
+        hostedActivated: hostedRows.length,
+        activated: toActivate.length,
+        dormant: skipped,
+        activationCap: cap,
+        capDisabled: cap === 0,
+        dormantIds: dormantRows.map((r) => r.id),
+        completedAt: Date.now(),
+      };
       if (rows.length > 0) {
         this.log.info(
           ctx,
-          `Rehydrated ${toActivate.length} of ${rows.length} persisted context-graph subscription(s)` +
+          `Rehydrated ${toActivate.length} of ${rows.length} non-system persisted context-graph subscription(s)` +
             (skipped > 0
               ? ` (${skipped} non-hosted left dormant — over the ${cap} activation cap; ` +
                 `${hostedRows.length} hosted always restored)`
@@ -3798,7 +3828,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           ctx,
           `${skipped} context-graph subscription(s) left dormant to avoid store contention (#997). ` +
             `Prune stale ones via 'DELETE /api/context-graph/subscriptions', or raise ` +
-            `maxRehydratedContextGraphSubscriptions.`,
+            `maxRehydratedContextGraphSubscriptions. Inspect ` +
+            `'GET /api/context-graph/subscriptions' for dormant ids.`,
         );
       }
     } catch (err) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3622,6 +3622,35 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return true;
   }
 
+  beginContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): void {
+    if (revision == null) return;
+    let pending = this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId);
+    if (!pending) {
+      pending = new Set<number>();
+      this.contextGraphSubscriptionPersistPendingRevisions.set(contextGraphId, pending);
+    }
+    pending.add(revision);
+  }
+
+  finishContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): void {
+    if (revision == null) return;
+    const pending = this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId);
+    pending?.delete(revision);
+    if (pending && pending.size > 0) return;
+    this.contextGraphSubscriptionPersistPendingRevisions.delete(contextGraphId);
+    this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
+  }
+
+  clearContextGraphSubscriptionPersistRevisionStateIfIdle(this: DKGAgent, contextGraphId: string): void {
+    if ((this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId)?.size ?? 0) > 0) return;
+    const sub = this.subscribedContextGraphs.get(contextGraphId);
+    if (sub?.subscribed === true || sub?.coreHosted === true) return;
+    if (this.contextGraphSubscriptionRehydrationAccountedIds.has(contextGraphId)) return;
+    this.contextGraphSubscriptionPersistRevisions.delete(contextGraphId);
+    this.contextGraphSubscriptionPersistAppliedRevisions.delete(contextGraphId);
+    this.contextGraphSubscriptionPersistCanceledRevisions.delete(contextGraphId);
+  }
+
   updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
     contextGraphId: string,
     next?: ContextGraphSub,
@@ -3723,6 +3752,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       dormantIds,
       completedAt: Date.now(),
     };
+    for (const id of clearedSet) {
+      this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(id);
+    }
   }
 
   deleteContextGraphSubscription(this: DKGAgent, contextGraphId: string): boolean {
@@ -3753,6 +3785,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // the host-only record MUST survive restart so a Core that was offline
     // during a publish remembers it hosts the CG and fills its gap. Drop the
     // row only when the node neither subscribes to nor hosts the CG.
+    this.beginContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
     if (!sub?.subscribed && !sub?.coreHosted) {
       void store.delete(contextGraphId)
         .then(() => {
@@ -3768,6 +3801,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             createOperationContext('system'),
             `Failed to delete persisted context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
           );
+        })
+        .finally(() => {
+          this.finishContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
         });
       return;
     }
@@ -3795,6 +3831,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         createOperationContext('system'),
         `Failed to persist context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
       );
+    }).finally(() => {
+      this.finishContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
     });
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3939,7 +3939,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         this.contextGraphSubscriptionRehydrationAccountedIds.add(row.id);
       }
       this.contextGraphSubscriptionRehydrationStatus = {
-        persistedTotal: persistedRows.length,
+        persistedTotal: rows.length,
         systemExcluded: persistedRows.length - rows.length,
         hostedActivated: hostedRows.length,
         hostedActivatedIds: hostedRows.map((r) => r.id),
@@ -4033,6 +4033,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
     }
     const total = persistedUserIds.length;
+    // Cancel any in-flight save callbacks that started before this bulk clear.
+    for (const id of new Set([...persistedUserIds, ...activeUserIds])) {
+      this.nextContextGraphSubscriptionPersistRevision(id);
+    }
 
     // Tear down active in-memory USER subscriptions (gossip topics + sync scope),
     // then REMOVE the registry entry. `unsubscribeFromContextGraph` only flips

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3578,14 +3578,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
     }
     if (options?.persist !== false) {
-      const revision = this.nextContextGraphSubscriptionPersistRevision(contextGraphId);
-      this.persistContextGraphSubscription(
-        contextGraphId,
-        {
-          revision,
-          updateRehydrationStatus: options?.updateRehydrationStatus !== false,
-        },
-      );
+      if (this.config.contextGraphSubscriptionStore) {
+        const revision = this.nextContextGraphSubscriptionPersistRevision(contextGraphId);
+        this.persistContextGraphSubscription(
+          contextGraphId,
+          {
+            revision,
+            updateRehydrationStatus: options?.updateRehydrationStatus !== false,
+          },
+        );
+      }
       if (next.subscribed) {
         this.persistLocalNodeMembership(contextGraphId);
       } else {
@@ -3608,6 +3610,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   cancelContextGraphSubscriptionPersistRevisions(this: DKGAgent, contextGraphId: string): void {
+    if (!this.config.contextGraphSubscriptionStore) {
+      this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
+      return;
+    }
     const revision = this.nextContextGraphSubscriptionPersistRevision(contextGraphId);
     this.contextGraphSubscriptionPersistCanceledRevisions.set(contextGraphId, revision);
   }
@@ -3632,6 +3638,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     pending.add(revision);
   }
 
+  enqueueContextGraphSubscriptionPersistWrite(
+    this: DKGAgent,
+    contextGraphId: string,
+    write: () => Promise<void>,
+  ): Promise<void> {
+    const previous = this.contextGraphSubscriptionPersistChains.get(contextGraphId) ?? Promise.resolve();
+    const run = previous.then(write);
+    const chain = run.catch(() => undefined);
+    this.contextGraphSubscriptionPersistChains.set(contextGraphId, chain);
+    void chain.finally(() => {
+      if (this.contextGraphSubscriptionPersistChains.get(contextGraphId) !== chain) return;
+      this.contextGraphSubscriptionPersistChains.delete(contextGraphId);
+      this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
+    });
+    return run;
+  }
+
   finishContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): void {
     if (revision == null) return;
     const pending = this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId);
@@ -3643,9 +3666,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
 
   clearContextGraphSubscriptionPersistRevisionStateIfIdle(this: DKGAgent, contextGraphId: string): void {
     if ((this.contextGraphSubscriptionPersistPendingRevisions.get(contextGraphId)?.size ?? 0) > 0) return;
+    if (this.contextGraphSubscriptionPersistChains.has(contextGraphId)) return;
     const sub = this.subscribedContextGraphs.get(contextGraphId);
     if (sub?.subscribed === true || sub?.coreHosted === true) return;
     if (this.contextGraphSubscriptionRehydrationAccountedIds.has(contextGraphId)) return;
+    this.contextGraphSubscriptionPersistPendingRevisions.delete(contextGraphId);
     this.contextGraphSubscriptionPersistRevisions.delete(contextGraphId);
     this.contextGraphSubscriptionPersistAppliedRevisions.delete(contextGraphId);
     this.contextGraphSubscriptionPersistCanceledRevisions.delete(contextGraphId);
@@ -3697,7 +3722,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       activated,
       dormant: dormantIds.length,
       dormantIds,
-      completedAt: Date.now(),
+      updatedAt: Date.now(),
     };
   }
 
@@ -3750,7 +3775,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       activated,
       dormant: dormantIds.length,
       dormantIds,
-      completedAt: Date.now(),
+      updatedAt: Date.now(),
     };
     for (const id of clearedSet) {
       this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(id);
@@ -3764,6 +3789,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   persistContextGraphSubscriptionState(this: DKGAgent, contextGraphId: string): void {
+    if (!this.config.contextGraphSubscriptionStore) {
+      this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
+      return;
+    }
     this.persistContextGraphSubscription(contextGraphId, {
       revision: this.nextContextGraphSubscriptionPersistRevision(contextGraphId),
       updateRehydrationStatus: false,
@@ -3779,7 +3808,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): void {
     this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
-    if (!store) return;
+    if (!store) {
+      this.clearContextGraphSubscriptionPersistRevisionStateIfIdle(contextGraphId);
+      return;
+    }
     const sub = this.subscribedContextGraphs.get(contextGraphId);
     // Persist member subscriptions AND (Phase D) public CGs this Core hosts —
     // the host-only record MUST survive restart so a Core that was offline
@@ -3787,7 +3819,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // row only when the node neither subscribes to nor hosts the CG.
     this.beginContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
     if (!sub?.subscribed && !sub?.coreHosted) {
-      void store.delete(contextGraphId)
+      void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.delete(contextGraphId))
         .then(() => {
           if (
             options?.updateRehydrationStatus === true &&
@@ -3807,7 +3839,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         });
       return;
     }
-    void store.save({
+    const record = {
       id: contextGraphId,
       name: sub.name,
       subscribed: sub.subscribed,
@@ -3819,21 +3851,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       lastReconciledOrdinal: sub.lastReconciledOrdinal,
       coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
-    }).then(() => {
-      if (
-        options?.updateRehydrationStatus === true &&
-        this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
-      ) {
-        this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, sub);
-      }
-    }).catch((err) => {
-      this.log.warn(
-        createOperationContext('system'),
-        `Failed to persist context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }).finally(() => {
-      this.finishContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
-    });
+    };
+    void this.enqueueContextGraphSubscriptionPersistWrite(contextGraphId, () => store.save(record))
+      .then(() => {
+        if (
+          options?.updateRehydrationStatus === true &&
+          this.claimContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
+        ) {
+          this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, sub);
+        }
+      }).catch((err) => {
+        this.log.warn(
+          createOperationContext('system'),
+          `Failed to persist context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }).finally(() => {
+        this.finishContextGraphSubscriptionPersistRevision(contextGraphId, options?.revision);
+      });
   }
 
   normalizeMembershipPrincipal(this: DKGAgent,
@@ -4001,6 +4035,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       for (const row of rows) {
         this.contextGraphSubscriptionRehydrationAccountedIds.add(row.id);
       }
+      const completedAt = Date.now();
       this.contextGraphSubscriptionRehydrationStatus = {
         persistedTotal: rows.length,
         systemExcluded: persistedRows.length - rows.length,
@@ -4011,7 +4046,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         activationCap: cap,
         capDisabled: cap === 0,
         dormantIds: dormantRows.map((r) => r.id),
-        completedAt: Date.now(),
+        completedAt,
+        updatedAt: completedAt,
       };
       if (rows.length > 0) {
         this.log.info(
@@ -4095,9 +4131,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         );
       }
     }
-    const total = persistedUserIds.length;
+    const activeUserIdsWithPendingStoreWrite = store
+      ? activeUserIds.filter((id) => this.contextGraphSubscriptionPersistChains.has(id))
+      : [];
+    const storeDeleteIds = [...new Set([...persistedUserIds, ...activeUserIdsWithPendingStoreWrite])];
+    const total = storeDeleteIds.length;
+    const idsToCancel = store ? [...new Set([...storeDeleteIds, ...activeUserIds])] : [];
     // Cancel any in-flight save callbacks that started before this bulk clear.
-    for (const id of new Set([...persistedUserIds, ...activeUserIds])) {
+    for (const id of idsToCancel) {
       this.cancelContextGraphSubscriptionPersistRevisions(id);
     }
 
@@ -4130,9 +4171,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     let failed = 0;
     if (store) {
       cleared = 0;
-      for (const id of persistedUserIds) {
+      for (const id of storeDeleteIds) {
         try {
-          await store.delete(id);
+          await this.enqueueContextGraphSubscriptionPersistWrite(id, () => store.delete(id));
           cleared++;
           clearedIds.push(id);
         } catch (err) {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3579,9 +3579,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.clearVmReconcileStateForContextGraph(contextGraphId);
     }
     if (options?.persist !== false) {
+      const revision = this.nextContextGraphSubscriptionPersistRevision(contextGraphId);
       this.persistContextGraphSubscription(
         contextGraphId,
-        options?.updateRehydrationStatus === false ? undefined : { existing, next },
+        {
+          existing,
+          next,
+          revision,
+          updateRehydrationStatus: options?.updateRehydrationStatus !== false,
+        },
       );
       if (next.subscribed) {
         this.persistLocalNodeMembership(contextGraphId);
@@ -3596,6 +3602,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
     this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
+  }
+
+  nextContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string): number {
+    const revision = (this.contextGraphSubscriptionPersistRevisions.get(contextGraphId) ?? 0) + 1;
+    this.contextGraphSubscriptionPersistRevisions.set(contextGraphId, revision);
+    return revision;
+  }
+
+  canApplyContextGraphSubscriptionPersistRevision(this: DKGAgent, contextGraphId: string, revision?: number): boolean {
+    return revision != null && this.contextGraphSubscriptionPersistRevisions.get(contextGraphId) === revision;
   }
 
   updateContextGraphSubscriptionRehydrationStatusAfterPersist(this: DKGAgent,
@@ -3644,6 +3660,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       activated,
       dormant: dormantIds.length,
       dormantIds,
+      completedAt: Date.now(),
     };
   }
 
@@ -3680,6 +3697,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       activated,
       dormant: dormantIds.length,
       dormantIds,
+      completedAt: Date.now(),
     };
   }
 
@@ -3690,12 +3708,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   }
 
   persistContextGraphSubscriptionState(this: DKGAgent, contextGraphId: string): void {
-    this.persistContextGraphSubscription(contextGraphId);
+    this.persistContextGraphSubscription(contextGraphId, {
+      revision: this.nextContextGraphSubscriptionPersistRevision(contextGraphId),
+      updateRehydrationStatus: false,
+    });
   }
 
   persistContextGraphSubscription(this: DKGAgent,
     contextGraphId: string,
-    options?: { existing?: ContextGraphSub; next?: ContextGraphSub },
+    options?: {
+      existing?: ContextGraphSub;
+      next?: ContextGraphSub;
+      revision?: number;
+      updateRehydrationStatus?: boolean;
+    },
   ): void {
     this.invalidateListContextGraphsCache();
     const store = this.config.contextGraphSubscriptionStore;
@@ -3708,7 +3734,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!sub?.subscribed && !sub?.coreHosted) {
       void store.delete(contextGraphId)
         .then(() => {
-          if (options) {
+          if (
+            options?.updateRehydrationStatus === true &&
+            this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
+          ) {
             this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, undefined);
           }
         })
@@ -3733,7 +3762,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       coreHosted: sub.coreHosted,
       syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
     }).then(() => {
-      if (options) {
+      if (
+        options?.updateRehydrationStatus === true &&
+        this.canApplyContextGraphSubscriptionPersistRevision(contextGraphId, options.revision)
+      ) {
         this.updateContextGraphSubscriptionRehydrationStatusAfterPersist(contextGraphId, options.existing, sub);
       }
     }).catch((err) => {

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -470,7 +470,10 @@ export class SwmSubstrateMethods extends DKGAgentBase {
    * devnet where storage cores otherwise auto-subscribe to everything they
    * host, masking the host-only fill path.
    */
-  unsubscribeFromContextGraph(this: DKGAgent, contextGraphId: string): void {
+  unsubscribeFromContextGraph(this: DKGAgent,
+    contextGraphId: string,
+    options?: { updateRehydrationStatus?: boolean },
+  ): void {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
 
@@ -517,7 +520,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     this.setContextGraphSubscription(
       contextGraphId,
       { ...existing, subscribed: false },
-      { persist: true },
+      { persist: true, updateRehydrationStatus: options?.updateRehydrationStatus },
     );
 
     void this.reconcileSwmHostModeSubscription(contextGraphId).catch((err) => {

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -472,7 +472,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
    */
   unsubscribeFromContextGraph(this: DKGAgent,
     contextGraphId: string,
-    options?: { updateRehydrationStatus?: boolean },
+    options?: { persist?: boolean; updateRehydrationStatus?: boolean },
   ): void {
     const existing = this.subscribedContextGraphs.get(contextGraphId);
     if (!existing) return;
@@ -520,7 +520,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     this.setContextGraphSubscription(
       contextGraphId,
       { ...existing, subscribed: false },
-      { persist: true, updateRehydrationStatus: options?.updateRehydrationStatus },
+      { persist: options?.persist ?? true, updateRehydrationStatus: options?.updateRehydrationStatus },
     );
 
     void this.reconcileSwmHostModeSubscription(contextGraphId).catch((err) => {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -658,7 +658,9 @@ export interface ContextGraphSubscriptionStore {
 }
 
 export interface ContextGraphSubscriptionRehydrationStatus {
+  /** Non-system persisted rows governed by the rehydration cap. */
   persistedTotal: number;
+  /** Persisted system rows seen during rehydration; excluded from cap math. */
   systemExcluded: number;
   hostedActivated: number;
   hostedActivatedIds: string[];

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -661,6 +661,7 @@ export interface ContextGraphSubscriptionRehydrationStatus {
   persistedTotal: number;
   systemExcluded: number;
   hostedActivated: number;
+  hostedActivatedIds: string[];
   activated: number;
   dormant: number;
   activationCap: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -657,6 +657,18 @@ export interface ContextGraphSubscriptionStore {
   delete(contextGraphId: string): Promise<void>;
 }
 
+export interface ContextGraphSubscriptionRehydrationStatus {
+  persistedTotal: number;
+  systemExcluded: number;
+  hostedActivated: number;
+  activated: number;
+  dormant: number;
+  activationCap: number;
+  capDisabled: boolean;
+  dormantIds: string[];
+  completedAt: number;
+}
+
 export interface ContextGraphWritePreflightProbe {
   exists: boolean;
   hasLocalContent: boolean;
@@ -1005,12 +1017,13 @@ export interface DKGAgentConfig {
   /** Durable local store for paged sync checkpoints. Defaults to in-memory. */
   syncCheckpointStore?: SyncCheckpointStore;
   /**
-   * Cap on how many persisted context-graph subscriptions are *activated*
-   * (gossip-subscribed + sync-tracked) when rehydrating at startup. A large
-   * backlog of stale subscriptions otherwise fans out store-touching gossip
-   * /sync work that starves authenticated store-backed routes (issue #997).
-   * Subscriptions beyond the cap stay persisted but inactive and can be
-   * pruned via `DELETE /api/context-graph/subscriptions`. Default
+   * Intentional cap on how many persisted context-graph subscriptions are
+   * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.
+   * A large backlog of stale subscriptions otherwise fans out store-touching
+   * gossip/sync work that starves authenticated store-backed routes (issue
+   * #997). Rows beyond the cap stay persisted but inactive, are reported via
+   * subscription diagnostics, and can be pruned via
+   * `DELETE /api/context-graph/subscriptions`. Default
    * `DEFAULT_MAX_REHYDRATED_SUBSCRIPTIONS`. `0` disables the cap.
    */
   maxRehydratedContextGraphSubscriptions?: number;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -669,7 +669,10 @@ export interface ContextGraphSubscriptionRehydrationStatus {
   activationCap: number;
   capDisabled: boolean;
   dormantIds: string[];
+  /** Startup rehydration completion timestamp; remains stable after boot. */
   completedAt: number;
+  /** Most recent timestamp for post-boot diagnostic count/id updates. */
+  updatedAt: number;
 }
 
 export interface ContextGraphWritePreflightProbe {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -105,6 +105,7 @@ export {
   type ContextGraphMembershipRecord,
   type ContextGraphMembershipStore,
   type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionRehydrationStatus,
   type ContextGraphSubscriptionStore,
   type ContextGraphWritePreflightProbe,
   type PeerHealth,

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -241,6 +241,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           persistedTotal: 173,
           systemExcluded: 0,
           hostedActivated: 0,
+          hostedActivatedIds: [],
           activated: 64,
           dormant: 109,
           activationCap: 64,
@@ -248,7 +249,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormantIds: rows.slice(64).map((r) => r.id),
         });
         expect(await agent.clearContextGraphSubscriptions()).toBe(173);
-        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toBeNull();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 0,
+          hostedActivated: 0,
+          hostedActivatedIds: [],
+          activated: 0,
+          dormant: 0,
+          dormantIds: [],
+        });
       } finally {
         await agent.stop().catch(() => {});
       }
@@ -329,6 +337,59 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('updates only the affected dormant rehydration diagnostic after a successful persisted write', async () => {
+      const rows = Array.from({ length: 66 }, (_, i) => ({
+        id: `one-write-cg-${String(i).padStart(3, '0')}`,
+        name: `One Write CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const saved: any[] = [];
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async (record: any) => {
+          saved.push(record);
+        },
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationOneWrite',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          activated: 64,
+          dormant: 2,
+          dormantIds: ['one-write-cg-064', 'one-write-cg-065'],
+        });
+
+        agent.setContextGraphSubscription('one-write-cg-064', {
+          name: 'One Write CG 64',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        expect(saved.map((r) => r.id)).toContain('one-write-cg-064');
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 66,
+          activated: 65,
+          dormant: 1,
+          dormantIds: ['one-write-cg-065'],
+        });
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('disables the rehydration activation cap when configured with zero', async () => {
       const rows = Array.from({ length: 70 }, (_, i) => ({
         id: `uncapped-cg-${String(i).padStart(3, '0')}`,
@@ -364,6 +425,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 0,
           activationCap: 0,
           capDisabled: true,
+          hostedActivatedIds: [],
           dormantIds: [],
         });
       } finally {
@@ -436,6 +498,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
           persistedTotal: rows.length,
           hostedActivated: hosted.length,
+          hostedActivatedIds: hosted.map((r) => r.id),
           activated: hosted.length + cap,
           dormant: user.length - cap,
           activationCap: cap,

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -387,13 +387,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 1,
           dormantIds: ['one-write-cg-065'],
         });
-        expect(afterStatus?.completedAt).toBeGreaterThanOrEqual(beforeStatus?.completedAt ?? 0);
+        expect(afterStatus?.completedAt).toBe(beforeStatus?.completedAt);
+        expect(afterStatus?.updatedAt).toBeGreaterThanOrEqual(beforeStatus?.updatedAt ?? 0);
       } finally {
         await agent.stop().catch(() => {});
       }
     });
 
-    it('ignores stale persisted-write callbacks when a newer write supersedes the same context graph', async () => {
+    it('serializes a queued delete after an earlier same-context save', async () => {
       const rows = Array.from({ length: 65 }, (_, i) => ({
         id: `stale-write-cg-${String(i).padStart(3, '0')}`,
         name: `Stale Write CG ${i}`,
@@ -444,13 +445,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
-          persistedTotal: 64,
+          persistedTotal: 65,
           activated: 64,
-          dormant: 0,
-          dormantIds: [],
+          dormant: 1,
+          dormantIds: ['stale-write-cg-064'],
         });
         expect(saveResolvers).toHaveLength(startupSaveCount + 1);
         saveResolvers[startupSaveCount]();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
           persistedTotal: 64,
@@ -464,7 +466,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
-    it('accounts a new subscription from the latest persisted callback when an earlier callback is stale', async () => {
+    it('serializes same-context persisted writes so the newest saved state wins', async () => {
       const rows = Array.from({ length: 64 }, (_, i) => ({
         id: `new-race-cg-${String(i).padStart(3, '0')}`,
         name: `New Race CG ${i}`,
@@ -474,11 +476,18 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         metaSynced: false,
         syncScoped: true,
       }));
+      const persisted = new Map<string, any>(rows.map((r) => [r.id, { ...r }]));
       const saveResolvers: Array<{ id: string; resolve: () => void }> = [];
       const subscriptionStore = {
-        loadAll: async () => rows,
+        loadAll: async () => [...persisted.values()],
         save: async (record: any) => new Promise<void>((resolve) => {
-          saveResolvers.push({ id: record.id, resolve });
+          saveResolvers.push({
+            id: record.id,
+            resolve: () => {
+              persisted.set(record.id, { ...record });
+              resolve();
+            },
+          });
         }),
         delete: async () => {},
       };
@@ -512,11 +521,17 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           sharedMemorySynced: false,
           metaSynced: false,
         });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
+          'new-race-created',
+        ]);
+
+        saveResolvers[startupSaveCount].resolve();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
           'new-race-created',
           'new-race-created',
         ]);
-
         saveResolvers[startupSaveCount + 1].resolve();
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
@@ -525,22 +540,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 0,
           dormantIds: [],
         });
-
-        saveResolvers[startupSaveCount].resolve();
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
-          persistedTotal: 65,
-          activated: 65,
-          dormant: 0,
-          dormantIds: [],
-        });
+        expect(persisted.get('new-race-created')?.synced).toBe(true);
       } finally {
         for (const { resolve } of saveResolvers) resolve();
         await agent.stop().catch(() => {});
       }
     });
 
-    it('accounts an older successful callback when a newer persisted write fails', async () => {
+    it('keeps an older successful persistence when a queued newer write fails', async () => {
       const rows = Array.from({ length: 64 }, (_, i) => ({
         id: `fail-race-cg-${String(i).padStart(3, '0')}`,
         name: `Fail Race CG ${i}`,
@@ -596,19 +603,10 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           sharedMemorySynced: false,
           metaSynced: false,
         });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
           'fail-race-created',
-          'fail-race-created',
         ]);
-
-        saveResolvers[startupSaveCount + 1].reject();
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
-          persistedTotal: 64,
-          activated: 64,
-          dormant: 0,
-          dormantIds: [],
-        });
 
         saveResolvers[startupSaveCount].resolve();
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -618,6 +616,20 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 0,
           dormantIds: [],
         });
+        expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
+          'fail-race-created',
+          'fail-race-created',
+        ]);
+
+        saveResolvers[startupSaveCount + 1].reject();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 65,
+          activated: 65,
+          dormant: 0,
+          dormantIds: [],
+        });
+        expect(persisted.get('fail-race-created')?.synced).toBe(false);
       } finally {
         for (const { resolve } of saveResolvers) resolve();
         await agent.stop().catch(() => {});
@@ -836,6 +848,7 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           'contextGraphSubscriptionPersistAppliedRevisions',
           'contextGraphSubscriptionPersistCanceledRevisions',
           'contextGraphSubscriptionPersistPendingRevisions',
+          'contextGraphSubscriptionPersistChains',
         ]) {
           expect((agent as any)[mapName].has('clear-cg-0')).toBe(false);
         }
@@ -896,21 +909,29 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           sharedMemorySynced: false,
           metaSynced: false,
         });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
           'preclear-created',
         ]);
 
-        expect(await agent.clearContextGraphSubscriptions()).toBe(64);
+        let clearSettled = false;
+        const clearPromise = agent.clearContextGraphSubscriptions().then((cleared) => {
+          clearSettled = true;
+          return cleared;
+        });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(clearSettled).toBe(false);
+
+        saveResolvers.find((entry) => entry.id === 'preclear-created')?.resolve();
+        expect(await clearPromise).toBe(65);
         expect(agent.getSubscribedContextGraphs().get('preclear-created')).toBeUndefined();
+        expect(persisted.has('preclear-created')).toBe(false);
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
           persistedTotal: 0,
           activated: 0,
           dormant: 0,
           dormantIds: [],
         });
-
-        saveResolvers.find((entry) => entry.id === 'preclear-created')?.resolve();
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
         expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
           persistedTotal: 0,
           activated: 0,
@@ -922,11 +943,51 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           'contextGraphSubscriptionPersistAppliedRevisions',
           'contextGraphSubscriptionPersistCanceledRevisions',
           'contextGraphSubscriptionPersistPendingRevisions',
+          'contextGraphSubscriptionPersistChains',
         ]) {
           expect((agent as any)[mapName].has('preclear-created')).toBe(false);
         }
       } finally {
         for (const { resolve } of saveResolvers) resolve();
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('does not allocate subscription persist revision state without a subscription store', async () => {
+      const agent = await DKGAgent.create({
+        name: 'StorelessSubscriptionRevisionCleanup',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+      try {
+        await agent.start();
+        agent.setContextGraphSubscription('storeless-transient', {
+          name: 'Storeless Transient',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        agent.persistContextGraphSubscriptionState('storeless-transient');
+        agent.setContextGraphSubscription('storeless-transient', {
+          name: 'Storeless Transient',
+          subscribed: false,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        expect(await agent.clearContextGraphSubscriptions()).toBe(0);
+
+        for (const mapName of [
+          'contextGraphSubscriptionPersistRevisions',
+          'contextGraphSubscriptionPersistAppliedRevisions',
+          'contextGraphSubscriptionPersistCanceledRevisions',
+          'contextGraphSubscriptionPersistPendingRevisions',
+          'contextGraphSubscriptionPersistChains',
+        ]) {
+          expect((agent as any)[mapName].has('storeless-transient')).toBe(false);
+        }
+      } finally {
         await agent.stop().catch(() => {});
       }
     });

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -247,6 +247,8 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           capDisabled: false,
           dormantIds: rows.slice(64).map((r) => r.id),
         });
+        expect(await agent.clearContextGraphSubscriptions()).toBe(173);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toBeNull();
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -831,6 +831,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 0,
           dormantIds: [],
         });
+        for (const mapName of [
+          'contextGraphSubscriptionPersistRevisions',
+          'contextGraphSubscriptionPersistAppliedRevisions',
+          'contextGraphSubscriptionPersistCanceledRevisions',
+          'contextGraphSubscriptionPersistPendingRevisions',
+        ]) {
+          expect((agent as any)[mapName].has('clear-cg-0')).toBe(false);
+        }
       } finally {
         await agent.stop().catch(() => {});
       }
@@ -909,6 +917,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
           dormant: 0,
           dormantIds: [],
         });
+        for (const mapName of [
+          'contextGraphSubscriptionPersistRevisions',
+          'contextGraphSubscriptionPersistAppliedRevisions',
+          'contextGraphSubscriptionPersistCanceledRevisions',
+          'contextGraphSubscriptionPersistPendingRevisions',
+        ]) {
+          expect((agent as any)[mapName].has('preclear-created')).toBe(false);
+        }
       } finally {
         for (const { resolve } of saveResolvers) resolve();
         await agent.stop().catch(() => {});

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -201,11 +201,9 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
     });
 
 
-    it('caps subscription activation at maxRehydratedContextGraphSubscriptions, leaving the rest dormant (#997)', async () => {
-      const N = 10;
-      const cap = 3;
-      const rows = Array.from({ length: N }, (_, i) => ({
-        id: `cap-cg-${i}`,
+    it('default rehydration deterministically activates 64 of a large persisted backlog (#997/#1180)', async () => {
+      const rows = Array.from({ length: 173 }, (_, i) => ({
+        id: `cap-cg-${String(i).padStart(3, '0')}`,
         name: `Cap CG ${i}`,
         subscribed: true,
         synced: false,
@@ -223,19 +221,140 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         listenHost: '127.0.0.1',
         chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
         contextGraphSubscriptionStore: subscriptionStore,
-        maxRehydratedContextGraphSubscriptions: cap,
       });
       try {
         await agent.start();
         const subs = agent.getSubscribedContextGraphs();
-        // Only `cap` of the N persisted rows are activated; the rest stay
-        // persisted (loadAll still returns all N) but dormant in-memory.
+        // Only the default activation cap is wired into gossip/sync scope; the
+        // rest stay persisted but dormant and are reported via diagnostics.
         const activated = rows.filter((r) => subs.get(r.id)?.subscribed === true).length;
-        expect(activated).toBe(cap);
+        expect(activated).toBe(64);
+        expect(subs.get('cap-cg-000')?.subscribed).toBe(true);
+        expect(subs.get('cap-cg-063')?.subscribed).toBe(true);
+        expect(subs.get('cap-cg-064')).toBeUndefined();
+        expect(subs.get('cap-cg-172')).toBeUndefined();
         const inSyncScope = ((agent as any).config.syncContextGraphs ?? []).filter(
           (id: string) => id.startsWith('cap-cg-'),
         ).length;
-        expect(inSyncScope).toBe(cap);
+        expect(inSyncScope).toBe(64);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 173,
+          systemExcluded: 0,
+          hostedActivated: 0,
+          activated: 64,
+          dormant: 109,
+          activationCap: 64,
+          capDisabled: false,
+          dormantIds: rows.slice(64).map((r) => r.id),
+        });
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('uses deterministic subscribed-first ordering when a custom rehydration cap is configured', async () => {
+      const rows = [
+        { id: 'cap-cg-c', name: 'C', subscribed: false, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
+        { id: 'cap-cg-b', name: 'B', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
+        { id: 'cap-cg-a', name: 'A', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
+        { id: 'cap-cg-d', name: 'D', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
+      ];
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async () => {},
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationOrdering',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+        maxRehydratedContextGraphSubscriptions: 2,
+      });
+      try {
+        await agent.start();
+        const subs = agent.getSubscribedContextGraphs();
+        expect(subs.get('cap-cg-a')?.subscribed).toBe(true);
+        expect(subs.get('cap-cg-b')?.subscribed).toBe(true);
+        expect(subs.get('cap-cg-c')).toBeUndefined();
+        expect(subs.get('cap-cg-d')).toBeUndefined();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()?.dormantIds).toEqual([
+          'cap-cg-d',
+          'cap-cg-c',
+        ]);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('disables the rehydration activation cap when configured with zero', async () => {
+      const rows = Array.from({ length: 70 }, (_, i) => ({
+        id: `uncapped-cg-${String(i).padStart(3, '0')}`,
+        name: `Uncapped CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async () => {},
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationDisabled',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+        maxRehydratedContextGraphSubscriptions: 0,
+      });
+      try {
+        await agent.start();
+        const subs = agent.getSubscribedContextGraphs();
+        expect(rows.filter((r) => subs.get(r.id)?.subscribed === true)).toHaveLength(rows.length);
+        expect(((agent as any).config.syncContextGraphs ?? []).filter(
+          (id: string) => id.startsWith('uncapped-cg-'),
+        )).toHaveLength(rows.length);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 70,
+          activated: 70,
+          dormant: 0,
+          activationCap: 0,
+          capDisabled: true,
+          dormantIds: [],
+        });
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('rebuilds persisted onChainHash reverse lookup during rehydration', async () => {
+      const wireId = `0x${'a'.repeat(64)}`;
+      const subscriptionStore = {
+        loadAll: async () => [{
+          id: 'wire-restore-cg',
+          name: 'Wire Restore',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+          onChainHash: wireId.toUpperCase(),
+          syncScoped: true,
+        }],
+        save: async () => {},
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'WireIdRehydration',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getSubscribedContextGraphs().get('wire-restore-cg')?.onChainHash).toBe(wireId);
+        expect((agent as any).wireIdToLocalCgId.get(wireId)).toBe('wire-restore-cg');
       } finally {
         await agent.stop().catch(() => {});
       }
@@ -272,6 +391,13 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         const userActive = user.filter((r) => subs.get(r.id)?.subscribed === true).length;
         expect(hostedActive).toBe(hosted.length); // all 3 hosted restored despite cap=2
         expect(userActive).toBe(cap);              // user backlog capped at 2
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: rows.length,
+          hostedActivated: hosted.length,
+          activated: hosted.length + cap,
+          dormant: user.length - cap,
+          activationCap: cap,
+        });
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -363,7 +363,8 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       });
       try {
         await agent.start();
-        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+        const beforeStatus = agent.getContextGraphSubscriptionRehydrationStatus();
+        expect(beforeStatus).toMatchObject({
           activated: 64,
           dormant: 2,
           dormantIds: ['one-write-cg-064', 'one-write-cg-065'],
@@ -379,13 +380,86 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
         expect(saved.map((r) => r.id)).toContain('one-write-cg-064');
-        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+        const afterStatus = agent.getContextGraphSubscriptionRehydrationStatus();
+        expect(afterStatus).toMatchObject({
           persistedTotal: 66,
           activated: 65,
           dormant: 1,
           dormantIds: ['one-write-cg-065'],
         });
+        expect(afterStatus?.completedAt).toBeGreaterThanOrEqual(beforeStatus?.completedAt ?? 0);
       } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('ignores stale persisted-write callbacks when a newer write supersedes the same context graph', async () => {
+      const rows = Array.from({ length: 65 }, (_, i) => ({
+        id: `stale-write-cg-${String(i).padStart(3, '0')}`,
+        name: `Stale Write CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const saveResolvers: Array<() => void> = [];
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async () => new Promise<void>((resolve) => {
+          saveResolvers.push(resolve);
+        }),
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationStaleWrite',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 65,
+          activated: 64,
+          dormant: 1,
+          dormantIds: ['stale-write-cg-064'],
+        });
+        const startupSaveCount = saveResolvers.length;
+
+        agent.setContextGraphSubscription('stale-write-cg-064', {
+          name: 'Stale Write CG 64',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        agent.setContextGraphSubscription('stale-write-cg-064', {
+          name: 'Stale Write CG 64',
+          subscribed: false,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+        expect(saveResolvers).toHaveLength(startupSaveCount + 1);
+        saveResolvers[startupSaveCount]();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+      } finally {
+        for (const resolve of saveResolvers) resolve();
         await agent.stop().catch(() => {});
       }
     });

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -540,6 +540,90 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('accounts an older successful callback when a newer persisted write fails', async () => {
+      const rows = Array.from({ length: 64 }, (_, i) => ({
+        id: `fail-race-cg-${String(i).padStart(3, '0')}`,
+        name: `Fail Race CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const persisted = new Map<string, any>(rows.map((r) => [r.id, { ...r }]));
+      const saveResolvers: Array<{ id: string; resolve: () => void; reject: () => void }> = [];
+      const subscriptionStore = {
+        loadAll: async () => [...persisted.values()],
+        save: async (record: any) => new Promise<void>((resolve, reject) => {
+          saveResolvers.push({
+            id: record.id,
+            resolve: () => {
+              persisted.set(record.id, { ...record });
+              resolve();
+            },
+            reject: () => reject(new Error('save failed')),
+          });
+        }),
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationFailedLatestRace',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+        const startupSaveCount = saveResolvers.length;
+
+        agent.setContextGraphSubscription('fail-race-created', {
+          name: 'Fail Race Created',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        agent.setContextGraphSubscription('fail-race-created', {
+          name: 'Fail Race Created',
+          subscribed: true,
+          synced: true,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
+          'fail-race-created',
+          'fail-race-created',
+        ]);
+
+        saveResolvers[startupSaveCount + 1].reject();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+
+        saveResolvers[startupSaveCount].resolve();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 65,
+          activated: 65,
+          dormant: 0,
+          dormantIds: [],
+        });
+      } finally {
+        for (const { resolve } of saveResolvers) resolve();
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('disables the rehydration activation cap when configured with zero', async () => {
       const rows = Array.from({ length: 70 }, (_, i) => ({
         id: `uncapped-cg-${String(i).padStart(3, '0')}`,
@@ -827,6 +911,59 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         });
       } finally {
         for (const { resolve } of saveResolvers) resolve();
+        await agent.stop().catch(() => {});
+      }
+    });
+
+
+    it('downgrades failed active deletes to dormant rehydration diagnostics during clear', async () => {
+      const failedId = 'clear-fail-cg-0';
+      const successId = 'clear-fail-cg-1';
+      const persisted = new Map<string, any>([failedId, successId].map((id) => [id, {
+        id,
+        name: id,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }]));
+      const subscriptionStore = {
+        loadAll: async () => [...persisted.values()],
+        save: async (record: any) => { persisted.set(record.id, { ...record }); },
+        delete: async (id: string) => {
+          if (id === failedId) throw new Error('delete failed');
+          if (!persisted.has(id)) throw new Error(`missing ${id}`);
+          persisted.delete(id);
+        },
+      };
+      const agent = await DKGAgent.create({
+        name: 'ClearSubscriptionsPartialFailure',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 2,
+          activated: 2,
+          dormant: 0,
+          dormantIds: [],
+        });
+
+        expect(await agent.clearContextGraphSubscriptions()).toBe(1);
+        expect(agent.getSubscribedContextGraphs().get(failedId)).toBeUndefined();
+        expect(agent.getSubscribedContextGraphs().get(successId)).toBeUndefined();
+        expect(persisted.has(failedId)).toBe(true);
+        expect(persisted.has(successId)).toBe(false);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 1,
+          activated: 0,
+          dormant: 1,
+          dormantIds: [failedId],
+        });
+      } finally {
         await agent.stop().catch(() => {});
       }
     });

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -702,6 +702,15 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         // (agents/ontology — the network control plane).
         expect([...persisted.keys()].filter((k) => k.startsWith('clear-cg-'))).toHaveLength(5);
         expect(agent.getSubscribedContextGraphs().get('clear-cg-0')?.subscribed).toBe(true);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 6,
+          systemExcluded: 0,
+          hostedActivated: 1,
+          hostedActivatedIds: ['hosted-cg'],
+          activated: 6,
+          dormant: 0,
+          dormantIds: [],
+        });
         for (const sys of systemIds) {
           expect(agent.getSubscribedContextGraphs().get(sys)?.subscribed).toBe(true);
         }
@@ -729,7 +738,95 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         // just like the rehydration cap, so host-mode/reconcile is never dropped).
         expect(agent.getSubscribedContextGraphs().get('hosted-cg')?.subscribed).toBe(true);
         expect(persisted.has('hosted-cg')).toBe(true);
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 1,
+          systemExcluded: 0,
+          hostedActivated: 1,
+          hostedActivatedIds: ['hosted-cg'],
+          activated: 1,
+          dormant: 0,
+          dormantIds: [],
+        });
       } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+
+    it('invalidates pending persisted callbacks before clearing subscriptions', async () => {
+      const rows = Array.from({ length: 64 }, (_, i) => ({
+        id: `preclear-cg-${String(i).padStart(3, '0')}`,
+        name: `Preclear CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const persisted = new Map<string, any>(rows.map((r) => [r.id, { ...r }]));
+      const saveResolvers: Array<{ id: string; resolve: () => void }> = [];
+      const subscriptionStore = {
+        loadAll: async () => [...persisted.values()],
+        save: async (record: any) => new Promise<void>((resolve) => {
+          saveResolvers.push({
+            id: record.id,
+            resolve: () => {
+              persisted.set(record.id, { ...record });
+              resolve();
+            },
+          });
+        }),
+        delete: async (id: string) => {
+          if (!persisted.has(id)) throw new Error(`missing ${id}`);
+          persisted.delete(id);
+        },
+      };
+      const agent = await DKGAgent.create({
+        name: 'ClearSubscriptionsPendingSave',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+        const startupSaveCount = saveResolvers.length;
+
+        agent.setContextGraphSubscription('preclear-created', {
+          name: 'Preclear Created',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
+          'preclear-created',
+        ]);
+
+        expect(await agent.clearContextGraphSubscriptions()).toBe(64);
+        expect(agent.getSubscribedContextGraphs().get('preclear-created')).toBeUndefined();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 0,
+          activated: 0,
+          dormant: 0,
+          dormantIds: [],
+        });
+
+        saveResolvers.find((entry) => entry.id === 'preclear-created')?.resolve();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 0,
+          activated: 0,
+          dormant: 0,
+          dormantIds: [],
+        });
+      } finally {
+        for (const { resolve } of saveResolvers) resolve();
         await agent.stop().catch(() => {});
       }
     });

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -464,6 +464,82 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
+    it('accounts a new subscription from the latest persisted callback when an earlier callback is stale', async () => {
+      const rows = Array.from({ length: 64 }, (_, i) => ({
+        id: `new-race-cg-${String(i).padStart(3, '0')}`,
+        name: `New Race CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const saveResolvers: Array<{ id: string; resolve: () => void }> = [];
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async (record: any) => new Promise<void>((resolve) => {
+          saveResolvers.push({ id: record.id, resolve });
+        }),
+        delete: async () => {},
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationNewRace',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 64,
+          activated: 64,
+          dormant: 0,
+          dormantIds: [],
+        });
+        const startupSaveCount = saveResolvers.length;
+
+        agent.setContextGraphSubscription('new-race-created', {
+          name: 'New Race Created',
+          subscribed: true,
+          synced: false,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        agent.setContextGraphSubscription('new-race-created', {
+          name: 'New Race Created',
+          subscribed: true,
+          synced: true,
+          sharedMemorySynced: false,
+          metaSynced: false,
+        });
+        expect(saveResolvers.slice(startupSaveCount).map((entry) => entry.id)).toEqual([
+          'new-race-created',
+          'new-race-created',
+        ]);
+
+        saveResolvers[startupSaveCount + 1].resolve();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 65,
+          activated: 65,
+          dormant: 0,
+          dormantIds: [],
+        });
+
+        saveResolvers[startupSaveCount].resolve();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          persistedTotal: 65,
+          activated: 65,
+          dormant: 0,
+          dormantIds: [],
+        });
+      } finally {
+        for (const { resolve } of saveResolvers) resolve();
+        await agent.stop().catch(() => {});
+      }
+    });
+
     it('disables the rehydration activation cap when configured with zero', async () => {
       const rows = Array.from({ length: 70 }, (_, i) => ({
         id: `uncapped-cg-${String(i).padStart(3, '0')}`,
@@ -608,7 +684,10 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       const subscriptionStore = {
         loadAll: async () => [...persisted.values()],
         save: async (r: any) => { persisted.set(r.id, { ...r }); },
-        delete: async (id: string) => { persisted.delete(id); },
+        delete: async (id: string) => {
+          if (!persisted.has(id)) throw new Error(`missing ${id}`);
+          persisted.delete(id);
+        },
       };
       const agent = await DKGAgent.create({
         name: 'ClearSubscriptions',

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -254,9 +254,9 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       }
     });
 
-    it('uses deterministic subscribed-first ordering when a custom rehydration cap is configured', async () => {
+    it('uses deterministic id ordering when a custom rehydration cap is configured', async () => {
       const rows = [
-        { id: 'cap-cg-c', name: 'C', subscribed: false, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
+        { id: 'cap-cg-c', name: 'C', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
         { id: 'cap-cg-b', name: 'B', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
         { id: 'cap-cg-a', name: 'A', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
         { id: 'cap-cg-d', name: 'D', subscribed: true, synced: false, sharedMemorySynced: false, metaSynced: false, syncScoped: true },
@@ -281,9 +281,49 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         expect(subs.get('cap-cg-c')).toBeUndefined();
         expect(subs.get('cap-cg-d')).toBeUndefined();
         expect(agent.getContextGraphSubscriptionRehydrationStatus()?.dormantIds).toEqual([
-          'cap-cg-d',
           'cap-cg-c',
+          'cap-cg-d',
         ]);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('keeps rehydration diagnostics when a persisted subscription delete fails', async () => {
+      const rows = Array.from({ length: 65 }, (_, i) => ({
+        id: `failed-delete-cg-${String(i).padStart(3, '0')}`,
+        name: `Failed Delete CG ${i}`,
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        syncScoped: true,
+      }));
+      const subscriptionStore = {
+        loadAll: async () => rows,
+        save: async () => {},
+        delete: async () => {
+          throw new Error('delete failed');
+        },
+      };
+      const agent = await DKGAgent.create({
+        name: 'CapRehydrationDeleteFailure',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+        contextGraphSubscriptionStore: subscriptionStore,
+      });
+      try {
+        await agent.start();
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          activated: 64,
+          dormant: 1,
+        });
+        agent.unsubscribeFromContextGraph('failed-delete-cg-000');
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(agent.getContextGraphSubscriptionRehydrationStatus()).toMatchObject({
+          activated: 64,
+          dormant: 1,
+        });
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -463,11 +463,13 @@ export interface DkgConfig {
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
   store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
   /**
-   * Cap on how many persisted context-graph subscriptions a node ACTIVATES on
-   * boot (gossip + sync). A large stale backlog otherwise fans out store work
-   * and starves authenticated routes (#997). coreHosted graphs are always
-   * restored regardless of this cap. Non-negative integer; 0 = no cap. Raise it
-   * on nodes that legitimately subscribe to more than the default (64).
+   * Intentional cap on how many persisted context-graph subscriptions a node
+   * ACTIVATES on boot (gossip + sync). A large stale backlog otherwise fans out
+   * store work and starves authenticated routes (#997). coreHosted graphs are
+   * always restored regardless of this cap. Rows beyond the cap stay persisted
+   * and are reported by GET /api/context-graph/subscriptions. Non-negative
+   * integer; 0 = no cap. Raise it on nodes that legitimately subscribe to more
+   * than the default (64).
    */
   maxRehydratedContextGraphSubscriptions?: number;
   /** Out-of-line storage for large public SWM RDF literal object terms. */

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1669,12 +1669,12 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     const map = agent.getSubscribedContextGraphs?.();
     const subscriptions = map
       ? [...map.entries()]
-          // ACTIVE USER / hosted entries only. Exclude (a) discoverable-only
-          // registry entries (`subscribed: false` and not `coreHosted`) and
-          // (b) the always-on AGENTS/ONTOLOGY system CGs — which the startup
-          // cap/log also exclude — while retaining host-only rows so the
-          // `rehydration.hostedActivated` count is inspectable in the payload.
-          .filter(([id, s]) => (s?.subscribed === true || s?.coreHosted === true) && !systemContextGraphs.has(id))
+          // ACTIVE USER subscriptions only. Exclude discoverable/host-only
+          // registry entries and the always-on AGENTS/ONTOLOGY system CGs.
+          // Host-only boot activations are exposed separately through
+          // `rehydration.hostedActivatedIds` so the legacy subscriptions
+          // contract stays subscribed-only.
+          .filter(([id, s]) => s?.subscribed === true && !systemContextGraphs.has(id))
           .map(([id, s]) => ({
             contextGraphId: id,
             subscribed: s?.subscribed === true,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1669,15 +1669,15 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     const map = agent.getSubscribedContextGraphs?.();
     const subscriptions = map
       ? [...map.entries()]
-          // ACTIVE USER subscriptions only. Exclude (a) discoverable-only /
-          // unsubscribed registry entries (`subscribed: false`) and (b) the
-          // always-on AGENTS/ONTOLOGY system CGs — which the startup cap/log also
-          // exclude — so `count` and the payload match the rehydrated
-          // user-subscription total rather than running ≥2 higher.
-          .filter(([id, s]) => s?.subscribed === true && !systemContextGraphs.has(id))
+          // ACTIVE USER / hosted entries only. Exclude (a) discoverable-only
+          // registry entries (`subscribed: false` and not `coreHosted`) and
+          // (b) the always-on AGENTS/ONTOLOGY system CGs — which the startup
+          // cap/log also exclude — while retaining host-only rows so the
+          // `rehydration.hostedActivated` count is inspectable in the payload.
+          .filter(([id, s]) => (s?.subscribed === true || s?.coreHosted === true) && !systemContextGraphs.has(id))
           .map(([id, s]) => ({
             contextGraphId: id,
-            subscribed: true,
+            subscribed: s?.subscribed === true,
             synced: s?.synced === true,
             coreHosted: s?.coreHosted === true,
           }))

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1653,9 +1653,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   }
 
   // GET /api/context-graph/subscriptions — list the node's ACTIVE in-memory
-  // context-graph subscriptions (diagnostics for #997: see how many are live).
-  // The total PERSISTED backlog is reported in the boot log ("Rehydrated X of
-  // Y"); anything beyond the activation cap is dormant until pruned below.
+  // context-graph subscriptions plus startup rehydration diagnostics (#997/#1180).
+  // Rows beyond the activation cap are persisted/dormant, not gossip/sync active.
   if (req.method === "GET" && path === "/api/context-graph/subscriptions") {
     // Operator-only: this is a NODE-WIDE view, so an agent-scoped token would
     // otherwise be able to enumerate OTHER agents' subscribed/private CG IDs.
@@ -1683,7 +1682,11 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
             coreHosted: s?.coreHosted === true,
           }))
       : [];
-    return jsonResponse(res, 200, { count: subscriptions.length, subscriptions });
+    return jsonResponse(res, 200, {
+      count: subscriptions.length,
+      subscriptions,
+      rehydration: agent.getContextGraphSubscriptionRehydrationStatus?.() ?? null,
+    });
   }
 
   // DELETE /api/context-graph/subscriptions — operator recovery for #997: tear

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -17,9 +17,12 @@ describe('context graph subscription diagnostics route', () => {
     dormantIds: ['cg-064', 'cg-065', 'cg-066', 'cg-067', 'cg-068', 'cg-069'],
     completedAt: 1_700_000_000_000,
   };
+  let rehydrationStatus: typeof rehydration | null = null;
+  let subscriptions: Map<string, any>;
 
   beforeEach(async () => {
-    const subscriptions = new Map<string, any>([
+    rehydrationStatus = rehydration;
+    subscriptions = new Map<string, any>([
       ['cg-000', { subscribed: true, synced: true, coreHosted: false }],
       ['cg-hosted', { subscribed: true, synced: false, coreHosted: true }],
       ['cg-discoverable', { subscribed: false, synced: false, coreHosted: false }],
@@ -27,7 +30,12 @@ describe('context graph subscription diagnostics route', () => {
     ]);
     const agent = {
       getSubscribedContextGraphs: () => subscriptions,
-      getContextGraphSubscriptionRehydrationStatus: () => rehydration,
+      getContextGraphSubscriptionRehydrationStatus: () => rehydrationStatus,
+      clearContextGraphSubscriptions: async () => {
+        rehydrationStatus = null;
+        subscriptions.clear();
+        return 6;
+      },
       resolveAgentByToken: (token?: string) => token === 'agent-token'
         ? '0x1111111111111111111111111111111111111111'
         : undefined,
@@ -119,5 +127,24 @@ describe('context graph subscription diagnostics route', () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toContain('node-level admin token');
+  });
+
+  it('returns null rehydration diagnostics after the admin clears the backlog', async () => {
+    const deleteResponse = await fetch(`${baseUrl}/api/context-graph/subscriptions`, {
+      method: 'DELETE',
+      headers: { authorization: 'Bearer admin-token' },
+    });
+    expect(deleteResponse.status).toBe(200);
+    expect(await deleteResponse.json()).toEqual({ cleared: 6 });
+
+    const response = await fetch(`${baseUrl}/api/context-graph/subscriptions`, {
+      headers: { authorization: 'Bearer admin-token' },
+    });
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(0);
+    expect(body.subscriptions).toEqual([]);
+    expect(body.rehydration).toBeNull();
   });
 });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -25,6 +25,7 @@ describe('context graph subscription diagnostics route', () => {
     subscriptions = new Map<string, any>([
       ['cg-000', { subscribed: true, synced: true, coreHosted: false }],
       ['cg-hosted', { subscribed: true, synced: false, coreHosted: true }],
+      ['cg-host-only', { subscribed: false, synced: false, coreHosted: true }],
       ['cg-discoverable', { subscribed: false, synced: false, coreHosted: false }],
       [SYSTEM_CONTEXT_GRAPHS.AGENTS, { subscribed: true, synced: true, coreHosted: false }],
     ]);
@@ -111,10 +112,11 @@ describe('context graph subscription diagnostics route', () => {
     const body = await response.json() as any;
 
     expect(response.status).toBe(200);
-    expect(body.count).toBe(2);
+    expect(body.count).toBe(3);
     expect(body.subscriptions).toEqual([
       { contextGraphId: 'cg-000', subscribed: true, synced: true, coreHosted: false },
       { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
+      { contextGraphId: 'cg-host-only', subscribed: false, synced: false, coreHosted: true },
     ]);
     expect(body.rehydration).toEqual(rehydration);
   });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -9,7 +9,8 @@ describe('context graph subscription diagnostics route', () => {
   const rehydration = {
     persistedTotal: 70,
     systemExcluded: 2,
-    hostedActivated: 1,
+    hostedActivated: 2,
+    hostedActivatedIds: ['cg-hosted', 'cg-host-only'],
     activated: 64,
     dormant: 6,
     activationCap: 64,
@@ -33,8 +34,17 @@ describe('context graph subscription diagnostics route', () => {
       getSubscribedContextGraphs: () => subscriptions,
       getContextGraphSubscriptionRehydrationStatus: () => rehydrationStatus,
       clearContextGraphSubscriptions: async () => {
-        rehydrationStatus = null;
-        subscriptions.clear();
+        rehydrationStatus = rehydrationStatus
+          ? {
+              ...rehydrationStatus,
+              persistedTotal: 2,
+              activated: 2,
+              dormant: 0,
+              dormantIds: [],
+            }
+          : null;
+        subscriptions.delete('cg-000');
+        subscriptions.delete('cg-discoverable');
         return 6;
       },
       resolveAgentByToken: (token?: string) => token === 'agent-token'
@@ -112,11 +122,10 @@ describe('context graph subscription diagnostics route', () => {
     const body = await response.json() as any;
 
     expect(response.status).toBe(200);
-    expect(body.count).toBe(3);
+    expect(body.count).toBe(2);
     expect(body.subscriptions).toEqual([
       { contextGraphId: 'cg-000', subscribed: true, synced: true, coreHosted: false },
       { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
-      { contextGraphId: 'cg-host-only', subscribed: false, synced: false, coreHosted: true },
     ]);
     expect(body.rehydration).toEqual(rehydration);
   });
@@ -131,7 +140,7 @@ describe('context graph subscription diagnostics route', () => {
     expect(body.error).toContain('node-level admin token');
   });
 
-  it('returns null rehydration diagnostics after the admin clears the backlog', async () => {
+  it('returns updated rehydration diagnostics after the admin clears the backlog', async () => {
     const deleteResponse = await fetch(`${baseUrl}/api/context-graph/subscriptions`, {
       method: 'DELETE',
       headers: { authorization: 'Bearer admin-token' },
@@ -145,8 +154,16 @@ describe('context graph subscription diagnostics route', () => {
     const body = await response.json() as any;
 
     expect(response.status).toBe(200);
-    expect(body.count).toBe(0);
-    expect(body.subscriptions).toEqual([]);
-    expect(body.rehydration).toBeNull();
+    expect(body.count).toBe(1);
+    expect(body.subscriptions).toEqual([
+      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
+    ]);
+    expect(body.rehydration).toEqual({
+      ...rehydration,
+      persistedTotal: 2,
+      activated: 2,
+      dormant: 0,
+      dormantIds: [],
+    });
   });
 });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -41,6 +41,7 @@ describe('context graph subscription diagnostics route', () => {
               activated: 2,
               dormant: 0,
               dormantIds: [],
+              completedAt: 1_700_000_000_001,
             }
           : null;
         subscriptions.delete('cg-000');
@@ -164,6 +165,7 @@ describe('context graph subscription diagnostics route', () => {
       activated: 2,
       dormant: 0,
       dormantIds: [],
+      completedAt: 1_700_000_000_001,
     });
   });
 });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+
+describe('context graph subscription diagnostics route', () => {
+  let server: Server | undefined;
+  let baseUrl = '';
+  const rehydration = {
+    persistedTotal: 70,
+    systemExcluded: 2,
+    hostedActivated: 1,
+    activated: 64,
+    dormant: 6,
+    activationCap: 64,
+    capDisabled: false,
+    dormantIds: ['cg-064', 'cg-065', 'cg-066', 'cg-067', 'cg-068', 'cg-069'],
+    completedAt: 1_700_000_000_000,
+  };
+
+  beforeEach(async () => {
+    const subscriptions = new Map<string, any>([
+      ['cg-000', { subscribed: true, synced: true, coreHosted: false }],
+      ['cg-hosted', { subscribed: true, synced: false, coreHosted: true }],
+      ['cg-discoverable', { subscribed: false, synced: false, coreHosted: false }],
+      [SYSTEM_CONTEXT_GRAPHS.AGENTS, { subscribed: true, synced: true, coreHosted: false }],
+    ]);
+    const agent = {
+      getSubscribedContextGraphs: () => subscriptions,
+      getContextGraphSubscriptionRehydrationStatus: () => rehydration,
+      resolveAgentByToken: (token?: string) => token === 'agent-token'
+        ? '0x1111111111111111111111111111111111111111'
+        : undefined,
+    };
+    const validTokens = new Set(['admin-token', 'agent-token']);
+
+    server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const auth = req.headers.authorization;
+      const requestToken = typeof auth === 'string'
+        ? auth.replace(/^Bearer\s+/i, '')
+        : undefined;
+      await handleContextGraphRoutes({
+        req,
+        res,
+        agent,
+        publisherControl: {},
+        publisherRuntime: null,
+        config: { auth: { enabled: true } },
+        startedAt: Date.now(),
+        dashDb: {},
+        opWallets: {},
+        network: {},
+        tracker: {},
+        memoryManager: {},
+        bridgeAuthToken: undefined,
+        nodeVersion: 'test',
+        nodeCommit: 'test',
+        catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
+        extractionRegistry: {},
+        fileStore: {},
+        extractionStatus: new Map(),
+        assertionImportLocks: new Map(),
+        vectorStore: {},
+        embeddingProvider: null,
+        validTokens,
+        apiHost: '127.0.0.1',
+        apiPortRef: { value: 0 },
+        routePlugins: [],
+        url,
+        path: url.pathname,
+        requestToken,
+        requestAgentAddress: agent.resolveAgentByToken(requestToken),
+      } as any);
+      if (!res.writableEnded) {
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => {
+        const address = server!.address();
+        if (typeof address === 'object' && address) {
+          baseUrl = `http://127.0.0.1:${address.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve, reject) => {
+      server!.close((err) => (err ? reject(err) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it('returns active user subscriptions with rehydration diagnostics to node admins', async () => {
+    const response = await fetch(`${baseUrl}/api/context-graph/subscriptions`, {
+      headers: { authorization: 'Bearer admin-token' },
+    });
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(2);
+    expect(body.subscriptions).toEqual([
+      { contextGraphId: 'cg-000', subscribed: true, synced: true, coreHosted: false },
+      { contextGraphId: 'cg-hosted', subscribed: true, synced: false, coreHosted: true },
+    ]);
+    expect(body.rehydration).toEqual(rehydration);
+  });
+
+  it('rejects agent-scoped tokens for node-wide subscription diagnostics', async () => {
+    const response = await fetch(`${baseUrl}/api/context-graph/subscriptions`, {
+      headers: { authorization: 'Bearer agent-token' },
+    });
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain('node-level admin token');
+  });
+});

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -17,6 +17,7 @@ describe('context graph subscription diagnostics route', () => {
     capDisabled: false,
     dormantIds: ['cg-064', 'cg-065', 'cg-066', 'cg-067', 'cg-068', 'cg-069'],
     completedAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
   };
   let rehydrationStatus: typeof rehydration | null = null;
   let subscriptions: Map<string, any>;
@@ -41,7 +42,7 @@ describe('context graph subscription diagnostics route', () => {
               activated: 2,
               dormant: 0,
               dormantIds: [],
-              completedAt: 1_700_000_000_001,
+              updatedAt: 1_700_000_000_001,
             }
           : null;
         subscriptions.delete('cg-000');
@@ -165,7 +166,8 @@ describe('context graph subscription diagnostics route', () => {
       activated: 2,
       dormant: 0,
       dormantIds: [],
-      completedAt: 1_700_000_000_001,
+      completedAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_001,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Keeps the default startup context-graph subscription activation cap at 64 as the #997 anti-starvation guard, while making the capped set deterministic and observable.
- Restores all `coreHosted` subscriptions outside the cap, then activates non-hosted rows in subscribed-first, ID-ascending order; over-budget rows remain persisted/dormant.
- Adds agent and admin-route rehydration diagnostics with persisted/activated/dormant counts and dormant IDs so operators can prune or tune the cap.

## Related

- Fixes #1180
- Related to #997

## Files changed

| File | What |
|------|------|
| `packages/agent/src/dkg-agent-lifecycle.ts` | Deterministic rehydration ordering, hosted exemption accounting, wire-id reverse-map restoration, and status snapshot exposure |
| `packages/agent/src/dkg-agent-base.ts` | Stores the latest rehydration status snapshot |
| `packages/agent/src/dkg-agent-types.ts` | Adds the public `ContextGraphSubscriptionRehydrationStatus` type and clarifies cap comments |
| `packages/agent/src/index.ts` | Re-exports the new status type |
| `packages/agent/test/agent.part-15.test.ts` | Covers default 64 cap over a 173-row backlog, uncapped mode, hosted exemption, deterministic order, and on-chain hash rehydration |
| `packages/cli/src/config.ts` | Clarifies that the cap is intentional, observable, and disabled by `0` |
| `packages/cli/src/daemon/routes/context-graph.ts` | Includes `rehydration` diagnostics in the admin subscriptions response while preserving `count` and `subscriptions` |
| `packages/cli/test/context-graph-subscriptions-route.test.ts` | Covers admin diagnostics response and agent-scoped token rejection |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg... build`
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/agent.part-15.test.ts --reporter verbose`
- [x] `pnpm --filter @origintrail-official/dkg test -- test/context-graph-subscriptions-route.test.ts --reporter verbose`
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg build`
- [x] `git diff --check`
- [x] Local `.codex` reviewer loop: round 1 found deterministic ordering/generated-noise issues; fixed/restored scope; round 2 returned no comments.